### PR TITLE
Dev/0.1.1

### DIFF
--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -39,6 +39,9 @@
     "src/components/ui/alert-dialog.tsx",
     "src/components/ui/collapsible.tsx",
     "src/components/ui/sonner.tsx",
-    "src/features/prompts/JailbreakSystemPrompt.tsx"
+    "src/features/prompts/JailbreakSystemPrompt.tsx",
+    "src/test/setup.ts",
+    "src/test/types/test-types.ts",
+    "src/test/utils/html-test-utils.ts"
   ]
 }

--- a/docs/history/refactoring_20250911_1430.md
+++ b/docs/history/refactoring_20250911_1430.md
@@ -1,0 +1,230 @@
+# Refactoring Plan: Chat Planning Status Visualization
+
+## 작업의 목적
+
+Chat.tsx에 AI Agent의 Planning 상태를 실시간으로 시각화하는 기능을 추가하여, 사용자가 대화 중에 AI의 현재 계획, 목표, 진행 상황을 GUI로 확인할 수 있도록 한다.
+
+## 현재의 상태 / 문제점
+
+### 현재 상태
+
+- Planning 서버(`planning-server.ts`)가 Web Worker에서 정상 동작 중
+- AI Agent가 `WebMCPToolProvider`를 통해 Planning 도구들을 사용하여 목표 설정, 할일 관리, 관찰 기록을 수행
+- `use-web-mcp-server.ts`가 싱글톤 패턴으로 구현되어 type-safe한 MCP 서버 접근 제공
+- Chat.tsx가 compound component 패턴으로 구조화됨
+
+### 문제점
+
+- AI Agent의 Planning 상태(목표, 할일, 관찰)를 사용자가 실시간으로 확인할 수 없음
+- Planning 서버에 UI용 상태 조회 기능이 없음 (`getServiceContext`는 텍스트 형태로만 제공)
+- 사용자가 AI의 계획 진행 상황을 파악하기 어려워 대화의 맥락 이해가 제한됨
+
+## 추가 분석 과제
+
+1. **상태 동기화 전략 분석**: AI Agent가 Planning 도구를 사용할 때와 UI 상태 업데이트 간의 최적 동기화 방법 연구
+2. **UX 최적화**: Planning 패널의 위치, 크기, 토글 방식에 대한 사용자 경험 최적화 방안 검토
+3. **성능 영향 평가**: 실시간 polling이나 상태 업데이트가 Chat 성능에 미치는 영향 분석
+
+## 변경 이후의 상태 / 해결 판정 기준
+
+### 목표 상태
+
+- Chat 인터페이스에서 AI Agent의 현재 목표, 진행 중인 할일, 완료된 할일, 최근 관찰 내용을 실시간으로 확인 가능
+- Planning 패널을 토글하여 필요시에만 표시하되, 대화 흐름을 방해하지 않음
+- Type-safe한 Planning 상태 접근으로 개발자 경험 향상
+
+### 성공 판정 기준
+
+- [ ] Planning 서버에서 구조화된 상태 데이터를 JSON 형태로 조회 가능
+- [ ] Chat 인터페이스에 Planning 패널이 토글 가능한 형태로 통합
+- [ ] AI가 Planning 도구를 사용한 후 UI 상태가 적절한 시간 내에 업데이트됨
+- [ ] 기존 Chat 기능에 영향 없이 Planning 시각화 기능이 동작
+- [ ] TypeScript 컴파일 오류 없이 type-safe한 구현 완료
+
+## 수정이 필요한 코드 및 수정부분의 코드 스니핏
+
+### 1. Planning 서버 확장 (`src/lib/web-mcp/modules/planning-server.ts`)
+
+**추가할 툴 정의:**
+
+```typescript
+{
+  name: 'get_current_state',
+  description: 'Get current planning state as structured JSON data for UI visualization',
+  inputSchema: { type: 'object', properties: {} },
+}
+```
+
+**callTool 케이스 추가:**
+
+```typescript
+case 'get_current_state': {
+  const currentState = {
+    goal: state.getGoal(),
+    lastClearedGoal: state.getLastClearedGoal(),
+    todos: state.getTodos(),
+    observations: state.getObservations(),
+  };
+
+  return {
+    jsonrpc: '2.0',
+    id: null,
+    result: {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(currentState)
+      }]
+    }
+  };
+}
+```
+
+### 2. TypeScript 타입 정의 (`src/models/planning.ts` - 새로 생성)
+
+```typescript
+export interface SimpleTodo {
+  name: string;
+  status: 'pending' | 'completed';
+}
+
+export interface PlanningState {
+  goal: string | null;
+  lastClearedGoal: string | null;
+  todos: SimpleTodo[];
+  observations: string[];
+}
+
+export interface PlanningServerProxy extends WebMCPServerProxy {
+  create_goal: (args: { goal: string }) => Promise<string>;
+  add_todo: (args: {
+    name: string;
+  }) => Promise<{ success: boolean; todos: SimpleTodo[] }>;
+  toggle_todo: (args: {
+    index: number;
+  }) => Promise<{ todo: SimpleTodo | null; todos: SimpleTodo[] }>;
+  clear_todos: () => Promise<{ success: boolean }>;
+  clear_session: () => Promise<void>;
+  add_observation: (args: { observation: string }) => Promise<void>;
+  get_current_state: () => Promise<PlanningState>;
+}
+```
+
+### 3. Planning Panel 컴포넌트 (`src/features/chat/components/ChatPlanningPanel.tsx` - 새로 생성)
+
+```typescript
+export function ChatPlanningPanel() {
+  const { server, loading, error } = useWebMCPServer<PlanningServerProxy>('planning');
+  const [planningState, setPlanningState] = useState<PlanningState | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const refreshState = useCallback(async () => {
+    if (!server?.get_current_state) return;
+
+    try {
+      setIsRefreshing(true);
+      const state = await server.get_current_state();
+      setPlanningState(state);
+    } catch (err) {
+      logger.error('Failed to refresh planning state', err);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [server]);
+
+  // 주기적 상태 업데이트 (30초마다)
+  useEffect(() => {
+    if (server) {
+      refreshState();
+      const interval = setInterval(refreshState, 30000);
+      return () => clearInterval(interval);
+    }
+  }, [server, refreshState]);
+
+  return (
+    <div className="planning-panel p-4 border-l border-gray-200 dark:border-gray-700">
+      {/* Goal Section */}
+      {/* Todos Section */}
+      {/* Observations Section */}
+    </div>
+  );
+}
+```
+
+### 4. Chat.tsx 수정
+
+```typescript
+function Chat({ children }: ChatProps) {
+  const [showPlanningPanel, setShowPlanningPanel] = useState(false);
+
+  return (
+    <ChatProvider>
+      <TimeLocationSystemPrompt />
+      <div className="h-full w-full font-mono flex rounded-lg overflow-hidden shadow-2xl">
+        {/* 메인 채팅 영역 */}
+        <div className="flex-1 flex flex-col">
+          {children}
+          <ToolsModal
+            isOpen={showToolsDetail}
+            onClose={() => setShowToolsDetail(false)}
+          />
+        </div>
+
+        {/* Planning 사이드 패널 */}
+        {showPlanningPanel && (
+          <div className="w-80">
+            <ChatPlanningPanel />
+          </div>
+        )}
+      </div>
+    </ChatProvider>
+  );
+}
+
+// Compound component 추가
+Chat.PlanningPanel = ChatPlanningPanel;
+```
+
+## 재사용 가능한 연관 코드
+
+### 핵심 파일 및 인터페이스
+
+1. **`src/hooks/use-web-mcp-server.ts`**
+   - 기능: WebMCP 서버에 type-safe하게 접근하는 React Hook
+   - 인터페이스: `useWebMCPServer<T>(serverName: string)`
+   - 재사용: Planning 외 다른 MCP 서버 시각화에도 활용 가능
+
+2. **`src/lib/web-mcp/mcp-proxy.ts`**
+   - 기능: Web Worker MCP 통신 프록시
+   - 인터페이스: `WebMCPProxy` 클래스의 `callTool`, `loadServer`, `listTools` 메서드
+   - 재사용: 모든 Web MCP 서버 통신의 기반
+
+3. **`src/features/chat/Chat.tsx`**
+   - 기능: Compound component 패턴으로 구조화된 Chat 인터페이스
+   - 패턴: `Chat.Header`, `Chat.Messages`, `Chat.Input` 등
+   - 재사용: 새로운 Chat 관련 컴포넌트 추가시 동일 패턴 적용
+
+4. **`src/context/ChatContext.tsx`**
+   - 기능: Chat 상태 관리 및 공유
+   - 인터페이스: ChatProvider, useChatContext
+   - 재사용: Planning 상태를 Chat 전체에서 공유할 때 활용 가능
+
+### 설계 패턴
+
+- **Compound Component Pattern**: Chat.tsx에서 사용 중인 패턴, Planning Panel에도 적용
+- **Singleton Pattern**: WebMCPProxyManager에서 사용 중, 전역 상태 관리에 참조
+- **Hook Pattern**: use-web-mcp-server.ts의 패턴, 다른 MCP 서버용 Hook 개발시 참조
+
+### 스타일링 가이드
+
+- **Tailwind CSS**: 기존 Chat 컴포넌트들과 일관된 스타일링
+- **Dark Mode**: `dark:` prefix 사용하여 다크 모드 지원
+- **Responsive**: 화면 크기에 따른 Planning Panel 크기 조절
+
+## 구현 순서 제안
+
+1. Planning 서버 확장 (`get_current_state` 툴 추가)
+2. TypeScript 타입 정의 추가
+3. 기본 ChatPlanningPanel 컴포넌트 구현
+4. Chat.tsx에 사이드 패널로 통합
+5. UI 스타일링 및 토글 기능 완성
+6. 실시간 업데이트 최적화 및 성능 테스트

