### PR TITLE
🎨 Palette: Ensure tooltips display on disabled action buttons

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -474,20 +474,35 @@ function DraftChatInner() {
 
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => fileInputRef.current?.click()}
-                        disabled={isSubmitting || isAttachmentLoading}
-                        className="mb-1 h-8 w-8 text-muted-foreground hover:text-primary hover:bg-primary/5 shrink-0 transition-colors"
-                        aria-label={t(
-                          'fileAttachment.attachFiles',
-                          'Attach files',
+                      <span
+                        tabIndex={
+                          isSubmitting || isAttachmentLoading ? 0 : undefined
+                        }
+                        className={cn(
+                          'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0 h-8 w-8',
+                          (isSubmitting || isAttachmentLoading) &&
+                            'cursor-not-allowed',
                         )}
                       >
-                        <Paperclip className="h-4 w-4" />
-                      </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => fileInputRef.current?.click()}
+                          disabled={isSubmitting || isAttachmentLoading}
+                          className={cn(
+                            'h-full w-full text-muted-foreground hover:text-primary hover:bg-primary/5 transition-colors',
+                            (isSubmitting || isAttachmentLoading) &&
+                              'pointer-events-none',
+                          )}
+                          aria-label={t(
+                            'fileAttachment.attachFiles',
+                            'Attach files',
+                          )}
+                        >
+                          <Paperclip className="h-4 w-4" />
+                        </Button>
+                      </span>
                     </TooltipTrigger>
                     <TooltipContent>
                       {t('fileAttachment.attachFiles', 'Attach files')}
@@ -526,26 +541,49 @@ function DraftChatInner() {
 
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        type="submit"
-                        disabled={
+                      <span
+                        tabIndex={
                           (!input.trim() && !hasAttachedFiles) ||
                           isSubmitting ||
                           isAttachmentLoading
+                            ? 0
+                            : undefined
                         }
-                        size="icon"
-                        className="mb-1 shrink-0 shadow-lg transition-all active:scale-95"
-                        aria-label={t(
-                          'agent.input.sendAriaLabel',
-                          'Send message',
+                        className={cn(
+                          'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0',
+                          ((!input.trim() && !hasAttachedFiles) ||
+                            isSubmitting ||
+                            isAttachmentLoading) &&
+                            'cursor-not-allowed',
                         )}
                       >
-                        {isSubmitting || isAttachmentLoading ? (
-                          <Loader2 className="animate-spin h-4 w-4" />
-                        ) : (
-                          <Send className="h-4 w-4" />
-                        )}
-                      </Button>
+                        <Button
+                          type="submit"
+                          disabled={
+                            (!input.trim() && !hasAttachedFiles) ||
+                            isSubmitting ||
+                            isAttachmentLoading
+                          }
+                          size="icon"
+                          className={cn(
+                            'w-full h-full shadow-lg transition-all active:scale-95',
+                            ((!input.trim() && !hasAttachedFiles) ||
+                              isSubmitting ||
+                              isAttachmentLoading) &&
+                              'pointer-events-none',
+                          )}
+                          aria-label={t(
+                            'agent.input.sendAriaLabel',
+                            'Send message',
+                          )}
+                        >
+                          {isSubmitting || isAttachmentLoading ? (
+                            <Loader2 className="animate-spin h-4 w-4" />
+                          ) : (
+                            <Send className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </span>
                     </TooltipTrigger>
                     <TooltipContent>
                       {t('agent.input.sendTooltip', 'Send')}

--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -556,6 +556,27 @@ function DraftChatInner() {
                             isAttachmentLoading) &&
                             'cursor-not-allowed',
                         )}
+                        aria-label={
+                          (!input.trim() && !hasAttachedFiles) ||
+                          isSubmitting ||
+                          isAttachmentLoading
+                            ? t('agent.input.sendAriaLabel', 'Send message')
+                            : undefined
+                        }
+                        aria-disabled={
+                          (!input.trim() && !hasAttachedFiles) ||
+                          isSubmitting ||
+                          isAttachmentLoading
+                            ? true
+                            : undefined
+                        }
+                        role={
+                          (!input.trim() && !hasAttachedFiles) ||
+                          isSubmitting ||
+                          isAttachmentLoading
+                            ? 'button'
+                            : undefined
+                        }
                       >
                         <Button
                           type="submit"
@@ -566,7 +587,7 @@ function DraftChatInner() {
                           }
                           size="icon"
                           className={cn(
-                            'w-full h-full shadow-lg transition-all active:scale-95',
+                            'shadow-lg transition-all active:scale-95',
                             ((!input.trim() && !hasAttachedFiles) ||
                               isSubmitting ||
                               isAttachmentLoading) &&

--- a/src/features/agent/components/AgentChatInput.tsx
+++ b/src/features/agent/components/AgentChatInput.tsx
@@ -376,22 +376,33 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
         {isBusy ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                type="button"
-                onClick={handleCancel}
-                variant="ghost"
-                size="icon"
-                className="mb-1 h-8 w-8 shrink-0 text-destructive hover:bg-destructive/10"
-                disabled={pendingCancel}
-                aria-label={t('agent.input.cancelAriaLabel')}
-                title={t('agent.input.cancelAriaLabel')}
-              >
-                {pendingCancel ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Square className="h-4 w-4" />
+              <span
+                tabIndex={pendingCancel ? 0 : undefined}
+                className={cn(
+                  'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0 h-8 w-8',
+                  pendingCancel && 'cursor-not-allowed',
                 )}
-              </Button>
+              >
+                <Button
+                  type="button"
+                  onClick={handleCancel}
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    'h-full w-full text-destructive hover:bg-destructive/10',
+                    pendingCancel && 'pointer-events-none',
+                  )}
+                  disabled={pendingCancel}
+                  aria-label={t('agent.input.cancelAriaLabel')}
+                  title={t('agent.input.cancelAriaLabel')}
+                >
+                  {pendingCancel ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Square className="h-4 w-4" />
+                  )}
+                </Button>
+              </span>
             </TooltipTrigger>
             <TooltipContent>
               {pendingCancel
@@ -402,20 +413,31 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                type="submit"
-                disabled={isSendDisabled}
-                size="icon"
-                className="mb-1 shrink-0"
-                aria-label={t('agent.input.sendAriaLabel')}
-                title={t('agent.input.sendAriaLabel')}
-              >
-                {hasProcessingFiles ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Send className="h-4 w-4" />
+              <span
+                tabIndex={isSendDisabled ? 0 : undefined}
+                className={cn(
+                  'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0',
+                  isSendDisabled && 'cursor-not-allowed',
                 )}
-              </Button>
+              >
+                <Button
+                  type="submit"
+                  disabled={isSendDisabled}
+                  size="icon"
+                  className={cn(
+                    'w-full h-full',
+                    isSendDisabled && 'pointer-events-none',
+                  )}
+                  aria-label={t('agent.input.sendAriaLabel')}
+                  title={t('agent.input.sendAriaLabel')}
+                >
+                  {hasProcessingFiles ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4" />
+                  )}
+                </Button>
+              </span>
             </TooltipTrigger>
             <TooltipContent>{t('agent.input.sendTooltip')}</TooltipContent>
           </Tooltip>

--- a/src/features/agent/components/AgentChatInput.tsx
+++ b/src/features/agent/components/AgentChatInput.tsx
@@ -419,15 +419,17 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
                   'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0',
                   isSendDisabled && 'cursor-not-allowed',
                 )}
+                aria-label={
+                  isSendDisabled ? t('agent.input.sendAriaLabel') : undefined
+                }
+                aria-disabled={isSendDisabled ? true : undefined}
+                role={isSendDisabled ? 'button' : undefined}
               >
                 <Button
                   type="submit"
                   disabled={isSendDisabled}
                   size="icon"
-                  className={cn(
-                    'w-full h-full',
-                    isSendDisabled && 'pointer-events-none',
-                  )}
+                  className={cn(isSendDisabled && 'pointer-events-none')}
                   aria-label={t('agent.input.sendAriaLabel')}
                   title={t('agent.input.sendAriaLabel')}
                 >

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
💡 **What**: Added `<span>` wrappers with explicit `tabIndex` conditionally set to 0 when disabled buttons are present, applying `pointer-events-none` to the actual button.
🎯 **Why**: When users hover or tab to a disabled button, Radix UI `TooltipTrigger` doesn't fire because standard HTML disabled elements suppress pointer and focus events. Wrapping them in a conditionally focusable span restores the tooltip, explaining why the button is inactive.
📸 **Before/After**: Hovering over the disabled Send button in AgentChatInput did nothing. Now, it displays the tooltip.
♿ **Accessibility**: Keyboard users can now tab to disabled buttons and hear the tooltip's descriptive text, instead of the button being completely invisible in the tab order. Tested carefully to avoid the "double tab-stop" bug by ensuring `tabIndex={0}` is only applied when the button itself is disabled.

---
*PR created automatically by Jules for task [11278216510063513841](https://jules.google.com/task/11278216510063513841) started by @fritzprix*