### PR TITLE
feat: Refactor observations to notes in ChatPlanningPanel and related…

### DIFF
--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -49,6 +49,7 @@
     "src/test/setup.ts",
     "src/test/types/test-types.ts",
     "src/test/utils/html-test-utils.ts",
-    "src/lib/web-mcp/examples/tool-result-usage.ts"
+    "src/lib/web-mcp/examples/tool-result-usage.ts",
+    "src/hooks/__tests__/use-ai-service.completeText.spec.ts"
   ]
 }

--- a/docs/analysis/openai-tool-message-error-analysis.md
+++ b/docs/analysis/openai-tool-message-error-analysis.md
@@ -1,0 +1,407 @@
+# OpenAI Tool Message Error Analysis
+
+**Date**: 2025-10-12  
+**Error**: `400 Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.`
+
+## 🔴 Problem Summary
+
+OpenAI API is rejecting message stacks because **tool messages exist without their corresponding assistant messages with tool_calls**. This error does NOT occur in Gemini because Gemini has aggressive message stack validation that removes orphaned tool messages.
+
+## 🔍 Root Cause Analysis
+
+### 1. OpenAI's Strict Message Ordering Requirements
+
+OpenAI API enforces strict message ordering rules:
+
+- Every `tool` message **MUST** be preceded by an `assistant` message with `tool_calls`
+- The `tool_call_id` in the tool message must match one of the `tool_calls` IDs in the preceding assistant message
+- If this pairing is broken, the API returns a 400 error
+
+### 2. Message Stack Processing Differences
+
+#### OpenAI (`openai.ts`)
+
+```typescript
+async *streamChat(messages: Message[], options) {
+  // Step 1: Base sanitization (removes thinking fields, converts tool_use to tool_calls)
+  const { sanitizedMessages } = this.prepareStreamChat(messages, options);
+
+  // Step 2: Convert to OpenAI format
+  const openaiMessages = this.convertToOpenAIMessages(
+    sanitizedMessages,
+    options.systemPrompt,
+  );
+
+  // Step 3: Send to OpenAI API ❌ NO VALIDATION OF TOOL CALL CHAINS
+}
+
+private convertToOpenAIMessages(messages: Message[], systemPrompt?: string) {
+  // Simply converts messages to OpenAI format
+  // ❌ Does NOT validate or fix orphaned tool messages
+  for (const m of messages) {
+    if (effectiveRole === 'tool') {
+      if (m.tool_call_id) {
+        openaiMessages.push({
+          role: 'tool',
+          tool_call_id: m.tool_call_id,
+          content: this.processMessageContent(m.content),
+        });
+      } else {
+        logger.warn(`Tool message missing tool_call_id: ${JSON.stringify(m)}`);
+      }
+    }
+  }
+  return openaiMessages;
+}
+```
+
+**Problem**: OpenAI implementation does NOT validate whether:
+
+- A tool message has a corresponding assistant message with tool_calls
+- The tool_call_id matches any existing tool_calls
+- The message order is valid
+
+#### Gemini (`gemini.ts`)
+
+```typescript
+async *streamChat(messages: Message[], options) {
+  // Step 1: Base sanitization
+  const { config, tools } = this.prepareStreamChat(messages, options);
+
+  // Step 2: ✅ VALIDATE MESSAGE STACK FOR GEMINI
+  const validatedMessages = this.validateGeminiMessageStack(messages);
+
+  // Step 3: Convert to Gemini format
+  const geminiMessages = this.convertToGeminiMessages(validatedMessages);
+}
+
+private validateGeminiMessageStack(messages: Message[]): Message[] {
+  // ✅ Converts ALL tool messages to user messages
+  const convertedMessages = messages.map((m) => {
+    if (m.role === 'tool') {
+      return { ...m, role: 'user' as const };
+    }
+    return m;
+  });
+
+  // ✅ Removes messages before first user message
+  const firstUserIndex = convertedMessages.findIndex(
+    (msg) => msg.role === 'user',
+  );
+  const validMessages = convertedMessages.slice(firstUserIndex);
+
+  return validMessages;
+}
+```
+
+**Solution**: Gemini's validation:
+
+1. Converts **ALL** `tool` role messages to `user` role
+2. Removes any messages before the first user message
+3. This eliminates the possibility of orphaned tool messages
+
+### 3. MessageNormalizer's Limited Scope
+
+The `MessageNormalizer.sanitizeMessagesForProvider()` handles:
+
+- ✅ Converting `thinking` fields removal for OpenAI family
+- ✅ Converting `tool_use` ↔️ `tool_calls` format conversion
+- ✅ **For Anthropic ONLY**: `fixAnthropicToolCallChain()` validates tool call pairing
+
+But for OpenAI family:
+
+```typescript
+private static sanitizeForOpenAIFamily(message: Message): Message {
+  // Remove thinking fields
+  if (message.thinking) delete message.thinking;
+  if (message.thinkingSignature) delete message.thinkingSignature;
+
+  // Convert tool_use to tool_calls
+  if (message.tool_use && !message.tool_calls) {
+    message.tool_calls = [...];
+    delete message.tool_use;
+  }
+
+  // ❌ NO VALIDATION OF TOOL CALL CHAINS
+  return message;
+}
+```
+
+## 🐛 How Orphaned Tool Messages Can Occur
+
+### Scenario 1: Message Stack Manipulation
+
+```typescript
+// Original stack:
+[
+  { role: 'assistant', tool_calls: [{ id: 'call_1', ... }] },  // Message A
+  { role: 'tool', tool_call_id: 'call_1', ... },              // Message B
+  { role: 'user', ... },                                       // Message C
+]
+
+// After some UI operation (e.g., delete Message A):
+[
+  { role: 'tool', tool_call_id: 'call_1', ... },  // ❌ Orphaned!
+  { role: 'user', ... },
+]
+```
+
+### Scenario 2: Incomplete Tool Call Response
+
+```typescript
+// Assistant makes tool call
+{ role: 'assistant', tool_calls: [{ id: 'call_1' }, { id: 'call_2' }] }
+
+// Only one tool responds (network error, timeout, etc.)
+{ role: 'tool', tool_call_id: 'call_1', ... }
+
+// Missing: { role: 'tool', tool_call_id: 'call_2', ... }
+```
+
+### Scenario 3: Cross-Provider Message Stack Reuse
+
+```typescript
+// Messages created with Anthropic (uses tool_use format)
+const anthropicMessages = [
+  { role: 'assistant', tool_use: { id: 'call_1', ... } },
+  { role: 'tool', tool_call_id: 'call_1', ... },
+];
+
+// Converted by MessageNormalizer for OpenAI
+// tool_use → tool_calls conversion might fail
+// Result: tool message without matching tool_calls
+```
+
+## 📊 Comparison Table
+
+| Feature                        | OpenAI       | Gemini                    | Anthropic                    |
+| ------------------------------ | ------------ | ------------------------- | ---------------------------- |
+| Tool message validation        | ❌ None      | ✅ Converts to user       | ✅ fixAnthropicToolCallChain |
+| Orphaned tool message handling | ❌ API Error | ✅ Converts to user       | ✅ Removes incomplete chains |
+| Message order validation       | ❌ None      | ✅ Starts from first user | ✅ Validates tool pairs      |
+| Tool call chain validation     | ❌ None      | N/A (no tool role)        | ✅ Validates completion      |
+
+## 🔧 Recommended Solutions
+
+### Solution A: Add OpenAI-Specific Validation (Minimal Impact)
+
+Add a validation method similar to Gemini's `validateGeminiMessageStack`:
+
+```typescript
+// In openai.ts
+private validateOpenAIMessageStack(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  const assistantToolCallIds = new Set<string>();
+
+  // First pass: collect all tool_call IDs from assistant messages
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      msg.tool_calls.forEach(tc => assistantToolCallIds.add(tc.id));
+    }
+  }
+
+  // Second pass: filter out orphaned tool messages
+  for (const msg of messages) {
+    if (msg.role === 'tool') {
+      if (msg.tool_call_id && assistantToolCallIds.has(msg.tool_call_id)) {
+        result.push(msg);
+      } else {
+        logger.warn('Skipping orphaned tool message', {
+          messageId: msg.id,
+          toolCallId: msg.tool_call_id,
+        });
+      }
+    } else {
+      result.push(msg);
+    }
+  }
+
+  return result;
+}
+```
+
+### Solution B: Extend MessageNormalizer (Consistent Approach)
+
+Add OpenAI tool chain validation to `MessageNormalizer`:
+
+```typescript
+// In message-normalizer.ts
+static sanitizeMessagesForProvider(
+  messages: Message[],
+  targetProvider: AIServiceProvider,
+): Message[] {
+  let processedMessages = messages;
+
+  // Apply provider-specific chain validation
+  if (targetProvider === AIServiceProvider.Anthropic) {
+    processedMessages = this.fixAnthropicToolCallChain(messages);
+  } else if (
+    targetProvider === AIServiceProvider.OpenAI ||
+    targetProvider === AIServiceProvider.Groq ||
+    targetProvider === AIServiceProvider.Cerebras ||
+    targetProvider === AIServiceProvider.Fireworks
+  ) {
+    // ✅ Add OpenAI family validation
+    processedMessages = this.fixOpenAIFamilyToolCallChain(messages);
+  }
+
+  // Continue with existing sanitization
+  return processedMessages
+    .map((msg) => this.sanitizeSingleMessage(msg, targetProvider))
+    .filter((msg) => msg !== null) as Message[];
+}
+
+private static fixOpenAIFamilyToolCallChain(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  const toolCallIds = new Set<string>();
+
+  // Collect valid tool_call IDs
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      msg.tool_calls.forEach(tc => toolCallIds.add(tc.id));
+    }
+  }
+
+  // Filter messages
+  for (const msg of messages) {
+    if (msg.role === 'tool') {
+      if (!msg.tool_call_id || !toolCallIds.has(msg.tool_call_id)) {
+        logger.warn('Removing orphaned tool message for OpenAI family', {
+          messageId: msg.id,
+          toolCallId: msg.tool_call_id,
+        });
+        continue; // Skip this message
+      }
+    }
+    result.push(msg);
+  }
+
+  return result;
+}
+```
+
+### Solution C: Sequence Validation (Most Robust)
+
+Validate the actual sequence order, not just the presence of IDs:
+
+```typescript
+private static fixOpenAIFamilyToolCallChain(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  const pendingToolCalls = new Map<string, boolean>();
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant') {
+      // Clear any pending tool calls from previous assistant message
+      pendingToolCalls.clear();
+
+      // Add new tool calls
+      if (msg.tool_calls) {
+        msg.tool_calls.forEach(tc => pendingToolCalls.set(tc.id, false));
+      }
+      result.push(msg);
+
+    } else if (msg.role === 'tool') {
+      // Only include if we have a pending tool call for this ID
+      if (msg.tool_call_id && pendingToolCalls.has(msg.tool_call_id)) {
+        pendingToolCalls.set(msg.tool_call_id, true);
+        result.push(msg);
+      } else {
+        logger.warn('Skipping out-of-sequence tool message', {
+          messageId: msg.id,
+          toolCallId: msg.tool_call_id,
+        });
+      }
+
+    } else {
+      // User or system messages
+      result.push(msg);
+    }
+  }
+
+  return result;
+}
+```
+
+## 🎯 Recommended Solution: Solution B (Extend MessageNormalizer)
+
+**Rationale**:
+
+1. **Consistency**: Uses the same architecture as Anthropic's tool chain validation
+2. **Centralized Logic**: All provider-specific validation in one place
+3. **Maintainability**: Easy to understand and debug
+4. **Reusability**: Benefits all OpenAI-compatible providers (Groq, Cerebras, Fireworks)
+5. **Non-Breaking**: Fits into existing code flow without changing interfaces
+
+## 📝 Implementation Checklist
+
+- [ ] Add `fixOpenAIFamilyToolCallChain()` method to `MessageNormalizer`
+- [ ] Update `sanitizeMessagesForProvider()` to call it for OpenAI family
+- [ ] Add comprehensive logging for debugging
+- [ ] Write unit tests for edge cases:
+  - [ ] Orphaned tool messages (no matching tool_call)
+  - [ ] Out-of-sequence tool messages
+  - [ ] Multiple assistant messages with tool_calls
+  - [ ] Partial tool responses (some tool_calls missing responses)
+- [ ] Test with all OpenAI-compatible providers:
+  - [ ] OpenAI
+  - [ ] Groq
+  - [ ] Cerebras
+  - [ ] Fireworks
+- [ ] Document the validation behavior in code comments
+
+## 🧪 Test Cases to Verify
+
+```typescript
+// Test Case 1: Orphaned tool message
+const messages1 = [
+  { role: 'tool', tool_call_id: 'call_1', content: 'Result' },
+  { role: 'user', content: 'Hello' },
+];
+// Expected: Tool message removed
+
+// Test Case 2: Valid tool chain
+const messages2 = [
+  { role: 'assistant', tool_calls: [{ id: 'call_1' }] },
+  { role: 'tool', tool_call_id: 'call_1', content: 'Result' },
+  { role: 'user', content: 'Hello' },
+];
+// Expected: All messages preserved
+
+// Test Case 3: Partial tool responses
+const messages3 = [
+  { role: 'assistant', tool_calls: [{ id: 'call_1' }, { id: 'call_2' }] },
+  { role: 'tool', tool_call_id: 'call_1', content: 'Result 1' },
+  // Missing: call_2 response
+  { role: 'user', content: 'Hello' },
+];
+// Expected: All messages preserved (OpenAI handles partial responses)
+
+// Test Case 4: Out-of-sequence tool message
+const messages4 = [
+  { role: 'assistant', tool_calls: [{ id: 'call_1' }] },
+  { role: 'user', content: 'Interrupt' },
+  { role: 'tool', tool_call_id: 'call_1', content: 'Result' },
+];
+// Expected: Tool message removed (comes after user interruption)
+```
+
+## 🚨 Prevention Strategies
+
+1. **Message Stack Integrity**: Implement validation when messages are created/deleted in the UI
+2. **Transaction-Based Updates**: Ensure tool_calls and tool responses are atomic operations
+3. **Provider-Agnostic Storage**: Store messages in a normalized format, convert only at API call time
+4. **Error Recovery**: Implement retry logic that automatically fixes message stacks on 400 errors
+
+## 📚 Related Files
+
+- `/src/lib/ai-service/openai.ts` - OpenAI service implementation
+- `/src/lib/ai-service/gemini.ts` - Gemini service with validation
+- `/src/lib/ai-service/message-normalizer.ts` - Message sanitization logic
+- `/src/lib/ai-service/base-service.ts` - Base service with prepareStreamChat
+- `/src/models/chat.ts` - Message type definitions
+
+## 🔗 OpenAI API Documentation
+
+- [Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create)
+- [Function Calling Guide](https://platform.openai.com/docs/guides/function-calling)
+- Error code 400: "messages with role 'tool' must be a response to a preceeding message with 'tool_calls'"

--- a/docs/history/refactoring_20251012_1445.md
+++ b/docs/history/refactoring_20251012_1445.md
@@ -1,0 +1,690 @@
+# OpenAI Tool Call Pairing Validation Fix
+
+## 작업의 목적
+
+OpenAI provider에서 발생하는 "messages with role 'tool' must be a response to a preceeding message with 'tool_calls'" 400 에러를 해결하기 위해, OpenAI family provider 전용 tool-call/tool-response 페어링 검증 로직을 `MessageNormalizer`에 추가한다.
+
+**핵심 목표:**
+
+- OpenAI provider의 tool message 페어링 요구사항 충족
+- 고아(orphaned) tool message 자동 제거
+- 불완전한 tool_calls 제거
+- 기존 정상 동작 중인 provider(Anthropic, Gemini)는 절대 건드리지 않음
+
+## 현재의 상태 / 문제점
+
+### 문제 상황
+
+OpenAI streaming 요청 시 다음 에러 발생:
+
+```text
+400 Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'
+```
+
+### 근본 원인
+
+**OpenAI provider path의 검증 부재:**
+
+- `message-normalizer.ts`의 `sanitizeMessagesForProvider()`에서 OpenAI family는 Anthropic처럼 tool-call chain 검증을 수행하지 않음
+- `sanitizeForOpenAIFamily()`는 단순히 thinking 필드 제거와 `tool_use` → `tool_calls` 변환만 수행
+- Assistant의 `tool_calls`와 tool response의 `tool_call_id` 페어링 검증 없음
+- 고아(orphaned) tool message가 API로 전송되면 OpenAI가 400 반환
+
+### 현재 코드 흐름 (Birdeye View)
+
+```text
+User Request
+    ↓
+BaseService.prepareStreamChat()
+    ↓
+MessageNormalizer.sanitizeMessagesForProvider(messages, provider)
+    ↓
+    ├─ provider === 'anthropic' → fixAnthropicToolCallChain()
+    │                              ✅ assistant tool_calls ↔ tool responses 페어링 검증
+    │
+    ├─ provider in OpenAI-family → (검증 없음!)
+    │                              → sanitizeForOpenAIFamily() per message
+    │                              ⚠️ 페어링 검증 없음 → 400 에러 발생
+    │
+    └─ provider === 'gemini' → (검증 없지만 tool→user 변환으로 회피)
+                               ✅ Gemini SDK 권고사항 준수
+    ↓
+Provider-specific conversion (convertToOpenAIMessages, etc.)
+    ↓
+Provider API 호출
+```
+
+### Provider별 현재 상태
+
+1. **✅ Anthropic**: 정상 동작
+   - `fixAnthropicToolCallChain()`으로 견고한 페어링 검증
+   - 불완전한 tool call chain 자동 제거
+
+2. **✅ Gemini**: 정상 동작
+   - `validateGeminiMessageStack()`에서 tool → user 변환
+   - Gemini SDK 공식 권고사항 준수
+   - 페어링 에러 발생 안 함
+
+3. **❌ OpenAI**: 문제 발생
+   - 페어링 검증 없음
+   - 고아 tool message 전송 시 400 에러
+
+4. **❓ Groq, Cerebras, Fireworks**: 미확인
+   - OpenAI-compatible API 사용
+   - 동일한 페어링 요구사항 예상
+
+### 주요 코드 위치
+
+- `src/lib/ai-service/message-normalizer.ts`:
+  - `sanitizeMessagesForProvider()`: Provider 분기 지점
+  - `fixAnthropicToolCallChain()`: Anthropic용 검증 (참조 구현)
+  - `sanitizeForOpenAIFamily()`: OpenAI-family용 (검증 부재)
+- `src/lib/ai-service/openai.ts`:
+  - `convertToOpenAIMessages()`: 내부 Message → OpenAI 메시지 변환
+  - `streamChat()`: Streaming 진입점
+- `src/models/chat.ts`:
+  - `Message` 타입 정의
+  - `ToolCall` 타입 정의 (`id`, `type`, `function` 포함)
+
+## 변경 이후의 상태 / 해결 판정 기준
+
+### 목표 상태
+
+1. **OpenAI provider 안전성:**
+   - 모든 `tool` 메시지가 대응되는 assistant `tool_calls` 보유
+   - 고아 tool message 자동 제거
+   - 부분 매칭 시 유효한 페어만 보존
+
+2. **기존 Provider 무영향:**
+   - Anthropic: 기존 검증 로직 그대로 유지
+   - Gemini: SDK 권고사항 준수 로직 그대로 유지
+   - 다른 provider: 기존 동작 유지
+
+3. **중앙화된 검증:**
+   - `MessageNormalizer`에서 OpenAI family 검증 책임
+   - Anthropic과 동일한 수준의 견고성
+
+### 성공 판정 기준
+
+#### 기능 검증
+
+- [ ] OpenAI streaming 요청 시 400 에러 미발생
+- [ ] 고아 tool message 자동 제거 동작
+- [ ] Assistant 다중 tool_calls 중 부분 매칭 시 유효한 것만 보존
+- [ ] Anthropic 검증 로직 영향 없음 (regression 없음)
+- [ ] Gemini provider 정상 동작 (변경 없음)
+
+#### 코드 품질
+
+- [ ] `pnpm refactor:validate` 통과 (lint, format, build, dead-code)
+- [ ] 단위 테스트 커버리지: 신규 함수 100%, edge case 포함
+- [ ] ESLint 규칙 준수 (`any` 사용 없음, 명시적 타입)
+- [ ] 중앙 logger 사용 (`console.*` 없음)
+
+#### 안전성
+
+- [ ] 기존 provider 동작 변경 없음
+- [ ] 잘못된 메시지 형식에 대한 graceful degradation
+- [ ] 로깅을 통한 디버깅 가능성 확보
+
+## 수정이 필요한 코드 및 수정 부분
+
+### 1. MessageNormalizer에 OpenAI-family 검증 추가
+
+**File:** `src/lib/ai-service/message-normalizer.ts`
+
+#### 새 함수 추가: `ensureToolCallPairing`
+
+```typescript
+/**
+ * Ensures tool-call/tool-response pairing for OpenAI-family providers.
+ * Similar to fixAnthropicToolCallChain but tailored for OpenAI API requirements.
+ *
+ * OpenAI API requires that every 'tool' role message must correspond to
+ * a tool_call in a preceding assistant message. This function:
+ * 1. Collects all tool_call ids from assistant messages
+ * 2. Maps tool responses by tool_call_id
+ * 3. Removes orphaned tool messages (no matching tool_call)
+ * 4. Removes unmatched tool_calls from assistant messages
+ * 5. Preserves message ordering and role semantics
+ *
+ * @param messages - Array of messages to validate
+ * @returns Sanitized array with valid tool-call pairings only
+ * @private
+ */
+private static ensureToolCallPairing(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  const validToolCallIds = new Set<string>();
+  const completedToolCallIds = new Set<string>();
+
+  // Step 1: Collect all tool_call ids from assistant messages
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls?.length) {
+      msg.tool_calls.forEach((tc) => {
+        if (tc.id) {
+          validToolCallIds.add(tc.id);
+        }
+      });
+    }
+  }
+
+  // Step 2: Identify completed tool_calls by finding matching tool responses
+  for (const msg of messages) {
+    if (
+      msg.role === 'tool' &&
+      msg.tool_call_id &&
+      validToolCallIds.has(msg.tool_call_id)
+    ) {
+      completedToolCallIds.add(msg.tool_call_id);
+    }
+  }
+
+  // Step 3: Reconstruct message list with only valid pairings
+  for (const msg of messages) {
+    const processedMsg = { ...msg };
+
+    if (msg.role === 'assistant' && msg.tool_calls?.length) {
+      // Keep only tool_calls that have matching tool responses
+      const completedToolCalls = msg.tool_calls.filter((tc) =>
+        completedToolCallIds.has(tc.id)
+      );
+
+      if (completedToolCalls.length !== msg.tool_calls.length) {
+        const removedIds = msg.tool_calls
+          .filter((tc) => !completedToolCallIds.has(tc.id))
+          .map((tc) => tc.id);
+
+        logger.warn(
+          'Removing incomplete tool_calls from assistant message for OpenAI',
+          {
+            messageId: msg.id,
+            removedToolIds: removedIds,
+            completedCount: completedToolCalls.length,
+            totalCount: msg.tool_calls.length,
+          }
+        );
+      }
+
+      if (completedToolCalls.length > 0) {
+        processedMsg.tool_calls = completedToolCalls;
+      } else {
+        // No valid tool_calls, remove the field but keep message
+        delete processedMsg.tool_calls;
+      }
+    } else if (msg.role === 'tool') {
+      // Only include tool messages that have matching tool_calls
+      if (!msg.tool_call_id || !completedToolCallIds.has(msg.tool_call_id)) {
+        logger.debug('Skipping orphaned tool message for OpenAI', {
+          messageId: msg.id,
+          toolCallId: msg.tool_call_id,
+        });
+        continue;
+      }
+    }
+
+    result.push(processedMsg);
+  }
+
+  // Remove any tool messages from the beginning of conversation
+  while (result.length > 0 && result[0].role === 'tool') {
+    logger.warn(
+      'Removing tool message from beginning of conversation for OpenAI',
+      {
+        messageId: result[0].id,
+      }
+    );
+    result.shift();
+  }
+
+  logger.info('OpenAI tool call pairing validation completed', {
+    originalMessages: messages.length,
+    processedMessages: result.length,
+    validToolCalls: validToolCallIds.size,
+    completedToolCalls: completedToolCallIds.size,
+  });
+
+  return result;
+}
+```
+
+#### `sanitizeMessagesForProvider` 수정
+
+```typescript
+static sanitizeMessagesForProvider(
+  messages: Message[],
+  targetProvider: AIServiceProvider,
+): Message[] {
+  let processedMessages = messages;
+
+  // Anthropic: 기존 검증 유지 (변경 없음)
+  if (targetProvider === AIServiceProvider.Anthropic) {
+    processedMessages = this.fixAnthropicToolCallChain(messages);
+  }
+
+  // ✅ NEW: OpenAI-family providers에 페어링 검증 추가
+  if (
+    [
+      AIServiceProvider.OpenAI,
+      AIServiceProvider.Groq,
+      AIServiceProvider.Cerebras,
+      AIServiceProvider.Fireworks,
+    ].includes(targetProvider)
+  ) {
+    processedMessages = this.ensureToolCallPairing(processedMessages);
+  }
+
+  // Gemini: 기존 동작 유지 (변경 없음)
+  // 다른 provider: 기존 동작 유지
+
+  // Second pass: sanitize individual messages
+  return processedMessages
+    .map((msg) => this.sanitizeSingleMessage(msg, targetProvider))
+    .filter((msg) => msg !== null) as Message[];
+}
+```
+
+### 2. 변경하지 않는 파일들
+
+**절대 수정하지 않음:**
+
+- ❌ `src/lib/ai-service/gemini.ts`: Gemini SDK 권고사항 준수 중, 정상 동작
+- ❌ `src/lib/ai-service/anthropic.ts`: 이미 완벽한 검증 로직 보유
+- ❌ `src/lib/ai-service/openai.ts`: 변환 로직은 그대로 (검증은 MessageNormalizer가 담당)
+
+## 재사용 가능한 연관 코드
+
+### 참조 구현: Anthropic Tool Chain Fixer
+
+**File:** `src/lib/ai-service/message-normalizer.ts`
+
+기존 `fixAnthropicToolCallChain()` 함수가 동일한 패턴을 사용:
+
+```typescript
+private static fixAnthropicToolCallChain(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  const pendingToolUseIds = new Set<string>();
+  const completedToolUseIds = new Set<string>();
+
+  // Step 1: Collect tool_calls
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      msg.tool_calls.forEach((tc) => pendingToolUseIds.add(tc.id));
+    }
+  }
+
+  // Step 2: Identify completed tool_uses
+  for (const msg of messages) {
+    if (msg.role === 'tool' && msg.tool_call_id && pendingToolUseIds.has(msg.tool_call_id)) {
+      completedToolUseIds.add(msg.tool_call_id);
+    }
+  }
+
+  // Step 3: Reconstruct with valid pairs only
+  // ... (filter logic)
+
+  return result;
+}
+```
+
+**활용 방법:**
+
+- OpenAI 검증 로직의 구조적 참조
+- 3-phase 접근법 (수집 → 매칭 → 필터링) 재사용
+- Logging 패턴 참고
+
+### 타입 정의
+
+**File:** `src/models/chat.ts`
+
+```typescript
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  tool_use?: ToolCall; // Anthropic legacy field
+  // ... other fields
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+```
+
+### Logger 사용 패턴
+
+```typescript
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('MessageNormalizer');
+
+// Debug level: 정상 동작 추적
+logger.debug('Skipping orphaned tool message', { messageId: 'abc' });
+
+// Warn level: 예상치 못한 상황 (치명적이지 않음)
+logger.warn('Removing incomplete tool_calls', {
+  removedToolIds: ['call_1'],
+});
+
+// Info level: 주요 동작 완료
+logger.info('OpenAI tool call pairing validation completed', {
+  originalMessages: 10,
+  processedMessages: 8,
+});
+```
+
+## Test Code 추가 가이드
+
+### 단위 테스트 파일 생성
+
+**File:** `src/lib/ai-service/__tests__/message-normalizer.openai.test.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { MessageNormalizer } from '../message-normalizer';
+import { AIServiceProvider } from '../types';
+import type { Message } from '@/models/chat';
+
+describe('MessageNormalizer - OpenAI Tool Call Pairing', () => {
+  it('should preserve valid tool-call/tool-response pairs', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        role: 'tool',
+        content: 'result',
+        tool_call_id: 'call_1',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].tool_calls).toHaveLength(1);
+    expect(result[1].role).toBe('tool');
+  });
+
+  it('should remove orphaned tool messages', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: 'response',
+      },
+      {
+        id: '2',
+        role: 'tool',
+        content: 'result',
+        tool_call_id: 'call_999', // No matching tool_call
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('assistant');
+  });
+
+  it('should handle partial tool_calls matching', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test1', arguments: '{}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'test2', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        role: 'tool',
+        content: 'result1',
+        tool_call_id: 'call_1',
+      },
+      // call_2 has no tool response
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result[0].tool_calls).toHaveLength(1);
+    expect(result[0].tool_calls![0].id).toBe('call_1');
+    expect(result).toHaveLength(2);
+  });
+
+  it('should remove all tool_calls when none match', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: 'I will call functions',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      // No tool response
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tool_calls).toBeUndefined();
+    expect(result[0].content).toBe('I will call functions'); // Content preserved
+  });
+
+  it('should preserve non-tool messages', () => {
+    const messages: Message[] = [
+      { id: '1', role: 'user', content: 'Hello' },
+      { id: '2', role: 'assistant', content: 'Hi' },
+      { id: '3', role: 'system', content: 'You are helpful' },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toEqual(messages);
+  });
+
+  it('should remove tool messages from conversation start', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'tool',
+        content: 'orphan',
+        tool_call_id: 'call_orphan',
+      },
+      { id: '2', role: 'user', content: 'Hello' },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result[0].role).toBe('user');
+    expect(result).toHaveLength(1);
+  });
+
+  it('should not affect Anthropic provider behavior', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Anthropic,
+    );
+
+    // Anthropic의 fixAnthropicToolCallChain 로직이 적용되어야 함
+    expect(result).toBeDefined();
+  });
+
+  it('should apply to Groq provider', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'tool',
+        content: 'orphan',
+        tool_call_id: 'call_999',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Groq,
+    );
+
+    expect(result).toHaveLength(0); // Orphan removed
+  });
+});
+```
+
+### 테스트 실행 및 검증
+
+```bash
+# 단위 테스트
+pnpm test message-normalizer
+
+# 전체 테스트
+pnpm test
+
+# 커버리지
+pnpm test:coverage
+
+# Validation pipeline
+pnpm refactor:validate
+```
+
+## 추가 분석 과제
+
+### 1. Ollama Provider 검증
+
+**상황:** Ollama가 OpenAI-compatible API를 사용하는지 확인 필요.
+
+**조사 항목:**
+
+- Ollama의 tool/function calling 지원 여부
+- 지원 시 OpenAI와 동일한 페어링 요구사항인지 확인
+
+**조사 방법:**
+
+- `src/lib/ai-service/ollama.ts` 코드 검토
+- Ollama 공식 문서 확인
+- 필요 시 `ensureToolCallPairing` 적용 provider 목록에 추가
+
+### 2. Groq/Cerebras/Fireworks 실제 동작 검증
+
+**상황:** OpenAI-compatible이라 가정하고 검증 로직 적용 예정이나, 실제 API 동작 미확인.
+
+**조사 방법:**
+
+- 각 provider로 tool calling 테스트
+- 페어링 에러 발생 여부 확인
+- 필요 시 provider별 예외 처리 추가
+
+### 3. Edge Case: Out-of-Order Tool Messages
+
+**상황:** Tool message가 assistant tool_call보다 먼저 오는 경우 처리 방식.
+
+**조사 항목:**
+
+- OpenAI API가 순서에 민감한지 확인
+- 현재 구현이 순서 무관하게 id 매칭만으로 처리하는 것이 안전한지 검증
+
+## 작업 순서 (High-Level)
+
+1. **코드 구현** (30분)
+   - `ensureToolCallPairing` 함수 추가
+   - `sanitizeMessagesForProvider`에 OpenAI family 분기 추가
+
+2. **단위 테스트 작성** (45분)
+   - 7개 핵심 테스트 케이스 구현
+   - Edge case 커버리지 확보
+
+3. **Validation 실행** (10분)
+   - `pnpm refactor:validate` 실행
+   - Lint/format/build 에러 수정
+
+4. **기존 Provider Regression 테스트** (15분)
+   - Anthropic, Gemini 동작 변경 없음 확인
+   - 기존 테스트 suite 실행
+
+5. **문서화 및 커밋** (15분)
+   - CHANGELOG 업데이트
+   - 커밋 메시지 작성 (conventional commits)
+
+## Rollback Plan
+
+변경 후 문제 발생 시:
+
+1. **즉시 대응:**
+   - OpenAI family 분기만 제거하면 원상복구
+   - 다른 provider는 영향 없음
+
+2. **Git Revert:**
+   - 단일 커밋으로 관리하여 쉬운 revert 가능
+
+3. **Monitoring:**
+   - Logger 출력으로 sanitization 동작 추적
+   - OpenAI provider 에러율 모니터링
+
+---
+
+**예상 소요 시간:** 1.5 - 2 시간  
+**우선순위:** High (OpenAI 400 에러는 사용자 경험에 직접적 영향)  
+**리스크:** Very Low (OpenAI family만 수정, 다른 provider 무영향)  
+**영향 범위:** OpenAI, Groq, Cerebras, Fireworks (4개 provider만)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,7 +52,7 @@ function App() {
                                 <AppHeader>
                                   <ThemeToggle />
                                 </AppHeader>
-                                <div className="flex-1 overflow-auto w-full">
+                                <div className="flex-1 w-full min-h-0">
                                   <Routes>
                                     <Route
                                       path="/"

--- a/src/features/chat/Chat.tsx
+++ b/src/features/chat/Chat.tsx
@@ -50,7 +50,7 @@ function ChatInner({ children }: ChatProps) {
       {showWorkspacePanel && <WorkspaceFilesPanel />}
 
       {/* Main chat area */}
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col min-h-0">
         {children}
         <ToolsModal
           isOpen={showToolsDetail}

--- a/src/features/chat/components/ChatPlanningPanel.tsx
+++ b/src/features/chat/components/ChatPlanningPanel.tsx
@@ -77,25 +77,23 @@ export function ChatPlanningPanel() {
           </div>
         </div>
 
-        {/* Observations Section */}
+        {/* Notes Section */}
         <div>
           <h4 className="font-medium text-sm text-muted-foreground mb-2">
-            Recent Observations
+            Recent Notes
           </h4>
           <div className="max-h-32 overflow-y-auto space-y-1">
-            {planningState?.observations.length ? (
-              planningState.observations.map((obs, index) => (
+            {planningState?.notes.length ? (
+              planningState.notes.map((note: string, index: number) => (
                 <div
                   key={index}
                   className="text-xs p-2 bg-accent/50 rounded-sm border-l-2 border-accent"
                 >
-                  {obs}
+                  {note}
                 </div>
               ))
             ) : (
-              <div className="text-sm text-muted-foreground">
-                No observations
-              </div>
+              <div className="text-sm text-muted-foreground">No notes</div>
             )}
           </div>
         </div>

--- a/src/hooks/__tests__/use-ai-service.completeText.spec.ts
+++ b/src/hooks/__tests__/use-ai-service.completeText.spec.ts
@@ -1,0 +1,223 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useAIService } from '../use-ai-service';
+import { AIServiceFactory } from '@/lib/ai-service';
+import type { Message } from '@/models/chat';
+
+type MockAIService = {
+  streamChat: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+};
+
+// Helper: async generator that yields chunks
+async function* makeStream(chunks: string[], throwAt?: number) {
+  for (let i = 0; i < chunks.length; i++) {
+    if (throwAt !== undefined && i === throwAt) {
+      throw new Error('stream error');
+    }
+    yield JSON.stringify({ content: chunks[i] });
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+describe('useAIService.completeText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should generate text from a single prompt without history', async () => {
+    const fakeService: MockAIService = {
+      streamChat: vi
+        .fn()
+        .mockImplementation(() => makeStream(['Hello', ' ', 'World'])),
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    let finalMessage: Message | undefined;
+    await act(async () => {
+      finalMessage = await result.current.completeText('Say hello');
+    });
+
+    expect(finalMessage).toBeDefined();
+    expect(finalMessage?.role).toBe('assistant');
+    expect(finalMessage?.content).toBeDefined();
+    const contentText = finalMessage?.content
+      .map((c) => ('text' in c ? c.text : ''))
+      .join('');
+    expect(contentText).toBe('Hello World');
+  });
+
+  it('should call streamChat with no tools', async () => {
+    const streamChatSpy = vi
+      .fn()
+      .mockImplementation(() => makeStream(['test']));
+    const fakeService: MockAIService = {
+      streamChat: streamChatSpy,
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    await act(async () => {
+      await result.current.completeText('Test prompt');
+    });
+
+    expect(streamChatSpy).toHaveBeenCalledTimes(1);
+    const callArgs = streamChatSpy.mock.calls[0];
+    const options = callArgs[1];
+
+    // Verify no tools are passed
+    expect(options.availableTools).toEqual([]);
+    expect(options.forceToolUse).toBe(false);
+  });
+
+  it('should call onProgress callback during streaming', async () => {
+    const fakeService: MockAIService = {
+      streamChat: vi
+        .fn()
+        .mockImplementation(() => makeStream(['part1', 'part2'])),
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    const progressCalls: Array<{ partial: string; isFinal?: boolean }> = [];
+    const onProgress = (partial: string, isFinal?: boolean) => {
+      progressCalls.push({ partial, isFinal });
+    };
+
+    await act(async () => {
+      await result.current.completeText('Test', { onProgress });
+    });
+
+    expect(progressCalls.length).toBeGreaterThan(0);
+    // Last call should be final
+    const lastCall = progressCalls[progressCalls.length - 1];
+    expect(lastCall.isFinal).toBe(true);
+  });
+
+  it('should return error message on stream failure', async () => {
+    const fakeService: MockAIService = {
+      streamChat: vi.fn().mockImplementation(() => makeStream(['one'], 1)), // throw at index 1
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    let errorMessage: Message | undefined;
+    await act(async () => {
+      errorMessage = await result.current.completeText('Fail prompt');
+    });
+
+    expect(errorMessage).toBeDefined();
+    expect(errorMessage?.role).toBe('assistant');
+    // Error message should contain error indication
+    const contentText = errorMessage?.content
+      .map((c) => ('text' in c ? c.text : ''))
+      .join('')
+      .toLowerCase();
+    expect(contentText).toMatch(/error|issue|problem|apologize/i);
+  });
+
+  it('should use custom model and systemPrompt from options', async () => {
+    const streamChatSpy = vi
+      .fn()
+      .mockImplementation(() => makeStream(['response']));
+    const fakeService: MockAIService = {
+      streamChat: streamChatSpy,
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    const customSystemPrompt = 'You are a test assistant';
+    const customModel = 'gpt-4';
+
+    await act(async () => {
+      await result.current.completeText('Test', {
+        model: customModel,
+        systemPrompt: customSystemPrompt,
+      });
+    });
+
+    expect(streamChatSpy).toHaveBeenCalledTimes(1);
+    const options = streamChatSpy.mock.calls[0][1];
+
+    expect(options.modelName).toBe(customModel);
+    expect(options.systemPrompt).toBe(customSystemPrompt);
+  });
+
+  it('should handle empty response gracefully', async () => {
+    const fakeService: MockAIService = {
+      streamChat: vi.fn().mockImplementation(() => makeStream([])),
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    let finalMessage: Message | undefined;
+    await act(async () => {
+      finalMessage = await result.current.completeText('Empty test');
+    });
+
+    expect(finalMessage).toBeDefined();
+    expect(finalMessage?.role).toBe('assistant');
+    const contentText = finalMessage?.content
+      .map((c) => ('text' in c ? c.text : ''))
+      .join('');
+    expect(contentText).toBe('No response generated.');
+  });
+
+  it('should ignore tool_calls in stream chunks', async () => {
+    async function* streamWithTools() {
+      yield JSON.stringify({
+        content: 'text',
+        tool_calls: [{ id: 'test', function: { name: 'test' } }],
+      });
+      yield JSON.stringify({ content: ' more text' });
+    }
+
+    const fakeService: MockAIService = {
+      streamChat: vi.fn().mockImplementation(() => streamWithTools()),
+      cancel: vi.fn(),
+    };
+    vi.spyOn(AIServiceFactory, 'getService').mockReturnValue(
+      fakeService as unknown as ReturnType<typeof AIServiceFactory.getService>,
+    );
+
+    const { result } = renderHook(() => useAIService());
+
+    let finalMessage: Message | undefined;
+    await act(async () => {
+      finalMessage = await result.current.completeText('Test with tools');
+    });
+
+    expect(finalMessage).toBeDefined();
+    // Should only contain text content, no tool_calls in final message
+    expect(finalMessage?.tool_calls).toBeUndefined();
+    const contentText = finalMessage?.content
+      .map((c) => ('text' in c ? c.text : ''))
+      .join('');
+    expect(contentText).toBe('text more text');
+  });
+});

--- a/src/lib/ai-service/__tests__/message-normalizer.openai.test.ts
+++ b/src/lib/ai-service/__tests__/message-normalizer.openai.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect } from 'vitest';
+import { MessageNormalizer } from '../message-normalizer';
+import { AIServiceProvider } from '../types';
+import type { Message } from '@/models/chat';
+
+describe('MessageNormalizer - OpenAI Tool Call Pairing', () => {
+  it('should preserve valid tool-call/tool-response pairs', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result' }],
+        tool_call_id: 'call_1',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].tool_calls).toHaveLength(1);
+    expect(result[1].role).toBe('tool');
+  });
+
+  it('should remove orphaned tool messages', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'response' }],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result' }],
+        tool_call_id: 'call_999', // No matching tool_call
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('assistant');
+  });
+
+  it('should handle partial tool_calls matching', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test1', arguments: '{}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'test2', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result1' }],
+        tool_call_id: 'call_1',
+      },
+      // call_2 has no tool response
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result[0].tool_calls).toHaveLength(1);
+    expect(result[0].tool_calls![0].id).toBe('call_1');
+    expect(result).toHaveLength(2);
+  });
+
+  it('should remove all tool_calls when none match', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will call functions' }],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      // No tool response
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tool_calls).toBeUndefined();
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'I will call functions' },
+    ]);
+  });
+
+  it('should preserve non-tool messages', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+      },
+      {
+        id: '3',
+        sessionId: 'test-session',
+        role: 'system',
+        content: [{ type: 'text', text: 'You are helpful' }],
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('assistant');
+    expect(result[2].role).toBe('system');
+  });
+
+  it('should remove tool messages from conversation start', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'orphan' }],
+        tool_call_id: 'call_orphan',
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result[0].role).toBe('user');
+    expect(result).toHaveLength(1);
+  });
+
+  it('should not affect Anthropic provider behavior', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Anthropic,
+    );
+
+    // Anthropic's fixAnthropicToolCallChain logic should apply
+    expect(result).toBeDefined();
+    // The incomplete tool_call should be removed by Anthropic's logic
+    expect(result[0].tool_calls).toBeUndefined();
+  });
+
+  it('should apply to Groq provider', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'orphan' }],
+        tool_call_id: 'call_999',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Groq,
+    );
+
+    expect(result).toHaveLength(0); // Orphan removed
+  });
+
+  it('should apply to Cerebras provider', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result' }],
+        tool_call_id: 'call_1',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Cerebras,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].tool_calls).toHaveLength(1);
+  });
+
+  it('should apply to Fireworks provider', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result' }],
+        tool_call_id: 'call_1',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.Fireworks,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].tool_calls).toHaveLength(1);
+  });
+
+  it('should handle empty message arrays', () => {
+    const messages: Message[] = [];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle messages with no tool_calls or tool responses', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there!' }],
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toEqual(messages);
+  });
+
+  it('should handle multiple assistant messages with interleaved tool responses', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test1', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result1' }],
+        tool_call_id: 'call_1',
+      },
+      {
+        id: '3',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'test2', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '4',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result2' }],
+        tool_call_id: 'call_2',
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    expect(result).toHaveLength(4);
+    expect(result[0].tool_calls).toHaveLength(1);
+    expect(result[1].role).toBe('tool');
+    expect(result[2].tool_calls).toHaveLength(1);
+    expect(result[3].role).toBe('tool');
+  });
+
+  it('should handle tool messages with null or undefined tool_call_id', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        sessionId: 'test-session',
+        role: 'assistant',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'test', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        id: '2',
+        sessionId: 'test-session',
+        role: 'tool',
+        content: [{ type: 'text', text: 'result without id' }],
+        tool_call_id: undefined,
+      },
+    ];
+
+    const result = MessageNormalizer.sanitizeMessagesForProvider(
+      messages,
+      AIServiceProvider.OpenAI,
+    );
+
+    // The orphaned tool message should be removed
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('assistant');
+    // The assistant's tool_call should also be removed since no matching response
+    expect(result[0].tool_calls).toBeUndefined();
+  });
+});


### PR DESCRIPTION
… services

- Renamed "observations" to "notes" in ChatPlanningPanel component for clarity.
- Updated state management in planning server to handle notes instead of observations.
- Introduced methods for adding and removing notes in the planning server.
- Updated tests to cover new note functionality and ensure proper handling of tool-call pairings.
- Enhanced message normalization for OpenAI to validate tool-call relationships.