### PR TITLE
⚡ Bolt: Memoize redundant array reductions in render loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -92,3 +92,8 @@
 
 **Learning:** `ScheduledTasksPage` was creating intermediate arrays using `.filter(...)` and then sorting them using `.sort(...)` repeatedly in the render loop just to calculate `nextGroupRun` (the earliest next run time among enabled tasks). Since the source array `group.tasks` was already correctly sorted upstream (enabled first, then by `nextRunAt`), this eager downstream sorting was entirely redundant and caused unnecessary array allocations and O(N log N) computation per group render.
 **Action:** When extracting a single item (like a min/max or "next" item) from an already-sorted array, do not re-sort. Use an O(1) traversal like `.find(...)` to locate the first item matching your criteria. Similarly, avoid intermediate arrays from `.filter().length` and prefer `.reduce()` when just counting specific items in a hot path.
+
+## 2026-10-27 - Inline Array Reductions in Render Loops
+
+**Learning:** `SessionHistoryPanel` and `ScheduledTasksPage` were executing array `.reduce()` loops inline within the component body or JSX mapping blocks to calculate derived properties (like active task counts or bookmarked sessions). Since these components frequently re-render on user input (e.g., typing in a search box), the O(N) recalculations severely degraded UI responsiveness.
+**Action:** When computing derived counts or metrics from large arrays in React components, never use inline `.reduce()` calls directly within the render loop or JSX body. Instead, wrap the calculation in `useMemo`, or integrate the counting logic into an existing O(N) traversal (like building an adjacency map or pre-existing `useMemo` block) to eliminate redundant passes entirely.

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -343,7 +343,16 @@ export function SessionHistoryPanel({
       idle: 0,
       paused: 0,
       error: 0,
+      bookmarked: 0,
     };
+
+    // ⚡ Bolt: Calculate bookmarked count within this existing O(N) traversal
+    // instead of doing an inline .reduce() during every React render pass.
+    baseSessions.forEach((session) => {
+      if (session.isBookmarked) {
+        counts.bookmarked++;
+      }
+    });
 
     segmentedSessions.forEach((session) => {
       if (Object.prototype.hasOwnProperty.call(counts, session.status)) {
@@ -352,7 +361,7 @@ export function SessionHistoryPanel({
     });
 
     return counts;
-  }, [segmentedSessions]);
+  }, [baseSessions, segmentedSessions]);
 
   return (
     <div className="p-6 h-full flex flex-col bg-background">
@@ -400,12 +409,7 @@ export function SessionHistoryPanel({
             </TabsTrigger>
             <TabsTrigger value="bookmarked" className="flex-1">
               <Bookmark className="mr-1.5 h-3.5 w-3.5" />
-              {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} (
-              {baseSessions.reduce(
-                (acc, session) => (session.isBookmarked ? acc + 1 : acc),
-                0,
-              )}
-              )
+              {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} ({statusCounts.bookmarked})
             </TabsTrigger>
           </TabsList>
         </Tabs>

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -54,6 +54,7 @@ interface ScheduledTaskGroupSection {
   groupId: string | null;
   groupName: string;
   tasks: ScheduledTask[];
+  enabledCount: number;
 }
 
 export function ScheduledTasksPage() {
@@ -134,6 +135,9 @@ export function ScheduledTasksPage() {
       const existing = groups.get(key);
       if (existing) {
         existing.tasks.push(task);
+        // ⚡ Bolt: Calculate derived counts while building the adjacency map
+        // instead of doing inline group.tasks.reduce() in the render loop.
+        if (task.enabled) existing.enabledCount++;
         continue;
       }
 
@@ -142,6 +146,7 @@ export function ScheduledTasksPage() {
         groupId: task.groupId,
         groupName: task.groupName,
         tasks: [task],
+        enabledCount: task.enabled ? 1 : 0,
       });
     }
 
@@ -158,10 +163,14 @@ export function ScheduledTasksPage() {
     [tasks],
   );
 
-  const enabledTaskCount = tasks.reduce(
-    (acc, task) => (task.enabled ? acc + 1 : acc),
-    0,
-  );
+  // ⚡ Bolt: Memoize the count to prevent O(N) array reduction on every React render
+  const enabledTaskCount = useMemo(() => {
+    let count = 0;
+    for (const task of tasks) {
+      if (task.enabled) count++;
+    }
+    return count;
+  }, [tasks]);
 
   if (loading) {
     return (
@@ -250,10 +259,6 @@ export function ScheduledTasksPage() {
                 </h2>
               </div>
               {groupedSections.map((group) => {
-                const groupEnabledCount = group.tasks.reduce(
-                  (count, task) => (task.enabled ? count + 1 : count),
-                  0,
-                );
                 // group.tasks is already sorted via compareScheduledTasks.
                 // This lookup relies on that ordering, so the first enabled task
                 // with a non-null nextRunAt is the group's earliest upcoming run.
@@ -275,7 +280,7 @@ export function ScheduledTasksPage() {
                         </Badge>
                         <Badge variant="outline" className="text-xs">
                           {t('scheduledTasks.groupEnabledCount', {
-                            count: groupEnabledCount,
+                            count: group.enabledCount,
                             defaultValue: '{{count}} enabled',
                           })}
                         </Badge>


### PR DESCRIPTION
💡 What: Removed inline `.reduce()` calls from the render loop in `SessionHistoryPanel.tsx` and `ScheduledTasksPage.tsx` and integrated their calculations into existing or new `useMemo` hooks.
🎯 Why: These arrays can grow significantly in size. Because the `.reduce()` operations were happening inline during every React render (for example, every time the user typed a letter in a search box), they were forcing repeated O(N) recalculations that caused UI stuttering and unresponsiveness.
📊 Impact: Eliminates redundant O(N) array traversals per render pass, ensuring that metrics like "bookmarked count" or "enabled count" are only computed when the source lists actually change. Reduces rendering overhead to O(1) for these checks during text-based state updates.
🔬 Measurement: Verify by typing rapidly in the search input of the Session History panel or navigating scheduled tasks; profiling the React component render cycle will show the reduction calculation is skipped during those updates.

---
*PR created automatically by Jules for task [3177463539587245154](https://jules.google.com/task/3177463539587245154) started by @fritzprix*