### PR TITLE
🪨 Rosetta: Localize Settings & Expand EN/KO

### DIFF
--- a/.jules/rosetta.md
+++ b/.jules/rosetta.md
@@ -1,5 +1,11 @@
 # ROSETTA'S JOURNAL - LOCALIZATION LOG
 
+## 2024-05-27 - [Settings]
+
+**Extracted:** 9
+**Languages updated:** [EN, KO]
+**Notes:** Extracted the "Danger Zone" string from `DangerZoneSettings.tsx` and all input placeholders from `SystemPerformanceSettings.tsx` into standard `t()` format. Created `settings.system.placeholders` namespace for inputs.
+
 ## 2026-03-04 - [Sidebar Navigation]
 
 **Extracted:** 3

--- a/.jules/rosetta.md
+++ b/.jules/rosetta.md
@@ -1,11 +1,5 @@
 # ROSETTA'S JOURNAL - LOCALIZATION LOG
 
-## 2024-05-27 - [Settings]
-
-**Extracted:** 9
-**Languages updated:** [EN, KO]
-**Notes:** Extracted the "Danger Zone" string from `DangerZoneSettings.tsx` and all input placeholders from `SystemPerformanceSettings.tsx` into standard `t()` format. Created `settings.system.placeholders` namespace for inputs.
-
 ## 2026-03-04 - [Sidebar Navigation]
 
 **Extracted:** 3
@@ -89,3 +83,9 @@
 **Extracted:** 4
 **Languages updated:** [EN, KO]
 **Notes:** Localized `AgentModelPicker` provider and model select placeholders, loading state, and refresh button tooltip.
+
+## 2026-03-14 - [Settings]
+
+**Extracted:** 9
+**Languages updated:** [EN, KO]
+**Notes:** Localized "Danger Zone" title and performance input placeholders across settings components. Synced missing reset-related strings in Korean.

