### PR TITLE
📜 Scribe: Update docs for src-tauri rustdoc warnings

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -208,3 +208,7 @@
 
 **Drift:** Rust documentation generated warnings due to unresolved links (`[validate_path]`, `[call_tool]`) and unclosed HTML tags (`Arc<RwLock>`, `Option<String>`, `Option<T>`).
 **Reality:** Fixed the links to correctly resolve to their respective struct methods and wrapped the HTML-like types in backticks (e.g., `Arc<RwLock>`) to eliminate rustdoc warnings.
+
+## 2026-03-14 - src-tauri/src/*
+**Drift:** Rust documentation generated 258 `clippy::doc_markdown` warnings due to missing backticks for types, variables, and code keywords across the rust codebase.
+**Reality:** Ran `cargo clippy --fix` to wrap terms like `SQLite`, `SeaORM`, `AppHandle`, and variable names in backticks to conform to Rust doc standards and remove warnings.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3165,7 +3165,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libragent"
-version = "0.5.34"
+version = "0.5.35"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/migration/src/helpers.rs
+++ b/src-tauri/migration/src/helpers.rs
@@ -2,7 +2,7 @@
 //!
 //! Shared patterns for safe, idempotent migration operations.
 //! Use these instead of raw SQL strings to avoid common pitfalls:
-//! - `COUNT(*)` column aliasing for SeaORM compatibility
+//! - `COUNT(*)` column aliasing for `SeaORM` compatibility
 //! - Table/column existence checks
 //! - Idempotent inserts
 
@@ -15,7 +15,7 @@ use sea_orm_migration::sea_orm::Statement;
 /// or `Some(n)` with the row count.
 ///
 /// # Why not `COUNT(*)`?
-/// SeaORM's `try_get("", "COUNT(*)")` is unreliable across backends.
+/// `SeaORM`'s `try_get("", "COUNT(*)")` is unreliable across backends.
 /// This helper always aliases the column to `row_count` for safe extraction.
 pub async fn count_rows(
     manager: &SchemaManager<'_>,
@@ -40,7 +40,7 @@ pub async fn count_rows(
     }
 }
 
