### PR TITLE
📜 Codex: Update local dev workflow in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ of agent automation with persistent tool state and built-in MCP support.
    - Alternatively, on macOS/Linux: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 5. Install system dependencies (Linux only):
    - Debian/Ubuntu: `sudo apt-get update && sudo apt-get install -y libglib2.0-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev`
-6. Install dependencies and build: `pnpm install && pnpm build`
+6. Install dependencies: `pnpm install`
 7. Run development mode: `pnpm tauri dev`
 
 **System Requirements:**


### PR DESCRIPTION
💡 What: Removed the unnecessary `pnpm build` command from the local development setup instructions in `CONTRIBUTING.md`.
🎯 Why: A full production build is not required before running the development server via `pnpm tauri dev`. It reduces the setup friction for new contributors.
📖 Preview: `6. Install dependencies: pnpm install`

---
*PR created automatically by Jules for task [16505527691314722388](https://jules.google.com/task/16505527691314722388) started by @fritzprix*