### PR TITLE
🕸️ Weaver: Refactor SkillsEditor using Custom Hook Pattern

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -139,3 +139,7 @@
 - **AgentPlanningUpdates:** Extracted the complex Tauri event listener ('agent:event') and debouncing logic from a monolithic `useEffect` into the `useAgentMessageTrigger` custom hook.
 - Added strict filtering via `messageFilter` to trigger context updates only for successful tool-result messages by checking `message.role === 'tool'`, `message.tool_call_id`, `!message.error`, and `message.metadata?.toolError !== true`.
 - **Benefits:** Decoupled event subscription from component rendering logic, standardized event handling across the chat interface, and avoided refreshes from failed tool executions.
+
+## 2024-04-10 - [SkillsEditor]
+**Learning:** Extracting complex Drag-and-Drop subscription logic out of a monolithic component into a dedicated custom hook (`useSkillsDnD`) strictly separates presentation from side-effects, significantly improving component readability and reusability.
+**Action:** Continually hunt for "God useEffect" blocks handling disparate UI concerns (like file drop events) and encapsulate them inside specialized hooks.

--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -140,6 +140,6 @@
 - Added strict filtering via `messageFilter` to trigger context updates only for successful tool-result messages by checking `message.role === 'tool'`, `message.tool_call_id`, `!message.error`, and `message.metadata?.toolError !== true`.
 - **Benefits:** Decoupled event subscription from component rendering logic, standardized event handling across the chat interface, and avoided refreshes from failed tool executions.
 
-## 2024-04-10 - [SkillsEditor]
+## 2026-04-10 - [SkillsEditor]
 **Learning:** Extracting complex Drag-and-Drop subscription logic out of a monolithic component into a dedicated custom hook (`useSkillsDnD`) strictly separates presentation from side-effects, significantly improving component readability and reusability.
 **Action:** Continually hunt for "God useEffect" blocks handling disparate UI concerns (like file drop events) and encapsulate them inside specialized hooks.

