### PR TITLE
Fix: Install clippy in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
         run: cd src-tauri && cargo check
 
       # Code Quality Checks (PR only)
+      - name: 🦀 Install Clippy
+        run: rustup component add clippy
       - name: 🔍 Rust Clippy (PR)
         if: github.event_name == 'pull_request'
         run: cd src-tauri && cargo clippy -- -D warnings


### PR DESCRIPTION
The CI job was failing because the `clippy` component was not installed for the Rust toolchain. This change adds a step to the CI workflow to install `clippy` using `rustup component add clippy` before running the `cargo clippy` command.