### PR TITLE
refactor(tests): remove unnecessary imports in test module for clarity

### DIFF
--- a/src-tauri/src/search/index_storage.rs
+++ b/src-tauri/src/search/index_storage.rs
@@ -126,17 +126,16 @@ pub fn delete_index(session_id: &str) -> Result<(), String> {
 ///
 /// # Returns
 /// Result indicating success or error message, with count of deleted files
-
 mod tests {
-    use super::*;
+    // ...existing code... (no use super::* needed because tests access module items directly)
 
     #[test]
     fn test_index_write_read_roundtrip() {
         let temp_dir = tempfile::tempdir().unwrap();
         let index_path = temp_dir.path().join("test.idx");
 
-        let original_data = IndexData {
-            metadata: IndexMetadata {
+        let original_data = super::IndexData {
+            metadata: super::IndexMetadata {
                 version: 1,
                 session_id: "test-session".to_string(),
                 doc_count: 100,
@@ -146,10 +145,10 @@ mod tests {
         };
 
         // Write
-        write_index_atomic(&index_path, &original_data).unwrap();
+        super::write_index_atomic(&index_path, &original_data).unwrap();
 
         // Read
-        let read_data = read_index(&index_path).unwrap();
+        let read_data = super::read_index(&index_path).unwrap();
 
         assert_eq!(read_data.metadata.version, 1);
         assert_eq!(read_data.metadata.session_id, "test-session");
@@ -159,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_read_nonexistent_file() {
-        let result = read_index(Path::new("/nonexistent/path.idx"));
+        let result = super::read_index(std::path::Path::new("/nonexistent/path.idx"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not found"));
     }

--- a/src/features/tools/BrowserToolProvider.tsx
+++ b/src/features/tools/BrowserToolProvider.tsx
@@ -18,8 +18,6 @@ import {
   scrollPageTool,
   navigateBackTool,
   navigateForwardTool,
-  //clickElementTool,
-  //inputTextTool,
   extractPageContentTool,
   listInteractableTool,
   // injectJavascriptTool, // <-- Add import


### PR DESCRIPTION
This pull request primarily updates the test code in `src-tauri/src/search/index_storage.rs` to improve clarity and maintainability by explicitly referencing items from the parent module using `super::`. Additionally, it includes a minor cleanup in a TypeScript file by removing commented-out imports.

Test code improvements in Rust:

* Updated all references to types and functions within the `tests` module to use explicit `super::` paths, making it clearer where each item is defined and improving maintainability. [[1]](diffhunk://#diff-1a73ea58f44e336fd905b79a5878da2effeb59db8bf6bb7f97cd28d4c7cca140L129-R138) [[2]](diffhunk://#diff-1a73ea58f44e336fd905b79a5878da2effeb59db8bf6bb7f97cd28d4c7cca140L149-R151) [[3]](diffhunk://#diff-1a73ea58f44e336fd905b79a5878da2effeb59db8bf6bb7f97cd28d4c7cca140L162-R161)

Minor cleanup in TypeScript:

* Removed commented-out imports for unused tools in `BrowserToolProvider.tsx`, reducing clutter in the import section.