### PR TITLE
🎨 Palette: Add tooltips to workspace panel actions

### DIFF
--- a/src/features/agent/components/AgentPlanningPanel.tsx
+++ b/src/features/agent/components/AgentPlanningPanel.tsx
@@ -35,7 +35,10 @@ export function AgentPlanningPanel() {
     [serviceContexts.scratchpad?.structuredState],
   );
   const completedTodos =
-    planningState?.todos.reduce((acc, todo) => (todo.checked ? acc + 1 : acc), 0) ?? 0;
+    planningState?.todos.reduce(
+      (acc, todo) => (todo.checked ? acc + 1 : acc),
+      0,
+    ) ?? 0;
   const totalTodos = planningState?.todos.length ?? 0;
   const scratchpadCount = scratchpadState?.items.length ?? 0;
   const progressPercent =

--- a/src/features/agent/components/AgentPlanningUpdates.tsx
+++ b/src/features/agent/components/AgentPlanningUpdates.tsx
@@ -103,7 +103,10 @@ function PlanningToastSummary({
       ? Math.max(todos.length - (lastVisibleIndex + 1), 0)
       : 0;
 
-  const completedTodos = todos.reduce((acc, todo) => (todo.checked ? acc + 1 : acc), 0);
+  const completedTodos = todos.reduce(
+    (acc, todo) => (todo.checked ? acc + 1 : acc),
+    0,
+  );
   const progressPercent =
     todos.length > 0 ? Math.round((completedTodos / todos.length) * 100) : 0;
 

--- a/src/features/agent/components/AgentWorkspacePanel.tsx
+++ b/src/features/agent/components/AgentWorkspacePanel.tsx
@@ -1,7 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import {
   Folder,
   RefreshCw,
@@ -265,6 +269,13 @@ export function AgentWorkspacePanel() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
+                      role={isOpeningNative ? 'button' : undefined}
+                      aria-label={
+                        isOpeningNative
+                          ? t('agent.workspace.openInExplorerAria')
+                          : undefined
+                      }
+                      aria-disabled={isOpeningNative ? 'true' : undefined}
                       tabIndex={isOpeningNative ? 0 : undefined}
                       className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-md"
                     >
@@ -285,12 +296,21 @@ export function AgentWorkspacePanel() {
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>
-                    {t('agent.workspace.openInExplorer')}
+                    {isOpeningNative
+                      ? t('agent.workspace.openingNative', 'Opening...')
+                      : t('agent.workspace.openInExplorer')}
                   </TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
+                      role={isOpeningNative ? 'button' : undefined}
+                      aria-label={
+                        isOpeningNative
+                          ? t('agent.workspace.openInTerminalAria')
+                          : undefined
+                      }
+                      aria-disabled={isOpeningNative ? 'true' : undefined}
                       tabIndex={isOpeningNative ? 0 : undefined}
                       className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-md"
                     >
@@ -311,7 +331,9 @@ export function AgentWorkspacePanel() {
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>
-                    {t('agent.workspace.openInTerminal')}
+                    {isOpeningNative
+                      ? t('agent.workspace.openingNative', 'Opening...')
+                      : t('agent.workspace.openInTerminal')}
                   </TooltipContent>
                 </Tooltip>
                 <Tooltip>

--- a/src/features/agent/components/AgentWorkspacePanel.tsx
+++ b/src/features/agent/components/AgentWorkspacePanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   Folder,
   RefreshCw,
@@ -261,48 +262,76 @@ export function AgentWorkspacePanel() {
                 <span>{t('agent.workspace.title')}</span>
               </div>
               <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleOpenInExplorer}
-                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-                  title={t('agent.workspace.openInExplorer')}
-                  aria-label={t('agent.workspace.openInExplorerAria')}
-                  disabled={isOpeningNative}
-                >
-                  {isOpeningNative ? (
-                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  ) : (
-                    <Folder className="w-3.5 h-3.5" />
-                  )}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleOpenInTerminal}
-                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-                  title={t('agent.workspace.openInTerminal')}
-                  aria-label={t('agent.workspace.openInTerminalAria')}
-                  disabled={isOpeningNative}
-                >
-                  {isOpeningNative ? (
-                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  ) : (
-                    <Terminal className="w-3.5 h-3.5" />
-                  )}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => loadDirectory(rootPath)}
-                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-                  title={t('agent.workspace.refresh')}
-                  aria-label={t('agent.workspace.refreshAria')}
-                >
-                  <RefreshCw
-                    className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
-                  />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      tabIndex={isOpeningNative ? 0 : undefined}
+                      className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-md"
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleOpenInExplorer}
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                        aria-label={t('agent.workspace.openInExplorerAria')}
+                        disabled={isOpeningNative}
+                      >
+                        {isOpeningNative ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <Folder className="w-3.5 h-3.5" />
+                        )}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t('agent.workspace.openInExplorer')}
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      tabIndex={isOpeningNative ? 0 : undefined}
+                      className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-md"
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleOpenInTerminal}
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                        aria-label={t('agent.workspace.openInTerminalAria')}
+                        disabled={isOpeningNative}
+                      >
+                        {isOpeningNative ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <Terminal className="w-3.5 h-3.5" />
+                        )}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t('agent.workspace.openInTerminal')}
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => loadDirectory(rootPath)}
+                      className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                      aria-label={t('agent.workspace.refreshAria')}
+                    >
+                      <RefreshCw
+                        className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
+                      />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t('agent.workspace.refresh')}
+                  </TooltipContent>
+                </Tooltip>
               </div>
             </div>
 

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -401,7 +401,11 @@ export function SessionHistoryPanel({
             <TabsTrigger value="bookmarked" className="flex-1">
               <Bookmark className="mr-1.5 h-3.5 w-3.5" />
               {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} (
-              {baseSessions.reduce((acc, session) => (session.isBookmarked ? acc + 1 : acc), 0)})
+              {baseSessions.reduce(
+                (acc, session) => (session.isBookmarked ? acc + 1 : acc),
+                0,
+              )}
+              )
             </TabsTrigger>
           </TabsList>
         </Tabs>

--- a/src/features/agent/components/__tests__/AgentWorkspacePanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentWorkspacePanel.test.tsx
@@ -349,4 +349,52 @@ describe('AgentWorkspacePanel', () => {
 
     expect(backend.setWorkspaceOverride).not.toHaveBeenCalled();
   });
+
+  it('provides accessible focus targets for disabled action buttons during native opening', async () => {
+    // Keep the native opening pending
+    let resolveOpening: () => void;
+    const openingPromise = new Promise<void>((resolve) => {
+      resolveOpening = resolve;
+    });
+    vi.mocked(backend.openWorkspaceInExplorer).mockReturnValue(openingPromise);
+
+    render(<AgentWorkspacePanel />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('agent.workspace.title').length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    const explorerButton = screen.getByLabelText(
+      'agent.workspace.openInExplorerAria',
+    );
+
+    // Trigger the opening
+    await act(async () => {
+      fireEvent.click(explorerButton);
+    });
+
+    // Button should be disabled
+    expect(explorerButton).toBeDisabled();
+
+    // The wrapper span should now be focusable and have accessibility labels
+    // We look for role="button" and the specific aria-label on the span
+    const wrappers = screen.getAllByRole('button', {
+      name: 'agent.workspace.openInExplorerAria',
+    });
+    // One is the disabled button, the other is the focusable span wrapper
+    const focusableWrapper = wrappers.find(
+      (el) => el.tagName.toLowerCase() === 'span',
+    );
+
+    expect(focusableWrapper).toBeInTheDocument();
+    expect(focusableWrapper).toHaveAttribute('tabIndex', '0');
+    expect(focusableWrapper).toHaveAttribute('aria-disabled', 'true');
+
+    // Clean up
+    await act(async () => {
+      resolveOpening!();
+    });
+  });
 });