--- a/src/features/tools/browser-tools/index.ts
+++ b/src/features/tools/browser-tools/index.ts
@@ -17,7 +17,11 @@ export { inputTextTool } from './InputTextTool';
 export { extractContentTool } from './ExtractContentTool';
 
 // Types and helpers
-export type { LocalMCPTool, BrowserLocalMCPTool } from './types';
+export type {
+  BrowserLocalMCPTool,
+  StrictLocalMCPTool,
+  StrictBrowserMCPTool,
+} from './types';
 export {
   BROWSER_TOOL_SCHEMAS,
   checkElementState,

--- a/src/features/tools/browser-tools/types.ts
+++ b/src/features/tools/browser-tools/types.ts
@@ -34,11 +34,3 @@ export type StrictBrowserMCPTool = MCPTool & {
     executeScript?: (sessionId: string, script: string) => Promise<string>,
   ) => Promise<MCPResponse>;
 };
-
-/**
- * @deprecated Use StrictLocalMCPTool instead for better type safety
- * Legacy type kept for backwards compatibility during migration
- */
-export type LocalMCPTool = MCPTool & {
-  execute: (args: Record<string, unknown>) => Promise<unknown>;
-};


### PR DESCRIPTION
This pull request focuses on refactoring and improving the type safety and maintainability of the browser tool provider system, as well as documenting a plan for visualizing AI planning status in the chat interface. The main changes include replacing legacy tool types with stricter, type-safe interfaces, removing unnecessary code, and updating tool registration and execution logic. Additionally, a comprehensive refactoring plan for the chat planning visualization feature has been added to the documentation.

