### PR TITLE
⚗️ Distill: Optimize MCP response for History

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3706,7 +3706,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/mcp/builtin/history/handlers.rs
+++ b/src-tauri/src/mcp/builtin/history/handlers.rs
@@ -530,7 +530,7 @@ fn render_message_content(content: &[MCPContent]) -> String {
                 "[resource from {}::{}]\n{}",
                 service_info.server_name,
                 service_info.tool_name,
-                serde_json::to_string_pretty(resource)
+                serde_json::to_string(resource)
                     .unwrap_or_else(|_| "[unserializable resource]".to_string())
             ),
         })
@@ -663,11 +663,12 @@ fn render_list_text(page: &Page<HistorySessionItem>) -> String {
         lines.push("No sessions matched the filters.".to_string());
     } else {
         lines.push(String::new());
-        lines.push("Sessions:".to_string());
+        lines.push("| Name | Session ID | Status | Messages | Updated At |".to_string());
+        lines.push("|---|---|---|---|---|".to_string());
         for session in &page.items {
             lines.push(format!(
-                "- {} (ID: {}) status={} messages={} updatedAt={}",
-                session.name.as_deref().unwrap_or("Unnamed session"),
+                "| {} | `{}` | {} | {} | {} |",
+                sanitize_markdown_table_cell(session.name.as_deref().unwrap_or("Unnamed session")),
                 session.session_id,
                 session.status,
                 session.message_count,
@@ -682,19 +683,15 @@ fn render_list_text(page: &Page<HistorySessionItem>) -> String {
 fn render_read_session_text(response: &HistorySessionReadResponse) -> String {
     let mut lines = vec![
         format!(
-            "Session {} ({}) has {} message(s). Showing page {} of {}.",
-            response
-                .session
-                .name
-                .as_deref()
-                .unwrap_or("Unnamed session"),
+            "Session {} (`{}`) has {} message(s). Showing page {} of {}.",
+            sanitize_markdown_table_cell(response.session.name.as_deref().unwrap_or("Unnamed session")),
             response.session.session_id,
             response.messages.total_items,
             response.messages.page,
             response.messages.total_pages
         ),
         format!(
-            "Status={} agentId={} lastMessageAt={}",
+            "Status={} agentId=`{}` lastMessageAt={}",
             response.session.status,
             response.session.agent_id.as_deref().unwrap_or("unknown"),
             response
@@ -709,15 +706,16 @@ fn render_read_session_text(response: &HistorySessionReadResponse) -> String {
         lines.push("This session has no messages on the requested page.".to_string());
     } else {
         lines.push(String::new());
-        lines.push("Messages:".to_string());
+        lines.push("| Message ID | Role | Created At | Length | Preview |".to_string());
+        lines.push("|---|---|---|---|---|".to_string());
         for message in &response.messages.items {
             lines.push(format!(
-                "- {} [{}] createdAt={} chars={}\n  Preview: {}",
+                "| `{}` | {} | {} | {} | {} |",
                 message.message_id,
                 message.role,
                 message.created_at,
                 message.content_length,
-                message.content_preview.replace('\n', " ")
+                sanitize_markdown_table_cell(&message.content_preview)
             ));
         }
     }
@@ -761,7 +759,8 @@ fn render_search_text(page: &Page<HistorySearchMatch>, caller_session_id: &str) 
         lines.push("No matches found for the requested filters.".to_string());
     } else {
         lines.push(String::new());
-        lines.push("Matches:".to_string());
+        lines.push("| Session ID | Locality | Message ID | Role | Score | Length | Snippet |".to_string());
+        lines.push("|---|---|---|---|---|---|---|".to_string());
         for item in &page.items {
             let locality = if item.session_id == caller_session_id {
                 "current-session"
@@ -769,17 +768,21 @@ fn render_search_text(page: &Page<HistorySearchMatch>, caller_session_id: &str) 
                 "other-session"
             };
             lines.push(format!(
-                "- session={} ({}) message={} [{}] score={:.3} chars={}\n  Snippet: {}",
+                "| `{}` | {} | `{}` | {} | {:.3} | {} | {} |",
                 item.session_id,
                 locality,
                 item.message_id,
                 item.role,
                 item.score,
                 item.content_length,
-                item.snippet.replace('\n', " ")
+                sanitize_markdown_table_cell(&item.snippet)
             ));
         }
     }
 
     lines.join("\n")
+}
+
+fn sanitize_markdown_table_cell(text: &str) -> String {
+    text.replace('|', "\\|").replace('\n', " ")
 }

--- a/src-tauri/src/mcp/builtin/history/handlers.rs
+++ b/src-tauri/src/mcp/builtin/history/handlers.rs
@@ -684,7 +684,13 @@ fn render_read_session_text(response: &HistorySessionReadResponse) -> String {
     let mut lines = vec![
         format!(
             "Session {} (`{}`) has {} message(s). Showing page {} of {}.",
-            sanitize_markdown_table_cell(response.session.name.as_deref().unwrap_or("Unnamed session")),
+            sanitize_markdown_table_cell(
+                response
+                    .session
+                    .name
+                    .as_deref()
+                    .unwrap_or("Unnamed session")
+            ),
             response.session.session_id,
             response.messages.total_items,
             response.messages.page,
@@ -759,7 +765,9 @@ fn render_search_text(page: &Page<HistorySearchMatch>, caller_session_id: &str) 
         lines.push("No matches found for the requested filters.".to_string());
     } else {
         lines.push(String::new());
-        lines.push("| Session ID | Locality | Message ID | Role | Score | Length | Snippet |".to_string());
+        lines.push(
+            "| Session ID | Locality | Message ID | Role | Score | Length | Snippet |".to_string(),
+        );
         lines.push("|---|---|---|---|---|---|---|".to_string());
         for item in &page.items {
             let locality = if item.session_id == caller_session_id {

--- a/src-tauri/tests/history_builtin_tests.rs
+++ b/src-tauri/tests/history_builtin_tests.rs
@@ -412,7 +412,7 @@ async fn history_search_returns_filtered_snippets() {
     let text = extract_text_content(&result);
     assert!(text.contains("history-message-a2"));
     assert!(!text.contains("history-message-b1"));
-    assert!(text.contains("session=history-session-a"));
+    assert!(text.contains("history-session-a"));
     assert!(text.contains("Use readSession(sessionId=\"...\")"));
     assert!(text.contains("Use readMessage(messageId=\"...\")"));
 


### PR DESCRIPTION
💡 **What**
Refactored the MCP output for the `history` builtin tools to return data formatted as Markdown tables. Added a `sanitize_markdown_table_cell` function to escape pipe characters (`|`) and convert newlines (`\n`) to spaces. Switched resource serialization from `serde_json::to_string_pretty` to `serde_json::to_string`. Explicitly quoted IDs with backticks.

🎯 **Why**
Markdown tables are read much faster and more reliably by the LLM context window than unstructured lists or excessively formatted JSON arrays. Highlighting the IDs explicitly guides the LLM to understand what keys must be extracted for chained tool calls, preventing hallucination. Changing JSON serialization from "pretty" to dense removes whitespace bloat, freeing up tokens.

📉 **Token Impact**
Significant decrease in tokens consumed by omitting unneeded list boilerplate and flattening large nested resource metadata into a single-line string instead of indented structures.

🛠️ **Error Recovery**
No error handling was changed as part of this PR. The change optimizes success responses primarily.

---
*PR created automatically by Jules for task [3060513113489178190](https://jules.google.com/task/3060513113489178190) started by @fritzprix*