--- a/src/features/assistant/SkillsEditor.tsx
+++ b/src/features/assistant/SkillsEditor.tsx
@@ -1,8 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getLogger } from '@/lib/logger';
-import { useDnDContext } from '@/context/DnDContext';
-import { importAssistantSkills } from '@/lib/backend/skills';
 import {
   Button,
   Card,
@@ -23,20 +20,16 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { RefreshCw, Copy, Trash2, Upload } from 'lucide-react';
-import { toast } from 'sonner';
 import { useEditor } from '@/context/EditorContext';
 import { Assistant } from '@/models/chat';
 import { useAssistantSkills } from './hooks/useAssistantSkills';
-
-const logger = getLogger('SkillsEditor');
+import { useSkillsDnD } from './hooks/useSkillsDnD';
 
 export default function SkillsEditor() {
   const { t } = useTranslation('common');
   const { draft } = useEditor<Assistant>();
-  const { subscribe } = useDnDContext();
   const cardRef = useRef<HTMLDivElement>(null);
 
-  const [isDragging, setIsDragging] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
 
   const {
@@ -51,45 +44,7 @@ export default function SkillsEditor() {
     confirmReset,
   } = useAssistantSkills();
 
-  // Subscribe to DnD events using the centralized context
-  useEffect(() => {
-    if (!draft?.id || !cardRef.current) return;
-
-    const unlisten = subscribe(
-      cardRef,
-      async (event, payload) => {
-        if (event === 'drag-over') {
-          setIsDragging(true);
-        } else if (event === 'leave') {
-          setIsDragging(false);
-        } else if (
-          event === 'drop' &&
-          payload.paths &&
-          payload.paths.length > 0
-        ) {
-          setIsDragging(false);
-          const filePath = payload.paths[0];
-          const toastId = toast.loading(t('skills.importing'));
-
-          try {
-            await importAssistantSkills(draft.id, filePath);
-            toast.success(t('skills.importSuccess'), { id: toastId });
-            fetchSkills();
-          } catch (error) {
-            logger.error('Failed to import skills:', error);
-            toast.error(`${t('skills.importFailed')}: ${error}`, {
-              id: toastId,
-            });
-          }
-        }
-      },
-      { priority: 1 }, // Higher priority to capture events
-    );
-
-    return () => {
-      unlisten();
-    };
-  }, [draft?.id, fetchSkills, subscribe, t]);
+  const { isDragging } = useSkillsDnD(draft?.id, cardRef, fetchSkills);
 
   const handleReset = () => {
     setShowResetDialog(true);

--- a/src/features/assistant/hooks/useSkillsDnD.ts
+++ b/src/features/assistant/hooks/useSkillsDnD.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getLogger } from '@/lib/logger';
+import { useDnDContext } from '@/context/DnDContext';
+import { importAssistantSkills } from '@/lib/backend/skills';
+import { toast } from 'sonner';
+
+const logger = getLogger('useSkillsDnD');
+
+export function useSkillsDnD(
+  draftId: string | undefined,
+  cardRef: React.RefObject<HTMLDivElement>,
+  fetchSkills: () => void,
+) {
+  const { t } = useTranslation('common');
+  const { subscribe } = useDnDContext();
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    if (!draftId || !cardRef.current) return;
+
+    const unlisten = subscribe(
+      cardRef,
+      async (event, payload) => {
+        if (event === 'drag-over') {
+          setIsDragging(true);
+        } else if (event === 'leave') {
+          setIsDragging(false);
+        } else if (
+          event === 'drop' &&
+          payload.paths &&
+          payload.paths.length > 0
+        ) {
+          setIsDragging(false);
+          const filePath = payload.paths[0];
+          const toastId = toast.loading(t('skills.importing'));
+
+          try {
+            await importAssistantSkills(draftId, filePath);
+            toast.success(t('skills.importSuccess'), { id: toastId });
+            fetchSkills();
+          } catch (error) {
+            logger.error('Failed to import skills:', error);
+            toast.error(`${t('skills.importFailed')}: ${error}`, {
+              id: toastId,
+            });
+          }
+        }
+      },
+      { priority: 1 }, // Higher priority to capture events
+    );
+
+    return () => {
+      unlisten();
+    };
+  }, [draftId, fetchSkills, subscribe, t, cardRef]);
+
+  return { isDragging };
+}

--- a/src/features/assistant/hooks/useSkillsDnD.ts
+++ b/src/features/assistant/hooks/useSkillsDnD.ts
@@ -23,27 +23,27 @@ export function useSkillsDnD(
       cardRef,
       async (event, payload) => {
         if (event === 'drag-over') {
-          setIsDragging(true);
+          if (payload.paths && payload.paths.length > 0) {
+            setIsDragging(true);
+          }
         } else if (event === 'leave') {
           setIsDragging(false);
-        } else if (
-          event === 'drop' &&
-          payload.paths &&
-          payload.paths.length > 0
-        ) {
+        } else if (event === 'drop') {
           setIsDragging(false);
-          const filePath = payload.paths[0];
-          const toastId = toast.loading(t('skills.importing'));
+          if (payload.paths && payload.paths.length > 0) {
+            const filePath = payload.paths[0];
+            const toastId = toast.loading(t('skills.importing'));
 
-          try {
-            await importAssistantSkills(draftId, filePath);
-            toast.success(t('skills.importSuccess'), { id: toastId });
-            fetchSkills();
-          } catch (error) {
-            logger.error('Failed to import skills:', error);
-            toast.error(`${t('skills.importFailed')}: ${error}`, {
-              id: toastId,
-            });
+            try {
+              await importAssistantSkills(draftId, filePath);
+              toast.success(t('skills.importSuccess'), { id: toastId });
+              fetchSkills();
+            } catch (error) {
+              logger.error('Failed to import skills:', error);
+              toast.error(`${t('skills.importFailed')}: ${error}`, {
+                id: toastId,
+              });
+            }
           }
         }
       },


### PR DESCRIPTION
🚫 **Eradicated**: 
- A "God `useEffect`" block within `SkillsEditor` that explicitly managed Drag-and-Drop (DnD) event subscription, file imports, state management (`isDragging`), and toaster notifications directly in the component body.

✨ **Woven**: 
- The Custom Hook Pattern via a new `useSkillsDnD` hook.
- It completely encapsulates the complex side effects, leaving `SkillsEditor` to focus solely on rendering UI and passing context.

📉 **Impact**: 
- Significantly reduces the complexity and prop-burden within `SkillsEditor`, cleanly separating event-driven side effects from presentation logic.

---
*PR created automatically by Jules for task [7634907826716458495](https://jules.google.com/task/7634907826716458495) started by @fritzprix*