-/// Check whether a table exists in the SQLite schema.
+/// Check whether a table exists in the `SQLite` schema.
 pub async fn table_exists(manager: &SchemaManager<'_>, table_name: &str) -> Result<bool, DbErr> {
     let result = manager
         .get_connection()
@@ -54,7 +54,7 @@ pub async fn table_exists(manager: &SchemaManager<'_>, table_name: &str) -> Resu
     Ok(result.is_some())
 }
 
-/// Check whether a column exists in a SQLite table via PRAGMA table_info.
+/// Check whether a column exists in a `SQLite` table via PRAGMA `table_info`.
 pub async fn column_exists(
     manager: &SchemaManager<'_>,
     table_name: &str,

--- a/src-tauri/src/agent/config.rs
+++ b/src-tauri/src/agent/config.rs
@@ -20,7 +20,7 @@ pub struct AgentConfig {
     /// System prompt defining the agent's role and behavior
     pub system_prompt: String,
 
-    /// MCP server IDs to connect to (references to MCPServerEntity IDs)
+    /// MCP server IDs to connect to (references to `MCPServerEntity` IDs)
     #[serde(default)]
     pub mcp_server_ids: Vec<String>,
 

--- a/src-tauri/src/agent/context/mod.rs
+++ b/src-tauri/src/agent/context/mod.rs
@@ -8,8 +8,8 @@ pub mod time_location;
 
 /// Trait for providers that inject read-only context into system prompts
 ///
-/// Unlike BuiltinMCPServer which provides tools + stateful context,
-/// ContextProvider is for information-only providers (skills, time, preferences, etc.)
+/// Unlike `BuiltinMCPServer` which provides tools + stateful context,
+/// `ContextProvider` is for information-only providers (skills, time, preferences, etc.)
 #[async_trait]
 pub trait ContextProvider: Send + Sync {
     /// Unique identifier for this provider

--- a/src-tauri/src/agent/events.rs
+++ b/src-tauri/src/agent/events.rs
@@ -104,8 +104,8 @@ pub fn emit_agent_event(app_handle: &AppHandle, event: AgentEvent) -> Result<(),
 
 /// Emit a resource update event (convenience wrapper)
 ///
-/// This is a shorthand for emitting ResourceUpdated events from builtin tools.
-/// Falls back silently if AppHandle is not available (e.g., during tests).
+/// This is a shorthand for emitting `ResourceUpdated` events from builtin tools.
+/// Falls back silently if `AppHandle` is not available (e.g., during tests).
 pub fn emit_resource_updated(resource_type: &str, action: &str, resource_id: Option<String>) {
     if let Some(app_handle) = crate::state::get_app_handle() {
         let event = AgentEvent::ResourceUpdated {

--- a/src-tauri/src/agent/llm/circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/circuit_breaker.rs
@@ -41,7 +41,7 @@ fn is_tool_error_message(message: &Message) -> bool {
     })
 }
 
-/// Build (name_by_id, signature_by_id) lookup maps from message history in a single pass.
+/// Build (`name_by_id`, `signature_by_id`) lookup maps from message history in a single pass.
 pub(crate) fn build_tool_call_indices(
     messages: &[Message],
 ) -> (HashMap<String, String>, HashMap<String, String>) {

--- a/src-tauri/src/agent/llm/completion.rs
+++ b/src-tauri/src/agent/llm/completion.rs
@@ -298,7 +298,7 @@ pub async fn maybe_trigger_post_idle_compaction(
 
 /// Request LLM completion from frontend
 ///
-/// Note: session_repo is passed through to handle_llm_response which uses it for status updates
+/// Note: `session_repo` is passed through to `handle_llm_response` which uses it for status updates
 pub async fn request_llm_completion(
     _session_repo: &Arc<dyn SessionRepository>,
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
@@ -1003,7 +1003,7 @@ async fn resolve_message_references(
 /// user message sits at the tail of history and the user sends another message
 /// before the agent can respond. The content of subsequent user messages is
 /// appended to the first with a separator. IDs and metadata from the first
-/// message are preserved. This operates on the CompletionRequest payload only —
+/// message are preserved. This operates on the `CompletionRequest` payload only —
 /// stored messages are never mutated.
 fn merge_consecutive_user_messages(messages: Vec<Message>) -> Vec<Message> {
     let mut result: Vec<Message> = Vec::with_capacity(messages.len());

--- a/src-tauri/src/agent/llm/token_utils.rs
+++ b/src-tauri/src/agent/llm/token_utils.rs
@@ -1,11 +1,11 @@
 use std::sync::OnceLock;
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
-/// Singleton tiktoken encoder for cl100k_base.
+/// Singleton tiktoken encoder for `cl100k_base`.
 /// Creating/freeing the BPE encoder can be expensive. We keep one instance alive for the app lifetime.
 static SHARED_ENCODER: OnceLock<Option<CoreBPE>> = OnceLock::new();
 
-/// Gets a reference to the shared cl100k_base encoder, initializing it if necessary.
+/// Gets a reference to the shared `cl100k_base` encoder, initializing it if necessary.
 pub fn get_shared_encoder() -> Option<&'static CoreBPE> {
     SHARED_ENCODER.get_or_init(|| cl100k_base().ok()).as_ref()
 }

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -41,7 +41,7 @@ impl std::fmt::Debug for AgentSessionManager {
 }
 
 impl AgentSessionManager {
-    /// Create a new AgentSessionManager with dependency injection
+    /// Create a new `AgentSessionManager` with dependency injection
     pub fn new(
         app_handle: AppHandle,
         proxy_manager: Arc<MCPServiceProxyManager>,
@@ -88,7 +88,7 @@ impl AgentSessionManager {
         }
     }
 
-    /// Create a new session (wrapper around create_session_with_repo using internal repo)
+    /// Create a new session (wrapper around `create_session_with_repo` using internal repo)
     pub async fn create_session(
         &self,
         session_id: String,
@@ -459,7 +459,7 @@ impl AgentSessionManager {
         Ok(())
     }
 
-    /// Returns the current yolo_mode for a session (false if session not found).
+    /// Returns the current `yolo_mode` for a session (false if session not found).
     pub async fn get_yolo_mode(&self, session_id: &str) -> bool {
         let active = self.active_sessions.read().await;
         active
@@ -608,7 +608,7 @@ impl AgentSessionManager {
     }
 
     /// Remove a message from the in-memory cache
-    /// Used when messages are deleted via messages_delete command to keep cache in sync
+    /// Used when messages are deleted via `messages_delete` command to keep cache in sync
     pub async fn remove_message_from_cache(
         &self,
         session_id: &str,

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -18,7 +18,7 @@ pub struct PendingToolExecution {
     pub message_id: String,
     pub total_expected: usize,
     pub results: Vec<Message>,
-    /// Maps tool_call_id to tool_name for event emission
+    /// Maps `tool_call_id` to `tool_name` for event emission
     pub tool_names: HashMap<String, String>,
     /// Tool call IDs expected for the current message execution
     pub expected_tool_call_ids: HashSet<String>,
@@ -100,7 +100,7 @@ pub struct AgentSession {
     pub pending_execution: Option<PendingToolExecution>,
 
     /// In-memory message cache (loaded once on init, updated in-place)
-    /// Thread-safe: Arc allows shared ownership, RwLock allows concurrent reads
+    /// Thread-safe: Arc allows shared ownership, `RwLock` allows concurrent reads
     pub messages: Arc<RwLock<Vec<Message>>>,
 
     /// Flag indicating if cache has been initialized from DB
@@ -110,7 +110,7 @@ pub struct AgentSession {
     pub last_synced_at: Arc<RwLock<Option<SystemTime>>>,
 
     /// Circuit breaker: consecutive thinking-only response count
-    /// Reset to 0 when content or tool_calls are generated
+    /// Reset to 0 when content or `tool_calls` are generated
     /// Max allowed: 3 (prevents infinite thinking loops)
     pub thinking_only_count: Arc<RwLock<u32>>,
 
@@ -118,7 +118,7 @@ pub struct AgentSession {
     pub pending_events: Arc<RwLock<PendingEventManager>>,
 
     /// Channels for pending tool execution approvals
-    /// Maps tool_call_id to PendingApprovalData (which unblocks the workflow with a bool)
+    /// Maps `tool_call_id` to `PendingApprovalData` (which unblocks the workflow with a bool)
     pub pending_approvals: Arc<RwLock<HashMap<String, PendingApprovalData>>>,
 
     /// Context registry for read-only information providers

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -319,7 +319,7 @@ pub fn create_error_tool_result(
     }
 }
 
-/// Convert MCP response result to agent MCPContent
+/// Convert MCP response result to agent `MCPContent`
 pub fn convert_mcp_response_content(
     result: Option<crate::mcp::types::MCPResponseResult>,
 ) -> Option<Vec<crate::mcp::types::MCPContent>> {

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -180,7 +180,7 @@ pub async fn agent_inject_messages(
     })
 }
 
-/// Handle LLM response from frontend (called by LLMServiceProvider in TS)
+/// Handle LLM response from frontend (called by `LLMServiceProvider` in TS)
 #[command]
 pub async fn agent_handle_llm_response(
     manager: State<'_, AgentSessionManager>,
@@ -302,7 +302,7 @@ pub struct ToolExecutionResult {
     pub is_error: bool,
 }
 
-/// Handle tool execution result from frontend (called by ToolBridgeProvider in TS)
+/// Handle tool execution result from frontend (called by `ToolBridgeProvider` in TS)
 #[command]
 pub async fn agent_handle_tool_result(
     manager: State<'_, AgentSessionManager>,
@@ -340,7 +340,7 @@ pub async fn agent_respond_tool_approval(
     })
 }
 
-/// Handle LLM error from frontend (called by LLMServiceProvider in TS)
+/// Handle LLM error from frontend (called by `LLMServiceProvider` in TS)
 #[command]
 pub async fn agent_handle_llm_error(
     manager: State<'_, AgentSessionManager>,
@@ -356,8 +356,8 @@ pub async fn agent_handle_llm_error(
     })
 }
 
-/// Call a builtin tool directly via proxy_manager (for testing and direct execution)
-/// Returns the unwrapped MCPResult (not the full MCPResponse wrapper)
+/// Call a builtin tool directly via `proxy_manager` (for testing and direct execution)
+/// Returns the unwrapped `MCPResult` (not the full `MCPResponse` wrapper)
 #[command]
 pub async fn agent_call_builtin_tool(
     session_id: String,

--- a/src-tauri/src/commands/browser_commands.rs
+++ b/src-tauri/src/commands/browser_commands.rs
@@ -155,7 +155,7 @@ pub async fn browser_script_result(
 ///
 /// # Arguments
 /// * `session_id` - The ID of the browser session.
-/// * `server` - The InteractiveBrowserServer state.
+/// * `server` - The `InteractiveBrowserServer` state.
 #[tauri::command]
 pub async fn browser_page_loaded(
     server: State<'_, InteractiveBrowserServer>,

--- a/src-tauri/src/commands/content_store_commands.rs
+++ b/src-tauri/src/commands/content_store_commands.rs
@@ -6,7 +6,7 @@ use crate::services::ContentStoreService;
 
 /// Delete content store data for a session.
 ///
-/// Removes SQLite rows (stores/contents/chunks) when a SQLite DB URL is configured,
+/// Removes `SQLite` rows (stores/contents/chunks) when a `SQLite` DB URL is configured,
 /// and removes the content store search index directory under the session workspace.
 ///
 /// # Arguments

--- a/src-tauri/src/commands/mcp_commands.rs
+++ b/src-tauri/src/commands/mcp_commands.rs
@@ -2,7 +2,7 @@
 ///
 /// This module contains commands related to built-in MCP servers,
 /// server probing, OAuth token management, and tool schema validation.
-/// Session-isolated external servers are managed through MCPServiceProxyManager per session.
+/// Session-isolated external servers are managed through `MCPServiceProxyManager` per session.
 use crate::mcp::types::BuiltinServerInfo;
 use crate::mcp::{MCPServerManager, MCPTool};
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,4 +1,4 @@
-/// Centralized configuration management for LibrAgent
+/// Centralized configuration management for `LibrAgent`
 ///
 /// This module provides environment-driven configuration with fallback defaults.
 /// All configuration values can be overridden via environment variables.
@@ -19,7 +19,7 @@
 /// - `LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT`: Graceful shutdown timeout in seconds (default: 3)
 /// - `LIBRAGENT_POLL_THRESHOLD`: Excessive polling detection threshold (default: 5 consecutive polls)
 /// - `MESSAGE_INDEX_SNIPPET_LENGTH`: Message snippet length for search index (default: 200)
-/// - `LIBRAGENT_DB_PATH`: SQLite database file path (default: user data directory)
+/// - `LIBRAGENT_DB_PATH`: `SQLite` database file path (default: user data directory)
 /// - `LIBRAGENT_MCP_IDLE_TIMEOUT_MINUTES`: MCP server idle timeout in minutes (default: 5)
 /// - `LIBRAGENT_MCP_CLEANUP_INTERVAL_MINUTES`: MCP cleanup interval in minutes (default: 5)
 use std::env;
@@ -44,7 +44,7 @@ const DEFAULT_POLL_THRESHOLD: u32 = 5;
 
 /// Get maximum output size for process stdout/stderr capture from environment or use default
 ///
-/// Environment variable: LIBRAGENT_MAX_OUTPUT_SIZE
+/// Environment variable: `LIBRAGENT_MAX_OUTPUT_SIZE`
 /// Default: 104857600 (100 MB)
 pub fn max_output_size() -> u64 {
     env::var("LIBRAGENT_MAX_OUTPUT_SIZE")
@@ -64,7 +64,7 @@ const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT: u64 = 3;
 
 /// Get graceful shutdown timeout (seconds) from environment or default
 ///
-/// Environment variable: LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT
+/// Environment variable: `LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT`
 pub fn graceful_shutdown_timeout() -> u64 {
     env::var("LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT")
         .ok()
@@ -80,7 +80,7 @@ pub fn graceful_shutdown_timeout() -> u64 {
 
 /// Get maximum file size from environment or use default
 ///
-/// Environment variable: LIBRAGENT_MAX_FILE_SIZE
+/// Environment variable: `LIBRAGENT_MAX_FILE_SIZE`
 /// Default: 104857600 (100 MB)
 pub fn max_file_size() -> usize {
     env::var("LIBRAGENT_MAX_FILE_SIZE")
@@ -97,7 +97,7 @@ pub fn max_file_size() -> usize {
 
 /// Get default execution timeout from environment or use default
 ///
-/// Environment variable: LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT
+/// Environment variable: `LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT`
 /// Default: 30 seconds
 pub fn default_execution_timeout() -> u64 {
     env::var("LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT")
@@ -114,7 +114,7 @@ pub fn default_execution_timeout() -> u64 {
 
 /// Get maximum execution timeout from environment or use default
 ///
-/// Environment variable: LIBRAGENT_MAX_EXECUTION_TIMEOUT
+/// Environment variable: `LIBRAGENT_MAX_EXECUTION_TIMEOUT`
 /// Default: 300 seconds (5 minutes)
 pub fn max_execution_timeout() -> u64 {
     let max_timeout = env::var("LIBRAGENT_MAX_EXECUTION_TIMEOUT")
@@ -144,7 +144,7 @@ pub fn max_execution_timeout() -> u64 {
 
 /// Get message index snippet length from environment or use default
 ///
-/// Environment variable: MESSAGE_INDEX_SNIPPET_LENGTH
+/// Environment variable: `MESSAGE_INDEX_SNIPPET_LENGTH`
 /// Default: 200 characters
 pub fn message_index_snippet_length() -> usize {
     env::var("MESSAGE_INDEX_SNIPPET_LENGTH")
@@ -161,7 +161,7 @@ pub fn message_index_snippet_length() -> usize {
 
 /// Get polling threshold for excessive polling detection from environment or use default
 ///
-/// Environment variable: LIBRAGENT_POLL_THRESHOLD
+/// Environment variable: `LIBRAGENT_POLL_THRESHOLD`
 /// Default: 5 consecutive polls while process is running
 pub fn poll_threshold() -> u32 {
     env::var("LIBRAGENT_POLL_THRESHOLD")
@@ -181,7 +181,7 @@ const DEFAULT_MCP_IDLE_TIMEOUT_MINUTES: u64 = 5;
 
 /// Get MCP server idle timeout in minutes from environment or use default
 ///
-/// Environment variable: LIBRAGENT_MCP_IDLE_TIMEOUT_MINUTES
+/// Environment variable: `LIBRAGENT_MCP_IDLE_TIMEOUT_MINUTES`
 /// Default: 5 minutes
 pub fn mcp_idle_timeout_minutes() -> u64 {
     env::var("LIBRAGENT_MCP_IDLE_TIMEOUT_MINUTES")
@@ -201,7 +201,7 @@ const DEFAULT_MCP_CLEANUP_INTERVAL_MINUTES: u64 = 5;
 
 /// Get MCP cleanup interval in minutes from environment or use default
 ///
-/// Environment variable: LIBRAGENT_MCP_CLEANUP_INTERVAL_MINUTES
+/// Environment variable: `LIBRAGENT_MCP_CLEANUP_INTERVAL_MINUTES`
 /// Default: 5 minutes
 pub fn mcp_cleanup_interval_minutes() -> u64 {
     env::var("LIBRAGENT_MCP_CLEANUP_INTERVAL_MINUTES")
@@ -222,7 +222,7 @@ const DEFAULT_MCP_STARTUP_TIMEOUT_SECONDS: u64 = 30;
 /// Get MCP server startup timeout in seconds
 ///
 /// Returns the default value of 30 seconds.
-/// User settings are applied through SessionIsolationConfig after initialization.
+/// User settings are applied through `SessionIsolationConfig` after initialization.
 pub fn mcp_startup_timeout_seconds() -> u64 {
     DEFAULT_MCP_STARTUP_TIMEOUT_SECONDS
 }

--- a/src-tauri/src/db_schema_validator.rs
+++ b/src-tauri/src/db_schema_validator.rs
@@ -33,7 +33,7 @@ impl std::error::Error for SchemaValidationError {}
 /// - Core tables exist (sessions, messages, assistants)
 /// - Planning module tables have correct columns
 ///
-/// Returns Ok(()) if validation passes, or SchemaValidationError if any check fails
+/// Returns Ok(()) if validation passes, or `SchemaValidationError` if any check fails
 pub async fn validate_schema(db: &DatabaseConnection) -> Result<(), SchemaValidationError> {
     info!("🔍 Validating database schema...");
 

--- a/src-tauri/src/entity/mod.rs
+++ b/src-tauri/src/entity/mod.rs
@@ -1,6 +1,6 @@
-//! SeaORM Entity Definitions
+//! `SeaORM` Entity Definitions
 //!
-//! This module contains all entity definitions for the LibrAgent database.
+//! This module contains all entity definitions for the `LibrAgent` database.
 
 // Core entities (sessions and messages)
 pub mod compact_context;

--- a/src-tauri/src/entity/settings.rs
+++ b/src-tauri/src/entity/settings.rs
@@ -1,6 +1,6 @@
 //! Settings entity definition for generic key-value storage
 //!
-//! This entity replaces the `objects` table in IndexedDB.
+//! This entity replaces the `objects` table in `IndexedDB`.
 
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,13 +102,13 @@ pub use state::{
     set_message_repository, set_playbook_repository, set_session_repository, set_sqlite_db_url,
 };
 
-/// A synchronous wrapper to initialize and run the application with SQLite support.
+/// A synchronous wrapper to initialize and run the application with `SQLite` support.
 ///
 /// This function sets up a Tokio runtime to perform async initialization of the
-/// `MCPServerManager` with a SQLite database, then calls the main `run` function.
+/// `MCPServerManager` with a `SQLite` database, then calls the main `run` function.
 ///
 /// # Arguments
-/// * `db_url` - The connection URL for the SQLite database.
+/// * `db_url` - The connection URL for the `SQLite` database.
 pub fn run_with_sqlite_sync(db_url: String) {
     lifecycle::run_with_sqlite_sync(db_url);
 }
@@ -120,7 +120,7 @@ pub fn run_with_sqlite_sync(db_url: String) {
 /// - The Tauri application builder with all necessary plugins (dialog, logging, opener).
 /// - The full list of invoke handlers (Tauri commands) available to the frontend.
 /// - A setup hook to initialize managed state like `SecureFileManager` and `InteractiveBrowserServer`.
-/// - Linux-specific environment variables and checks for WebKit compatibility.
+/// - Linux-specific environment variables and checks for `WebKit` compatibility.
 /// - Graceful error handling for panics that may occur during application startup.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::{App, Emitter, Listener, Manager};
 
-/// Marker file written into every bundled skill directory in AppData.
+/// Marker file written into every bundled skill directory in `AppData`.
 /// Used to distinguish bundled skills from user-created ones so that skills
 /// removed from the bundle can be cleaned up automatically on the next launch.
 const BUNDLED_SKILL_MARKER: &str = ".bundled_skill";

--- a/src-tauri/src/lifecycle/database_backup.rs
+++ b/src-tauri/src/lifecycle/database_backup.rs
@@ -35,7 +35,7 @@ impl BackupManager {
 
     /// Create a timestamped backup of the database using VACUUM INTO for WAL-safe snapshot.
     ///
-    /// `VACUUM INTO` is the only reliable way to back up a WAL-mode SQLite database:
+    /// `VACUUM INTO` is the only reliable way to back up a WAL-mode `SQLite` database:
     /// it performs an atomic, consistent copy that includes all committed WAL data
     /// without requiring a checkpoint or file-level copy.
     pub async fn create_backup(&self, db: &DatabaseConnection) -> DatabaseResult<PathBuf> {

--- a/src-tauri/src/lifecycle/database_error.rs
+++ b/src-tauri/src/lifecycle/database_error.rs
@@ -40,7 +40,7 @@ pub enum DatabaseError {
         found_hash: String,
     },
 
-    /// SeaORM error
+    /// `SeaORM` error
     SeaOrmError(DbErr),
 
     /// IO error

--- a/src-tauri/src/lifecycle/mod.rs
+++ b/src-tauri/src/lifecycle/mod.rs
@@ -14,7 +14,7 @@ use crate::session::get_session_manager;
 use crate::state::set_sqlite_db_url;
 use log::info;
 
-/// A synchronous wrapper to initialize and run the application with SQLite support.
+/// A synchronous wrapper to initialize and run the application with `SQLite` support.
 pub fn run_with_sqlite_sync(db_url: String) {
     // Set the SQLite URL
     set_sqlite_db_url(db_url.clone());

--- a/src-tauri/src/lifecycle/retry_utils.rs
+++ b/src-tauri/src/lifecycle/retry_utils.rs
@@ -40,7 +40,7 @@ where
     unreachable!()
 }
 
-/// Async version of retry_with_backoff
+/// Async version of `retry_with_backoff`
 pub async fn retry_with_backoff_async<F, Fut, T, E>(
     mut operation: F,
     max_attempts: u32,

--- a/src-tauri/src/lifecycle/schema_version.rs
+++ b/src-tauri/src/lifecycle/schema_version.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Snapshot of the `schema_version` table row created by migration #10.
 ///
-/// Columns: version (PK, string), migration_count (integer), applied_at (bigint), checksum (string nullable)
+/// Columns: version (PK, string), `migration_count` (integer), `applied_at` (bigint), checksum (string nullable)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchemaVersionRecord {
     /// Semver string from Cargo.toml at migration time (e.g. "0.5.3")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,15 +1,15 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-/// The main entry point for the LibrAgent application.
+/// The main entry point for the `LibrAgent` application.
 ///
 /// This function is responsible for:
-/// 1. Setting Linux-specific WebKit compatibility environment variables (if on Linux)
+/// 1. Setting Linux-specific `WebKit` compatibility environment variables (if on Linux)
 /// 2. Loading environment variables from .env file (development mode only)
-/// 3. Determining the path for the SQLite database. It prioritizes the `LIBRAGENT_DB_PATH`
+/// 3. Determining the path for the `SQLite` database. It prioritizes the `LIBRAGENT_DB_PATH`
 ///    environment variable, falling back to a default location within the user's data directory.
 /// 4. Ensuring the directory for the database exists.
-/// 5. Constructing the final SQLite connection URL.
+/// 5. Constructing the final `SQLite` connection URL.
 /// 6. Calling the main application runner (`run_with_sqlite_sync`) from the `tauri_mcp_agent_lib`
 ///    crate, passing it the database URL to initialize the application with database support.
 fn main() {

--- a/src-tauri/src/mcp/builtin/assistant/mod.rs
+++ b/src-tauri/src/mcp/builtin/assistant/mod.rs
@@ -24,7 +24,7 @@ struct ContextCache {
 /// Assistant MCP Server
 ///
 /// Provides global assistant configuration management.
-/// Global scope: Assistants are shared across all sessions (no session_id FK).
+/// Global scope: Assistants are shared across all sessions (no `session_id` FK).
 #[derive(Debug)]
 pub struct AssistantServer {
     db: Arc<DatabaseConnection>,
@@ -32,7 +32,7 @@ pub struct AssistantServer {
 }
 
 impl AssistantServer {
-    /// Create a new AssistantServer
+    /// Create a new `AssistantServer`
     ///
     /// Note: Unlike other servers, this is NOT session-bound.
     /// Assistants are global and can be reused across multiple sessions.

--- a/src-tauri/src/mcp/builtin/assistant/operations.rs
+++ b/src-tauri/src/mcp/builtin/assistant/operations.rs
@@ -109,7 +109,7 @@ fn merge_config_from_request(params: ConfigMergeParams<'_>) -> Value {
     config
 }
 
-/// Validate that all mcpServerIds exist in the mcp_servers table
+/// Validate that all mcpServerIds exist in the `mcp_servers` table
 async fn validate_mcp_server_ids(
     db: &sea_orm::DatabaseConnection,
     server_ids: &[String],
@@ -410,7 +410,7 @@ pub async fn update_assistant(
 /// Used by the self-modification and self-deletion guards. Returns an error
 /// if the session doesn't exist or has no assistant binding — callers treat
 /// that as "no guard needed" (fail-open is intentional: a session without a
-/// known assistant_id should not be blocked).
+/// known `assistant_id` should not be blocked).
 async fn get_caller_assistant_id(session_id: &str) -> Result<String, String> {
     let session = crate::get_session_repository()
         .get_session(session_id)

--- a/src-tauri/src/mcp/builtin/bootstrap/platform.rs
+++ b/src-tauri/src/mcp/builtin/bootstrap/platform.rs
@@ -3,7 +3,7 @@
 //! This module provides comprehensive, cross-platform detection of system information.
 //!
 //! ## Supported Platforms
-//! - **Windows**: Full support via `where` command and PowerShell detection
+//! - **Windows**: Full support via `where` command and `PowerShell` detection
 //! - **macOS**: Full support via `command -v` and Homebrew detection
 //! - **Linux**: Full support with distro detection via `/etc/os-release`
 //!

--- a/src-tauri/src/mcp/builtin/browser/mod.rs
+++ b/src-tauri/src/mcp/builtin/browser/mod.rs
@@ -15,7 +15,7 @@ mod navigation;
 mod session;
 mod tools;
 
-/// A built-in MCP server that constructs a bridge to the InteractiveBrowserServer service
+/// A built-in MCP server that constructs a bridge to the `InteractiveBrowserServer` service
 ///
 /// # Browser Tool Workflows
 ///

--- a/src-tauri/src/mcp/builtin/browser/tools.rs
+++ b/src-tauri/src/mcp/builtin/browser/tools.rs
@@ -259,7 +259,7 @@ pub fn close_session_tool() -> MCPTool {
 
 // --- Alias wrappers (Playwright-style short names) ---
 
-/// Alias for navigate_to_url_tool with short name "goto"
+/// Alias for `navigate_to_url_tool` with short name "goto"
 pub fn goto_tool() -> MCPTool {
     let mut tool = navigate_to_url_tool();
     tool.name = "goto".to_string();
@@ -267,7 +267,7 @@ pub fn goto_tool() -> MCPTool {
     tool
 }
 
-/// Alias for extract_web_content_tool with merged schema including `page` for cache reads
+/// Alias for `extract_web_content_tool` with merged schema including `page` for cache reads
 pub fn content_tool() -> MCPTool {
     let mut tool = extract_web_content_tool();
     tool.name = "content".to_string();
@@ -337,7 +337,7 @@ NEXT STEPS:
     }
 }
 
-/// Alias for click_element_tool with short name "click"
+/// Alias for `click_element_tool` with short name "click"
 pub fn click_tool() -> MCPTool {
     let mut tool = click_element_tool();
     tool.name = "click".to_string();
@@ -345,7 +345,7 @@ pub fn click_tool() -> MCPTool {
     tool
 }
 
-/// Alias for input_text_tool with short name "fill"
+/// Alias for `input_text_tool` with short name "fill"
 pub fn fill_tool() -> MCPTool {
     let mut tool = input_text_tool();
     tool.name = "fill".to_string();
@@ -355,21 +355,21 @@ pub fn fill_tool() -> MCPTool {
     tool
 }
 
-/// Alias for scroll_page_tool with short name "scroll"
+/// Alias for `scroll_page_tool` with short name "scroll"
 pub fn scroll_tool() -> MCPTool {
     let mut tool = scroll_page_tool();
     tool.name = "scroll".to_string();
     tool
 }
 
-/// Alias for navigate_back_tool with short name "back"
+/// Alias for `navigate_back_tool` with short name "back"
 pub fn back_tool() -> MCPTool {
     let mut tool = navigate_back_tool();
     tool.name = "back".to_string();
     tool
 }
 
-/// Alias for navigate_forward_tool with short name "forward"
+/// Alias for `navigate_forward_tool` with short name "forward"
 pub fn forward_tool() -> MCPTool {
     let mut tool = navigate_forward_tool();
     tool.name = "forward".to_string();

--- a/src-tauri/src/mcp/builtin/browser_content_store.rs
+++ b/src-tauri/src/mcp/builtin/browser_content_store.rs
@@ -148,7 +148,7 @@ impl BrowserContentStore {
             .retain(|_, session| now.saturating_sub(session.timestamp) < max_age_secs);
     }
 
-    /// Count tokens in text using cl100k_base tokenizer (GPT-4, GPT-3.5-turbo)
+    /// Count tokens in text using `cl100k_base` tokenizer (GPT-4, GPT-3.5-turbo)
     fn count_tokens(text: &str) -> usize {
         match cl100k_base() {
             Ok(bpe) => bpe.encode_with_special_tokens(text).len(),

--- a/src-tauri/src/mcp/builtin/content_store/storage.rs
+++ b/src-tauri/src/mcp/builtin/content_store/storage.rs
@@ -151,7 +151,7 @@ impl ContentStoreStorage {
         })
     }
 
-    /// Create storage with existing SeaORM DatabaseConnection
+    /// Create storage with existing `SeaORM` `DatabaseConnection`
     pub async fn new_with_db(db: sea_orm::DatabaseConnection) -> Result<Self, String> {
         // Note: Migrations should already be run at application startup
 
@@ -172,7 +172,7 @@ impl ContentStoreStorage {
         })
     }
 
-    /// List contents for a session, sorted by uploaded_at (newest first)
+    /// List contents for a session, sorted by `uploaded_at` (newest first)
     pub async fn list_contents_by_session(
         &self,
         session_id: &str,
@@ -482,7 +482,7 @@ impl ContentStoreStorage {
         Ok((paginated, total))
     }
 
-    /// Get session_id for a content item
+    /// Get `session_id` for a content item
     pub fn get_content_session_id(&self, content_id: &str) -> Option<String> {
         self.contents
             .get(content_id)

--- a/src-tauri/src/mcp/builtin/error_guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance.rs
@@ -2,7 +2,7 @@
 ///
 /// This module provides a centralized error guidance system that ensures consistent,
 /// actionable error messages across all built-in tools. It follows the best practices
-/// documented in docs/guides/builtin_tool_bp.md.
+/// documented in `docs/guides/builtin_tool_bp.md`.
 ///
 /// Key principles:
 /// - Every error includes visual markers (✗)
@@ -65,7 +65,7 @@ pub struct ErrorGuidance {
 /// Canonical builder for constructing `ErrorGuidance` instances.
 ///
 /// Why this exists:
-/// - Makes the "category + message + tool_group + guidance" contract explicit.
+/// - Makes the "category + message + `tool_group` + guidance" contract explicit.
 /// - Allows optional override of default guidance in a consistent way.
 /// - Enables gradual migration without breaking the existing helper functions.
 #[must_use]
@@ -158,7 +158,7 @@ impl ErrorGuidance {
         }
     }
 
-    /// Convert to MCPResult
+    /// Convert to `MCPResult`
     pub fn to_mcp_result(&self) -> MCPResult {
         let guidance_text = self
             .guidance
@@ -410,12 +410,12 @@ impl SuccessHint {
         }
     }
 
-    /// Create a success MCPResult with hints
+    /// Create a success `MCPResult` with hints
     pub fn to_mcp_result(&self) -> MCPResult {
         self.to_mcp_result_with_data(None)
     }
 
-    /// Create a success MCPResult with hints and structured data
+    /// Create a success `MCPResult` with hints and structured data
     pub fn to_mcp_result_with_data(&self, data: Option<serde_json::Value>) -> MCPResult {
         let hint_text = if self.next_actions.is_empty() {
             String::new()

--- a/src-tauri/src/mcp/builtin/knowledge/mod.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/mod.rs
@@ -15,7 +15,7 @@ mod tools;
 /// Knowledge Server - Session-scoped knowledge base with full-text search
 ///
 /// This server provides session-specific knowledge storage and retrieval using
-/// SQLite FTS5 for efficient full-text search.
+/// `SQLite` FTS5 for efficient full-text search.
 #[derive(Debug)]
 pub struct KnowledgeServer {
     assistant_id: String,
@@ -23,7 +23,7 @@ pub struct KnowledgeServer {
 }
 
 impl KnowledgeServer {
-    /// Create a new KnowledgeServer instance for a specific assistant
+    /// Create a new `KnowledgeServer` instance for a specific assistant
     pub async fn new(assistant_id: String, db: Arc<DatabaseConnection>) -> Result<Self, String> {
         let server = Self { assistant_id, db };
 

--- a/src-tauri/src/mcp/builtin/memory/mod.rs
+++ b/src-tauri/src/mcp/builtin/memory/mod.rs
@@ -22,7 +22,7 @@ pub struct MemoryServer {
 }
 
 impl MemoryServer {
-    /// Create a new MemoryServer for the given session.
+    /// Create a new `MemoryServer` for the given session.
     pub async fn new(session_id: String, db: Arc<DatabaseConnection>) -> Result<Self, String> {
         Ok(Self { session_id, db })
     }

--- a/src-tauri/src/mcp/builtin/mod.rs
+++ b/src-tauri/src/mcp/builtin/mod.rs
@@ -356,7 +356,7 @@ impl BuiltinServerRegistry {
     /// using the provided `SessionManager`.
     ///
     /// Note: Only registers stateless servers. Stateful servers (knowledge, planning, playbook,
-    /// assistant, browser) are instantiated per-session in MCPServiceProxy.
+    /// assistant, browser) are instantiated per-session in `MCPServiceProxy`.
     pub fn new_with_session_manager(session_manager: std::sync::Arc<SessionManager>) -> Self {
         let mut registry = Self {
             servers: std::collections::HashMap::new(),
@@ -387,11 +387,11 @@ impl BuiltinServerRegistry {
         registry
     }
 
-    /// Creates a new `BuiltinServerRegistry` with SQLite support.
+    /// Creates a new `BuiltinServerRegistry` with `SQLite` support.
     ///
     /// # Arguments
     /// * `session_manager` - A shared reference to the `SessionManager`.
-    /// * `sqlite_db_url` - The connection URL for the SQLite database.
+    /// * `sqlite_db_url` - The connection URL for the `SQLite` database.
     pub async fn new_with_session_manager_and_sqlite(
         session_manager: std::sync::Arc<SessionManager>,
         sqlite_db_url: String,
@@ -430,11 +430,11 @@ impl BuiltinServerRegistry {
         registry
     }
 
-    /// Creates a new `BuiltinServerRegistry` with SeaORM DatabaseConnection.
+    /// Creates a new `BuiltinServerRegistry` with `SeaORM` `DatabaseConnection`.
     ///
     /// # Arguments
     /// * `session_manager` - A shared reference to the `SessionManager`.
-    /// * `db` - The SeaORM DatabaseConnection instance.
+    /// * `db` - The `SeaORM` `DatabaseConnection` instance.
     pub async fn new_with_session_manager_and_db(
         session_manager: std::sync::Arc<SessionManager>,
         db: sea_orm::DatabaseConnection,

--- a/src-tauri/src/mcp/builtin/planning/mod.rs
+++ b/src-tauri/src/mcp/builtin/planning/mod.rs
@@ -26,7 +26,7 @@ pub struct PlanningServer {
 }
 
 impl PlanningServer {
-    /// Create a new PlanningServer for the given session
+    /// Create a new `PlanningServer` for the given session
     pub async fn new(session_id: String, db: Arc<DatabaseConnection>) -> Result<Self, String> {
         let server = Self {
             session_id: session_id.clone(),

--- a/src-tauri/src/mcp/builtin/planning/todos.rs
+++ b/src-tauri/src/mcp/builtin/planning/todos.rs
@@ -7,7 +7,7 @@ use crate::state::get_planning_repository;
 use sea_orm::DatabaseConnection;
 use serde_json::{json, Value};
 
-/// Unified todo update — dispatches to check_todo or cancel_todo based on action.
+/// Unified todo update — dispatches to `check_todo` or `cancel_todo` based on action.
 pub async fn update_todo(
     db: &DatabaseConnection,
     session_id: &str,

--- a/src-tauri/src/mcp/builtin/service_id.rs
+++ b/src-tauri/src/mcp/builtin/service_id.rs
@@ -32,7 +32,7 @@ use std::fmt;
 
 /// Type-safe, stable identifier for a builtin MCP service.
 ///
-/// The serde representation (snake_case of the variant name) is the **stable DB key**
+/// The serde representation (`snake_case` of the variant name) is the **stable DB key**
 /// — it must never change.  The `name()` method currently returns the same values,
 /// so **both must be kept in sync**.  To truly decouple them, add explicit
 /// `#[serde(rename = "...")]` attributes to each variant and then `name()` can

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -12,7 +12,7 @@ use super::formatting::*;
 use super::types::*;
 use super::utils::*;
 
-/// Helper to map raw session JSON to the standardized AgentSessionResponse.
+/// Helper to map raw session JSON to the standardized `AgentSessionResponse`.
 fn map_session_response(
     session: &Value,
     turn_count: usize,

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -244,7 +244,7 @@ use serde_json::json;
 /// for correct routing of user interactions on the frontend.
 ///
 /// # Arguments
-/// * `uri` - The resource URI (e.g., "ui://prompt/123")
+/// * `uri` - The resource URI (e.g., "<ui://prompt/123>")
 /// * `mime_type` - The MIME type (typically "text/html")
 /// * `html` - The rendered HTML content
 /// * `server_name` - The name of the server (e.g., "ui", "playbook")

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/execute_pending.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/execute_pending.rs
@@ -20,7 +20,7 @@ use super::super::normalization;
 use super::security;
 
 impl WorkspaceServer {
-    /// Handle execute_pending_shell tool call (2nd tool call)
+    /// Handle `execute_pending_shell` tool call (2nd tool call)
     /// Executes pending command with user input via stdin
     pub async fn handle_execute_pending_shell(
         &self,

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
@@ -11,7 +11,7 @@ use super::ui;
 
 impl WorkspaceServer {
     /// Handle interactive shell execution (1st tool call)
-    /// Returns UIResource with execution_id for user input
+    /// Returns `UIResource` with `execution_id` for user input
     pub(crate) async fn handle_interactive_shell(
         &self,
         command: &str,
@@ -87,7 +87,7 @@ impl WorkspaceServer {
     }
 
     /// Get platform-aware prompt configuration for user input
-    /// Returns (prompt, input_type) tuple
+    /// Returns (prompt, `input_type`) tuple
     fn get_prompt_config<'a>(&self, command: &str, args: &'a Value) -> (&'a str, &'a str) {
         // Check if privilege escalation detected (Unix only)
         let is_privilege_cmd = validation::detect_privilege_escalation(command);

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/ui.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/ui.rs
@@ -2,8 +2,8 @@ use crate::mcp::builtin::workspace::tools::code_tools::{
     CANCEL_PENDING_EXECUTION, EXECUTE_PENDING_SHELL,
 };
 
-/// Build UIResource HTML for shell input form
-/// Returns HTML string with embedded execution_id, prompt, and input type
+/// Build `UIResource` HTML for shell input form
+/// Returns HTML string with embedded `execution_id`, prompt, and input type
 pub fn build_shell_input_ui(
     execution_id: &str,
     prompt: &str,

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
@@ -150,7 +150,7 @@ fn decode_process_output(bytes: &[u8]) -> String {
 }
 
 /// Spawn process and stream stdout/stderr to files (common logic for sync/async)
-/// Returns (pid, exit_code, stdout_content, stderr_content)
+/// Returns (pid, `exit_code`, `stdout_content`, `stderr_content`)
 /// Respects cancellation token for graceful shutdown
 pub async fn spawn_and_stream_to_files(
     mut cmd: Command,
@@ -417,7 +417,7 @@ pub async fn spawn_and_stream_to_files(
 }
 
 /// Spawn process and stream output to both in-memory buffers and files (for async/long-running processes)
-/// Returns (pid, exit_code, streaming_handle)
+/// Returns (pid, `exit_code`, `streaming_handle`)
 /// Provides real-time access to output through broadcast channels and circular buffers
 pub async fn spawn_and_stream_hybrid(
     mut cmd: Command,

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -49,7 +49,7 @@ pub struct PendingShellExecution {
 }
 
 /// Thread-safe storage for pending shell executions
-/// Manages a map of execution_id -> PendingShellExecution
+/// Manages a map of `execution_id` -> `PendingShellExecution`
 #[derive(Debug)]
 pub struct PendingExecutions(Mutex<HashMap<String, PendingShellExecution>>);
 

--- a/src-tauri/src/mcp/builtin/workspace/persistent_shell/manager.rs
+++ b/src-tauri/src/mcp/builtin/workspace/persistent_shell/manager.rs
@@ -17,7 +17,7 @@ use crate::session_isolation::types::ShellType;
 /// handling lifecycle management and cleanup.
 #[derive(Debug)]
 pub struct PersistentShellManager {
-    /// session_id -> PersistentShell mapping
+    /// `session_id` -> `PersistentShell` mapping
     shells: Arc<Mutex<HashMap<String, Arc<Mutex<PersistentShell>>>>>,
 
     /// Maximum shells per session (resource limit)
@@ -85,7 +85,7 @@ impl PersistentShellManager {
     /// Execute command in persistent shell
     ///
     /// Automatically handles shell creation and retries on crash.
-    /// Returns (stdout, stderr, exit_code, cwd).
+    /// Returns (stdout, stderr, `exit_code`, cwd).
     pub async fn execute(
         &self,
         session_id: String,

--- a/src-tauri/src/mcp/builtin/workspace/persistent_shell/session.rs
+++ b/src-tauri/src/mcp/builtin/workspace/persistent_shell/session.rs
@@ -24,9 +24,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tracing::{debug, warn};
 
-/// Read a line from BufReader with lossy UTF-8 conversion
+/// Read a line from `BufReader` with lossy UTF-8 conversion
 ///
-/// This handles PowerShell error messages that may contain non-UTF8 characters
+/// This handles `PowerShell` error messages that may contain non-UTF8 characters
 /// (e.g., Windows CP949 encoding for Korean error messages).
 ///
 /// # Arguments
@@ -81,10 +81,10 @@ impl PersistentShell {
     /// # Arguments
     /// * `session_id` - Unique identifier for this shell session
     /// * `workspace_path` - Working directory for the shell session
-    /// * `shell_type` - Type of shell to spawn (Bash, PowerShell, or Cmd)
+    /// * `shell_type` - Type of shell to spawn (Bash, `PowerShell`, or Cmd)
     ///
     /// # Platform-specific behavior
-    /// - Unix: Spawns `bash --norc --noprofile` (shell_type must be Bash)
+    /// - Unix: Spawns `bash --norc --noprofile` (`shell_type` must be Bash)
     /// - Windows (PowerShell): Spawns `powershell.exe -NoProfile -NoLogo -NonInteractive`
     /// - Windows (Cmd): Spawns `cmd.exe /Q /K` (no echo, keep running)
     pub async fn new(
@@ -234,7 +234,7 @@ impl PersistentShell {
     ///
     /// # Returns
     ///
-    /// Tuple of (stdout, stderr, exit_code, cwd)
+    /// Tuple of (stdout, stderr, `exit_code`, cwd)
     ///
     /// # Algorithm
     ///
@@ -456,7 +456,7 @@ impl PersistentShell {
     /// * `user_input` - Input to inject via stdin
     ///
     /// # Returns
-    /// Tuple of (stdout, stderr, exit_code, cwd)
+    /// Tuple of (stdout, stderr, `exit_code`, cwd)
     ///
     /// # Security
     /// Input is passed via stdin pipe, not visible in process command line

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -1,7 +1,7 @@
 use crate::mcp::{utils::schema_builder::*, MCPTool};
 use std::collections::HashMap;
 
-/// Create read_process_output tool
+/// Create `read_process_output` tool
 pub fn create_read_process_output_tool() -> MCPTool {
     let mut props = HashMap::new();
 
@@ -56,7 +56,7 @@ pub fn create_read_process_output_tool() -> MCPTool {
     }
 }
 
-/// Create wait_for_process tool
+/// Create `wait_for_process` tool
 pub fn create_wait_for_process_tool() -> MCPTool {
     let mut props = HashMap::new();
 
@@ -86,7 +86,7 @@ pub fn create_wait_for_process_tool() -> MCPTool {
     }
 }
 
-/// Create list_processes tool
+/// Create `list_processes` tool
 pub fn create_list_processes_tool() -> MCPTool {
     let mut props = HashMap::new();
 
@@ -110,7 +110,7 @@ pub fn create_list_processes_tool() -> MCPTool {
     }
 }
 
-/// Create stop_process tool
+/// Create `stop_process` tool
 pub fn create_stop_process_tool() -> MCPTool {
     let mut props = HashMap::new();
 

--- a/src-tauri/src/mcp/builtin/workspace/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/utils.rs
@@ -66,7 +66,7 @@ pub fn validate_timeout(timeout: Option<u64>) -> u64 {
 /// Shared utility used across workspace server components
 ///
 /// # Security
-/// This function sanitizes commands before storing them in logs or ProcessRegistry
+/// This function sanitizes commands before storing them in logs or `ProcessRegistry`
 /// to prevent revealing sensitive implementation details like stdin-based password transmission.
 ///
 /// # Examples

--- a/src-tauri/src/mcp/server/mod.rs
+++ b/src-tauri/src/mcp/server/mod.rs
@@ -47,7 +47,7 @@ impl MCPServerManager {
         server_manager
     }
 
-    /// Creates a new `MCPServerManager` with support for both `SessionManager` and SQLite.
+    /// Creates a new `MCPServerManager` with support for both `SessionManager` and `SQLite`.
     pub async fn new_with_session_manager_and_sqlite(
         session_manager: Arc<SessionManager>,
         sqlite_db_url: String,
@@ -74,7 +74,7 @@ impl MCPServerManager {
         server_manager
     }
 
-    /// Creates a new `MCPServerManager` with support for both `SessionManager` and SeaORM DatabaseConnection.
+    /// Creates a new `MCPServerManager` with support for both `SessionManager` and `SeaORM` `DatabaseConnection`.
     pub async fn new_with_session_manager_and_db(
         session_manager: Arc<SessionManager>,
         db: sea_orm::DatabaseConnection,

--- a/src-tauri/src/mcp/server/tools.rs
+++ b/src-tauri/src/mcp/server/tools.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-/// Helper function to convert serde_json::Value to JsonRpcId
+/// Helper function to convert `serde_json::Value` to `JsonRpcId`
 fn value_to_json_rpc_id(value: serde_json::Value) -> JsonRpcId {
     match value {
         serde_json::Value::String(s) => JsonRpcId::String(s),
@@ -580,7 +580,7 @@ pub async fn get_service_context(
 /// - Knowledge (5 tools): Assistant-scoped knowledge base
 /// - Browser (13 tools): Web browser automation
 /// - Workspace (30+ tools): File operations and shell execution
-/// - ContentStore (5 tools): File attachment and semantic search
+/// - `ContentStore` (5 tools): File attachment and semantic search
 /// - Assistant (4 tools): Assistant configuration management
 /// - Playbook (4 tools): Playbook execution
 /// - Bootstrap (2 tools): Platform and environment info

--- a/src-tauri/src/mcp/service_proxy/builder.rs
+++ b/src-tauri/src/mcp/service_proxy/builder.rs
@@ -5,7 +5,7 @@ use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tauri::AppHandle;
 
-/// Builder for MCPServiceProxy
+/// Builder for `MCPServiceProxy`
 pub struct MCPServiceProxyBuilder {
     session_id: String,
     tool_ids: Vec<String>,
@@ -49,7 +49,7 @@ impl MCPServiceProxyBuilder {
         self
     }
 
-    /// Build the MCPServiceProxy
+    /// Build the `MCPServiceProxy`
     pub async fn build(self) -> Result<MCPServiceProxy, String> {
         // Fetch system settings to get timeout configuration
         let timeout = Self::fetch_tool_timeout().await;

--- a/src-tauri/src/mcp/service_proxy/factory.rs
+++ b/src-tauri/src/mcp/service_proxy/factory.rs
@@ -14,7 +14,7 @@ use tauri::AppHandle;
 /// # Arguments
 /// * `tool_id` - The builtin tool identifier (e.g., "knowledge", "planning")
 /// * `session_id` - The session to bind the server to
-/// * `db` - Shared SeaORM database connection
+/// * `db` - Shared `SeaORM` database connection
 ///
 /// # Returns
 /// * `Ok(Some(Box<dyn BuiltinMCPServer>))` - Server instance

--- a/src-tauri/src/mcp/service_proxy/mod.rs
+++ b/src-tauri/src/mcp/service_proxy/mod.rs
@@ -32,17 +32,17 @@ pub struct MCPServiceProxy {
     session_id: String,
 
     /// Session-specific builtin server instances
-    /// Key: tool_id (e.g., "knowledge", "planning")
-    /// Value: Boxed trait object implementing BuiltinMCPServer
+    /// Key: `tool_id` (e.g., "knowledge", "planning")
+    /// Value: Boxed trait object implementing `BuiltinMCPServer`
     builtin_servers: HashMap<String, Box<dyn BuiltinMCPServer>>,
 
     /// Cached tools from session-isolated stdio servers
-    /// Key: server_name, Value: list of tools
+    /// Key: `server_name`, Value: list of tools
     /// This cache is populated during session creation (eager tool discovery)
     session_stdio_tool_cache: Arc<RwLock<HashMap<String, Vec<MCPTool>>>>,
 
     /// Cached tools from session-isolated HTTP servers
-    /// Key: server_name, Value: list of tools
+    /// Key: `server_name`, Value: list of tools
     session_http_tool_cache: Arc<RwLock<HashMap<String, Vec<MCPTool>>>>,
 
     /// Session-specific managers
@@ -58,8 +58,8 @@ impl MCPServiceProxy {
     /// # Arguments
     /// * `session_id` - Unique identifier for the agent session
     /// * `external_mcp_manager` - Shared manager for external MCP servers
-    /// * `db` - Shared SeaORM database connection
-    /// * `session_manager` - Shared SessionManager for workspace/attachments
+    /// * `db` - Shared `SeaORM` database connection
+    /// * `session_manager` - Shared `SessionManager` for workspace/attachments
     /// * `http_manager` - Session-specific HTTP manager
     /// * `stdio_manager` - Session-specific Stdio manager
     ///
@@ -130,11 +130,11 @@ impl MCPServiceProxy {
     /// Call a tool through this proxy
     ///
     /// Routes the call to either:
-    /// - Builtin server (if tool_name's service prefix matches a known builtin service)
+    /// - Builtin server (if `tool_name`'s service prefix matches a known builtin service)
     /// - External MCP server (stdio-based)
     ///
     /// # Arguments
-    /// * `tool_name` - Full tool name (e.g., "attachments__addContent")
+    /// * `tool_name` - Full tool name (e.g., "`attachments__addContent`")
     /// * `args` - JSON arguments for the tool
     ///
     /// # Returns
@@ -517,7 +517,7 @@ impl MCPServiceProxy {
     /// unnecessary DB round-trips when context would be empty.
     ///
     /// # Returns
-    /// * `HashMap<String, ServiceContext>` - Map of tool_id -> ServiceContext
+    /// * `HashMap<String, ServiceContext>` - Map of `tool_id` -> `ServiceContext`
     pub async fn get_service_contexts(&self) -> HashMap<String, ServiceContext> {
         let futures: Vec<_> = self
             .builtin_servers

--- a/src-tauri/src/mcp/service_proxy/types.rs
+++ b/src-tauri/src/mcp/service_proxy/types.rs
@@ -5,7 +5,7 @@ use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tauri::AppHandle;
 
-/// Configuration for creating an MCPServiceProxy
+/// Configuration for creating an `MCPServiceProxy`
 #[derive(Debug)]
 pub struct ProxyConfig {
     /// Unique identifier for the agent session
@@ -16,14 +16,14 @@ pub struct ProxyConfig {
     pub app_handle: Option<AppHandle>,
 }
 
-/// Shared manager dependencies for MCPServiceProxy
+/// Shared manager dependencies for `MCPServiceProxy`
 #[derive(Debug, Clone)]
 pub struct SharedManagers {
     /// Shared manager for external MCP servers
     pub external_mcp: Arc<MCPServerManager>,
-    /// Shared SeaORM database connection
+    /// Shared `SeaORM` database connection
     pub db: Arc<DatabaseConnection>,
-    /// Shared SessionManager for workspace/attachments
+    /// Shared `SessionManager` for workspace/attachments
     pub session_manager: Arc<SessionManager>,
 }
 

--- a/src-tauri/src/mcp/service_proxy_manager/creation.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/creation.rs
@@ -17,8 +17,8 @@ impl MCPServiceProxyManager {
     /// Create a new proxy manager
     ///
     /// # Arguments
-    /// * `db` - Shared SeaORM database connection
-    /// * `session_manager` - Shared SessionManager for workspace/attachments
+    /// * `db` - Shared `SeaORM` database connection
+    /// * `session_manager` - Shared `SessionManager` for workspace/attachments
     pub fn new(db: Arc<DatabaseConnection>, session_manager: Arc<SessionManager>) -> Self {
         Self::new_with_config(db, session_manager, SessionIsolationConfig::default())
     }
@@ -26,8 +26,8 @@ impl MCPServiceProxyManager {
     /// Create a new proxy manager with custom configuration
     ///
     /// # Arguments
-    /// * `db` - Shared SeaORM database connection
-    /// * `session_manager` - Shared SessionManager for workspace/attachments
+    /// * `db` - Shared `SeaORM` database connection
+    /// * `session_manager` - Shared `SessionManager` for workspace/attachments
     /// * `config` - Session isolation configuration
     pub fn new_with_config(
         db: Arc<DatabaseConnection>,
@@ -54,7 +54,7 @@ impl MCPServiceProxyManager {
     /// Create a new proxy manager from static singleton references
     ///
     /// This is a convenience constructor that retrieves the global MCP manager
-    /// and SeaORM database connection from the application state and creates Arc references.
+    /// and `SeaORM` database connection from the application state and creates Arc references.
     pub fn new_from_static_refs() -> Self {
         use crate::state::get_database_connection;
 

--- a/src-tauri/src/mcp/service_proxy_manager/management.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/management.rs
@@ -111,7 +111,7 @@ impl MCPServiceProxyManager {
     ///
     /// # Arguments
     /// * `session_id` - The session making the tool call
-    /// * `tool_name` - Name of the tool to invoke (e.g., "attachments__addContent" or "filesystem__read_file")
+    /// * `tool_name` - Name of the tool to invoke (e.g., "`attachments__addContent`" or "`filesystem__read_file`")
     /// * `args` - JSON arguments for the tool
     ///
     /// # Returns

--- a/src-tauri/src/mcp/service_proxy_manager/mod.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/mod.rs
@@ -28,10 +28,10 @@ pub use caching::spawn_tool_cache_update;
 ///
 /// # Session Isolation for External MCP Servers
 ///
-/// - **Stdio servers**: Each session gets independent process instances via SessionMCPManager
-/// - **HTTP servers**: Shared connections with session ID injection via HttpSessionManager
+/// - **Stdio servers**: Each session gets independent process instances via `SessionMCPManager`
+/// - **HTTP servers**: Shared connections with session ID injection via `HttpSessionManager`
 pub struct MCPServiceProxyManager {
-    /// Map of session_id to session-specific proxy instances
+    /// Map of `session_id` to session-specific proxy instances
     proxies: Arc<RwLock<HashMap<String, Arc<MCPServiceProxy>>>>,
 
     /// Session-specific stdio MCP server managers (lazy-spawned per session)
@@ -40,10 +40,10 @@ pub struct MCPServiceProxyManager {
     /// Session-specific HTTP MCP server managers (shared connections with session headers)
     session_http_managers: Arc<RwLock<HashMap<String, HttpSessionManager>>>,
 
-    /// Shared SeaORM database connection for all sessions
+    /// Shared `SeaORM` database connection for all sessions
     db: Arc<DatabaseConnection>,
 
-    /// Shared SessionManager for workspace/attachments servers
+    /// Shared `SessionManager` for workspace/attachments servers
     session_manager: Arc<SessionManager>,
 
     /// Background cleanup task handle
@@ -60,7 +60,7 @@ pub struct MCPServiceProxyManager {
     proxy_readiness: Arc<RwLock<HashMap<String, Arc<tokio::sync::watch::Sender<bool>>>>>,
 
     /// Per-session creation lock to prevent duplicate proxy creation under concurrent calls.
-    /// Two concurrent `create_proxy` calls for the same session_id will serialize here;
+    /// Two concurrent `create_proxy` calls for the same `session_id` will serialize here;
     /// the second caller blocks until the first finishes and then hits the idempotency re-check.
     creation_guards: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 }

--- a/src-tauri/src/mcp/session_isolation/mod.rs
+++ b/src-tauri/src/mcp/session_isolation/mod.rs
@@ -5,8 +5,8 @@
 /// state conflicts during concurrent execution.
 ///
 /// ## Architecture:
-/// - **Stdio servers**: Independent processes per session (SessionMCPManager)
-/// - **HTTP servers**: Shared connections with session ID injection (HttpSessionManager)
+/// - **Stdio servers**: Independent processes per session (`SessionMCPManager`)
+/// - **HTTP servers**: Shared connections with session ID injection (`HttpSessionManager`)
 pub mod error;
 pub mod http_manager;
 pub mod process;

--- a/src-tauri/src/mcp/session_isolation/process.rs
+++ b/src-tauri/src/mcp/session_isolation/process.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 /// Represents a running MCP server process with its associated client and metadata.
 ///
-/// Note: The actual child process is managed internally by rmcp's TokioChildProcess.
+/// Note: The actual child process is managed internally by rmcp's `TokioChildProcess`.
 /// We only store the client handle and metadata here.
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -25,7 +25,7 @@ pub struct MCPProcess {
 }
 
 impl MCPProcess {
-    /// Creates a new MCPProcess instance.
+    /// Creates a new `MCPProcess` instance.
     pub fn new(client: rmcp::service::RunningService<rmcp::service::RoleClient, ()>) -> Self {
         Self {
             client,
@@ -38,7 +38,7 @@ impl MCPProcess {
     /// Gracefully shutdown the process.
     ///
     /// This will cancel the rmcp client, which will also terminate the underlying
-    /// child process managed by TokioChildProcess.
+    /// child process managed by `TokioChildProcess`.
     pub async fn shutdown(self) {
         debug!("Shutting down MCP process");
 

--- a/src-tauri/src/mcp/session_isolation/stdio_manager/lifecycle.rs
+++ b/src-tauri/src/mcp/session_isolation/stdio_manager/lifecycle.rs
@@ -16,7 +16,7 @@ use tokio::sync::{Mutex, RwLock};
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 impl SessionMCPManager {
-    /// Creates a new SessionMCPManager for the given session.
+    /// Creates a new `SessionMCPManager` for the given session.
     pub fn new(
         session_id: String,
         server_configs: HashMap<String, MCPServerConfig>,

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -241,7 +241,7 @@ pub enum MCPContent {
 }
 
 /// Represents the pure result of a tool execution (without JSON-RPC wrapper).
-/// This is what built-in tools should return before being wrapped in MCPResponse.
+/// This is what built-in tools should return before being wrapped in `MCPResponse`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MCPResult {
@@ -257,7 +257,7 @@ pub struct MCPResult {
 }
 
 impl MCPResult {
-    /// Creates a successful MCPResult with text content.
+    /// Creates a successful `MCPResult` with text content.
     #[allow(dead_code)]
     pub fn success(text: &str) -> Self {
         Self {
@@ -270,7 +270,7 @@ impl MCPResult {
         }
     }
 
-    /// Creates a successful MCPResult with text and structured content.
+    /// Creates a successful `MCPResult` with text and structured content.
     #[allow(dead_code)]
     pub fn success_with_data(text: &str, data: serde_json::Value) -> Self {
         Self {
@@ -283,7 +283,7 @@ impl MCPResult {
         }
     }
 
-    /// Creates an error MCPResult.
+    /// Creates an error `MCPResult`.
     #[allow(dead_code)]
     pub fn error(message: &str) -> Self {
         Self {
@@ -296,7 +296,7 @@ impl MCPResult {
         }
     }
 
-    /// Creates an error MCPResult with additional structured data.
+    /// Creates an error `MCPResult` with additional structured data.
     #[allow(dead_code)]
     pub fn error_with_data(message: &str, data: serde_json::Value) -> Self {
         Self {
@@ -486,7 +486,7 @@ pub struct ServiceContext<T = serde_json::Value> {
 // Builtin Server Metadata (UI-facing)
 // ========================================
 
-/// UI metadata for builtin MCP servers (matches TypeScript ServiceMetadata interface)
+/// UI metadata for builtin MCP servers (matches TypeScript `ServiceMetadata` interface)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BuiltinServerMetadata {

--- a/src-tauri/src/mcp/utils/command_helper.rs
+++ b/src-tauri/src/mcp/utils/command_helper.rs
@@ -47,17 +47,17 @@ fn needs_shell_wrapper(command: &str) -> bool {
 
 /// Wraps a command with appropriate shell on Windows if needed
 ///
-/// Returns (final_command, final_args) tuple:
-/// - On Windows with .cmd/.bat files: ("cmd.exe", ["/C", original_command, ...args])
-/// - On Windows with .ps1 files: ("powershell.exe", ["-File", original_command, ...args])
-/// - Otherwise: (original_command, args)
+/// Returns (`final_command`, `final_args`) tuple:
+/// - On Windows with .cmd/.bat files: ("cmd.exe", ["/C", `original_command`, ...args])
+/// - On Windows with .ps1 files: ("powershell.exe", ["-File", `original_command`, ...args])
+/// - Otherwise: (`original_command`, args)
 ///
 /// # Arguments
 /// * `command` - The command to execute
 /// * `args` - Command arguments
 ///
 /// # Returns
-/// Tuple of (final_command, final_args) ready for Command::new()
+/// Tuple of (`final_command`, `final_args`) ready for `Command::new()`
 pub fn prepare_command(command: &str, args: &[String]) -> (String, Vec<String>) {
     #[cfg(windows)]
     {

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -20,7 +20,7 @@ pub struct Message {
     pub id: String,
     pub session_id: String,
     pub role: String,
-    /// Structured content array (MCPContent[]) - matches TypeScript
+    /// Structured content array (`MCPContent`[]) - matches TypeScript
     pub content: Vec<MCPContent>,
     /// Tool calls as structured array - matches TypeScript
     pub tool_calls: Option<Vec<ToolCall>>,

--- a/src-tauri/src/repositories/assistant_repository.rs
+++ b/src-tauri/src/repositories/assistant_repository.rs
@@ -56,14 +56,14 @@ pub trait AssistantRepository: Send + Sync {
     async fn count_assistants(&self) -> Result<u64, DbError>;
 }
 
-/// SQLite implementation of AssistantRepository using SeaORM
+/// `SQLite` implementation of `AssistantRepository` using `SeaORM`
 #[derive(Debug, Clone)]
 pub struct SqliteAssistantRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteAssistantRepository {
-    /// Create a new SQLite assistant repository with the given database connection
+    /// Create a new `SQLite` assistant repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/repositories/content_store_repository.rs
+++ b/src-tauri/src/repositories/content_store_repository.rs
@@ -14,14 +14,14 @@ pub trait ContentStoreRepository: Send + Sync {
     async fn delete_by_session(&self, session_id: &str) -> Result<(), DbError>;
 }
 
-/// SQLite implementation of ContentStoreRepository
+/// `SQLite` implementation of `ContentStoreRepository`
 #[derive(Debug)]
 pub struct SqliteContentStoreRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteContentStoreRepository {
-    /// Create a new SQLite content store repository with the given database connection
+    /// Create a new `SQLite` content store repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/repositories/error.rs
+++ b/src-tauri/src/repositories/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 /// Database error types for repository operations
 #[derive(Debug, Error)]
 pub enum DbError {
-    /// SeaORM database query execution failed
+    /// `SeaORM` database query execution failed
     #[error("SeaORM query failed: {0}")]
     SeaOrmQueryFailed(#[from] sea_orm::DbErr),
 
@@ -32,7 +32,7 @@ pub enum DbError {
     ResourceNotFound(String),
 }
 
-/// Convert DbError to String for Tauri command compatibility
+/// Convert `DbError` to String for Tauri command compatibility
 impl From<DbError> for String {
     fn from(err: DbError) -> String {
         err.to_string()

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// In-memory implementation of SessionRepository for ephemeral sessions
+/// In-memory implementation of `SessionRepository` for ephemeral sessions
 ///
 /// This implementation stores session data in memory only, without DB persistence.
 /// Ideal for temporary sessions that are converted to persistent later.
@@ -149,7 +149,7 @@ impl SessionRepository for InMemorySessionRepository {
 
     /// Get all sessions stored in memory
     ///
-    /// Returns sessions in arbitrary order (HashMap iteration order).
+    /// Returns sessions in arbitrary order (`HashMap` iteration order).
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
         let sessions = self.sessions.read().await;
         let result: Vec<SessionMetadata> = sessions.values().cloned().collect();

--- a/src-tauri/src/repositories/mcp_server_repository.rs
+++ b/src-tauri/src/repositories/mcp_server_repository.rs
@@ -43,14 +43,14 @@ pub trait MCPServerRepository: Send + Sync {
     ) -> Result<(), DbError>;
 }
 
-/// SQLite implementation of MCPServerRepository using SeaORM
+/// `SQLite` implementation of `MCPServerRepository` using `SeaORM`
 #[derive(Debug, Clone)]
 pub struct SqliteMCPServerRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteMCPServerRepository {
-    /// Create a new SQLite MCP server repository with the given database connection
+    /// Create a new `SQLite` MCP server repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -71,7 +71,7 @@ pub trait MessageRepository: Send + Sync {
     /// Get all distinct session IDs that have messages
     async fn get_distinct_sessions(&self) -> Result<Vec<String>, DbError>;
 
-    /// Get message models (raw SeaORM models) for search indexing
+    /// Get message models (raw `SeaORM` models) for search indexing
     async fn get_message_models_by_session(
         &self,
         session_id: &str,
@@ -82,19 +82,19 @@ pub trait MessageRepository: Send + Sync {
     async fn get_recent_message_models(&self, limit: u64) -> Result<Vec<message::Model>, DbError>;
 }
 
-/// SQLite implementation of MessageRepository using SeaORM
+/// `SQLite` implementation of `MessageRepository` using `SeaORM`
 #[derive(Debug)]
 pub struct SqliteMessageRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteMessageRepository {
-    /// Create a new SQLite message repository with the given database connection
+    /// Create a new `SQLite` message repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
 
-    /// Convert SeaORM message model to Message type
+    /// Convert `SeaORM` message model to Message type
     fn model_to_message(model: message::Model) -> Message {
         let content: Vec<crate::mcp::types::MCPContent> = from_json_or_default(&model.content);
 
@@ -131,7 +131,7 @@ impl SqliteMessageRepository {
         }
     }
 
-    /// Convert Message type to SeaORM ActiveModel
+    /// Convert Message type to `SeaORM` `ActiveModel`
     fn message_to_active_model(message: &Message) -> Result<message::ActiveModel, DbError> {
         // Serialize structured types to JSON strings for DB storage
         let content_json = serde_json::to_string(&message.content).map_err(|e| {
@@ -179,7 +179,7 @@ impl SqliteMessageRepository {
         })
     }
 
-    /// Helper to get the OnConflict strategy for upserting messages
+    /// Helper to get the `OnConflict` strategy for upserting messages
     fn get_upsert_on_conflict() -> sea_orm::sea_query::OnConflict {
         use sea_orm::sea_query::OnConflict;
         OnConflict::column(message::Column::Id)

--- a/src-tauri/src/repositories/playbook_repository.rs
+++ b/src-tauri/src/repositories/playbook_repository.rs
@@ -71,14 +71,14 @@ pub trait PlaybookRepository: Send + Sync {
     async fn count_playbooks(&self, assistant_id: &str) -> Result<u64, DbError>;
 }
 
-/// SQLite implementation of PlaybookRepository using SeaORM
+/// `SQLite` implementation of `PlaybookRepository` using `SeaORM`
 #[derive(Debug, Clone)]
 pub struct SqlitePlaybookRepository {
     db: DatabaseConnection,
 }
 
 impl SqlitePlaybookRepository {
-    /// Create a new SQLite playbook repository with the given database connection
+    /// Create a new `SQLite` playbook repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/repositories/scheduled_task_repository.rs
+++ b/src-tauri/src/repositories/scheduled_task_repository.rs
@@ -32,7 +32,7 @@ pub trait ScheduledTaskRepository: Send + Sync {
         assistant_id: Option<&str>,
     ) -> Result<Vec<scheduled_task::Model>, DbErr>;
 
-    /// List enabled tasks whose next_run_at is <= the given epoch ms (due tasks)
+    /// List enabled tasks whose `next_run_at` is <= the given epoch ms (due tasks)
     async fn list_due_tasks(&self, now_ms: i64) -> Result<Vec<scheduled_task::Model>, DbErr>;
 
     /// Update mutable fields of a scheduled task
@@ -46,7 +46,7 @@ pub trait ScheduledTaskRepository: Send + Sync {
         next_run_at: Option<Option<i64>>,
     ) -> Result<scheduled_task::Model, DbErr>;
 
-    /// Record that a task has just run: update session_id, last_run_at, next_run_at
+    /// Record that a task has just run: update `session_id`, `last_run_at`, `next_run_at`
     async fn record_run(
         &self,
         id: &str,

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -45,7 +45,7 @@ impl FromStr for SessionStatus {
     }
 }
 
-/// Session metadata stored in SQLite
+/// Session metadata stored in `SQLite`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionMetadata {
@@ -104,7 +104,7 @@ pub trait SessionRepository: Send + Sync {
     /// Update session status
     async fn update_status(&self, session_id: &str, status: SessionStatus) -> Result<(), DbError>;
 
-    /// Update session configuration (model, provider, and/or agent_config)
+    /// Update session configuration (model, provider, and/or `agent_config`)
     async fn update_session_config(
         &self,
         session_id: &str,
@@ -122,7 +122,7 @@ pub trait SessionRepository: Send + Sync {
     /// Delete a session
     async fn delete_session(&self, session_id: &str) -> Result<(), DbError>;
 
-    /// Delete only this session, orphaning its direct children (set their parent_session_id to NULL)
+    /// Delete only this session, orphaning its direct children (set their `parent_session_id` to NULL)
     async fn orphan_and_delete_session(&self, session_id: &str) -> Result<(), DbError>;
 
     /// Toggle the bookmark flag for a session
@@ -139,14 +139,14 @@ pub trait SessionRepository: Send + Sync {
     ) -> Result<(), DbError>;
 }
 
-/// SQLite implementation of SessionRepository using SeaORM
+/// `SQLite` implementation of `SessionRepository` using `SeaORM`
 #[derive(Debug, Clone)]
 pub struct SqliteSessionRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteSessionRepository {
-    /// Create a new SQLite session repository with the given database connection
+    /// Create a new `SQLite` session repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/repositories/settings_repository.rs
+++ b/src-tauri/src/repositories/settings_repository.rs
@@ -27,14 +27,14 @@ pub trait SettingsRepository: Send + Sync {
     async fn list(&self) -> Result<Vec<settings::Model>, DbError>;
 }
 
-/// SQLite implementation of SettingsRepository using SeaORM
+/// `SQLite` implementation of `SettingsRepository` using `SeaORM`
 #[derive(Debug, Clone)]
 pub struct SqliteSettingsRepository {
     db: DatabaseConnection,
 }
 
 impl SqliteSettingsRepository {
-    /// Create a new SQLite settings repository with the given database connection
+    /// Create a new `SQLite` settings repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -4,7 +4,7 @@
 /// - BM25 search engine for message content
 /// - Session-level index management with persistence
 /// - Incremental index building and background reindexing
-/// - Index metadata tracking in SQLite
+/// - Index metadata tracking in `SQLite`
 pub mod background_worker;
 pub mod index_storage;
 pub mod message_index;

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -111,8 +111,8 @@ impl AgentService {
             })
     }
 
-    /// Call a builtin tool directly via proxy_manager (for testing and direct execution)
-    /// Returns the unwrapped MCPResult (not the full MCPResponse wrapper)
+    /// Call a builtin tool directly via `proxy_manager` (for testing and direct execution)
+    /// Returns the unwrapped `MCPResult` (not the full `MCPResponse` wrapper)
     pub async fn call_builtin_tool(
         session_id: String,
         tool_name: String,

--- a/src-tauri/src/services/content_store_service.rs
+++ b/src-tauri/src/services/content_store_service.rs
@@ -8,7 +8,7 @@ pub struct ContentStoreService;
 impl ContentStoreService {
     /// Delete content store data for a session.
     ///
-    /// Removes SQLite rows (stores/contents/chunks) when a SQLite DB URL is configured,
+    /// Removes `SQLite` rows (stores/contents/chunks) when a `SQLite` DB URL is configured,
     /// and removes the content store search index directory under the session workspace.
     pub async fn delete_content_store(session_id: &str) -> Result<(), String> {
         // 1) Remove SQLite entries if SQLITE_DB_URL configured

--- a/src-tauri/src/services/interactive_browser_server/traits.rs
+++ b/src-tauri/src/services/interactive_browser_server/traits.rs
@@ -9,7 +9,7 @@ pub struct CreateWindowParams<'a> {
     pub on_close: Box<dyn Fn() + Send + Sync>,
 }
 
-/// Trait defining the environment adapter for the InteractiveBrowserServer.
+/// Trait defining the environment adapter for the `InteractiveBrowserServer`.
 /// This decouples the domain logic from the underlying framework (e.g., Tauri).
 pub trait BrowserEnvironment: Send + Sync {
     /// Creates a new browser window/session.

--- a/src-tauri/src/services/message_service.rs
+++ b/src-tauri/src/services/message_service.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
 
-/// Global cache for loaded search indices (session_id -> MessageSearchEngine)
+/// Global cache for loaded search indices (`session_id` -> `MessageSearchEngine`)
 static INDEX_CACHE: once_cell::sync::Lazy<Mutex<HashMap<String, MessageSearchEngine>>> =
     once_cell::sync::Lazy::new(|| Mutex::new(HashMap::new()));
 

--- a/src-tauri/src/services/playbook_service.rs
+++ b/src-tauri/src/services/playbook_service.rs
@@ -101,7 +101,7 @@ impl PlaybookService {
         Ok(())
     }
 
-    /// Helper to get assistant_id from session
+    /// Helper to get `assistant_id` from session
     pub async fn get_assistant_id_from_session(session_id: &str) -> Result<String, String> {
         let session_model = crate::state::get_session_repository()
             .get_session(session_id)

--- a/src-tauri/src/services/session_cleanup_service.rs
+++ b/src-tauri/src/services/session_cleanup_service.rs
@@ -31,7 +31,7 @@ impl SessionCleanupService {
     /// 2. Database Metadata (SQL)
     ///
     /// Note: This does NOT remove the workspace directory or update the session pool.
-    /// The caller must handle that via SessionManager or DirectoryService.
+    /// The caller must handle that via `SessionManager` or `DirectoryService`.
     pub async fn cleanup_auxiliary_resources(
         session_id: &str,
         message_repo: &impl MessageRepository,

--- a/src-tauri/src/services/skill_service.rs
+++ b/src-tauri/src/services/skill_service.rs
@@ -307,7 +307,7 @@ pub async fn import_assistant_skills(
     .map_err(|e| format!("Task join error: {}", e))?
 }
 
-/// Synchronous implementation of skill import, safe to run inside spawn_blocking.
+/// Synchronous implementation of skill import, safe to run inside `spawn_blocking`.
 fn import_assistant_skills_blocking(
     assistant_skills_dir: PathBuf,
     temp_dir: PathBuf,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,7 +1,7 @@
 /// Global state management module
 ///
 /// This module provides centralized access to application-wide state including
-/// the MCP service proxy manager, SQLite database URL,
+/// the MCP service proxy manager, `SQLite` database URL,
 /// database connection, and repositories.
 use crate::agent::concurrency::ConcurrencyGate;
 use crate::agent::session_bus::SessionBus;
@@ -23,7 +23,7 @@ use tokio::sync::RwLock as TokioRwLock;
 /// A global, thread-safe, once-initialized instance of the `MCPServiceProxyManager`.
 static MCP_SERVICE_PROXY_MANAGER: OnceLock<Arc<MCPServiceProxyManager>> = OnceLock::new();
 
-/// A global, thread-safe, once-initialized string for the SQLite database URL.
+/// A global, thread-safe, once-initialized string for the `SQLite` database URL.
 static SQLITE_DB_URL: OnceLock<String> = OnceLock::new();
 
 /// A global, thread-safe, once-initialized database connection.
@@ -62,7 +62,7 @@ static SCHEDULED_TASK_REPOSITORY: OnceLock<SqliteScheduledTaskRepository> = Once
 /// A global, thread-safe, once-initialized compact context repository.
 static COMPACT_CONTEXT_REPOSITORY: OnceLock<SqliteCompactContextRepository> = OnceLock::new();
 
-/// A global, thread-safe, once-initialized Tauri AppHandle for event emission.
+/// A global, thread-safe, once-initialized Tauri `AppHandle` for event emission.
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
 
 /// A global, thread-safe, once-initialized session event bus (SP1).
@@ -72,11 +72,11 @@ static SESSION_BUS: OnceLock<SessionBus> = OnceLock::new();
 static CONCURRENCY_GATE: OnceLock<ConcurrencyGate> = OnceLock::new();
 
 /// A global, thread-safe, once-initialized active sessions map (SP6).
-/// Shared Arc from AgentSessionManager so external subsystems (e.g. builtin MCP tools)
+/// Shared Arc from `AgentSessionManager` so external subsystems (e.g. builtin MCP tools)
 /// can read per-session cancellation tokens without going through Tauri managed state.
 static ACTIVE_SESSIONS: OnceLock<Arc<TokioRwLock<HashMap<String, AgentSession>>>> = OnceLock::new();
 
-/// Initialize the global AppHandle
+/// Initialize the global `AppHandle`
 /// Should be called once during application setup
 pub fn init_app_handle(handle: AppHandle) {
     if APP_HANDLE.set(handle).is_err() {
@@ -84,13 +84,13 @@ pub fn init_app_handle(handle: AppHandle) {
     }
 }
 
-/// Get the global AppHandle for event emission
+/// Get the global `AppHandle` for event emission
 /// Returns None if not initialized yet
 pub fn get_app_handle() -> Option<&'static AppHandle> {
     APP_HANDLE.get()
 }
 
-/// Sets the global SQLite database URL.
+/// Sets the global `SQLite` database URL.
 ///
 /// # Panics
 /// This function will panic if the URL is already set.
@@ -98,7 +98,7 @@ pub fn set_sqlite_db_url(url: String) {
     SQLITE_DB_URL.set(url).expect("SQLite DB URL already set");
 }
 
-/// Gets a reference to the global SQLite database URL, if it has been set.
+/// Gets a reference to the global `SQLite` database URL, if it has been set.
 ///
 /// # Returns
 /// An `Option` containing a reference to the URL string, or `None` if not yet set.
@@ -447,7 +447,7 @@ pub fn get_active_sessions() -> &'static Arc<TokioRwLock<HashMap<String, AgentSe
 
 /// Retrieve the `cancel_pending` flag Arc for the given session, or `None` if the
 /// session is not currently active.  Holds the read-lock only for the duration of
-/// the clone — very cheap.  Callers can then poll the AtomicBool without holding
+/// the clone — very cheap.  Callers can then poll the `AtomicBool` without holding
 /// any lock, making this safe to use inside hot async loops.
 pub async fn get_session_cancel_pending(session_id: &str) -> Option<Arc<AtomicBool>> {
     let sessions = get_active_sessions().read().await;

--- a/src-tauri/src/utils/json.rs
+++ b/src-tauri/src/utils/json.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Helper to serialize optional JSON fields to `Option<String>`.
 /// Returns None if the input is None.
-/// Returns Ok(Some(json_string)) if serialization succeeds.
+/// Returns `Ok(Some(json_string))` if serialization succeeds.
 /// Returns Err if serialization fails.
 pub fn to_json_option<T: Serialize>(
     value: &Option<T>,
@@ -27,7 +27,7 @@ pub fn from_json_option<T: for<'a> Deserialize<'a>>(value: &Option<String>) -> O
     }
 }
 
-/// Helper to deserialize a JSON string to T, or return T::default() if deserialization fails.
+/// Helper to deserialize a JSON string to T, or return `T::default()` if deserialization fails.
 /// Useful for mandatory fields that might be corrupt or in an old format.
 pub fn from_json_or_default<T: for<'a> Deserialize<'a> + Default>(value: &str) -> T {
     serde_json::from_str(value).unwrap_or_default()


### PR DESCRIPTION
fix: 🐛 Rustdoc backticks warnings found.
docs: 📝 Added backticks to various Rust structs and parameters in rustdoc comments across multiple repositories and services.
verify: ✅ Confirmed `cargo clippy -- -W clippy::doc_markdown` generates no warnings.

---
*PR created automatically by Jules for task [13053847792329624732](https://jules.google.com/task/13053847792329624732) started by @fritzprix*