### PR TITLE
⚡ Bolt: Replace redundant O(N log N) sort with O(1) find for next run calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,8 @@
 
 **Learning:** Reusable formatter caches are often re-implemented in multiple component files instead of a centralized utility file, fragmenting the cache and increasing overall memory footprint.
 **Action:** When centralizing `Intl` formats in a `utils` file, ensure you support `locale` variations by storing instances in a `Map` within the central utility function, so that various localized formats can be safely cached and reused without recreating localized formatters locally in components.
+
+## 2026-10-26 - Redundant O(N log N) Sorting on Derived Arrays in Render Loop
+
+**Learning:** `ScheduledTasksPage` was creating intermediate arrays using `.filter(...)` and then sorting them using `.sort(...)` repeatedly in the render loop just to calculate `nextGroupRun` (the earliest next run time among enabled tasks). Since the source array `group.tasks` was already correctly sorted upstream (enabled first, then by `nextRunAt`), this eager downstream sorting was entirely redundant and caused unnecessary array allocations and O(N log N) computation per group render.
+**Action:** When extracting a single item (like a min/max or "next" item) from an already-sorted array, do not re-sort. Use an O(1) traversal like `.find(...)` to locate the first item matching your criteria. Similarly, avoid intermediate arrays from `.filter().length` and prefer `.reduce()` when just counting specific items in a hot path.

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -247,17 +247,17 @@ export function ScheduledTasksPage() {
                 </h2>
               </div>
               {groupedSections.map((group) => {
-                const groupEnabledCount = group.tasks.filter(
-                  (task) => task.enabled,
-                ).length;
+                const groupEnabledCount = group.tasks.reduce(
+                  (count, task) => (task.enabled ? count + 1 : count),
+                  0,
+                );
+                // group.tasks is already sorted by nextRunAt via compareScheduledTasks
+                // and groupedSections filtering ensures enabled tasks are sorted logically.
+                // We just need the first task with an upcoming run time.
                 const nextGroupRun =
-                  group.tasks
-                    .filter((task) => task.enabled && task.nextRunAt !== null)
-                    .sort((left, right) => {
-                      if (left.nextRunAt === null) return 1;
-                      if (right.nextRunAt === null) return -1;
-                      return left.nextRunAt - right.nextRunAt;
-                    })[0]?.nextRunAt ?? null;
+                  group.tasks.find(
+                    (task) => task.enabled && task.nextRunAt !== null,
+                  )?.nextRunAt ?? null;
 
                 return (
                   <Card key={group.key} className="gap-4 py-4">

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -251,9 +251,9 @@ export function ScheduledTasksPage() {
                   (count, task) => (task.enabled ? count + 1 : count),
                   0,
                 );
-                // group.tasks is already sorted by nextRunAt via compareScheduledTasks
-                // and groupedSections filtering ensures enabled tasks are sorted logically.
-                // We just need the first task with an upcoming run time.
+                // group.tasks is already sorted via compareScheduledTasks.
+                // This lookup relies on that ordering, so the first enabled task
+                // with a non-null nextRunAt is the group's earliest upcoming run.
                 const nextGroupRun =
                   group.tasks.find(
                     (task) => task.enabled && task.nextRunAt !== null,


### PR DESCRIPTION
💡 What
Removed redundant O(N log N) sorting and intermediate array allocations within the `ScheduledTasksPage` render loop. Specifically, `groupEnabledCount` was refactored to use an in-place `.reduce()` instead of `.filter(...).length`, and `nextGroupRun` was optimized to use a simple `.find()` instead of a `.filter(...).sort(...)[0]` operation.

🎯 Why
`ScheduledTasksPage` already sorts its `tasks` array efficiently inside a parent `useMemo` block using `compareScheduledTasks` (which places enabled tasks first, and orders them by upcoming `nextRunAt`). Because the downstream list was already correctly sorted, running `.sort()` inside the map logic for every group component render was entirely redundant, causing unnecessary array allocations and forcing O(N log N) computation where an O(N) or even O(1) `find` operation would suffice. Additionally, `filter().length` creates a wasteful intermediate array, adding to Garbage Collection (GC) overhead during React rendering.

📊 Impact
- Eliminates O(N log N) re-sorting within the component mapping loop.
- Reduces memory pressure by removing intermediate allocations created by chained `.filter()` operations on arrays.
- Faster rendering for users with many Scheduled Tasks groups.

🔬 Measurement
Verify the optimizations mechanically by running `pnpm lint` and `pnpm test`. The changes are strictly performance optimizations over existing pure array operations and functionally preserve exactly identical outputs (verifiable via existing unit tests in `src/features/scheduled-tasks/__tests__/ScheduledTasksPage.test.tsx`).

---
*PR created automatically by Jules for task [16320272687429982533](https://jules.google.com/task/16320272687429982533) started by @fritzprix*