### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in present_interactive UI templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -63,3 +63,7 @@
 **Vulnerability:** SQL injection vulnerability in `database_backup.rs` where the backup file path was directly interpolated into a `VACUUM INTO '{path}'` SQL string without escaping single quotes.
 **Learning:** `VACUUM INTO` requires a string literal and cannot be parameterized with standard placeholder bindings (like `?`). Standard interpolation (`format!`) without sanitization allows breaking out of the string literal if the path contains single quotes, leading to syntax errors or potentially arbitrary SQL execution on SQLite databases.
 **Prevention:** Always manually escape single quotes by replacing them with two single quotes (`''`) when dynamically constructing paths for statements like `VACUUM INTO` that cannot use standard query parameters.
+## 2025-02-27 - Cross-Site Scripting (XSS) in UI Interactions
+**Vulnerability:** XSS via unescaped URL parameter in the `present_interactive` MCP tool's markdown parser.
+**Learning:** Checking for safe URL schemes (like `https:` or `mailto:`) is not enough to prevent XSS if the URL itself is not properly escaped before being embedded into an HTML attribute. An attacker can break out of the `href` attribute by providing double quotes and injecting event handlers (e.g., `onmouseover`).
+**Prevention:** Always ensure that dynamically generated URLs are properly escaped, especially double quotes (`"`), before inserting them into HTML attributes, even after verifying their schemes.

--- a/src-tauri/src/mcp/builtin/ui/templates/present-interactive.hbs
+++ b/src-tauri/src/mcp/builtin/ui/templates/present-interactive.hbs
@@ -224,7 +224,7 @@
                   .replace(/\*([^*]+)\*/g, '<em>$1</em>')
                   .replace(/_([^_]+)_/g, '<em>$1</em>')
                   .replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(_, text, url) {
-                    var safe = /^(https?:|mailto:|#)/.test(url.trim()) ? url : '#';
+                    var safe = /^(https?:|mailto:|#)/.test(url.trim()) ? url.trim().replace(/"/g, '&quot;') : '#';
                     return '<a href="' + safe + '" target="_blank" rel="noopener">' + text + '</a>';
                   });
               }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) vulnerability in the `present_interactive` MCP tool's markdown parser. The template validated URL protocols but did not escape double quotes, allowing attackers to break out of the `<a href=" ">` attribute and inject event handlers.
🎯 Impact: An attacker could execute arbitrary JavaScript within the application context if a malicious link is provided in the markdown content.
🔧 Fix: Updated the `safe` URL assignment in the `parseInline` function within `src-tauri/src/mcp/builtin/ui/templates/present-interactive.hbs` to use `.replace(/"/g, '&quot;')`, ensuring double quotes are correctly escaped.
✅ Verification: Tested manually with a mock script demonstrating the injection and verified the mitigation successfully neutralizes the attack. Ran all frontend tests and the backend tests targeting the UI module to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [13935055231939925418](https://jules.google.com/task/13935055231939925418) started by @fritzprix*