--- a/src/features/settings/components/DangerZoneSettings.tsx
+++ b/src/features/settings/components/DangerZoneSettings.tsx
@@ -39,7 +39,7 @@ export function DangerZoneSettings({
   return (
     <div className="border-t pt-8 mt-4">
       <h3 className="text-lg font-medium text-destructive mb-4 flex items-center gap-2">
-        ⚠️ Danger Zone
+        {t('settings.dangerZone.title', '⚠️ Danger Zone')}
       </h3>
       <div className="space-y-6">
         {/* Delete All Sessions Card */}

--- a/src/features/settings/components/SystemPerformanceSettings.tsx
+++ b/src/features/settings/components/SystemPerformanceSettings.tsx
@@ -36,7 +36,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 50"
+              placeholder={t('settings.system.placeholders.maxFileUploadSize', 'e.g., 50')}
               min={1}
               value={localSystemSettings.maxFileUploadSizeMB}
               onChange={(e) =>
@@ -65,7 +65,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 10"
+              placeholder={t('settings.system.placeholders.workspaceCapacity', 'e.g., 10')}
               min={1}
               value={localSystemSettings.workspaceCapacityMB}
               onChange={(e) =>
@@ -100,7 +100,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 5"
+              placeholder={t('settings.system.placeholders.searchIndexFrequency', 'e.g., 5')}
               min={1}
               value={localSystemSettings.searchIndexFrequencyMinutes}
               onChange={(e) =>
@@ -129,7 +129,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 30"
+              placeholder={t('settings.system.placeholders.webActionTimeout', 'e.g., 30')}
               min={5}
               value={localSystemSettings.webActionTimeoutSeconds}
               onChange={(e) =>
@@ -158,7 +158,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 60"
+              placeholder={t('settings.system.placeholders.mcpServerStartupTimeout', 'e.g., 60')}
               min={10}
               max={120}
               value={localSystemSettings.mcpServerStartupTimeoutSeconds}
@@ -195,7 +195,7 @@ export function SystemPerformanceSettings({
             </div>
             <Input
               type="number"
-              placeholder="0 (disabled)"
+              placeholder={t('settings.system.placeholders.mcpToolTimeout', '0 (disabled)')}
               min={0}
               value={localSystemSettings.mcpToolTimeoutSeconds ?? 0}
               onChange={(e) =>
@@ -224,7 +224,7 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder="e.g., 24"
+              placeholder={t('settings.system.placeholders.activeSessionRetention', 'e.g., 24')}
               min={1}
               value={localSystemSettings.activeSessionRetentionHours}
               onChange={(e) =>
@@ -264,7 +264,7 @@ export function SystemPerformanceSettings({
           </label>
           <Input
             type="number"
-            placeholder="e.g., 3030"
+            placeholder={t('settings.system.placeholders.httpServerPort', 'e.g., 3030')}
             min={1}
             max={65535}
             value={localSystemSettings.httpServerPort ?? 3030}

--- a/src/features/settings/components/SystemPerformanceSettings.tsx
+++ b/src/features/settings/components/SystemPerformanceSettings.tsx
@@ -36,7 +36,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.maxFileUploadSize', 'e.g., 50')}
+              placeholder={t(
+                'settings.system.placeholders.maxFileUploadSize',
+                'e.g., 50',
+              )}
               min={1}
               value={localSystemSettings.maxFileUploadSizeMB}
               onChange={(e) =>
@@ -65,7 +68,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.workspaceCapacity', 'e.g., 10')}
+              placeholder={t(
+                'settings.system.placeholders.workspaceCapacity',
+                'e.g., 10',
+              )}
               min={1}
               value={localSystemSettings.workspaceCapacityMB}
               onChange={(e) =>
@@ -100,7 +106,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.searchIndexFrequency', 'e.g., 5')}
+              placeholder={t(
+                'settings.system.placeholders.searchIndexFrequency',
+                'e.g., 5',
+              )}
               min={1}
               value={localSystemSettings.searchIndexFrequencyMinutes}
               onChange={(e) =>
@@ -129,7 +138,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.webActionTimeout', 'e.g., 30')}
+              placeholder={t(
+                'settings.system.placeholders.webActionTimeout',
+                'e.g., 30',
+              )}
               min={5}
               value={localSystemSettings.webActionTimeoutSeconds}
               onChange={(e) =>
@@ -158,7 +170,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.mcpServerStartupTimeout', 'e.g., 60')}
+              placeholder={t(
+                'settings.system.placeholders.mcpServerStartupTimeout',
+                'e.g., 60',
+              )}
               min={10}
               max={120}
               value={localSystemSettings.mcpServerStartupTimeoutSeconds}
@@ -195,7 +210,10 @@ export function SystemPerformanceSettings({
             </div>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.mcpToolTimeout', '0 (disabled)')}
+              placeholder={t(
+                'settings.system.placeholders.mcpToolTimeout',
+                '0 (disabled)',
+              )}
               min={0}
               value={localSystemSettings.mcpToolTimeoutSeconds ?? 0}
               onChange={(e) =>
@@ -224,7 +242,10 @@ export function SystemPerformanceSettings({
             </label>
             <Input
               type="number"
-              placeholder={t('settings.system.placeholders.activeSessionRetention', 'e.g., 24')}
+              placeholder={t(
+                'settings.system.placeholders.activeSessionRetention',
+                'e.g., 24',
+              )}
               min={1}
               value={localSystemSettings.activeSessionRetentionHours}
               onChange={(e) =>
@@ -264,7 +285,10 @@ export function SystemPerformanceSettings({
           </label>
           <Input
             type="number"
-            placeholder={t('settings.system.placeholders.httpServerPort', 'e.g., 3030')}
+            placeholder={t(
+              'settings.system.placeholders.httpServerPort',
+              'e.g., 3030',
+            )}
             min={1}
             max={65535}
             value={localSystemSettings.httpServerPort ?? 3030}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -373,7 +373,17 @@
       "activeSessionRetention": "Keep Active Sessions For (Hours)",
       "activeSessionRetentionDescription": "How long to keep session data in fast memory.",
       "networkRestartFailed": "Failed to restart the app. Please restart manually.",
-      "networkRestartNotice": "Changes to HTTP server network settings are applied after restarting the app."
+      "networkRestartNotice": "Changes to HTTP server network settings are applied after restarting the app.",
+      "placeholders": {
+        "maxFileUploadSize": "e.g., 50",
+        "workspaceCapacity": "e.g., 10",
+        "searchIndexFrequency": "e.g., 5",
+        "webActionTimeout": "e.g., 30",
+        "mcpServerStartupTimeout": "e.g., 60",
+        "mcpToolTimeout": "0 (disabled)",
+        "activeSessionRetention": "e.g., 24",
+        "httpServerPort": "e.g., 3030"
+      }
     },
     "about": {
       "title": "About",
@@ -387,7 +397,7 @@
       "checkForUpdates": "Check for Updates"
     },
     "dangerZone": {
-      "title": "Danger Zone"
+      "title": "⚠️ Danger Zone"
     },
     "factoryReset": {
       "title": "Factory Reset",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -325,7 +325,17 @@
       "backgroundTasks": "백그라운드 작업",
       "mcpToolTimeoutDisabled": "비활성화",
       "networkRestartFailed": "앱 재시작에 실패했습니다. 수동으로 재시작해 주세요.",
-      "networkRestartNotice": "HTTP 서버 네트워크 설정 변경사항은 앱 재시작 후 적용됩니다."
+      "networkRestartNotice": "HTTP 서버 네트워크 설정 변경사항은 앱 재시작 후 적용됩니다.",
+      "placeholders": {
+        "maxFileUploadSize": "예: 50",
+        "workspaceCapacity": "예: 10",
+        "searchIndexFrequency": "예: 5",
+        "webActionTimeout": "예: 30",
+        "mcpServerStartupTimeout": "예: 60",
+        "mcpToolTimeout": "0 (비활성화)",
+        "activeSessionRetention": "예: 24",
+        "httpServerPort": "예: 3030"
+      }
     },
     "about": {
       "title": "정보",
@@ -342,13 +352,22 @@
       "title": "초기화",
       "resetting": "초기화 중...",
       "success": "초기화가 완료되었습니다. 변경사항을 완전히 적용하려면 재시작이 필요합니다.",
-      "error": "초기화에 실패했습니다. 로그를 확인해 주세요."
+      "error": "초기화에 실패했습니다. 로그를 확인해 주세요.",
+      "description": "이 작업은 완전한 공장 초기화를 수행합니다. 모든 데이터를 삭제합니다.",
+      "button": "모든 데이터 및 설정 초기화",
+      "confirmTitle": "공장 초기화 확인",
+      "confirmDescription": "세션, 어시스턴트, MCP 서버 및 플레이북을 포함한 모든 데이터를 영구적으로 삭제합니다. 확실합니까?",
+      "confirmButton": "모두 초기화"
     },
     "dataReset": {
       "title": "데이터 & 초기화",
       "deleting": "삭제 중...",
       "success": "모든 세션이 삭제되었습니다. 재시작을 권장합니다.",
-      "error": "세션 삭제에 실패했습니다."
+      "error": "세션 삭제에 실패했습니다.",
+      "description": "모든 로컬 세션, 메시지 및 작업 공간 파일 저장소를 영구적으로 삭제합니다.",
+      "clearAll": "모든 세션 및 작업 공간 지우기",
+      "confirmTitle": "모든 세션, 메시지 및 작업 공간 삭제",
+      "confirmDescription": "이 작업은 모든 로컬 세션, 메시지 및 작업 공간 파일 저장소를 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다. 계속하시겠습니까?"
     },
     "skills": {
       "modalTitle": "사용 가능한 스킬 ({{count}})",
@@ -375,6 +394,9 @@
       "revert": "전역으로 되돌리기",
       "resetTitle": "스킬 재정의를 초기화하시겠습니까?",
       "resetConfirm": "이 작업은 모든 어시스턴트 전용 스킬을 제거하고 전역 기본값으로 되돌립니다. 이 작업은 되돌릴 수 없습니다."
+    },
+    "dangerZone": {
+      "title": "⚠️ 위험 구역"
     }
   },
   "mcpServer": {


### PR DESCRIPTION
🌐 Scope
- Extracted and localized hardcoded strings in `src/features/settings/components/DangerZoneSettings.tsx`.
- Extracted and localized all `<Input>` placeholders in `src/features/settings/components/SystemPerformanceSettings.tsx`.

🔑 Keys Added
- Added `settings.dangerZone.title`
- Added missing `settings.dataReset.*` keys in Korean locale (`description`, `clearAll`, `confirmTitle`, `confirmDescription`).
- Added missing `settings.factoryReset.*` keys in Korean locale (`description`, `button`, `confirmTitle`, `confirmDescription`, `confirmButton`).
- Added `settings.system.placeholders.*` for input placeholders.

🌍 Languages
- Synced and verified EN and KO in `src/locales/en/common.json` and `src/locales/ko/common.json`.
- Accurately translated placeholders in KO.

⚠️ Visual QA
- Verified UI rendering using Playwright visual tests; ensuring layouts do not break and text aligns correctly with standard `react-i18next` interpolations. All fallback strings work as intended without rendering bugs.

---
*PR created automatically by Jules for task [4072287537009153868](https://jules.google.com/task/4072287537009153868) started by @fritzprix*