### PR TITLE
🎨 Palette: Improve keyboard focus visibility for extension install button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,8 @@
 
 **Learning:** For Radix UI tooltips wrapping a trigger with `asChild`, ensuring `asChild` propagates the event up the DOM needs proper usage of Radix primitive, particularly combining `DropdownMenuTrigger` with `TooltipTrigger` on `Button`. Also `forwardRef` warnings show up if the inner button is not using forwardRef correctly, but in `SessionNotificationsBell` combining them with `asChild` creates refs warning if not nested correctly. `TooltipTrigger asChild` around `DropdownMenuTrigger asChild` is needed.
 **Action:** When nesting Tooltips around Radix `DropdownMenuTrigger`, ensure both have `asChild` property so the original `<Button>` element receives both tooltip and dropdown aria/ref properties.
+
+## 2026-03-22 - Missing Keyboard Focus on Container with Action Button
+
+**Learning:** When using `opacity-X group-hover:opacity-100` to fade in a section containing interactive controls (like a download/install button), keyboard users who tab to the button will not see the section fully opaque unless `group-focus-within:opacity-100` is also applied.
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` when the element contains focusable interactive children, ensuring they become fully visible upon receiving keyboard focus.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -115,7 +115,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
                 </p>
               </div>
               {!isInstalled && (
-                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 transition-opacity">
+                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <code className="text-[10px] bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">
                     {preset.command} {preset.args?.[0]}
                   </code>


### PR DESCRIPTION
💡 What
Added `group-focus-within:opacity-100` to the section containing the "Install extension" button in `RecommendedPresets.tsx`.
Logged a learning entry in `.jules/palette.md` for this accessibility pattern.

🎯 Why
Previously, the download command and install button were wrapped in an element with `opacity-60 group-hover:opacity-100`. While this works for mouse users hovering over the preset card, a keyboard user tabbing through the interface would move focus to the button but the section would remain somewhat transparent (opacity-60), failing to adequately highlight the interactive control. Adding `group-focus-within:opacity-100` ensures that whenever focus lands on a child control (like the install button), the entire section becomes fully opaque and readable.

📸 Before/After
*   **Before:** Tabbing to the "Install" button inside the Recommended Extensions grid leaves the button and command text at 60% opacity.
*   **After:** Tabbing to the "Install" button correctly shifts the opacity to 100%, offering clear visual feedback for keyboard users.

♿ Accessibility
Improves visual focus indication and contrast for keyboard-only and screen reader users navigating the Recommended Presets list.

---
*PR created automatically by Jules for task [9456091817083787371](https://jules.google.com/task/9456091817083787371) started by @fritzprix*