--- a/src/features/history/org-sessions.ts
+++ b/src/features/history/org-sessions.ts
@@ -75,7 +75,10 @@ export function selectOrgSummaries(sessions: AgentSession[]): OrgSummary[] {
         return left.createdAt.getTime() - right.createdAt.getTime();
       }),
       memberCount: members.length,
-      busyCount: members.reduce((acc, session) => (session.status === 'busy' ? acc + 1 : acc), 0),
+      busyCount: members.reduce(
+        (acc, session) => (session.status === 'busy' ? acc + 1 : acc),
+        0,
+      ),
       updatedAt,
     });
   }

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -158,7 +158,10 @@ export function ScheduledTasksPage() {
     [tasks],
   );
 
-  const enabledTaskCount = tasks.reduce((acc, task) => (task.enabled ? acc + 1 : acc), 0);
+  const enabledTaskCount = tasks.reduce(
+    (acc, task) => (task.enabled ? acc + 1 : acc),
+    0,
+  );
 
   if (loading) {
     return (

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -523,7 +523,10 @@ export async function prepareMessagesForLLM(
     0,
   );
 
-  const errorMessageCount = messages.reduce((acc, msg) => (msg.error ? acc + 1 : acc), 0);
+  const errorMessageCount = messages.reduce(
+    (acc, msg) => (msg.error ? acc + 1 : acc),
+    0,
+  );
 
   if (attachmentCount > 0 || errorMessageCount > 0) {
     logger.info('Processed messages for LLM', {

--- a/src/models/planning.ts
+++ b/src/models/planning.ts
@@ -70,7 +70,10 @@ export function calculatePlanningMetadata(
   }
 
   const totalTodos = state.todos.length;
-  const completedTodos = state.todos.reduce((acc, t) => (t.checked ? acc + 1 : acc), 0);
+  const completedTodos = state.todos.reduce(
+    (acc, t) => (t.checked ? acc + 1 : acc),
+    0,
+  );
   const activeTodos = totalTodos - completedTodos;
 
   return {


### PR DESCRIPTION
### 💡 What
Replaced native `title` attributes on the "Open in Explorer", "Open in Terminal", and "Refresh" buttons in the Agent Workspace Panel header with Radix UI `Tooltip` components.

### 🎯 Why
Native tooltips (via `title`) are notoriously inconsistent across browsers and operating systems, often having poor accessibility and long delay times. Custom tooltips using the design system's `Tooltip` component provide immediate, styled visual feedback that aligns with the rest of the application interface, improving micro-interactions.

### 📸 Before/After
**Before:** Hovering over the workspace action buttons relied on the browser's native, unstyled tooltip. Disabled buttons offered no tooltip for keyboard users.
**After:** Hovering or focusing now displays the styled, app-consistent Radix UI tooltips. Disabled buttons (e.g., when opening a directory natively) correctly retain tooltips for all users.

### ♿ Accessibility
The modification thoughtfully addressed keyboard accessibility for disabled interactive elements. Disabled `<button>` elements do not fire native mouse or focus events. To ensure keyboard users can read the tooltips even when disabled (to know *why* they can't click them), the buttons were wrapped in a conditional `span` container that is focusable via tab (`tabIndex={isOpeningNative ? 0 : undefined}`) and appropriately styled with `focus-visible` outline rings.

---
*PR created automatically by Jules for task [8720165149541602090](https://jules.google.com/task/8720165149541602090) started by @fritzprix*