### PR TITLE
⚗️ Distill: Optimize MCP response for Agent tools

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -137,15 +137,15 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
 
     let mut results = Vec::new();
     let mut text_summary = format!("Found {} agent configurations.\n\n", total);
-    if !paged_agents.is_empty() {
-        text_summary.push_str("| Name | ID | Capabilities | Servers | Description |\n");
-        text_summary.push_str("|---|---|---|---|---|\n");
-    } else if total > 0 {
+    if total > 0 && paged_agents.is_empty() {
         text_summary.push_str(&format!(
             "No results for this page (offset {}, limit {}). Try a smaller offset.\n",
             offset, limit
         ));
     }
+
+    text_summary.push_str("| Name | ID | Capabilities | Servers | Description |\n");
+    text_summary.push_str("|---|---|---|---|---|\n");
 
     for agent in paged_agents {
         let config: Value = serde_json::from_str(&agent.config).unwrap_or_default();
@@ -242,30 +242,28 @@ async fn list_delegated_sessions(caller_session_id: &str) -> Result<MCPResult, S
     }
 
     let mut message = format!("Found {} sub-agent sessions.\n\n", results.len());
-    if !results.is_empty() {
-        message.push_str("| Name | Session ID | Status |\n");
-        message.push_str("|---|---|---|\n");
-        for result in &results {
-            let name_clean = result["name"]
-                .as_str()
-                .unwrap_or("")
-                .replace('|', "\\|")
-                .replace('\n', " ");
-            let id_clean = result["id"]
-                .as_str()
-                .unwrap_or("")
-                .replace('|', "\\|")
-                .replace('\n', " ");
-            let status_clean = result["status"]
-                .as_str()
-                .unwrap_or("")
-                .replace('|', "\\|")
-                .replace('\n', " ");
-            message.push_str(&format!(
-                "| {} | `{}` | {} |\n",
-                name_clean, id_clean, status_clean
-            ));
-        }
+    message.push_str("| Name | Session ID | Status |\n");
+    message.push_str("|---|---|---|\n");
+    for result in &results {
+        let name_clean = result["name"]
+            .as_str()
+            .unwrap_or("")
+            .replace('|', "\\|")
+            .replace('\n', " ");
+        let id_clean = result["id"]
+            .as_str()
+            .unwrap_or("")
+            .replace('|', "\\|")
+            .replace('\n', " ");
+        let status_clean = result["status"]
+            .as_str()
+            .unwrap_or("")
+            .replace('|', "\\|")
+            .replace('\n', " ");
+        message.push_str(&format!(
+            "| {} | `{}` | {} |\n",
+            name_clean, id_clean, status_clean
+        ));
     }
 
     let hint = SuccessHint::new(

--- a/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
@@ -45,7 +45,7 @@ pub async fn create_org(
         session.org_root_session_id.clone(),
     ) {
         let message = format!(
-            "Current session already owns explicit org '{}' (ID: {}, root session: {}).",
+            "Current session already owns explicit org '{}' (ID: `{}`, root session: `{}`).",
             existing_org_name, existing_org_id, existing_root_id
         );
         let mut response_data = build_agent_tool_data(
@@ -90,7 +90,7 @@ pub async fn create_org(
         .map_err(|error| format!("Failed to persist org identity: {}", error))?;
 
     let message = format!(
-        "Explicit org created.\n\nOrg: {} (ID: {})\nRoot session: {}\n\nOnly sessions created through spawnOrgAgent under this org will appear in Org view.",
+        "Explicit org created.\n\nOrg: {} (ID: `{}`)\nRoot session: `{}`\n\nOnly sessions created through spawnOrgAgent under this org will appear in Org view.",
         org_name, org_id, org_root_session_id
     );
     let mut response_data = build_agent_tool_data(
@@ -177,25 +177,37 @@ pub async fn get_org(
         .org_name
         .clone()
         .unwrap_or_else(|| target_org_id.clone());
-    let member_lines = members
-        .iter()
-        .map(|session| {
-            format!(
-                "- {} [{}] depth={} session={}",
-                session.name.clone().unwrap_or_else(|| session.id.clone()),
-                session.status.as_str(),
-                session.depth.unwrap_or(0),
-                session.id
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+
+    let mut member_lines =
+        String::from("| Name | Status | Depth | Session ID |\n|---|---|---|---|\n");
+    member_lines.push_str(
+        &members
+            .iter()
+            .map(|session| {
+                let name_clean = session
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| session.id.clone())
+                    .replace('|', "\\|")
+                    .replace('\n', " ");
+                format!(
+                    "| {} | {} | {} | `{}` |",
+                    name_clean,
+                    session.status.as_str(),
+                    session.depth.unwrap_or(0),
+                    session.id
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
     let busy_count = members
         .iter()
         .filter(|session| session.status == crate::repositories::SessionStatus::Busy)
         .count();
     let message = format!(
-        "Explicit org summary\n\nOrg: {} (ID: {})\nRoot session: {}\nMembers: {} (busy: {})\n\n{}",
+        "Explicit org summary\n\nOrg: {} (ID: `{}`)\nRoot session: `{}`\nMembers: {} (busy: {})\n\n{}",
         org_name,
         target_org_id,
         root_session.id,

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -244,7 +244,7 @@ pub async fn message_to_session(
     };
 
     let hint = SuccessHint::new(
-        format!("Message {} for session {}.", response.status, session_id),
+        format!("Message {} for session `{}`.", response.status, session_id),
         vec![format!(
             "Use checkSession(\"{}\", wait=true) to see the response.",
             session_id
@@ -300,7 +300,7 @@ pub async fn stop_session(
         .await
         .remove(&session_id);
 
-    let hint = SuccessHint::new(format!("Session {} stopped.", session_id), vec![]);
+    let hint = SuccessHint::new(format!("Session `{}` stopped.", session_id), vec![]);
     let message = hint.message.clone();
     let mut response_data = build_agent_tool_data(
         "stopSession",
@@ -399,12 +399,12 @@ pub async fn compact_session_context(
     if !triggered {
         let message = if let Some(record) = previous_record {
             format!(
-                "No new compaction was needed for session {}. Existing compact summary already covers {} -> {}.",
+                "No new compaction was needed for session `{}`. Existing compact summary already covers `{}` -> `{}`.",
                 session_id, record.from_id, record.to_id
             )
         } else {
             format!(
-                "No compaction was needed for session {}. There is not enough uncompacted history yet.",
+                "No compaction was needed for session `{}`. There is not enough uncompacted history yet.",
                 session_id
             )
         };
@@ -480,7 +480,7 @@ pub async fn compact_session_context(
         "compacted"
     };
     let message = format!(
-        "Session {} {}.\n\nCompaction boundary: {} -> {}\n\nCompact summary:\n{}",
+        "Session `{}` {}.\n\nCompaction boundary: `{}` -> `{}`\n\nCompact summary:\n{}",
         session_id,
         state_label,
         compact_record.from_id,


### PR DESCRIPTION
### 💡 What
Refactors the MCP tool responses in the `agent` namespace (`configs.rs`, `orgs.rs`, and `sessions.rs`) to use unconditional Markdown table formatting for lists of entities and wraps all internal IDs (`sessionId`, `orgId`, etc.) in explicit backticks.

### 🎯 Why
Raw bulleted lists or nested string formats cause token bloat and instability during LLM parsing. When IDs are returned without explicit quotation, the agent occasionally drops constraints or hallucinates when chaining tools. Dense Markdown tables are faster for LLMs to read and explicit backticks guarantee exact ID matching. Unconditionally adding table headers ensures structural stability even for empty result sets.

### 📉 Token Impact
- Improves parsing stability for tools returning collections (`list(configs)`, `list(sessions)`, `getOrg`).
- Reduces token variation across lists by ensuring a predictable header structure.

### 🛠️ Error Recovery
- Exact backtick quotation around IDs ensures that when an error occurs, the LLM will successfully retrieve and pass the correct identifier to subsequent recovery tools.

---
*PR created automatically by Jules for task [11922928001249422007](https://jules.google.com/task/11922928001249422007) started by @fritzprix*