### PR TITLE
🕸️ Weaver: Refactor SessionHistoryPanel using Derived State & Adjusting State During Render

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -139,3 +139,6 @@
 - **AgentPlanningUpdates:** Extracted the complex Tauri event listener ('agent:event') and debouncing logic from a monolithic `useEffect` into the `useAgentMessageTrigger` custom hook.
 - Added strict filtering via `messageFilter` to trigger context updates only for successful tool-result messages by checking `message.role === 'tool'`, `message.tool_call_id`, `!message.error`, and `message.metadata?.toolError !== true`.
 - **Benefits:** Decoupled event subscription from component rendering logic, standardized event handling across the chat interface, and avoided refreshes from failed tool executions.
+## 2026-04-12 - [SessionHistoryPanel]
+**Learning:** When a user-overridable state needs to respond to prop changes (like default expansions based on filters), using the 'Adjusting State During Render' pattern correctly synchronizes state without breaking functional purity, while pure derived computation (like useMemo) handles strict dependency state (like selected IDs).
+**Action:** Always prefer 'Adjusting State During Render' over 'useEffect' for one-way syncs to avoid extra render cycles and action-effect chains.

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -65,12 +65,20 @@ export function SessionHistoryPanel({
   emptyStateSubtitle,
 }: SessionHistoryPanelProps) {
   const { t } = useTranslation('common');
-  const [selectedLineageId, setSelectedLineageId] = useState<string | null>(
+  const [selectedLineageIdState, setSelectedLineageId] = useState<string | null>(
     null,
   );
   const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(
     () => new Set(),
   );
+
+  const selectedLineageId = useMemo(() => {
+    if (!selectedLineageIdState) return null;
+    const stillExists = sessions.some(
+      (session) => session.lineageId === selectedLineageIdState,
+    );
+    return stillExists ? selectedLineageIdState : null;
+  }, [selectedLineageIdState, sessions]);
 
   const defaultHeading =
     heading ?? t('sessionHistory.defaultHeading', 'Recent Sessions');
@@ -132,19 +140,6 @@ export function SessionHistoryPanel({
     });
   }, [activeStatusFilter, deferredSearchQuery, segmentedSessions]);
 
-  useEffect(() => {
-    if (!selectedLineageId) {
-      return;
-    }
-
-    const stillExists = sessions.some(
-      (session) => session.lineageId === selectedLineageId,
-    );
-    if (!stillExists) {
-      setSelectedLineageId(null);
-    }
-  }, [selectedLineageId, sessions]);
-
   const descendantCounts = useMemo(
     () => buildDescendantCounts(sessions),
     [sessions],
@@ -185,17 +180,18 @@ export function SessionHistoryPanel({
     return expandedIds;
   }, [baseSessions, filtersActive, matchedSessions]);
 
-  useEffect(() => {
-    if (autoExpandedAncestorIds.size === 0) {
-      return;
-    }
+  const [prevAutoExpandedAncestorIds, setPrevAutoExpandedAncestorIds] = useState<Set<string>>(new Set());
 
-    setExpandedSessionIds((prev) => {
-      const next = new Set(prev);
-      autoExpandedAncestorIds.forEach((sessionId) => next.add(sessionId));
-      return next;
-    });
-  }, [autoExpandedAncestorIds]);
+  if (autoExpandedAncestorIds !== prevAutoExpandedAncestorIds) {
+    setPrevAutoExpandedAncestorIds(autoExpandedAncestorIds);
+    if (autoExpandedAncestorIds.size > 0) {
+      setExpandedSessionIds((prev) => {
+        const next = new Set(prev);
+        autoExpandedAncestorIds.forEach((sessionId) => next.add(sessionId));
+        return next;
+      });
+    }
+  }
 
   const displayRows = useMemo(() => {
     type SessionRow = {


### PR DESCRIPTION
### 🚫 Eradicated
- **Action-Effect Chains / Derived State:** The `useEffect` hook syncing `selectedLineageId` to `null` if a session is deleted, which caused an unnecessary second render.
- **Action-Effect Chains:** The `useEffect` hook syncing `autoExpandedAncestorIds` into the `expandedSessionIds` state, creating an inefficient double render cycle.

### ✨ Woven
- **Pure Derived State:** Dynamically calculated the `selectedLineageId` via `useMemo` based on session existence instead of syncing back `null` via an effect.
- **Adjusting State During Render:** Tracked `prevAutoExpandedAncestorIds` and updated `expandedSessionIds` strictly inside the render body when references change, eliminating the cascading effect loop while still allowing users to collapse auto-expanded folders.

### 📉 Impact
- Completely avoids two extra DOM reconciliation/rendering cycles on session modification or filter changes.
- Improves application performance and enforces proper Unidirectional Data Flow per React best practices.

---
*PR created automatically by Jules for task [12029997628639288151](https://jules.google.com/task/12029997628639288151) started by @fritzprix*