### PR TITLE
Fix skill frontmatter BOM parsing

### DIFF
--- a/src-tauri/src/services/skill_service.rs
+++ b/src-tauri/src/services/skill_service.rs
@@ -264,6 +264,7 @@ pub fn parse_skill_metadata(path: &Path) -> Result<SkillMetadata, String> {
             e.to_string()
         }
     })?;
+    let content = content.strip_prefix('\u{feff}').unwrap_or(&content);
 
     // Simple frontmatter parsing
     if let Some(stripped) = content.strip_prefix("---") {

--- a/src-tauri/tests/skill_parsing_test.rs
+++ b/src-tauri/tests/skill_parsing_test.rs
@@ -24,6 +24,22 @@ description: A test skill
 }
 
 #[test]
+fn test_parse_skill_metadata_valid_with_utf8_bom() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("SKILL.md");
+    let mut file = fs::File::create(&file_path).unwrap();
+
+    let content =
+        "\u{feff}---\nname: BOM Skill\ndescription: A BOM-prefixed skill\n---\n# Content\n";
+    file.write_all(content.as_bytes()).unwrap();
+
+    let metadata = parse_skill_metadata(&file_path).unwrap();
+    assert_eq!(metadata.name, "BOM Skill");
+    assert_eq!(metadata.description, "A BOM-prefixed skill");
+    assert_eq!(metadata.path, file_path.to_string_lossy());
+}
+
+#[test]
 fn test_parse_skill_metadata_missing_frontmatter() {
     let temp_dir = TempDir::new().unwrap();
     let file_path = temp_dir.path().join("SKILL.md");
@@ -52,4 +68,18 @@ name: [Invalid YAML
     let result = parse_skill_metadata(&file_path);
     assert!(result.is_err());
     assert!(result.err().unwrap().contains("YAML parse error"));
+}
+
+#[test]
+fn test_parse_skill_metadata_rejects_leading_text_before_frontmatter() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("SKILL.md");
+    let mut file = fs::File::create(&file_path).unwrap();
+
+    let content = "Intro text\n---\nname: Test Skill\ndescription: A test skill\n---\n";
+    file.write_all(content.as_bytes()).unwrap();
+
+    let result = parse_skill_metadata(&file_path);
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap(), "No valid YAML frontmatter found");
 }


### PR DESCRIPTION
This pull request improves the robustness of the `parse_skill_metadata` function by handling UTF-8 BOM characters and adds new tests to ensure correct parsing behavior, especially for edge cases. The changes enhance both the reliability and test coverage of skill metadata parsing.

**Skill metadata parsing improvements:**

* Updated `parse_skill_metadata` in `skill_service.rs` to strip a leading UTF-8 BOM character (`\u{feff}`) from file content before parsing, preventing parsing errors when files contain a BOM.

**Test coverage enhancements:**

* Added a test to verify that skill metadata with a UTF-8 BOM is parsed correctly (`test_parse_skill_metadata_valid_with_utf8_bom`).
* Added a test to ensure that files with leading text before the frontmatter are rejected, confirming that only valid frontmatter at the start (or after BOM) is accepted (`test_parse_skill_metadata_rejects_leading_text_before_frontmatter`).