### PR TITLE
fix: correct indentation in pnpm-workspace.yaml for packages section

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - '@swc/core'
   - '@tailwindcss/oxide'


### PR DESCRIPTION
This pull request introduces a small configuration update to the `pnpm-workspace.yaml` file, specifying the current directory as a workspace package. This helps pnpm better manage dependencies and scripts at the repository root. 

- Added the current directory (`'.'`) to the `packages` field in `pnpm-workspace.yaml` to include the root as a workspace package.