### PR TITLE
🌌 Nexus: Architectural decoupling of Interactive Shell UI

### DIFF
--- a/.jules/airlock.md
+++ b/.jules/airlock.md
@@ -1,0 +1,3 @@
+## 2025-03-17 - [UI Bleed via MCP Protocol]
+**Learning:** Sending fully formed HTML/CSS (even via internal `ui://` URIs meant for iframe rendering) violates strict frontend/backend separation (Airlock protocol) because it couples presentation styling (`color: white`, form structures, DOM event binding) within the Rust backend logic.
+**Action:** Instead of generating raw HTML strings, return semantic JSON DTOs mapped to the URI scheme, and build corresponding native React components that consume these DTOs for rendering and action handling (e.g. `InteractiveShellInput`).

--- a/src-tauri/src/agent/llm/circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/circuit_breaker.rs
@@ -180,6 +180,7 @@ mod tests {
             source: None,
             error: None,
             metadata,
+            usage: None,
         }
     }
 

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
@@ -64,7 +64,7 @@ impl WorkspaceServer {
         // Create UI resource JSON
         let _ui_resource = serde_json::json!({
             "uri": format!("ui://shell-input/{}", execution_id),
-            "mimeType": "text/html",
+            "mimeType": "application/json",
             "text": html,
             "_meta": {
                 "title": "Shell Command Input",
@@ -76,7 +76,7 @@ impl WorkspaceServer {
         // Return response with text and resource
         Ok(crate::mcp::builtin::utils::create_resource_response(
             &format!("ui://shell-input/{}", execution_id),
-            "text/html",
+            "application/json",
             &html,
             "workspace",
             PERSISTENT_SHELL_TOOL,

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/ui.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/ui.rs
@@ -1,9 +1,5 @@
-use crate::mcp::builtin::workspace::tools::code_tools::{
-    CANCEL_PENDING_EXECUTION, EXECUTE_PENDING_SHELL,
-};
-
-/// Build UIResource HTML for shell input form
-/// Returns HTML string with embedded execution_id, prompt, and input type
+/// Build UIResource DTO for shell input form
+/// Returns JSON string with execution_id, prompt, and input type
 pub fn build_shell_input_ui(
     execution_id: &str,
     prompt: &str,
@@ -16,198 +12,57 @@ pub fn build_shell_input_ui(
         "text"
     };
 
-    format!(
-        r#"<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <style>
-      body {{
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        padding: 20px;
-        background: #1e1e1e;
-        color: #d4d4d4;
-        margin: 0;
-      }}
-      .container {{
-        max-width: 500px;
-        margin: 0 auto;
-      }}
-      h3 {{
-        margin-top: 0;
-        color: #e0e0e0;
-      }}
-      input {{
-        width: 100%;
-        padding: 10px;
-        margin: 10px 0;
-        background: #2d2d2d;
-        color: #d4d4d4;
-        border: 1px solid #444;
-        border-radius: 4px;
-        box-sizing: border-box;
-        font-size: 14px;
-      }}
-      input:focus {{
-        outline: none;
-        border-color: #0e639c;
-      }}
-      button {{
-        padding: 10px 20px;
-        margin: 5px 5px 5px 0;
-        background: #0e639c;
-        color: white;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 14px;
-      }}
-      button:hover {{
-        background: #1177bb;
-      }}
-      .cancel {{
-        background: #6c757d;
-      }}
-      .cancel:hover {{
-        background: #5a6268;
-      }}
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <h3>{}</h3>
-      <form id="inputForm">
-        <input
-          type="{}"
-          id="userInput"
-          placeholder="Enter input..."
-          required
-          autofocus
-        />
-        <div>
-          <button type="submit">Submit</button>
-          <button type="button" class="cancel" onclick="handleCancel()">
-            Cancel
-          </button>
-        </div>
-      </form>
-    </div>
+    let dto = serde_json::json!({
+        "type": "shell_input",
+        "execution_id": execution_id,
+        "prompt": prompt,
+        "input_type": safe_input_type,
+        "nonce": nonce
+    });
 
-    <script>
-      const executionId = '{}';
-      const nonce = '{}';
-
-      function obfuscate(input, nonce) {{
-        const textEncoder = new TextEncoder();
-        const inputBytes = textEncoder.encode(input);
-        const nonceBytes = textEncoder.encode(nonce);
-        const xored = new Uint8Array(inputBytes.length);
-        for (let i = 0; i < inputBytes.length; i++) {{
-          xored[i] = inputBytes[i] ^ nonceBytes[i % nonceBytes.length];
-        }}
-        // Convert to Base64 more safely (avoid stack overflow)
-        let binary = '';
-        for (let i = 0; i < xored.length; i++) {{
-          binary += String.fromCharCode(xored[i]);
-        }}
-        return btoa(binary);
-      }}
-
-      document
-        .getElementById('inputForm')
-        .addEventListener('submit', async (e) => {{
-          e.preventDefault();
-          const userInput = document.getElementById('userInput').value;
-          const obfuscatedInput = obfuscate(userInput, nonce);
-
-          // Send to parent window (MCP Worker) - triggers 2nd tool call
-          // IMPORTANT: Use window.parent.postMessage to send to parent frame
-          // Using MCP-UI protocol format: type='tool' with payload wrapper
-          window.parent.postMessage(
-            {{
-              type: 'tool',
-              payload: {{
-                toolName: '{}',
-                params: {{
-                  executionId: executionId,
-                  userInput: obfuscatedInput,
-                }},
-              }},
-            }},
-            '*',
-          );
-
-          // Clear input immediately
-          document.getElementById('userInput').value = '';
-          document.body.innerHTML =
-            '<p style="text-align:center; color:#d4d4d4;">⏳ Executing command...</p>';
-        }});
-
-      function handleCancel() {{
-        // Send to parent window (MCP Worker) - triggers cancel tool call
-        // IMPORTANT: Use window.parent.postMessage to send to parent frame
-        // Using MCP-UI protocol format: type='tool' with payload wrapper
-        window.parent.postMessage(
-          {{
-            type: 'tool',
-            payload: {{
-              toolName: '{}',
-              params: {{
-                executionId: executionId,
-              }},
-            }},
-          }},
-          '*',
-        );
-
-        document.body.innerHTML =
-          '<p style="text-align:center; color:#d4d4d4;">❌ Cancelled</p>';
-      }}
-    </script>
-  </body>
-</html>"#,
-        html_escape::encode_safe(prompt),
-        safe_input_type,
-        execution_id,
-        nonce,
-        EXECUTE_PENDING_SHELL,
-        CANCEL_PENDING_EXECUTION
-    )
+    serde_json::to_string(&dto).unwrap_or_else(|_| "{}".to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::build_shell_input_ui;
+    use serde_json::Value;
 
     #[test]
     fn test_build_shell_input_ui_whitelists_input_type() {
-        let html = build_shell_input_ui("exec-1", "Prompt", "password", "nonce-1");
-        assert!(
-            html.contains(r#"type="password""#),
+        let json_str = build_shell_input_ui("exec-1", "Prompt", "password", "nonce-1");
+        let dto: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            dto["input_type"],
+            "password",
             "password should be preserved as allowed input type"
         );
 
-        let html_with_invalid_type = build_shell_input_ui(
+        let json_with_invalid_type = build_shell_input_ui(
             "exec-2",
             "Prompt",
             r#"text" autofocus onfocus="alert(1)""#,
             "nonce-2",
         );
-        assert!(
-            html_with_invalid_type.contains(r#"type="text""#),
+        let invalid_dto: Value = serde_json::from_str(&json_with_invalid_type).unwrap();
+        assert_eq!(
+            invalid_dto["input_type"],
+            "text",
             "invalid input_type should be downgraded to text"
         );
         assert!(
-            !html_with_invalid_type.contains("autofocus onfocus"),
-            "injected attributes must not appear in generated HTML"
+            !json_with_invalid_type.contains("autofocus onfocus"),
+            "injected attributes must not appear in generated JSON"
         );
     }
 
     #[test]
     fn test_build_shell_input_ui_uses_static_placeholder() {
-        let html = build_shell_input_ui("exec-3", "Prompt", "password", "nonce-3");
-        assert!(html.contains(r#"placeholder="Enter input...""#));
-        assert!(!html.contains("Enter password..."));
+        let json_str = build_shell_input_ui("exec-3", "Prompt", "password", "nonce-3");
+        let dto: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(dto["type"], "shell_input");
+        assert_eq!(dto["execution_id"], "exec-3");
+        assert_eq!(dto["prompt"], "Prompt");
+        assert_eq!(dto["nonce"], "nonce-3");
     }
 }

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -256,7 +256,7 @@ mod tests {
             max_fanout: None,
             created_at: 1234567890,
             updated_at: 1234567890,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         // Upsert session
@@ -287,7 +287,7 @@ mod tests {
             max_fanout: None,
             created_at: 100,
             updated_at: 100,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         repo.upsert_session(&session).await.unwrap();
@@ -330,7 +330,7 @@ mod tests {
             max_fanout: None,
             created_at: 100,
             updated_at: 100,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         repo.upsert_session(&session).await.unwrap();
@@ -366,7 +366,7 @@ mod tests {
                 max_fanout: None,
                 created_at: 100,
                 updated_at: 100,
-                yolo_mode: false,
+                yolo_mode: false, workspace_override: None,
             };
             repo.upsert_session(&session).await.unwrap();
         }
@@ -397,7 +397,7 @@ mod tests {
                 max_fanout: None,
                 created_at: 100,
                 updated_at: 100,
-                yolo_mode: false,
+                yolo_mode: false, workspace_override: None,
             };
             repo.upsert_session(&session).await.unwrap();
         }
@@ -436,7 +436,7 @@ mod tests {
                     depth: None,
                     max_depth: None,
                     max_fanout: None,
-                    yolo_mode: false,
+                    yolo_mode: false, workspace_override: None,
                 };
                 repo_clone.upsert_session(&session).await.unwrap();
             });

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -495,6 +495,7 @@ mod tests {
             source: None,
             error: None,
             metadata: None,
+            usage: None,
         }
     }
 

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -382,7 +382,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         // Test upsert
@@ -422,7 +422,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         repo.upsert_session(&session)
@@ -469,7 +469,7 @@ mod tests {
                 created_at: now,
                 updated_at: now + i,
                 is_bookmarked: false,
-                yolo_mode: false,
+                yolo_mode: false, workspace_override: None,
             };
 
             repo.upsert_session(&session)
@@ -537,7 +537,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         repo.upsert_session(&session)
@@ -555,7 +555,7 @@ mod tests {
             created_at: now,
             updated_at: now + 1000,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
             parent_session_id: None,
             lineage_id: None,
             depth: None,
@@ -597,7 +597,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
             parent_session_id: None,
             lineage_id: None,
             depth: None,
@@ -643,7 +643,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             is_bookmarked: false,
-            yolo_mode: false,
+            yolo_mode: false, workspace_override: None,
         };
 
         repo.upsert_session(&session)

--- a/src-tauri/src/search/message_index.rs
+++ b/src-tauri/src/search/message_index.rs
@@ -341,6 +341,7 @@ mod tests {
             updated_at: 1000,
             source: None,
             error: None,
+            usage: None,
         };
 
         let doc = MessageDocument::from(model);

--- a/src/features/agent/components/AgentMessageRenderer/components/InteractiveShellInput.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/InteractiveShellInput.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Loader2, XCircle } from 'lucide-react';
+import { UIActionResult } from '@mcp-ui/client';
+
+export interface InteractiveShellInputProps {
+  resource: {
+    uri: string;
+    mimeType: string;
+    text?: string;
+  };
+  onUIAction: (action: UIActionResult) => void;
+}
+
+export const InteractiveShellInput: React.FC<InteractiveShellInputProps> = ({
+  resource,
+  onUIAction,
+}) => {
+  const { t } = useTranslation('common');
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'cancelled'>(
+    'idle',
+  );
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(resource.text || '{}');
+  } catch (e) {
+    return (
+      <div className="text-destructive text-sm p-4 border rounded">
+        Failed to parse shell input parameters.
+      </div>
+    );
+  }
+
+  const { execution_id, prompt, input_type, nonce } = parsed;
+
+  const obfuscate = (text: string, nonceStr: string) => {
+    const textEncoder = new TextEncoder();
+    const inputBytes = textEncoder.encode(text);
+    const nonceBytes = textEncoder.encode(nonceStr);
+    const xored = new Uint8Array(inputBytes.length);
+    for (let i = 0; i < inputBytes.length; i++) {
+      xored[i] = inputBytes[i] ^ nonceBytes[i % nonceBytes.length];
+    }
+    // Base64 encoding
+    let binary = '';
+    for (let i = 0; i < xored.length; i++) {
+      binary += String.fromCharCode(xored[i]);
+    }
+    return btoa(binary);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input || status !== 'idle') return;
+
+    setStatus('submitting');
+    const obfuscatedInput = obfuscate(input, nonce);
+
+    onUIAction({
+      type: 'tool',
+      payload: {
+        toolName: 'workspace__executePendingShell',
+        params: {
+          executionId: execution_id,
+          userInput: obfuscatedInput,
+        },
+      },
+    });
+
+    setInput('');
+  };
+
+  const handleCancel = () => {
+    if (status !== 'idle') return;
+    setStatus('cancelled');
+
+    onUIAction({
+      type: 'tool',
+      payload: {
+        toolName: 'workspace__cancelPendingExecution',
+        params: {
+          executionId: execution_id,
+        },
+      },
+    });
+  };
+
+  if (status === 'submitting') {
+    return (
+      <div className="flex flex-col items-center justify-center p-6 bg-card border rounded-lg text-muted-foreground">
+        <Loader2 className="w-5 h-5 animate-spin mb-2" />
+        <span className="text-sm">Executing command...</span>
+      </div>
+    );
+  }
+
+  if (status === 'cancelled') {
+    return (
+      <div className="flex flex-col items-center justify-center p-6 bg-card border rounded-lg text-muted-foreground">
+        <XCircle className="w-5 h-5 mb-2 text-destructive" />
+        <span className="text-sm">Cancelled</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 bg-card border rounded-lg max-w-lg">
+      <h3 className="text-sm font-medium mb-3 text-foreground">{prompt}</h3>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <Input
+          type={input_type === 'password' ? 'password' : 'text'}
+          placeholder="Enter input..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          required
+          autoFocus
+          className="w-full bg-background"
+        />
+        <div className="flex items-center gap-2">
+          <Button type="submit" size="sm" disabled={!input}>
+            Submit
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={handleCancel}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/features/agent/components/AgentMessageRenderer/index.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/index.tsx
@@ -26,6 +26,7 @@ import { groupContent } from './utils/contentGrouping';
 import { CodeBlock } from './components/CodeBlock';
 import { MarkdownText } from './components/MarkdownText';
 import { STATIC_MARKDOWN_COMPONENTS } from './config/markdown';
+import { InteractiveShellInput } from './components/InteractiveShellInput';
 
 const logger = getLogger('AgentMessageRenderer');
 
@@ -250,6 +251,20 @@ const AgentMessageRendererImpl: React.FC<AgentMessageRendererProps> = ({
                 item,
               });
               return null;
+            }
+
+            if (
+              resourceItem.resource.mimeType === 'application/json' &&
+              resourceItem.resource.uri.startsWith('ui://shell-input/')
+            ) {
+              return (
+                <div key={itemKey} className="my-2 w-full max-w-full overflow-x-auto">
+                  <InteractiveShellInput
+                    resource={resourceItem.resource}
+                    onUIAction={handleUIAction}
+                  />
+                </div>
+              );
             }
 
             return (


### PR DESCRIPTION
This PR refactors the Interactive Shell Input generated by the backend to prevent "UI Bleed". Previously, `ui.rs` and `interactive_shell.rs` output a serialized raw HTML page, including CSS variables like `color: white;` and internal script DOM bindings. This violated the strict separation of concerns, where the React frontend should only receive DTOs (Data Transfer Objects).

Changes:
1. Rewrote `src-tauri/src/mcp/builtin/workspace/code_execution/interactive/ui.rs` to return a `JSON DTO` representing the shell prompt rather than rendering raw HTML.
2. Updated `interactive_shell.rs` to set the resource `mimeType` to `application/json`.
3. Created a new native React component `InteractiveShellInput.tsx` to render the UI locally, handle state, apply XSS protections, parse the payload, and orchestrate the cryptographic XOR obfuscation inside the UI layer.
4. Hooked `InteractiveShellInput.tsx` into `AgentMessageRenderer/index.tsx` as a recognized application/json resource component for `ui://shell-input/*` URIs.
5. Recorded learning in `.jules/airlock.md`.

---
*PR created automatically by Jules for task [5539491997176550848](https://jules.google.com/task/5539491997176550848) started by @fritzprix*