### Type Safety and Codebase Cleanup

* Replaced the deprecated `LocalMCPTool` type with `StrictLocalMCPTool` and updated all relevant imports and usages in `BrowserToolProvider.tsx` and `browser-tools/index.ts` for improved type safety. [[1]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L27-R26) [[2]](diffhunk://#diff-47e0cb1c0603b6e185bbb498ad5503c9db37cce2ed41d2e31e2ee32474f3d4e8L20-R24) [[3]](diffhunk://#diff-994d2b45c32b0428d3f26a13b4c47de74d4626a5b1515eef8d72cc6f04d3603eL37-L44)
* Removed legacy code related to `LocalMCPTool` and the `useRustBackend` hook, simplifying the `BrowserToolProvider.tsx` implementation. [[1]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L4) [[2]](diffhunk://#diff-7cbb44bfee7a1796a73e3caa64879bffc078d59e9b802825486757ea2f168045L39) [[3]](diffhunk://#diff-994d2b45c32b0428d3f26a13b4c47de74d4626a5b1515eef8d72cc6f04d3603eL37-L44)
* Updated the tool execution logic in `BrowserToolProvider.tsx` to assume all tools return an `MCPResponse`, eliminating special cases and legacy fallbacks. Added a warning for unexpected non-MCPResponse returns.

### Documentation and Planning

* Added a detailed refactoring plan in `docs/history/refactoring_20250911_1430.md` outlining the steps and requirements for implementing a real-time AI planning status visualization panel in the chat UI, including type definitions, server extensions, and UI integration.

### Configuration Updates

* Updated the `.unimportedrc.json` configuration to include new test utility files for import tracking and code cleanliness.