### PR TITLE
⚡ Bolt: Optimize minimum nextRunAt extraction in ScheduledTasksPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,7 @@
 
 **Learning:** Reusable formatter caches are often re-implemented in multiple component files instead of a centralized utility file, fragmenting the cache and increasing overall memory footprint.
 **Action:** When centralizing `Intl` formats in a `utils` file, ensure you support `locale` variations by storing instances in a `Map` within the central utility function, so that various localized formats can be safely cached and reused without recreating localized formatters locally in components.
+## 2024-05-27 - Redundant Sorting for Min/Max Extraction
+
+**Learning:** `ScheduledTasksPage` was calling `.filter().sort()` inside a loop during every render specifically to extract the minimum `nextRunAt` timestamp. This forced an unnecessary O(N log N) computation and allocated intermediate arrays just to find a single minimum value.
+**Action:** When extracting a minimum or maximum value from a list in a React render loop, use a single-pass `Array.prototype.reduce()` to explicitly calculate the value in O(N). Avoid using `.find()` unless upstream sorting is strictly guaranteed and explicitly intended for this purpose, and never redundantly sort with `.filter().sort()[0]`.

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -250,14 +250,17 @@ export function ScheduledTasksPage() {
                 const groupEnabledCount = group.tasks.filter(
                   (task) => task.enabled,
                 ).length;
-                const nextGroupRun =
-                  group.tasks
-                    .filter((task) => task.enabled && task.nextRunAt !== null)
-                    .sort((left, right) => {
-                      if (left.nextRunAt === null) return 1;
-                      if (right.nextRunAt === null) return -1;
-                      return left.nextRunAt - right.nextRunAt;
-                    })[0]?.nextRunAt ?? null;
+                // ⚡ Bolt: O(N) single-pass minimum calculation prevents redundant intermediate
+                // array allocation from .filter() and expensive O(N log N) .sort() on every render
+                const nextGroupRun = group.tasks.reduce<number | null>(
+                  (min, task) => {
+                    if (!task.enabled || task.nextRunAt === null) return min;
+                    return min === null || task.nextRunAt < min
+                      ? task.nextRunAt
+                      : min;
+                  },
+                  null,
+                );
 
                 return (
                   <Card key={group.key} className="gap-4 py-4">


### PR DESCRIPTION
💡 What: Replaced a `.filter(condition).sort(compare)[0]` operation with a single-pass `Array.prototype.reduce()` to find the minimum `nextRunAt` timestamp in `ScheduledTasksPage`.
🎯 Why: The original implementation had an O(N log N) time complexity and forced the allocation of an intermediate array via `.filter()` on every render cycle just to extract a single minimum value.
📊 Impact: Reduces time complexity from O(N log N) to O(N) and eliminates intermediate array allocations, reducing garbage collection pressure during renders.
🔬 Measurement: Verify via React Profiler that `ScheduledTasksPage` renders marginally faster, and that the calculated "Next group run" time remains correct across task groups.

---
*PR created automatically by Jules for task [14014219220419710441](https://jules.google.com/task/14014219220419710441) started by @fritzprix*