### PR TITLE
feat: unify workspace editFile contract

### DIFF
--- a/docs/specs/workspace.md
+++ b/docs/specs/workspace.md
@@ -68,5 +68,5 @@ Atomic file creation and overwriting with strict safety controls.
 
 ## Legacy/Related Tools
 
-- `editFile`: Use for targeted replacements (safer than overwriting).
+- `editFile`: Use for targeted replacements, insertions, and deletions. The `edits[]` item contract is op-specific and schema-defined.
 - `deleteFile`: Destructive removal.

--- a/docs/specs/workspace.md
+++ b/docs/specs/workspace.md
@@ -68,5 +68,6 @@ Atomic file creation and overwriting with strict safety controls.
 
 ## Legacy/Related Tools
 
-- `editFile`: Use for targeted replacements, insertions, and deletions. The `edits[]` item contract is op-specific and schema-defined.
+- `editFiles`: Use for targeted replacements, insertions, and deletions across one or more files. Each `edits[]` item includes its own `path`, and the contract remains op-specific and schema-defined.
+- `editFile`: Legacy single-file compatibility alias that normalizes into `editFiles`.
 - `deleteFile`: Destructive removal.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -650,6 +650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +756,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1814,6 +1826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3586,6 +3639,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex 0.16.2",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +3810,7 @@ dependencies = [
  "html-escape",
  "html2md",
  "ignore",
+ "jsonschema",
  "keyring",
  "libsqlite3-sys",
  "log",
@@ -4354,6 +4435,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -5035,6 +5122,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -6162,6 +6255,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,6 +6358,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -8451,7 +8559,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bstr",
- "fancy-regex",
+ "fancy-regex 0.12.0",
  "lazy_static",
  "parking_lot",
  "rustc-hash 1.1.0",
@@ -9196,6 +9304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9229,6 +9348,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,7 @@ dirs = "5.0"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 handlebars = "6.4"
 ammonia = "4.0"
+jsonschema = "0.33"
 
 # Windows-only: decode process output captured from stdio pipes using the system ANSI code page
 windows-sys = { version = "0.59", features = ["Win32_Globalization"] }

--- a/src-tauri/bundled_skills/playbook-creator/references/workflow-patterns.md
+++ b/src-tauri/bundled_skills/playbook-creator/references/workflow-patterns.md
@@ -30,7 +30,7 @@ Use these patterns to design robust, reusable workflows.
 1. **Implementation**: `workspace__writeFile` to create code. (output: `feature_code`)
 2. **Testing**: `workspace__runPowerShell` to execute tests. (output: `test_output`)
 3. **Analysis**: Use `test_output` to identify failures.
-4. **Fix**: `workspace__editFile` to correct errors based on analysis.
+4. **Fix**: `workspace__editFiles` to correct errors based on analysis.
 5. **Verification**: `workspace__runPowerShell` to re-run tests.
 
 ---
@@ -55,4 +55,4 @@ Use these patterns to design robust, reusable workflows.
 1. **Granularity**: Break steps into atomic actions. Don't "Read, Analyze, and Write" in one step.
 2. **Robustness**: Use `requiredData` to ensure steps only run when previous dependencies are met.
 3. **Traceability**: Give `outputVariable` names that clearly describe the data they hold (e.g., `config_json`, `search_results`).
-4. **Tool Appropriateness**: Use the right tool for the job. Use `runPowerShell` for complex shell logic and `editFile` for precise code modifications.
+4. **Tool Appropriateness**: Use the right tool for the job. Use `runPowerShell` for complex shell logic and `editFiles` for precise code modifications.

--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -659,7 +659,7 @@ pub async fn handle_llm_response(
 
         // Execute tool calls
         // 🔥 CRITICAL CHANGE: Execute tools SEQUENTIALLY to prevent race conditions
-        // (e.g., writeFile followed by editFile on the same file)
+        // (e.g., writeFile followed by editFiles on the same file)
         let session_repo_clone = session_repo.clone();
         let active_sessions_clone = active_sessions.clone();
         let app_handle_clone = app_handle.clone();

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -784,7 +784,7 @@ mod tests {
     use crate::mcp::types::MCPContent;
 
     /// Regression: builtin tools that return is_error=true WITH mcp_content
-    /// (e.g. guided_error from editFile) must surface that content to the
+    /// (e.g. guided_error from editFiles) must surface that content to the
     /// agent — NOT collapse it to the bare "Unknown error" fallback.
     ///
     /// Root cause was that handle_tool_result only checked `result.is_error` and

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -417,8 +417,7 @@ impl SuccessHint {
             ],
             ("readFile", ToolGroup::Workspace) => vec![
                 "Use writeFile to modify the content".to_string(),
-                "Use replaceLines, insertAfterLine, or deleteLines to make targeted edits"
-                    .to_string(),
+                "Use editFiles to make targeted edits".to_string(),
             ],
             ("listDirectory", ToolGroup::Workspace) => vec![
                 "Use readFile to view file contents".to_string(),
@@ -426,7 +425,7 @@ impl SuccessHint {
                 "Use search with filePattern to narrow down names".to_string(),
             ],
             (
-                "editFile" | "replaceLines" | "insertAfterLine" | "deleteLines",
+                "editFiles" | "editFile" | "replaceLines" | "insertAfterLine" | "deleteLines",
                 ToolGroup::Workspace,
             ) => vec![
                 "Use readFile to verify your edits".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
@@ -1,3 +1,4 @@
+use super::super::tools::file_tools::create_edit_file_input_schema;
 use super::super::WorkspaceServer;
 use super::utils::{
     compute_line_hash, format_hashline, format_prefix_hash, initial_prefix_hash_state,
@@ -7,7 +8,7 @@ use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, ErrorCategory, SuccessHint, ToolGroup,
 };
 use crate::mcp::types::MCPResult;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 /// A single edit operation.
 #[derive(Debug, Clone)]
@@ -34,6 +35,149 @@ fn requires_existing_line_anchor(edit: &LineEdit) -> bool {
 fn requires_end_hash(edit: &LineEdit) -> bool {
     matches!(edit.action, EditAction::Replace | EditAction::Delete)
         && edit.end_line > edit.start_line
+}
+
+fn normalize_edit_op_value(value: &str) -> String {
+    match value {
+        "replace" | "REPLACE" => "replace".to_string(),
+        "insert_after" | "INSERT_AFTER" => "insert_after".to_string(),
+        "delete" | "DELETE" => "delete".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn infer_legacy_edit_op(edit_obj: &Map<String, Value>) -> Option<&'static str> {
+    if edit_obj
+        .get("insertAfter")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        Some("insert_after")
+    } else if let Some(v) = edit_obj.get("new_value") {
+        if v.as_str() == Some("") {
+            Some("delete")
+        } else {
+            Some("replace")
+        }
+    } else {
+        None
+    }
+}
+
+fn canonicalize_edit_object(edit: &Value) -> Value {
+    let Some(edit_obj) = edit.as_object() else {
+        return edit.clone();
+    };
+
+    let mut canonical = Map::new();
+
+    for (key, value) in edit_obj {
+        match key.as_str() {
+            "op" => {
+                if value.is_null() {
+                    continue;
+                }
+                if let Some(op) = value.as_str() {
+                    canonical.insert("op".to_string(), Value::String(normalize_edit_op_value(op)));
+                } else {
+                    canonical.insert("op".to_string(), value.clone());
+                }
+            }
+            "action" => {
+                if value.is_null() {
+                    continue;
+                }
+                if !canonical.contains_key("op") {
+                    if let Some(op) = value.as_str() {
+                        canonical
+                            .insert("op".to_string(), Value::String(normalize_edit_op_value(op)));
+                    } else {
+                        canonical.insert("op".to_string(), value.clone());
+                    }
+                }
+            }
+            "line" | "startLine" | "afterLine" => {
+                if !value.is_null() {
+                    canonical.insert("startLine".to_string(), value.clone());
+                }
+            }
+            "endLine" => {
+                if !value.is_null() {
+                    canonical.insert("endLine".to_string(), value.clone());
+                }
+            }
+            "anchor" | "startAnchor" => {
+                if !value.is_null() {
+                    canonical.insert("startAnchor".to_string(), value.clone());
+                }
+            }
+            "endAnchor" => {
+                if !value.is_null() {
+                    canonical.insert("endAnchor".to_string(), value.clone());
+                }
+            }
+            "new_value" | "content" => {
+                if !value.is_null() {
+                    canonical.insert("content".to_string(), value.clone());
+                }
+            }
+            _ => {
+                canonical.insert(key.clone(), value.clone());
+            }
+        }
+    }
+
+    if !canonical.contains_key("op") {
+        if let Some(inferred_op) = infer_legacy_edit_op(edit_obj) {
+            canonical.insert("op".to_string(), Value::String(inferred_op.to_string()));
+        }
+    }
+
+    Value::Object(canonical)
+}
+
+fn canonicalize_edit_file_args(args: &Value) -> Value {
+    let Some(args_obj) = args.as_object() else {
+        return args.clone();
+    };
+
+    let mut canonical = Map::new();
+
+    for (key, value) in args_obj {
+        if key == "edits" {
+            if let Some(edits) = value.as_array() {
+                canonical.insert(
+                    "edits".to_string(),
+                    Value::Array(edits.iter().map(canonicalize_edit_object).collect()),
+                );
+            } else {
+                canonical.insert("edits".to_string(), value.clone());
+            }
+        } else {
+            canonical.insert(key.clone(), value.clone());
+        }
+    }
+
+    Value::Object(canonical)
+}
+
+fn validate_edit_file_arguments(args: &Value) -> Result<(), String> {
+    let schema_json = serde_json::to_value(create_edit_file_input_schema())
+        .map_err(|error| format!("Failed to serialize editFile schema: {error}"))?;
+    let validator = jsonschema::validator_for(&schema_json)
+        .map_err(|error| format!("Failed to build editFile validator: {error}"))?;
+
+    let errors = validator
+        .iter_errors(args)
+        .take(3)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
 }
 
 /// Pure apply function — applies sorted edits (high → low) to a slice of lines.
@@ -193,13 +337,32 @@ impl WorkspaceServer {
         args: Value,
         session_id: Option<String>,
     ) -> Result<MCPResult, String> {
+        let canonical_args = canonicalize_edit_file_args(&args);
+
+        if let Err(validation_error) = validate_edit_file_arguments(&canonical_args) {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "editFile arguments do not match the declared schema: {validation_error}"
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Replace: [{\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
+                "Insert top: [{\"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
+                "Delete range: [{\"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
         // --- Parameter extraction ---
-        let path_str = match args.get("path").and_then(|v| v.as_str()) {
+        let path_str = match canonical_args.get("path").and_then(|v| v.as_str()) {
             Some(p) => p,
             None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
         };
 
-        let edits_array = match args.get("edits").and_then(|v| v.as_array()) {
+        let edits_array = match canonical_args.get("edits").and_then(|v| v.as_array()) {
             Some(arr) => arr,
             None => {
                 return Ok(guided_error(
@@ -208,9 +371,9 @@ impl WorkspaceServer {
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
-                    "Replace:      [{\"line\": 10, \"action\": \"REPLACE\", \"new_value\": \"text\"}]".to_string(),
-                    "Insert-top:   [{\"line\": 0, \"action\": \"INSERT_AFTER\", \"new_value\": \"header\"}]".to_string(),
-                    "Delete range: [{\"line\": 10, \"endLine\": 15, \"action\": \"DELETE\", \"anchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                    "Replace:      [{\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
+                    "Insert-top:   [{\"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
+                    "Delete range: [{\"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
                     "Use readFile(showLineAnchors=true) to get anchor values first".to_string(),
                 ])
                 .to_mcp_result());
@@ -240,66 +403,49 @@ impl WorkspaceServer {
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
-                        "Single-line: {\"line\": 10, \"new_value\": \"text\"}".to_string(),
-                        "Range:       {\"line\": 10, \"endLine\": 15, \"new_value\": \"...\"}"
+                        "Single-line: {\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
+                        "Range:       {\"op\": \"replace\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}"
                             .to_string(),
                     ])
                     .to_mcp_result());
                 }
             };
 
-            // `action` — REPLACE, INSERT_AFTER, DELETE
-            let action_str = edit_obj.get("action").and_then(|v| v.as_str());
-            let action = match action_str {
-                Some("REPLACE") => EditAction::Replace,
-                Some("INSERT_AFTER") => EditAction::InsertAfter,
-                Some("DELETE") => EditAction::Delete,
+            let op_str = edit_obj.get("op").and_then(|v| v.as_str());
+            let action = match op_str {
+                Some("replace") => EditAction::Replace,
+                Some("insert_after") => EditAction::InsertAfter,
+                Some("delete") => EditAction::Delete,
                 Some(other) => {
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
-                        format!("Edit at index {}: invalid action '{}'", idx, other),
+                        format!("Edit at index {}: invalid op '{}'", idx, other),
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
-                        "Supported actions: REPLACE, INSERT_AFTER, DELETE".to_string()
+                        "Supported ops: replace, insert_after, delete".to_string()
                     ])
                     .to_mcp_result());
                 }
                 None => {
-                    // Legacy/Implicit detection
-                    if edit_obj
-                        .get("insertAfter")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false)
-                    {
-                        EditAction::InsertAfter
-                    } else if let Some(v) = edit_obj.get("new_value") {
-                        if v.as_str() == Some("") {
-                            EditAction::Delete
-                        } else {
-                            EditAction::Replace
-                        }
-                    } else {
-                        EditAction::Replace // Default
-                    }
+                    return Ok(missing_param_error("op", ToolGroup::Workspace));
                 }
             };
 
-            // `line` — start line (1-based, except line: 0 for INSERT_AFTER)
-            let start_line = match edit_obj.get("line").and_then(|v| v.as_u64()) {
+            let start_line = match edit_obj.get("startLine").and_then(|v| v.as_u64()) {
                 Some(n) => n as usize,
                 _ => {
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "Edit at index {}: 'line' field is required and must be an integer",
+                            "Edit at index {}: 'startLine' field is required and must be an integer",
                             idx
                         ),
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
-                        "Provide line number as integer (e.g., \"line\": 10)".to_string(),
-                        "Use line: 0 ONLY with action='INSERT_AFTER' to insert at top".to_string(),
+                        "Provide startLine as an integer (e.g., \"startLine\": 10)".to_string(),
+                        "Use startLine: 0 ONLY with op='insert_after' to insert at top".to_string(),
                     ])
                     .to_mcp_result());
                 }
@@ -309,13 +455,13 @@ impl WorkspaceServer {
                 return Ok(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "Edit at index {}: line 0 is only valid for action 'INSERT_AFTER'",
+                        "Edit at index {}: startLine 0 is only valid for op 'insert_after'",
                         idx
                     ),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
-                    "To insert at the beginning, use line: 0 and action: 'INSERT_AFTER'"
+                    "To insert at the beginning, use startLine: 0 and op: 'insert_after'"
                         .to_string(),
                 ])
                 .to_mcp_result());
@@ -334,7 +480,7 @@ impl WorkspaceServer {
                         ),
                         ToolGroup::Workspace,
                     )
-                    .guidance(vec!["endLine must be ≥ line".to_string()])
+                    .guidance(vec!["endLine must be ≥ startLine".to_string()])
                     .to_mcp_result());
                 }
                 None => {
@@ -351,19 +497,19 @@ impl WorkspaceServer {
                 return Ok(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "Edit at index {}: 'endLine' cannot be used with action 'INSERT_AFTER'",
+                        "Edit at index {}: 'endLine' cannot be used with op 'insert_after'",
                         idx
                     ),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
-                    "INSERT_AFTER only targets one line (or line 0). Remove 'endLine'.".to_string(),
+                    "insert_after only targets one line (or startLine 0). Remove 'endLine'."
+                        .to_string(),
                 ])
                 .to_mcp_result());
             }
 
-            // `new_value` extraction
-            let new_value = match edit_obj.get("new_value").and_then(|v| v.as_str()) {
+            let new_value = match edit_obj.get("content").and_then(|v| v.as_str()) {
                 Some(s) => s.to_string(),
                 None => {
                     if action == EditAction::Delete {
@@ -371,19 +517,20 @@ impl WorkspaceServer {
                     } else {
                         return Ok(guided_error(
                             ErrorCategory::InvalidInput,
-                            format!("Edit at index {}: 'new_value' is required for REPLACE and INSERT_AFTER", idx),
+                            format!(
+                                "Edit at index {}: 'content' is required for replace and insert_after",
+                                idx
+                            ),
                             ToolGroup::Workspace,
                         )
-                        .guidance(vec![
-                            "Provide replacement/insertion content as a string".to_string()
-                        ])
+                        .guidance(vec!["Provide replacement/insertion content as a string".to_string()])
                         .to_mcp_result());
                     }
                 }
             };
 
             let start_anchor = edit_obj
-                .get("anchor")
+                .get("startAnchor")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
@@ -395,12 +542,12 @@ impl WorkspaceServer {
             let requires_anchor = !(action == EditAction::InsertAfter && start_line == 0);
             if requires_anchor && start_anchor.is_none() {
                 return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Edit at index {} targets existing content and requires 'anchor'",
-                        idx
-                    ),
-                    ToolGroup::Workspace,
+                        ErrorCategory::InvalidInput,
+                        format!(
+                            "Edit at index {} targets existing content and requires 'startAnchor'",
+                            idx
+                        ),
+                        ToolGroup::Workspace,
                 )
                 .guidance(vec![
                     "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
@@ -408,7 +555,7 @@ impl WorkspaceServer {
                     "Copy only the 6-character start-line anchor from the form N:anchor|content (the part between ':' and '|')".to_string(),
                     "If the edit also uses endLine for a range, copy only the 6-character endAnchor from the exact final line"
                         .to_string(),
-                    "Only INSERT_AFTER with line: 0 may omit anchors".to_string(),
+                    "Only insert_after with startLine: 0 may omit anchors".to_string(),
                 ])
                 .to_mcp_result());
             }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
@@ -8,6 +8,7 @@ use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, ErrorCategory, SuccessHint, ToolGroup,
 };
 use crate::mcp::types::MCPResult;
+use once_cell::sync::Lazy;
 use serde_json::{json, Map, Value};
 
 /// A single edit operation.
@@ -64,12 +65,26 @@ fn infer_legacy_edit_op(edit_obj: &Map<String, Value>) -> Option<&'static str> {
     }
 }
 
+static EDIT_FILE_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
+    serde_json::to_value(create_edit_file_input_schema())
+        .map_err(|error| format!("Failed to serialize editFile schema: {error}"))
+});
+
+static EDIT_FILE_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
+    let schema_json = EDIT_FILE_SCHEMA_JSON
+        .as_ref()
+        .map_err(|error| error.clone())?;
+    jsonschema::validator_for(schema_json)
+        .map_err(|error| format!("Failed to build editFile validator: {error}"))
+});
+
 fn canonicalize_edit_object(edit: &Value) -> Value {
     let Some(edit_obj) = edit.as_object() else {
         return edit.clone();
     };
 
     let mut canonical = Map::new();
+    let inferred_legacy_op = infer_legacy_edit_op(edit_obj);
 
     for (key, value) in edit_obj {
         match key.as_str() {
@@ -118,9 +133,13 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
             }
             "new_value" | "content" => {
                 if !value.is_null() {
+                    if key == "new_value" && inferred_legacy_op == Some("delete") {
+                        continue;
+                    }
                     canonical.insert("content".to_string(), value.clone());
                 }
             }
+            "insertAfter" => {}
             _ => {
                 canonical.insert(key.clone(), value.clone());
             }
@@ -128,7 +147,7 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
     }
 
     if !canonical.contains_key("op") {
-        if let Some(inferred_op) = infer_legacy_edit_op(edit_obj) {
+        if let Some(inferred_op) = inferred_legacy_op {
             canonical.insert("op".to_string(), Value::String(inferred_op.to_string()));
         }
     }
@@ -162,10 +181,9 @@ fn canonicalize_edit_file_args(args: &Value) -> Value {
 }
 
 fn validate_edit_file_arguments(args: &Value) -> Result<(), String> {
-    let schema_json = serde_json::to_value(create_edit_file_input_schema())
-        .map_err(|error| format!("Failed to serialize editFile schema: {error}"))?;
-    let validator = jsonschema::validator_for(&schema_json)
-        .map_err(|error| format!("Failed to build editFile validator: {error}"))?;
+    let validator = EDIT_FILE_VALIDATOR
+        .as_ref()
+        .map_err(|error| error.clone())?;
 
     let errors = validator
         .iter_errors(args)
@@ -475,7 +493,7 @@ impl WorkspaceServer {
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "Edit at index {}: 'endLine' ({}) must be ≥ 'line' ({})",
+                            "Edit at index {}: 'endLine' ({}) must be ≥ 'startLine' ({})",
                             idx, n, start_line
                         ),
                         ToolGroup::Workspace,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line.rs
@@ -1,4 +1,4 @@
-use super::super::tools::file_tools::create_edit_file_input_schema;
+use super::super::tools::file_tools::create_edit_files_input_schema;
 use super::super::WorkspaceServer;
 use super::utils::{
     compute_line_hash, format_hashline, format_prefix_hash, initial_prefix_hash_state,
@@ -10,6 +10,7 @@ use crate::mcp::builtin::error_guidance::{
 use crate::mcp::types::MCPResult;
 use once_cell::sync::Lazy;
 use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
 
 /// A single edit operation.
 #[derive(Debug, Clone)]
@@ -20,6 +21,22 @@ struct LineEdit {
     start_anchor: Option<String>,
     end_anchor: Option<String>,
     action: EditAction,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedEdit {
+    path: String,
+    edit: LineEdit,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedFileEdit {
+    path: String,
+    edits: Vec<LineEdit>,
+    original_content: String,
+    new_content: String,
+    original_line_count: usize,
+    new_hash_sections: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,17 +82,17 @@ fn infer_legacy_edit_op(edit_obj: &Map<String, Value>) -> Option<&'static str> {
     }
 }
 
-static EDIT_FILE_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
-    serde_json::to_value(create_edit_file_input_schema())
-        .map_err(|error| format!("Failed to serialize editFile schema: {error}"))
+static EDIT_FILES_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
+    serde_json::to_value(create_edit_files_input_schema())
+        .map_err(|error| format!("Failed to serialize editFiles schema: {error}"))
 });
 
-static EDIT_FILE_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
-    let schema_json = EDIT_FILE_SCHEMA_JSON
+static EDIT_FILES_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
+    let schema_json = EDIT_FILES_SCHEMA_JSON
         .as_ref()
         .map_err(|error| error.clone())?;
     jsonschema::validator_for(schema_json)
-        .map_err(|error| format!("Failed to build editFile validator: {error}"))
+        .map_err(|error| format!("Failed to build editFiles validator: {error}"))
 });
 
 fn canonicalize_edit_object(edit: &Value) -> Value {
@@ -180,8 +197,64 @@ fn canonicalize_edit_file_args(args: &Value) -> Value {
     Value::Object(canonical)
 }
 
-fn validate_edit_file_arguments(args: &Value) -> Result<(), String> {
-    let validator = EDIT_FILE_VALIDATOR
+fn canonicalize_edit_files_args(args: &Value) -> Value {
+    let Some(args_obj) = args.as_object() else {
+        return args.clone();
+    };
+
+    let mut canonical = Map::new();
+
+    for (key, value) in args_obj {
+        if key == "edits" {
+            if let Some(edits) = value.as_array() {
+                canonical.insert(
+                    "edits".to_string(),
+                    Value::Array(edits.iter().map(canonicalize_edit_object).collect()),
+                );
+            } else {
+                canonical.insert("edits".to_string(), value.clone());
+            }
+        } else {
+            canonical.insert(key.clone(), value.clone());
+        }
+    }
+
+    Value::Object(canonical)
+}
+
+fn canonicalize_legacy_edit_file_args_as_edit_files(args: &Value) -> Value {
+    let canonical = canonicalize_edit_file_args(args);
+    let root_path = canonical.get("path").cloned();
+    let edits = canonical
+        .get("edits")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    let Some(edit_obj) = item.as_object() else {
+                        return item.clone();
+                    };
+
+                    let mut with_path = edit_obj.clone();
+                    if !with_path.contains_key("path") {
+                        if let Some(path) = &root_path {
+                            if !path.is_null() {
+                                with_path.insert("path".to_string(), path.clone());
+                            }
+                        }
+                    }
+                    Value::Object(with_path)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    json!({ "edits": edits })
+}
+
+fn validate_edit_files_arguments(args: &Value) -> Result<(), String> {
+    let validator = EDIT_FILES_VALIDATOR
         .as_ref()
         .map_err(|error| error.clone())?;
 
@@ -196,6 +269,216 @@ fn validate_edit_file_arguments(args: &Value) -> Result<(), String> {
     } else {
         Err(errors.join("; "))
     }
+}
+
+fn parse_line_edit(edit_obj: &Map<String, Value>, idx: usize) -> Result<LineEdit, MCPResult> {
+    let op_str = edit_obj.get("op").and_then(|v| v.as_str());
+    let action = match op_str {
+        Some("replace") => EditAction::Replace,
+        Some("insert_after") => EditAction::InsertAfter,
+        Some("delete") => EditAction::Delete,
+        Some(other) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!("Edit at index {}: invalid op '{}'", idx, other),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Supported ops: replace, insert_after, delete".to_string()
+            ])
+            .to_mcp_result());
+        }
+        None => {
+            return Err(missing_param_error("op", ToolGroup::Workspace));
+        }
+    };
+
+    let start_line = match edit_obj.get("startLine").and_then(|v| v.as_u64()) {
+        Some(n) => n as usize,
+        _ => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Edit at index {}: 'startLine' field is required and must be an integer",
+                    idx
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Provide startLine as an integer (e.g., \"startLine\": 10)".to_string(),
+                "Use startLine: 0 ONLY with op='insert_after' to insert at top".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    if start_line == 0 && action != EditAction::InsertAfter {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Edit at index {}: startLine 0 is only valid for op 'insert_after'",
+                idx
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "To insert at the beginning, use startLine: 0 and op: 'insert_after'".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    let has_end_line = edit_obj.get("endLine").is_some();
+    let end_line = match edit_obj.get("endLine").and_then(|v| v.as_u64()) {
+        Some(n) if n >= start_line as u64 => n as usize,
+        Some(n) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Edit at index {}: 'endLine' ({}) must be ≥ 'startLine' ({})",
+                    idx, n, start_line
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec!["endLine must be ≥ startLine".to_string()])
+            .to_mcp_result());
+        }
+        None => {
+            if start_line == 0 {
+                0
+            } else {
+                start_line
+            }
+        }
+    };
+
+    if action == EditAction::InsertAfter && has_end_line {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Edit at index {}: 'endLine' cannot be used with op 'insert_after'",
+                idx
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "insert_after only targets one line (or startLine 0). Remove 'endLine'.".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    let new_value = match edit_obj.get("content").and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => {
+            if action == EditAction::Delete {
+                String::new()
+            } else {
+                return Err(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!(
+                        "Edit at index {}: 'content' is required for replace and insert_after",
+                        idx
+                    ),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Provide replacement/insertion content as a string".to_string()
+                ])
+                .to_mcp_result());
+            }
+        }
+    };
+
+    let start_anchor = edit_obj
+        .get("startAnchor")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let end_anchor = edit_obj
+        .get("endAnchor")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let requires_anchor = !(action == EditAction::InsertAfter && start_line == 0);
+    if requires_anchor && start_anchor.is_none() {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Edit at index {} targets existing content and requires 'startAnchor'",
+                idx
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
+                .to_string(),
+            "Copy only the 6-character start-line anchor from the form N:anchor|content (the part between ':' and '|')".to_string(),
+            "If the edit also uses endLine for a range, copy only the 6-character endAnchor from the exact final line"
+                .to_string(),
+            "Only insert_after with startLine: 0 may omit anchors".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    if matches!(action, EditAction::Replace | EditAction::Delete)
+        && end_line > start_line
+        && end_anchor.is_none()
+    {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Edit at index {} uses 'endLine' and requires 'endAnchor' for the exact end line",
+                idx
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first".to_string(),
+            "Copy the start-line anchor as 'startAnchor' and the final-line anchor as 'endAnchor'"
+                .to_string(),
+            "Only multi-line replace and delete need 'endAnchor'".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    Ok(LineEdit {
+        start_line,
+        end_line,
+        new_value,
+        start_anchor,
+        end_anchor,
+        action,
+    })
+}
+
+fn validate_edits_do_not_overlap(edits: &[LineEdit]) -> Result<(), MCPResult> {
+    let mut sorted_ranges: Vec<(usize, usize, usize)> = edits
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.start_line, e.end_line, i))
+        .collect();
+    sorted_ranges.sort_by_key(|&(s, _, _)| s);
+
+    for window in sorted_ranges.windows(2) {
+        let (_start_a, end_a, idx_a) = window[0];
+        let (start_b, _, idx_b) = window[1];
+
+        if start_b <= end_a && start_b > 0 {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Overlapping edits: edit #{} overlaps with edit #{}",
+                    idx_a, idx_b
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Each line can only be covered by one edit per file".to_string()
+            ])
+            .to_mcp_result());
+        }
+    }
+
+    Ok(())
 }
 
 /// Pure apply function — applies sorted edits (high → low) to a slice of lines.
@@ -226,6 +509,46 @@ fn apply_edits(orig_lines: &[&str], edits: &[LineEdit]) -> Vec<String> {
         }
     }
     modified
+}
+
+fn build_new_hash_sections(edits: &[LineEdit], new_content: &str) -> Vec<String> {
+    let new_content_lines: Vec<&str> = new_content.lines().collect();
+    let mut full_prefix_state = initial_prefix_hash_state();
+    let full_hashlines: Vec<String> = new_content_lines
+        .iter()
+        .enumerate()
+        .map(|(idx, line)| format_hashline(idx + 1, line, &mut full_prefix_state))
+        .collect();
+    let mut sorted_asc = edits.to_vec();
+    sorted_asc.sort_by_key(|e| e.start_line);
+
+    let mut new_hash_sections = Vec::new();
+    let mut line_delta: i64 = 0;
+    for edit in &sorted_asc {
+        let n_lines = edit
+            .new_value
+            .lines()
+            .count()
+            .max(if edit.new_value.is_empty() { 0 } else { 1 });
+        let start_in_new = if edit.action == EditAction::InsertAfter {
+            (edit.start_line as i64 + line_delta) as usize
+        } else {
+            ((edit.start_line as i64 - 1) + line_delta) as usize
+        };
+
+        let end_in_new = (start_in_new + n_lines).min(new_content_lines.len());
+        let section: Vec<String> = full_hashlines[start_in_new..end_in_new].to_vec();
+        new_hash_sections.push(section.join("\n"));
+
+        let orig_len = if edit.action == EditAction::InsertAfter {
+            0
+        } else {
+            (edit.end_line - edit.start_line + 1) as i64
+        };
+        line_delta += n_lines as i64 - orig_len;
+    }
+
+    new_hash_sections
 }
 
 impl WorkspaceServer {
@@ -350,304 +673,40 @@ impl WorkspaceServer {
         self.handle_edit_file(delegated, session_id).await
     }
 
-    pub async fn handle_edit_file(
+    async fn prepare_file_edit_batch(
         &self,
-        args: Value,
+        path_str: &str,
+        edits: Vec<LineEdit>,
         session_id: Option<String>,
-    ) -> Result<MCPResult, String> {
-        let canonical_args = canonicalize_edit_file_args(&args);
+    ) -> Result<PreparedFileEdit, MCPResult> {
+        validate_edits_do_not_overlap(&edits)?;
 
-        if let Err(validation_error) = validate_edit_file_arguments(&canonical_args) {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                format!(
-                    "editFile arguments do not match the declared schema: {validation_error}"
-                ),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
-                "Replace: [{\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
-                "Insert top: [{\"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
-                "Delete range: [{\"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
-                "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
-            ])
-            .to_mcp_result());
-        }
-
-        // --- Parameter extraction ---
-        let path_str = match canonical_args.get("path").and_then(|v| v.as_str()) {
-            Some(p) => p,
-            None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
-        };
-
-        let edits_array = match canonical_args.get("edits").and_then(|v| v.as_array()) {
-            Some(arr) => arr,
-            None => {
-                return Ok(guided_error(
-                    ErrorCategory::MissingRequiredParam,
-                    "Parameter 'edits' is required and must be an array",
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Replace:      [{\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
-                    "Insert-top:   [{\"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
-                    "Delete range: [{\"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
-                    "Use readFile(showLineAnchors=true) to get anchor values first".to_string(),
-                ])
-                .to_mcp_result());
-            }
-        };
-
-        if edits_array.is_empty() {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                "Parameter 'edits' cannot be empty",
-                ToolGroup::Workspace,
-            )
-            .guidance(vec!["Provide at least one edit operation".to_string()])
-            .to_mcp_result());
-        }
-
-        // --- Parse each edit item ---
-        let mut edits: Vec<LineEdit> = Vec::with_capacity(edits_array.len());
-
-        for (idx, edit_obj) in edits_array.iter().enumerate() {
-            let edit_obj = match edit_obj.as_object() {
-                Some(obj) => obj,
-                None => {
-                    return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!("Edit at index {} must be an object", idx),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec![
-                        "Single-line: {\"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
-                        "Range:       {\"op\": \"replace\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}"
-                            .to_string(),
-                    ])
-                    .to_mcp_result());
-                }
-            };
-
-            let op_str = edit_obj.get("op").and_then(|v| v.as_str());
-            let action = match op_str {
-                Some("replace") => EditAction::Replace,
-                Some("insert_after") => EditAction::InsertAfter,
-                Some("delete") => EditAction::Delete,
-                Some(other) => {
-                    return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!("Edit at index {}: invalid op '{}'", idx, other),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec![
-                        "Supported ops: replace, insert_after, delete".to_string()
-                    ])
-                    .to_mcp_result());
-                }
-                None => {
-                    return Ok(missing_param_error("op", ToolGroup::Workspace));
-                }
-            };
-
-            let start_line = match edit_obj.get("startLine").and_then(|v| v.as_u64()) {
-                Some(n) => n as usize,
-                _ => {
-                    return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!(
-                            "Edit at index {}: 'startLine' field is required and must be an integer",
-                            idx
-                        ),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec![
-                        "Provide startLine as an integer (e.g., \"startLine\": 10)".to_string(),
-                        "Use startLine: 0 ONLY with op='insert_after' to insert at top".to_string(),
-                    ])
-                    .to_mcp_result());
-                }
-            };
-
-            if start_line == 0 && action != EditAction::InsertAfter {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Edit at index {}: startLine 0 is only valid for op 'insert_after'",
-                        idx
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "To insert at the beginning, use startLine: 0 and op: 'insert_after'"
-                        .to_string(),
-                ])
-                .to_mcp_result());
-            }
-
-            // `endLine` validation
-            let has_end_line = edit_obj.get("endLine").is_some();
-            let end_line = match edit_obj.get("endLine").and_then(|v| v.as_u64()) {
-                Some(n) if n >= start_line as u64 => n as usize,
-                Some(n) => {
-                    return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!(
-                            "Edit at index {}: 'endLine' ({}) must be ≥ 'startLine' ({})",
-                            idx, n, start_line
-                        ),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec!["endLine must be ≥ startLine".to_string()])
-                    .to_mcp_result());
-                }
-                None => {
-                    if start_line == 0 {
-                        0
-                    } else {
-                        start_line
-                    }
-                }
-            };
-
-            // Check for mutual exclusivity of INSERT_AFTER and endLine
-            if action == EditAction::InsertAfter && has_end_line {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Edit at index {}: 'endLine' cannot be used with op 'insert_after'",
-                        idx
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "insert_after only targets one line (or startLine 0). Remove 'endLine'."
-                        .to_string(),
-                ])
-                .to_mcp_result());
-            }
-
-            let new_value = match edit_obj.get("content").and_then(|v| v.as_str()) {
-                Some(s) => s.to_string(),
-                None => {
-                    if action == EditAction::Delete {
-                        String::new()
-                    } else {
-                        return Ok(guided_error(
-                            ErrorCategory::InvalidInput,
-                            format!(
-                                "Edit at index {}: 'content' is required for replace and insert_after",
-                                idx
-                            ),
-                            ToolGroup::Workspace,
-                        )
-                        .guidance(vec!["Provide replacement/insertion content as a string".to_string()])
-                        .to_mcp_result());
-                    }
-                }
-            };
-
-            let start_anchor = edit_obj
-                .get("startAnchor")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            let end_anchor = edit_obj
-                .get("endAnchor")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            let requires_anchor = !(action == EditAction::InsertAfter && start_line == 0);
-            if requires_anchor && start_anchor.is_none() {
-                return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!(
-                            "Edit at index {} targets existing content and requires 'startAnchor'",
-                            idx
-                        ),
-                        ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
-                        .to_string(),
-                    "Copy only the 6-character start-line anchor from the form N:anchor|content (the part between ':' and '|')".to_string(),
-                    "If the edit also uses endLine for a range, copy only the 6-character endAnchor from the exact final line"
-                        .to_string(),
-                    "Only insert_after with startLine: 0 may omit anchors".to_string(),
-                ])
-                .to_mcp_result());
-            }
-
-            if matches!(action, EditAction::Replace | EditAction::Delete)
-                && end_line > start_line
-                && end_anchor.is_none()
-            {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Edit at index {} uses 'endLine' and requires 'endAnchor' for the exact end line",
-                        idx
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
-                        .to_string(),
-                    "Copy the start-line anchor as 'anchor' and the final-line anchor as 'endAnchor'"
-                        .to_string(),
-                    "Only multi-line REPLACE and DELETE need 'endAnchor'".to_string(),
-                ])
-                .to_mcp_result());
-            }
-
-            edits.push(LineEdit {
-                start_line,
-                end_line,
-                new_value,
-                start_anchor,
-                end_anchor,
-                action,
-            });
-        }
-
-        // --- Overlap detection ---
+        let safe_path = match self.validate_path_with_error_for_write(path_str, session_id.clone())
         {
-            let mut sorted_ranges: Vec<(usize, usize, usize)> = edits
-                .iter()
-                .enumerate()
-                .map(|(i, e)| (e.start_line, e.end_line, i))
-                .collect();
-            sorted_ranges.sort_by_key(|&(s, _, _)| s);
-
-            for window in sorted_ranges.windows(2) {
-                let (_start_a, end_a, idx_a) = window[0];
-                let (start_b, _, idx_b) = window[1];
-
-                if start_b <= end_a && start_b > 0 {
-                    return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!(
-                            "Overlapping edits: edit #{} overlaps with edit #{}",
-                            idx_a, idx_b
-                        ),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec![
-                        "Each line can only be covered by one edit per operation".to_string(),
-                    ])
-                    .to_mcp_result());
-                }
+            Ok(path) => path,
+            Err(error) => {
+                return Err(guided_error(
+                    ErrorCategory::PermissionDenied,
+                    format!("Path validation failed for '{}': {}", path_str, error),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Use paths relative to workspace root".to_string(),
+                    "Use listDirectory to inspect valid target paths".to_string(),
+                ])
+                .to_mcp_result());
             }
-        }
+        };
 
-        let safe_path = self.validate_path_with_error_for_write(path_str, session_id.clone())?;
         let original_content = match read_file_as_string(&safe_path).await {
             Ok(content) => content,
-            Err(e) => {
-                return Ok(
-                    guided_error(ErrorCategory::OperationFailed, e, ToolGroup::Workspace)
-                        .to_mcp_result(),
+            Err(error) => {
+                return Err(guided_error(
+                    ErrorCategory::OperationFailed,
+                    error,
+                    ToolGroup::Workspace,
                 )
+                .to_mcp_result());
             }
         };
 
@@ -662,18 +721,17 @@ impl WorkspaceServer {
             })
             .collect();
 
-        // --- Validate all edits against file content ---
         for edit in &edits {
             if !requires_existing_line_anchor(edit) {
                 continue;
             }
 
             if edit.start_line > line_count {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "Line {} does not exist (file has {} lines)",
-                        edit.start_line, line_count
+                        "File '{}': line {} does not exist (file has {} lines)",
+                        path_str, edit.start_line, line_count
                     ),
                     ToolGroup::Workspace,
                 )
@@ -683,18 +741,17 @@ impl WorkspaceServer {
             if matches!(edit.action, EditAction::Replace | EditAction::Delete)
                 && edit.end_line > line_count
             {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "End line {} does not exist (file has {} lines)",
-                        edit.end_line, line_count
+                        "File '{}': end line {} does not exist (file has {} lines)",
+                        path_str, edit.end_line, line_count
                     ),
                     ToolGroup::Workspace,
                 )
                 .to_mcp_result());
             }
 
-            // Hash validation
             let expected_anchor = edit
                 .start_anchor
                 .as_ref()
@@ -702,11 +759,11 @@ impl WorkspaceServer {
             let (expected_hash, expected_prefix) = match parse_anchor(expected_anchor) {
                 Some(parts) => parts,
                 None => {
-                    return Ok(guided_error(
+                    return Err(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "Invalid anchor for line {}: expected 6-character hexadecimal code",
-                            edit.start_line
+                            "File '{}': invalid anchor for line {}: expected 6-character hexadecimal code",
+                            path_str, edit.start_line
                         ),
                         ToolGroup::Workspace,
                     )
@@ -722,11 +779,11 @@ impl WorkspaceServer {
             let actual = orig_lines[edit.start_line - 1];
             let actual_hash = compute_line_hash(actual);
             if actual_hash != expected_hash {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "STALE ANCHOR on line {} (current line content changed)",
-                        edit.start_line
+                        "File '{}': STALE ANCHOR on line {} (current line content changed)",
+                        path_str, edit.start_line
                     ),
                     ToolGroup::Workspace,
                 )
@@ -739,11 +796,11 @@ impl WorkspaceServer {
 
             let actual_prefix_hash = &prefix_hashes[edit.start_line - 1];
             if actual_prefix_hash != expected_prefix {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "STALE ANCHOR on line {} (earlier content changed before this line)",
-                        edit.start_line
+                        "File '{}': STALE ANCHOR on line {} (earlier content changed before this line)",
+                        path_str, edit.start_line
                     ),
                     ToolGroup::Workspace,
                 )
@@ -764,30 +821,30 @@ impl WorkspaceServer {
                 ) {
                     Some(parts) => parts,
                     None => {
-                        return Ok(guided_error(
-                        ErrorCategory::InvalidInput,
-                        format!(
-                            "Invalid endAnchor for line {}: expected 6-character hexadecimal code",
-                            edit.end_line
-                        ),
-                        ToolGroup::Workspace,
-                    )
-                    .guidance(vec![
-                        "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
-                            .to_string(),
-                        "Copy only the 6-character endAnchor from the returned N:anchor|content line (the part between ':' and '|')".to_string(),
-                    ])
-                    .to_mcp_result());
+                        return Err(guided_error(
+                            ErrorCategory::InvalidInput,
+                            format!(
+                                "File '{}': invalid endAnchor for line {}: expected 6-character hexadecimal code",
+                                path_str, edit.end_line
+                            ),
+                            ToolGroup::Workspace,
+                        )
+                        .guidance(vec![
+                            "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
+                                .to_string(),
+                            "Copy only the 6-character endAnchor from the returned N:anchor|content line (the part between ':' and '|')".to_string(),
+                        ])
+                        .to_mcp_result());
                     }
                 };
                 let actual_end_line = orig_lines[edit.end_line - 1];
                 let actual_end_hash = compute_line_hash(actual_end_line);
                 if actual_end_hash != expected_end_hash {
-                    return Ok(guided_error(
+                    return Err(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "STALE END ANCHOR on line {} (range boundary changed)",
-                            edit.end_line
+                            "File '{}': STALE END ANCHOR on line {} (range boundary changed)",
+                            path_str, edit.end_line
                         ),
                         ToolGroup::Workspace,
                     )
@@ -798,15 +855,14 @@ impl WorkspaceServer {
                     ])
                     .to_mcp_result());
                 }
-                // Also validate the prefix hash so that drift in lines *before*
-                // the end line (but within the edited range) is caught.
+
                 let actual_end_prefix = &prefix_hashes[edit.end_line - 1];
                 if actual_end_prefix != expected_end_prefix {
-                    return Ok(guided_error(
+                    return Err(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "STALE END ANCHOR on line {} (earlier content changed before range boundary)",
-                            edit.end_line
+                            "File '{}': STALE END ANCHOR on line {} (earlier content changed before range boundary)",
+                            path_str, edit.end_line
                         ),
                         ToolGroup::Workspace,
                     )
@@ -828,94 +884,263 @@ impl WorkspaceServer {
             new_content
         };
 
-        let file_manager = self.get_file_manager(session_id.clone());
-        if let Err(e) = file_manager.write_file_string(path_str, &new_content).await {
+        Ok(PreparedFileEdit {
+            path: path_str.to_string(),
+            edits: edits.clone(),
+            original_content,
+            new_content: new_content.clone(),
+            original_line_count: line_count,
+            new_hash_sections: build_new_hash_sections(&edits, &new_content),
+        })
+    }
+
+    fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) -> MCPResult {
+        let mut file_sections = Vec::new();
+        let total_edits: usize = prepared_batches.iter().map(|batch| batch.edits.len()).sum();
+
+        for batch in prepared_batches {
+            let edit_summary = batch
+                .edits
+                .iter()
+                .map(|edit| match edit.action {
+                    EditAction::InsertAfter => format!(
+                        "  Insert after line {}: {} line(s)",
+                        edit.start_line,
+                        edit.new_value.lines().count()
+                    ),
+                    EditAction::Delete => {
+                        format!("  Delete lines {}-{}", edit.start_line, edit.end_line)
+                    }
+                    EditAction::Replace => format!(
+                        "  Replace lines {}-{}: {} line(s)",
+                        edit.start_line,
+                        edit.end_line,
+                        edit.new_value.lines().count()
+                    ),
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let diff_summary = format!(
+                "{} lines in, {} lines out",
+                batch.new_content.lines().count(),
+                batch.original_line_count
+            );
+            let anchors = if batch.new_hash_sections.is_empty() {
+                "(No new lines were created by these edits)".to_string()
+            } else {
+                batch.new_hash_sections.join("\n...\n")
+            };
+
+            file_sections.push(format!(
+                "File: '{}'\nChanges:\n{}\nSummary: {}\n\nNew anchors:\n```\n{}\n```",
+                batch.path, edit_summary, diff_summary, anchors
+            ));
+        }
+
+        let hint = SuccessHint::new(
+            format!(
+                "Applied {} edit(s) across {} file(s)\n\n{}",
+                total_edits,
+                prepared_batches.len(),
+                file_sections.join("\n\n")
+            ),
+            vec![
+                "Anchors above are current — reuse them with editFiles per file".to_string(),
+                "Use readFile only if you need broader context beyond the edited ranges"
+                    .to_string(),
+            ],
+        );
+
+        hint.to_mcp_result_with_data(Some(json!({
+            "file_count": prepared_batches.len(),
+            "edit_count": total_edits,
+            "files": prepared_batches
+                .iter()
+                .map(|batch| json!({
+                    "path": batch.path,
+                    "edit_count": batch.edits.len(),
+                    "line_count_before": batch.original_line_count,
+                    "line_count_after": batch.new_content.lines().count(),
+                }))
+                .collect::<Vec<_>>()
+        })))
+    }
+
+    pub async fn handle_edit_files(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        let canonical_args = canonicalize_edit_files_args(&args);
+
+        if let Err(validation_error) = validate_edit_files_arguments(&canonical_args) {
             return Ok(guided_error(
-                ErrorCategory::OperationFailed,
-                e.to_string(),
+                ErrorCategory::InvalidInput,
+                format!(
+                    "editFiles arguments do not match the declared schema: {validation_error}"
+                ),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Check file permissions".to_string(),
-                "Ensure sufficient disk space".to_string(),
+                "Replace: [{\"path\": \"src/a.ts\", \"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
+                "Insert top: [{\"path\": \"src/a.ts\", \"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
+                "Delete range: [{\"path\": \"src/b.ts\", \"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
             ])
             .to_mcp_result());
         }
 
-        self.invalidate_context_cache().await;
+        let edits_array = match canonical_args.get("edits").and_then(|v| v.as_array()) {
+            Some(arr) => arr,
+            None => {
+                return Ok(guided_error(
+                    ErrorCategory::MissingRequiredParam,
+                    "Parameter 'edits' is required and must be an array",
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Replace: [{\"path\": \"src/a.ts\", \"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
+                    "Insert-top: [{\"path\": \"src/a.ts\", \"op\": \"insert_after\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
+                    "Delete range: [{\"path\": \"src/b.ts\", \"op\": \"delete\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                    "Use readFile(showLineAnchors=true) to get anchor values first".to_string(),
+                ])
+                .to_mcp_result());
+            }
+        };
 
-        // --- Success response with summary, diff, and new anchors ---
-        let edit_summary = edits
-            .iter()
-            .map(|e| match e.action {
-                EditAction::InsertAfter => format!(
-                    "  Insert after line {}: {} line(s)",
-                    e.start_line,
-                    e.new_value.lines().count()
-                ),
-                EditAction::Delete => format!("  Delete lines {}-{}", e.start_line, e.end_line),
-                EditAction::Replace => format!(
-                    "  Replace lines {}-{}: {} line(s)",
-                    e.start_line,
-                    e.end_line,
-                    e.new_value.lines().count()
-                ),
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Simple diff (just added/removed counts for now to stay concise)
-        let diff_summary = format!(
-            "{} lines in, {} lines out",
-            new_content.lines().count(),
-            line_count
-        );
-
-        let new_content_lines: Vec<&str> = new_content.lines().collect();
-        let mut full_prefix_state = initial_prefix_hash_state();
-        let full_hashlines: Vec<String> = new_content_lines
-            .iter()
-            .enumerate()
-            .map(|(idx, line)| format_hashline(idx + 1, line, &mut full_prefix_state))
-            .collect();
-        let mut sorted_asc = edits.clone();
-        sorted_asc.sort_by_key(|e| e.start_line);
-
-        let mut new_hash_sections = Vec::new();
-        let mut line_delta: i64 = 0;
-        for edit in &sorted_asc {
-            let n_lines = edit
-                .new_value
-                .lines()
-                .count()
-                .max(if edit.new_value.is_empty() { 0 } else { 1 });
-            let start_in_new = if edit.action == EditAction::InsertAfter {
-                (edit.start_line as i64 + line_delta) as usize
-            } else {
-                ((edit.start_line as i64 - 1) + line_delta) as usize
-            };
-
-            let end_in_new = (start_in_new + n_lines).min(new_content_lines.len());
-            let section: Vec<String> = full_hashlines[start_in_new..end_in_new].to_vec();
-            new_hash_sections.push(section.join("\n"));
-
-            let orig_len = if edit.action == EditAction::InsertAfter {
-                0
-            } else {
-                (edit.end_line - edit.start_line + 1) as i64
-            };
-            line_delta += n_lines as i64 - orig_len;
+        if edits_array.is_empty() {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Parameter 'edits' cannot be empty",
+                ToolGroup::Workspace,
+            )
+            .guidance(vec!["Provide at least one edit operation".to_string()])
+            .to_mcp_result());
         }
 
-        let hint = SuccessHint::new(
-            format!("✓ Applied {} edit(s) to '{}'\n\nChanges:\n{}\n\nSummary: {}\n\nNew anchors:\n```\n{}\n```", edits.len(), path_str, edit_summary, diff_summary, new_hash_sections.join("\n...\n")),
-            vec![
-                "Anchors above are current — use anchor for the start line, and add endAnchor when a range edit includes endLine".to_string(),
-                "Use readFile only if you need broader context beyond the edited lines".to_string(),
-            ],
-        );
+        let mut parsed_edits = Vec::with_capacity(edits_array.len());
+        for (idx, edit_value) in edits_array.iter().enumerate() {
+            let edit_obj = match edit_value.as_object() {
+                Some(obj) => obj,
+                None => {
+                    return Ok(guided_error(
+                        ErrorCategory::InvalidInput,
+                        format!("Edit at index {} must be an object", idx),
+                        ToolGroup::Workspace,
+                    )
+                    .guidance(vec![
+                        "Single-line: {\"path\": \"src/a.ts\", \"op\": \"replace\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
+                        "Range: {\"path\": \"src/a.ts\", \"op\": \"replace\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}".to_string(),
+                    ])
+                    .to_mcp_result());
+                }
+            };
 
-        Ok(hint.to_mcp_result())
+            let path = match edit_obj.get("path").and_then(|v| v.as_str()) {
+                Some(path) if !path.trim().is_empty() => path.trim().to_string(),
+                _ => {
+                    return Ok(guided_error(
+                        ErrorCategory::InvalidInput,
+                        format!(
+                            "Edit at index {}: 'path' field is required and must be a non-empty string",
+                            idx
+                        ),
+                        ToolGroup::Workspace,
+                    )
+                    .guidance(vec![
+                        "Each edit item must include its own path".to_string(),
+                        "Example: {\"path\": \"src/main.rs\", ...}".to_string(),
+                    ])
+                    .to_mcp_result());
+                }
+            };
+
+            let edit = match parse_line_edit(edit_obj, idx) {
+                Ok(edit) => edit,
+                Err(result) => return Ok(result),
+            };
+
+            parsed_edits.push(ParsedEdit { path, edit });
+        }
+
+        let mut grouped: BTreeMap<String, Vec<LineEdit>> = BTreeMap::new();
+        for parsed in parsed_edits {
+            grouped.entry(parsed.path).or_default().push(parsed.edit);
+        }
+
+        let mut prepared_batches = Vec::with_capacity(grouped.len());
+        for (path, edits) in grouped {
+            let prepared = match self
+                .prepare_file_edit_batch(&path, edits, session_id.clone())
+                .await
+            {
+                Ok(batch) => batch,
+                Err(result) => return Ok(result),
+            };
+            prepared_batches.push(prepared);
+        }
+
+        let file_manager = self.get_file_manager(session_id.clone());
+        let mut written_paths: Vec<String> = Vec::new();
+
+        for batch in &prepared_batches {
+            if let Err(error) = file_manager
+                .write_file_string(&batch.path, &batch.new_content)
+                .await
+            {
+                let mut rollback_failures = Vec::new();
+                for written_path in written_paths.iter().rev() {
+                    if let Some(previous_batch) = prepared_batches
+                        .iter()
+                        .find(|candidate| &candidate.path == written_path)
+                    {
+                        if let Err(rollback_error) = file_manager
+                            .write_file_string(
+                                &previous_batch.path,
+                                &previous_batch.original_content,
+                            )
+                            .await
+                        {
+                            rollback_failures
+                                .push(format!("{} ({})", previous_batch.path, rollback_error));
+                        }
+                    }
+                }
+
+                let rollback_note = if rollback_failures.is_empty() {
+                    "Any earlier writes in this request were rolled back.".to_string()
+                } else {
+                    format!("Rollback failed for: {}", rollback_failures.join(", "))
+                };
+
+                return Ok(guided_error(
+                    ErrorCategory::OperationFailed,
+                    format!("Failed to write '{}': {}", batch.path, error),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    rollback_note,
+                    "Check file permissions and available disk space".to_string(),
+                    "Rerun readFile(showLineAnchors=true) before retrying if files may have changed"
+                        .to_string(),
+                ])
+                .to_mcp_result());
+            }
+            written_paths.push(batch.path.clone());
+        }
+
+        self.invalidate_context_cache().await;
+
+        Ok(Self::build_edit_files_success(&prepared_batches))
+    }
+
+    pub async fn handle_edit_file(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        let canonical_args = canonicalize_legacy_edit_file_args_as_edit_files(&args);
+        self.handle_edit_files(canonical_args, session_id).await
     }
 }
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -270,13 +270,13 @@ impl WorkspaceServer {
                 };
 
                 let first_hint = if show_line_anchors {
-                    "Use editFile with only the 6-character startAnchor; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+                    "Use editFiles with path plus only the 6-character startAnchor; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
                 } else {
-                    "Rerun with showLineAnchors=true to get anchors for precise line editing with editFile".to_string()
+                    "Rerun with showLineAnchors=true to get anchors for precise line editing with editFiles".to_string()
                 };
                 let mut next_actions = vec![
                     first_hint,
-                    "Use editFile with op='insert_after', startLine, and startAnchor to insert below an existing line".to_string(),
+                    "Use editFiles with path, op='insert_after', startLine, and startAnchor to insert below an existing line".to_string(),
                     "writeFile for full file replacement".to_string(),
                 ];
                 if let (Some(next_start_line), Some(suggested_end_line)) =

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -270,13 +270,13 @@ impl WorkspaceServer {
                 };
 
                 let first_hint = if show_line_anchors {
-                    "Use replaceLines or deleteLines with only the 6-character start-line anchor; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+                    "Use editFile with only the 6-character startAnchor; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
                 } else {
-                    "Rerun with showLineAnchors=true to get anchors for precise line editing (replaceLines, deleteLines, insertAfterLine)".to_string()
+                    "Rerun with showLineAnchors=true to get anchors for precise line editing with editFile".to_string()
                 };
                 let mut next_actions = vec![
                     first_hint,
-                    "Use insertAfterLine with afterLine and the anchor from the line after which content should be inserted".to_string(),
+                    "Use editFile with op='insert_after', startLine, and startAnchor to insert below an existing line".to_string(),
                     "writeFile for full file replacement".to_string(),
                 ];
                 if let (Some(next_start_line), Some(suggested_end_line)) =

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -157,7 +157,7 @@ pub(super) async fn search_content_in_file(
         }
 
         if show_hashes {
-            s.push_str("Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
+            s.push_str("Use the returned anchors with editFiles. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
         } else {
             s.push_str(
                 "Run with `showLineAnchors: true` to get anchors for targeted editing tools.\n",
@@ -479,7 +479,7 @@ pub(super) async fn search_content_in_dir(
         vec!["Use search with a specific file path to see all matches in that file".to_string()];
     if show_hashes {
         next_steps.push(
-            "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
+            "Use the returned anchors with editFiles; add endAnchor for range replacement/deletion"
                 .to_string(),
         );
     } else {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -157,7 +157,7 @@ pub(super) async fn search_content_in_file(
         }
 
         if show_hashes {
-            s.push_str("Use the returned anchors with replaceLines, insertAfterLine, or deleteLines. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
+            s.push_str("Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
         } else {
             s.push_str(
                 "Run with `showLineAnchors: true` to get anchors for targeted editing tools.\n",
@@ -479,7 +479,7 @@ pub(super) async fn search_content_in_dir(
         vec!["Use search with a specific file path to see all matches in that file".to_string()];
     if show_hashes {
         next_steps.push(
-            "Use the returned anchors with replaceLines, insertAfterLine, or deleteLines; add endAnchor for range replacement/deletion"
+            "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
                 .to_string(),
         );
     } else {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
@@ -15,7 +15,7 @@ const ANCHOR_LEN: usize = LINE_HASH_LEN + PREFIX_HASH_LEN;
 ///
 /// Uses FNV-1a 32-bit with output folding to produce a stable 2-char identifier
 /// per line. This hash is embedded into opaque line anchors when `showLineAnchors`
-/// is enabled, and validated by `editFile` after parsing the agent-facing anchor.
+/// is enabled, and validated by `editFiles` after parsing the agent-facing anchor.
 /// detect file staleness before applying edits.
 pub fn compute_line_hash(content: &str) -> String {
     let mut hash = FNV_OFFSET;

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -109,7 +109,7 @@ impl WorkspaceServer {
                         path_str
                     ),
                     format!(
-                        "Use editFile for targeted edits to \"{}\" instead of rewriting the whole file.",
+                        "Use editFiles for targeted edits to \"{}\" instead of rewriting the whole file.",
                         path_str
                     ),
                 ])
@@ -238,7 +238,7 @@ impl WorkspaceServer {
                     || path_str.ends_with(".ts")
                 {
                     next_steps.push(format!(
-                        "Use editFile for targeted edits to \"{}\"",
+                        "Use editFiles for targeted edits to \"{}\"",
                         path_str
                     ));
                 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -109,7 +109,7 @@ impl WorkspaceServer {
                         path_str
                     ),
                     format!(
-                        "Use replaceLines, insertAfterLine, or deleteLines for targeted edits to \"{}\" instead of rewriting the whole file.",
+                        "Use editFile for targeted edits to \"{}\" instead of rewriting the whole file.",
                         path_str
                     ),
                 ])
@@ -238,7 +238,7 @@ impl WorkspaceServer {
                     || path_str.ends_with(".ts")
                 {
                     next_steps.push(format!(
-                        "Use replaceLines, insertAfterLine, or deleteLines for targeted edits to \"{}\"",
+                        "Use editFile for targeted edits to \"{}\"",
                         path_str
                     ));
                 }

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -614,8 +614,10 @@ impl BuiltinMCPServer for WorkspaceServer {
             "listDirectory" => self.handle_list_directory(args, session_id).await,
             "importFiles" => self.handle_import_files(args, session_id).await,
             "search" => self.handle_search(args, session_id).await,
-            // editFile is the model-facing mutation tool. The legacy per-operation aliases remain
-            // dispatchable for backward compatibility and internally normalize into editFile.
+            // editFiles is the model-facing mutation tool. The legacy editFile and per-operation
+            // aliases remain dispatchable for backward compatibility and internally normalize
+            // into editFiles.
+            "editFiles" => self.handle_edit_files(args, session_id).await,
             "editFile" => self.handle_edit_file(args, session_id).await,
             "replaceLines" => self.handle_replace_lines(args, session_id).await,
             "insertAfterLine" => self.handle_insert_after_line(args, session_id).await,

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -614,10 +614,8 @@ impl BuiltinMCPServer for WorkspaceServer {
             "listDirectory" => self.handle_list_directory(args, session_id).await,
             "importFiles" => self.handle_import_files(args, session_id).await,
             "search" => self.handle_search(args, session_id).await,
-            // Compatibility dispatch only: editFile stays callable for older clients and
-            // internal batching paths, but it is intentionally hidden from normal tool
-            // discovery because its action-based union contract is broader than the explicit
-            // replaceLines / insertAfterLine / deleteLines tools.
+            // editFile is the model-facing mutation tool. The legacy per-operation aliases remain
+            // dispatchable for backward compatibility and internally normalize into editFile.
             "editFile" => self.handle_edit_file(args, session_id).await,
             "replaceLines" => self.handle_replace_lines(args, session_id).await,
             "insertAfterLine" => self.handle_insert_after_line(args, session_id).await,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -41,7 +41,7 @@ pub fn create_read_file_tool() -> MCPTool {
     MCPTool {
         name: "readFile".to_string(),
         title: Some("Read File".to_string()),
-        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true before calling editFile to obtain anchor values."
+        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true before calling editFiles to obtain anchor values."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -222,7 +222,7 @@ pub fn create_search_tool() -> MCPTool {
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(
-            "Include edit anchors in results for use with editFile (default: false). For edit tools, copy only the 6-character anchor between ':' and '|'.",
+            "Include edit anchors in results for use with editFiles (default: false). For edit tools, copy only the 6-character anchor between ':' and '|'.",
         )),
     );
 
@@ -556,7 +556,8 @@ fn build_edit_variant_schema(
     schema
 }
 
-pub fn create_edit_file_input_schema() -> JSONSchema {
+fn create_edit_item_schema(path_required: bool) -> JSONSchema {
+    let path_desc = "Relative path to the file to edit (from workspace root).";
     let start_line_desc =
         "Target start line number (1-based). Use 0 only with op='insert_after' to prepend at the file top.";
     let end_line_desc =
@@ -568,6 +569,12 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     let content_desc = "Replacement or inserted content. May include \\n to span multiple lines.";
 
     let mut replace_single_props = HashMap::new();
+    if path_required {
+        replace_single_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     replace_single_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -589,16 +596,28 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let replace_single_schema = build_edit_variant_schema(
         replace_single_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "startAnchor".to_string(),
-            "content".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "startAnchor".to_string(),
+                "content".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Single-line replace variant: requires startLine, startAnchor, and content.",
     );
 
     let mut replace_range_props = HashMap::new();
+    if path_required {
+        replace_range_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     replace_range_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -628,18 +647,30 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let replace_range_schema = build_edit_variant_schema(
         replace_range_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "endLine".to_string(),
-            "startAnchor".to_string(),
-            "endAnchor".to_string(),
-            "content".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "endLine".to_string(),
+                "startAnchor".to_string(),
+                "endAnchor".to_string(),
+                "content".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Multi-line replace variant: requires startLine, endLine, startAnchor, endAnchor, and content.",
     );
 
     let mut insert_existing_props = HashMap::new();
+    if path_required {
+        insert_existing_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     insert_existing_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -661,16 +692,28 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let insert_existing_schema = build_edit_variant_schema(
         insert_existing_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "startAnchor".to_string(),
-            "content".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "startAnchor".to_string(),
+                "content".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Insert-after variant for an existing line: requires startLine, startAnchor, and content.",
     );
 
     let mut insert_top_props = HashMap::new();
+    if path_required {
+        insert_top_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     insert_top_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -691,15 +734,27 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let insert_top_schema = build_edit_variant_schema(
         insert_top_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "content".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "content".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Top-prepend variant: startLine must be 0 and no anchor is required.",
     );
 
     let mut delete_single_props = HashMap::new();
+    if path_required {
+        delete_single_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     delete_single_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -717,15 +772,27 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let delete_single_schema = build_edit_variant_schema(
         delete_single_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "startAnchor".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "startAnchor".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Single-line delete variant: requires startLine and startAnchor.",
     );
 
     let mut delete_range_props = HashMap::new();
+    if path_required {
+        delete_range_props.insert(
+            "path".to_string(),
+            string_prop(Some(1), Some(1000), Some(path_desc)),
+        );
+    }
     delete_range_props.insert(
         "op".to_string(),
         string_const_prop(
@@ -751,17 +818,23 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     let delete_range_schema = build_edit_variant_schema(
         delete_range_props,
-        vec![
-            "op".to_string(),
-            "startLine".to_string(),
-            "endLine".to_string(),
-            "startAnchor".to_string(),
-            "endAnchor".to_string(),
-        ],
+        {
+            let mut required = vec![
+                "op".to_string(),
+                "startLine".to_string(),
+                "endLine".to_string(),
+                "startAnchor".to_string(),
+                "endAnchor".to_string(),
+            ];
+            if path_required {
+                required.insert(0, "path".to_string());
+            }
+            required
+        },
         "Multi-line delete variant: requires startLine, endLine, startAnchor, and endAnchor.",
     );
 
-    let edit_item_schema = one_of_object_schema(
+    one_of_object_schema(
         vec![
             replace_single_schema,
             replace_range_schema,
@@ -771,8 +844,10 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
             delete_range_schema,
         ],
         Some("A single edit operation. The required fields depend on op."),
-    );
+    )
+}
 
+pub fn create_edit_file_input_schema() -> JSONSchema {
     let mut props = HashMap::new();
     props.insert(
         "path".to_string(),
@@ -785,33 +860,48 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     props.insert(
         "edits".to_string(),
         array_schema(
-            edit_item_schema,
-            Some("Ordered list of edit operations to apply atomically. All edits are schema-validated and anchor-validated before any write. Edits must not overlap."),
+            create_edit_item_schema(false),
+            Some("Ordered list of edit operations to apply atomically to one file. All edits are schema-validated and anchor-validated before any write. Edits must not overlap."),
         ),
     );
 
     object_schema(props, vec!["path".to_string(), "edits".to_string()])
 }
 
-pub fn create_edit_file_tool() -> MCPTool {
+pub fn create_edit_files_input_schema() -> JSONSchema {
+    let edit_item_schema = create_edit_item_schema(true);
+
+    let mut props = HashMap::new();
+    props.insert(
+        "edits".to_string(),
+        array_schema(
+            edit_item_schema,
+            Some("Ordered list of edit operations to apply atomically across one or more files. Every item includes its own path. All edits are schema-validated and anchor-validated before any write. Edits must not overlap within the same file."),
+        ),
+    );
+
+    object_schema(props, vec!["edits".to_string()])
+}
+
+pub fn create_edit_files_tool() -> MCPTool {
     MCPTool {
-        name: "editFile".to_string(),
-        title: Some("Edit File (Batch)".to_string()),
-        description: "Apply multiple line edits to a file atomically in a single operation.
+        name: "editFiles".to_string(),
+        title: Some("Edit Files (Batch)".to_string()),
+        description: "Apply multiple line edits across one or more files atomically in a single operation.
 
 PREREQUISITE: Call readFile(showLineAnchors=true) first to obtain anchor values. For anchors, pass only the 6 hex characters between ':' and '|'.
 
-Each edit uses op-specific schema validation:
-- replace single line: startLine + startAnchor + content
-- replace range: startLine + startAnchor + endLine + endAnchor + content
-- insert_after existing line: startLine + startAnchor + content
-- insert_after file top: startLine=0 + content
-- delete single line: startLine + startAnchor
-- delete range: startLine + startAnchor + endLine + endAnchor
+Each edit item carries its own path and uses op-specific schema validation:
+- replace single line: path + startLine + startAnchor + content
+- replace range: path + startLine + startAnchor + endLine + endAnchor + content
+- insert_after existing line: path + startLine + startAnchor + content
+- insert_after file top: path + startLine=0 + content
+- delete single line: path + startLine + startAnchor
+- delete range: path + startLine + startAnchor + endLine + endAnchor
 
-Edits are applied bottom-to-top so line numbers stay stable within the batch. Legacy replaceLines / insertAfterLine / deleteLines still route here for backward compatibility."
+Edits are grouped by file and applied bottom-to-top so line numbers stay stable within each file. All files are validated before any write begins. Legacy editFile / replaceLines / insertAfterLine / deleteLines still route here for backward compatibility."
             .to_string(),
-        input_schema: create_edit_file_input_schema(),
+        input_schema: create_edit_files_input_schema(),
         output_schema: None,
         annotations: None,
     }

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -802,10 +802,12 @@ pub fn create_edit_file_tool() -> MCPTool {
 PREREQUISITE: Call readFile(showLineAnchors=true) first to obtain anchor values. For anchors, pass only the 6 hex characters between ':' and '|'.
 
 Each edit uses op-specific schema validation:
-- replace: startLine + startAnchor + content
+- replace single line: startLine + startAnchor + content
+- replace range: startLine + startAnchor + endLine + endAnchor + content
 - insert_after existing line: startLine + startAnchor + content
 - insert_after file top: startLine=0 + content
-- delete: startLine + startAnchor
+- delete single line: startLine + startAnchor
+- delete range: startLine + startAnchor + endLine + endAnchor
 
 Edits are applied bottom-to-top so line numbers stay stable within the batch. Legacy replaceLines / insertAfterLine / deleteLines still route here for backward compatibility."
             .to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -1,4 +1,4 @@
-use crate::mcp::{utils::schema_builder::*, MCPTool};
+use crate::mcp::{schema::JSONSchema, utils::schema_builder::*, MCPTool};
 
 use std::collections::HashMap;
 
@@ -41,7 +41,7 @@ pub fn create_read_file_tool() -> MCPTool {
     MCPTool {
         name: "readFile".to_string(),
         title: Some("Read File".to_string()),
-        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true before calling edit tools (replaceLines, insertAfterLine, deleteLines, editFile) to obtain anchor values."
+        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true before calling editFile to obtain anchor values."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -222,7 +222,7 @@ pub fn create_search_tool() -> MCPTool {
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(
-            "Include edit anchors in results for use with replaceLines, insertAfterLine, or deleteLines (default: false). For edit tools, copy only the 6-character anchor between ':' and '|'.",
+            "Include edit anchors in results for use with editFile (default: false). For edit tools, copy only the 6-character anchor between ':' and '|'.",
         )),
     );
 
@@ -546,66 +546,231 @@ Use flat params (line/anchor) for a single deletion, or the `edits` array for mu
     }
 }
 
-pub fn create_edit_file_tool() -> MCPTool {
-    // Compatibility-only batch delegator:
-    // editFile remains implemented because older callers and internal batching still route
-    // through it, but we intentionally prefer the three dedicated mutation tools for normal
-    // model-facing discovery. The reason is contract clarity: action=REPLACE / INSERT_AFTER /
-    // DELETE each require different fields and invariants, so splitting them into separate
-    // tools keeps each exposed schema narrow and predictable for planning.
-    // Build the schema for a single edit item inside the `edits` array.
-    let mut edit_item_props = HashMap::new();
-    edit_item_props.insert(
-        "action".to_string(),
-        enum_prop_required(
-            vec!["REPLACE", "INSERT_AFTER", "DELETE"],
-            "Edit action. REPLACE: swap lines with new_value. INSERT_AFTER: insert below the anchor line. DELETE: remove lines.",
+fn build_edit_variant_schema(
+    properties: HashMap<String, JSONSchema>,
+    required: Vec<String>,
+    description: &str,
+) -> JSONSchema {
+    let mut schema = object_schema(properties, required);
+    schema.description = Some(description.to_string());
+    schema
+}
+
+pub fn create_edit_file_input_schema() -> JSONSchema {
+    let start_line_desc =
+        "Target start line number (1-based). Use 0 only with op='insert_after' to prepend at the file top.";
+    let end_line_desc =
+        "Inclusive end line for a multi-line replace/delete range. Omit for a single-line edit.";
+    let start_anchor_desc =
+        "6-character opaque anchor for the start line from readFile(showLineAnchors=true). Do not include the line number or '|content'.";
+    let end_anchor_desc =
+        "6-character opaque anchor for the end line. Required when endLine is set for a multi-line replace/delete range.";
+    let content_desc = "Replacement or inserted content. May include \\n to span multiple lines.";
+
+    let mut replace_single_props = HashMap::new();
+    replace_single_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "replace",
+            Some("Replace one line or a contiguous line range with content."),
         ),
     );
-    edit_item_props.insert(
-        "line".to_string(),
-        integer_prop(
-            Some(0),
-            None,
-            Some("Target line number (1-based). Use 0 only with INSERT_AFTER to prepend at file top."),
-        ),
+    replace_single_props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
     );
-    edit_item_props.insert(
-        "endLine".to_string(),
-        integer_prop(
-            Some(1),
-            None,
-            Some("Inclusive end line for a multi-line REPLACE or DELETE range. Omit for single-line operations. Cannot be used with INSERT_AFTER."),
-        ),
+    replace_single_props.insert(
+        "startAnchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
     );
-    edit_item_props.insert(
-        "new_value".to_string(),
-        string_prop(
-            None,
-            None,
-            Some("Replacement or insertion content. Required for REPLACE and INSERT_AFTER. Omit for DELETE. May contain \\n to span multiple lines."),
-        ),
+    replace_single_props.insert(
+        "content".to_string(),
+        string_prop(None, None, Some(content_desc)),
     );
-    edit_item_props.insert(
-        "anchor".to_string(),
-        string_prop(
-            None,
-            None,
-            Some("6-character opaque anchor for the start line from readFile(showLineAnchors=true). Required for all operations except INSERT_AFTER with line=0. Do not include the line number or '|content'."),
-        ),
-    );
-    edit_item_props.insert(
-        "endAnchor".to_string(),
-        string_prop(
-            None,
-            None,
-            Some("6-character opaque anchor for the end line. Required when endLine is set for a multi-line REPLACE or DELETE. Do not include the line number or '|content'."),
-        ),
+    let replace_single_schema = build_edit_variant_schema(
+        replace_single_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "startAnchor".to_string(),
+            "content".to_string(),
+        ],
+        "Single-line replace variant: requires startLine, startAnchor, and content.",
     );
 
-    let edit_item_schema = object_schema(
-        edit_item_props,
-        vec!["action".to_string(), "line".to_string()],
+    let mut replace_range_props = HashMap::new();
+    replace_range_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "replace",
+            Some("Replace one line or a contiguous line range with content."),
+        ),
+    );
+    replace_range_props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
+    );
+    replace_range_props.insert(
+        "endLine".to_string(),
+        integer_prop(Some(1), None, Some(end_line_desc)),
+    );
+    replace_range_props.insert(
+        "startAnchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
+    );
+    replace_range_props.insert(
+        "endAnchor".to_string(),
+        string_prop(None, None, Some(end_anchor_desc)),
+    );
+    replace_range_props.insert(
+        "content".to_string(),
+        string_prop(None, None, Some(content_desc)),
+    );
+    let replace_range_schema = build_edit_variant_schema(
+        replace_range_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "endLine".to_string(),
+            "startAnchor".to_string(),
+            "endAnchor".to_string(),
+            "content".to_string(),
+        ],
+        "Multi-line replace variant: requires startLine, endLine, startAnchor, endAnchor, and content.",
+    );
+
+    let mut insert_existing_props = HashMap::new();
+    insert_existing_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "insert_after",
+            Some("Insert content after an existing line."),
+        ),
+    );
+    insert_existing_props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
+    );
+    insert_existing_props.insert(
+        "startAnchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
+    );
+    insert_existing_props.insert(
+        "content".to_string(),
+        string_prop(None, None, Some(content_desc)),
+    );
+    let insert_existing_schema = build_edit_variant_schema(
+        insert_existing_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "startAnchor".to_string(),
+            "content".to_string(),
+        ],
+        "Insert-after variant for an existing line: requires startLine, startAnchor, and content.",
+    );
+
+    let mut insert_top_props = HashMap::new();
+    insert_top_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "insert_after",
+            Some("Insert content at the very beginning of the file."),
+        ),
+    );
+    insert_top_props.insert(
+        "startLine".to_string(),
+        integer_const_prop(
+            0,
+            Some("Use startLine=0 with op='insert_after' to prepend at the file top."),
+        ),
+    );
+    insert_top_props.insert(
+        "content".to_string(),
+        string_prop(None, None, Some(content_desc)),
+    );
+    let insert_top_schema = build_edit_variant_schema(
+        insert_top_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "content".to_string(),
+        ],
+        "Top-prepend variant: startLine must be 0 and no anchor is required.",
+    );
+
+    let mut delete_single_props = HashMap::new();
+    delete_single_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "delete",
+            Some("Delete one line or a contiguous line range."),
+        ),
+    );
+    delete_single_props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
+    );
+    delete_single_props.insert(
+        "startAnchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
+    );
+    let delete_single_schema = build_edit_variant_schema(
+        delete_single_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "startAnchor".to_string(),
+        ],
+        "Single-line delete variant: requires startLine and startAnchor.",
+    );
+
+    let mut delete_range_props = HashMap::new();
+    delete_range_props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "delete",
+            Some("Delete one line or a contiguous line range."),
+        ),
+    );
+    delete_range_props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
+    );
+    delete_range_props.insert(
+        "endLine".to_string(),
+        integer_prop(Some(1), None, Some(end_line_desc)),
+    );
+    delete_range_props.insert(
+        "startAnchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
+    );
+    delete_range_props.insert(
+        "endAnchor".to_string(),
+        string_prop(None, None, Some(end_anchor_desc)),
+    );
+    let delete_range_schema = build_edit_variant_schema(
+        delete_range_props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "endLine".to_string(),
+            "startAnchor".to_string(),
+            "endAnchor".to_string(),
+        ],
+        "Multi-line delete variant: requires startLine, endLine, startAnchor, and endAnchor.",
+    );
+
+    let edit_item_schema = one_of_object_schema(
+        vec![
+            replace_single_schema,
+            replace_range_schema,
+            insert_existing_schema,
+            insert_top_schema,
+            delete_single_schema,
+            delete_range_schema,
+        ],
+        Some("A single edit operation. The required fields depend on op."),
     );
 
     let mut props = HashMap::new();
@@ -621,10 +786,14 @@ pub fn create_edit_file_tool() -> MCPTool {
         "edits".to_string(),
         array_schema(
             edit_item_schema,
-            Some("Ordered list of edit operations to apply atomically. All anchors are validated against the original file before any change is written. Edits must not overlap."),
+            Some("Ordered list of edit operations to apply atomically. All edits are schema-validated and anchor-validated before any write. Edits must not overlap."),
         ),
     );
 
+    object_schema(props, vec!["path".to_string(), "edits".to_string()])
+}
+
+pub fn create_edit_file_tool() -> MCPTool {
     MCPTool {
         name: "editFile".to_string(),
         title: Some("Edit File (Batch)".to_string()),
@@ -632,14 +801,15 @@ pub fn create_edit_file_tool() -> MCPTool {
 
 PREREQUISITE: Call readFile(showLineAnchors=true) first to obtain anchor values. For anchors, pass only the 6 hex characters between ':' and '|'.
 
-Edits are applied bottom-to-top so line numbers stay stable within the batch.
+Each edit uses op-specific schema validation:
+- replace: startLine + startAnchor + content
+- insert_after existing line: startLine + startAnchor + content
+- insert_after file top: startLine=0 + content
+- delete: startLine + startAnchor
 
-Use editFile when making multiple edits to the same file. Use replaceLines / insertAfterLine / deleteLines for a single targeted edit."
+Edits are applied bottom-to-top so line numbers stay stable within the batch. Legacy replaceLines / insertAfterLine / deleteLines still route here for backward compatibility."
             .to_string(),
-        input_schema: object_schema(
-            props,
-            vec!["path".to_string(), "edits".to_string()],
-        ),
+        input_schema: create_edit_file_input_schema(),
         output_schema: None,
         annotations: None,
     }

--- a/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
@@ -13,15 +13,10 @@ pub fn file_tools() -> Vec<MCPTool> {
         file_tools::create_list_directory_tool(),
         file_tools::create_import_files_tool(),
         file_tools::create_search_tool(),
-        // Intentionally do NOT expose editFile in normal tool discovery.
-        // editFile multiplexes three different contracts (REPLACE / INSERT_AFTER / DELETE)
-        // behind an action discriminator, which makes the agent-facing contract broader and
-        // less predictable than the dedicated tools below. Keep it dispatchable for
-        // compatibility/batching internals, but steer model planning toward the explicit
-        // per-operation tools whose schemas match a single mutation contract.
-        file_tools::create_replace_lines_tool(),
-        file_tools::create_insert_after_line_tool(),
-        file_tools::create_delete_lines_tool(),
+        // editFile is now the single model-facing mutation tool.
+        // Legacy per-operation tools remain dispatchable for older clients, but are hidden from
+        // discovery so the agent only plans against one contract.
+        file_tools::create_edit_file_tool(),
     ]
 }
 

--- a/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
@@ -13,10 +13,10 @@ pub fn file_tools() -> Vec<MCPTool> {
         file_tools::create_list_directory_tool(),
         file_tools::create_import_files_tool(),
         file_tools::create_search_tool(),
-        // editFile is now the single model-facing mutation tool.
-        // Legacy per-operation tools remain dispatchable for older clients, but are hidden from
-        // discovery so the agent only plans against one contract.
-        file_tools::create_edit_file_tool(),
+        // editFiles is the single model-facing mutation tool.
+        // Legacy editFile and per-operation tools remain dispatchable for older clients, but are
+        // hidden from discovery so the agent only plans against one contract.
+        file_tools::create_edit_files_tool(),
     ]
 }
 

--- a/src-tauri/src/mcp/schema.rs
+++ b/src-tauri/src/mcp/schema.rs
@@ -8,10 +8,18 @@ pub enum JSONSchemaType {
     #[serde(rename = "string")]
     String {
         /// The minimum length of the string.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "minLength",
+            alias = "min_length",
+            skip_serializing_if = "Option::is_none"
+        )]
         min_length: Option<u32>,
         /// The maximum length of the string.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "maxLength",
+            alias = "max_length",
+            skip_serializing_if = "Option::is_none"
+        )]
         max_length: Option<u32>,
         /// A regular expression pattern for the string to match.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,13 +38,25 @@ pub enum JSONSchemaType {
         #[serde(skip_serializing_if = "Option::is_none")]
         maximum: Option<f64>,
         /// The exclusive minimum value.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "exclusiveMinimum",
+            alias = "exclusive_minimum",
+            skip_serializing_if = "Option::is_none"
+        )]
         exclusive_minimum: Option<f64>,
         /// The exclusive maximum value.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "exclusiveMaximum",
+            alias = "exclusive_maximum",
+            skip_serializing_if = "Option::is_none"
+        )]
         exclusive_maximum: Option<f64>,
         /// Specifies that the value must be a multiple of this number.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "multipleOf",
+            alias = "multiple_of",
+            skip_serializing_if = "Option::is_none"
+        )]
         multiple_of: Option<f64>,
     },
     /// An integer type, with optional range and multiple-of constraints.
@@ -49,13 +69,25 @@ pub enum JSONSchemaType {
         #[serde(skip_serializing_if = "Option::is_none")]
         maximum: Option<i64>,
         /// The exclusive minimum value.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "exclusiveMinimum",
+            alias = "exclusive_minimum",
+            skip_serializing_if = "Option::is_none"
+        )]
         exclusive_minimum: Option<i64>,
         /// The exclusive maximum value.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "exclusiveMaximum",
+            alias = "exclusive_maximum",
+            skip_serializing_if = "Option::is_none"
+        )]
         exclusive_maximum: Option<i64>,
         /// Specifies that the value must be a multiple of this number.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "multipleOf",
+            alias = "multiple_of",
+            skip_serializing_if = "Option::is_none"
+        )]
         multiple_of: Option<i64>,
     },
     /// A boolean type.
@@ -68,13 +100,25 @@ pub enum JSONSchemaType {
         #[serde(skip_serializing_if = "Option::is_none")]
         items: Option<Box<JSONSchema>>,
         /// The minimum number of items in the array.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "minItems",
+            alias = "min_items",
+            skip_serializing_if = "Option::is_none"
+        )]
         min_items: Option<u32>,
         /// The maximum number of items in the array.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "maxItems",
+            alias = "max_items",
+            skip_serializing_if = "Option::is_none"
+        )]
         max_items: Option<u32>,
         /// If true, all items in the array must be unique.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "uniqueItems",
+            alias = "unique_items",
+            skip_serializing_if = "Option::is_none"
+        )]
         unique_items: Option<bool>,
     },
     /// An object type, with optional constraints on its properties.
@@ -87,13 +131,25 @@ pub enum JSONSchemaType {
         #[serde(skip_serializing_if = "Option::is_none")]
         required: Option<Vec<String>>,
         /// If false, no additional properties are allowed.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "additionalProperties",
+            alias = "additional_properties",
+            skip_serializing_if = "Option::is_none"
+        )]
         additional_properties: Option<bool>,
         /// The minimum number of properties.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "minProperties",
+            alias = "min_properties",
+            skip_serializing_if = "Option::is_none"
+        )]
         min_properties: Option<u32>,
         /// The maximum number of properties.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "maxProperties",
+            alias = "max_properties",
+            skip_serializing_if = "Option::is_none"
+        )]
         max_properties: Option<u32>,
     },
     /// A null type.
@@ -125,6 +181,13 @@ pub struct JSONSchema {
     /// A constant value that the schema must match.
     #[serde(rename = "const", skip_serializing_if = "Option::is_none")]
     pub const_value: Option<serde_json::Value>,
+    /// A set of alternative schemas where exactly one must validate.
+    #[serde(
+        rename = "oneOf",
+        alias = "one_of",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub one_of: Option<Vec<JSONSchema>>,
 }
 
 impl JSONSchema {
@@ -138,6 +201,7 @@ impl JSONSchema {
             examples: None,
             enum_values: None,
             const_value: None,
+            one_of: None,
         }
     }
 }
@@ -163,6 +227,7 @@ impl Default for MCPToolInputSchema {
             examples: None,
             enum_values: None,
             const_value: None,
+            one_of: None,
         }
     }
 }

--- a/src-tauri/src/mcp/utils/schema_builder.rs
+++ b/src-tauri/src/mcp/utils/schema_builder.rs
@@ -21,6 +21,7 @@ pub fn string_prop(
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -44,6 +45,7 @@ pub fn integer_prop(
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -67,6 +69,7 @@ pub fn number_prop(
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -91,6 +94,7 @@ pub fn integer_prop_with_default(
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -104,6 +108,7 @@ pub fn boolean_prop(description: Option<&str>) -> JSONSchema {
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -130,6 +135,7 @@ pub fn object_schema(properties: HashMap<String, JSONSchema>, required: Vec<Stri
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -148,6 +154,7 @@ pub fn array_schema(items: JSONSchema, description: Option<&str>) -> JSONSchema 
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -171,6 +178,7 @@ pub fn string_prop_with_examples(
         examples: Some(examples),
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -199,6 +207,7 @@ pub fn enum_prop(values: Vec<&str>, default: &str, description: Option<&str>) ->
         examples: None,
         enum_values: Some(enum_values),
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -222,6 +231,7 @@ pub fn enum_prop_optional(values: Vec<&str>, description: Option<&str>) -> JSONS
         examples: None,
         enum_values: Some(enum_values),
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -245,6 +255,7 @@ pub fn enum_prop_required(values: Vec<&str>, description: &str) -> JSONSchema {
         examples: None,
         enum_values: Some(enum_values),
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -270,6 +281,7 @@ pub fn object_prop(
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
     }
 }
 
@@ -289,5 +301,65 @@ pub fn object_map_prop(description: Option<&str>) -> JSONSchema {
         examples: None,
         enum_values: None,
         const_value: None,
+        one_of: None,
+    }
+}
+
+/// Creates a string property constrained to a single constant value.
+pub fn string_const_prop(value: &str, description: Option<&str>) -> JSONSchema {
+    JSONSchema {
+        schema_type: JSONSchemaType::String {
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            format: None,
+        },
+        title: None,
+        description: description.map(|s| s.to_string()),
+        default: None,
+        examples: None,
+        enum_values: None,
+        const_value: Some(Value::String(value.to_string())),
+        one_of: None,
+    }
+}
+
+/// Creates an integer property constrained to a single constant value.
+pub fn integer_const_prop(value: i64, description: Option<&str>) -> JSONSchema {
+    JSONSchema {
+        schema_type: JSONSchemaType::Integer {
+            minimum: None,
+            maximum: None,
+            exclusive_minimum: None,
+            exclusive_maximum: None,
+            multiple_of: None,
+        },
+        title: None,
+        description: description.map(|s| s.to_string()),
+        default: None,
+        examples: None,
+        enum_values: None,
+        const_value: Some(Value::Number(serde_json::Number::from(value))),
+        one_of: None,
+    }
+}
+
+/// Creates an object schema that validates exactly one of the provided variants.
+pub fn one_of_object_schema(variants: Vec<JSONSchema>, description: Option<&str>) -> JSONSchema {
+    JSONSchema {
+        schema_type: JSONSchemaType::Object {
+            properties: None,
+            required: None,
+            additional_properties: None,
+            min_properties: None,
+            max_properties: None,
+        },
+        title: None,
+        description: description.map(|s| s.to_string()),
+        default: None,
+        examples: None,
+        enum_values: None,
+        const_value: None,
+        one_of: Some(variants),
     }
 }

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -1,6 +1,7 @@
 use serde_json::json;
 use std::sync::Arc;
 use tauri_mcp_agent_lib::mcp::builtin::workspace::file_operations::utils::format_as_hashlines;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_file_input_schema;
 use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
 use tauri_mcp_agent_lib::session::SessionManager;
@@ -52,6 +53,23 @@ fn later_prefix_hash_changes_when_earlier_content_changes() {
     assert_ne!(original_third, changed_third);
 }
 
+#[test]
+fn edit_file_schema_exposes_op_variants_via_one_of() {
+    let schema_json =
+        serde_json::to_value(create_edit_file_input_schema()).expect("serialize editFile schema");
+    let edits_items = schema_json
+        .get("properties")
+        .and_then(|properties| properties.get("edits"))
+        .and_then(|edits| edits.get("items"))
+        .expect("edits.items schema");
+    let variants = edits_items
+        .get("oneOf")
+        .and_then(|value| value.as_array())
+        .expect("oneOf variants");
+
+    assert_eq!(variants.len(), 6, "expected replace/insert/delete variants");
+}
+
 #[tokio::test]
 async fn edit_file_rejects_hashless_replace_of_existing_line() {
     let temp_dir = tempdir().expect("temp dir");
@@ -67,9 +85,9 @@ async fn edit_file_rejects_hashless_replace_of_existing_line() {
                 "path": "sample.txt",
                 "edits": [
                     {
-                        "line": 1,
-                        "action": "REPLACE",
-                        "new_value": "ALPHA"
+                        "op": "replace",
+                        "startLine": 1,
+                        "content": "ALPHA"
                     }
                 ]
             }),
@@ -81,7 +99,7 @@ async fn edit_file_rejects_hashless_replace_of_existing_line() {
     let text = extract_text_content(&result);
     assert_eq!(result.is_error, Some(true));
     assert!(
-        text.contains("requires 'anchor'"),
+        text.contains("declared schema") && text.contains("startAnchor"),
         "expected missing-anchor error, got: {text}"
     );
 }
@@ -101,9 +119,9 @@ async fn edit_file_allows_hashless_insert_at_top() {
                 "path": "sample.txt",
                 "edits": [
                     {
-                        "line": 0,
-                        "action": "INSERT_AFTER",
-                        "new_value": "header"
+                        "op": "insert_after",
+                        "startLine": 0,
+                        "content": "header"
                     }
                 ]
             }),
@@ -139,11 +157,11 @@ async fn edit_file_rejects_multiline_replace_without_end_hash() {
                 "path": "sample.txt",
                 "edits": [
                     {
-                        "line": 1,
+                        "op": "replace",
+                        "startLine": 1,
                         "endLine": 2,
-                        "action": "REPLACE",
-                        "anchor": anchor_parts[1],
-                        "new_value": "ALPHA\nBETA"
+                        "startAnchor": anchor_parts[1],
+                        "content": "ALPHA\nBETA"
                     }
                 ]
             }),
@@ -155,7 +173,7 @@ async fn edit_file_rejects_multiline_replace_without_end_hash() {
     assert_eq!(result.is_error, Some(true));
     let text = extract_text_content(&result);
     assert!(
-        text.contains("requires 'endAnchor'"),
+        text.contains("declared schema") && text.contains("endAnchor"),
         "expected missing endAnchor error, got: {text}"
     );
 }
@@ -193,12 +211,12 @@ async fn edit_file_allows_multiline_replace_with_end_anchor() {
                 "path": "sample.txt",
                 "edits": [
                     {
-                        "line": 1,
+                        "op": "replace",
+                        "startLine": 1,
                         "endLine": 2,
-                        "action": "REPLACE",
-                        "anchor": start_parts[1],
+                        "startAnchor": start_parts[1],
                         "endAnchor": end_parts[1],
-                        "new_value": "ALPHA\nBETA"
+                        "content": "ALPHA\nBETA"
                     }
                 ]
             }),
@@ -210,4 +228,39 @@ async fn edit_file_allows_multiline_replace_with_end_anchor() {
     assert_eq!(result.is_error, Some(false));
     let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
     assert_eq!(updated, "ALPHA\nBETA\ngamma\n");
+}
+
+#[tokio::test]
+async fn legacy_replace_lines_alias_still_routes_through_edit_file() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "legacy-replace-lines-alias";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let anchors = format_as_hashlines("alpha\nbeta\n");
+    let start_anchor = anchors
+        .lines()
+        .next()
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("start anchor");
+
+    let result = server
+        .handle_replace_lines(
+            json!({
+                "path": "sample.txt",
+                "line": 1,
+                "anchor": start_anchor,
+                "new_value": "ALPHA"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("legacy alias should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "ALPHA\nbeta\n");
 }

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 use std::sync::Arc;
 use tauri_mcp_agent_lib::mcp::builtin::workspace::file_operations::utils::format_as_hashlines;
-use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_file_input_schema;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_files_input_schema;
 use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
 use tauri_mcp_agent_lib::session::SessionManager;
@@ -54,9 +54,9 @@ fn later_prefix_hash_changes_when_earlier_content_changes() {
 }
 
 #[test]
-fn edit_file_schema_exposes_op_variants_via_one_of() {
+fn edit_files_schema_exposes_op_variants_via_one_of() {
     let schema_json =
-        serde_json::to_value(create_edit_file_input_schema()).expect("serialize editFile schema");
+        serde_json::to_value(create_edit_files_input_schema()).expect("serialize editFiles schema");
     let edits_items = schema_json
         .get("properties")
         .and_then(|properties| properties.get("edits"))
@@ -68,6 +68,16 @@ fn edit_file_schema_exposes_op_variants_via_one_of() {
         .expect("oneOf variants");
 
     assert_eq!(variants.len(), 6, "expected replace/insert/delete variants");
+    for variant in variants {
+        let required = variant
+            .get("required")
+            .and_then(|value| value.as_array())
+            .expect("variant required array");
+        assert!(
+            required.iter().any(|value| value.as_str() == Some("path")),
+            "every editFiles variant should require path"
+        );
+    }
 }
 
 #[tokio::test]
@@ -333,4 +343,123 @@ async fn legacy_edit_file_empty_new_value_still_deletes() {
     assert_eq!(result.is_error, Some(false));
     let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
     assert_eq!(updated, "beta\n");
+}
+
+#[tokio::test]
+async fn edit_files_applies_multi_file_batch_atomically() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-multi-file";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("a.txt"), "alpha\nbeta\n").expect("write a");
+    std::fs::write(workspace_dir.join("b.txt"), "one\ntwo\n").expect("write b");
+
+    let a_anchors = format_as_hashlines("alpha\nbeta\n");
+    let a_anchor = a_anchors
+        .lines()
+        .next()
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("a anchor");
+    let b_anchors = format_as_hashlines("one\ntwo\n");
+    let b_anchor = b_anchors
+        .lines()
+        .nth(1)
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("b anchor");
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "a.txt",
+                        "op": "replace",
+                        "startLine": 1,
+                        "startAnchor": a_anchor,
+                        "content": "ALPHA"
+                    },
+                    {
+                        "path": "b.txt",
+                        "op": "delete",
+                        "startLine": 2,
+                        "startAnchor": b_anchor
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("multi-file edit should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    assert_eq!(
+        std::fs::read_to_string(workspace_dir.join("a.txt")).expect("read a"),
+        "ALPHA\nbeta\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace_dir.join("b.txt")).expect("read b"),
+        "one\n"
+    );
+}
+
+#[tokio::test]
+async fn edit_files_rejects_stale_anchor_without_partial_write() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-rollback";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("a.txt"), "alpha\nbeta\n").expect("write a");
+    std::fs::write(workspace_dir.join("b.txt"), "one\ntwo\n").expect("write b");
+
+    let a_anchors = format_as_hashlines("alpha\nbeta\n");
+    let a_anchor = a_anchors
+        .lines()
+        .next()
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("a anchor");
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "a.txt",
+                        "op": "replace",
+                        "startLine": 1,
+                        "startAnchor": a_anchor,
+                        "content": "ALPHA"
+                    },
+                    {
+                        "path": "b.txt",
+                        "op": "replace",
+                        "startLine": 1,
+                        "startAnchor": "deadbe",
+                        "content": "ONE"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("multi-file edit should return MCPResult");
+
+    assert_eq!(result.is_error, Some(true));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("STALE ANCHOR"),
+        "expected stale anchor error, got: {text}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace_dir.join("a.txt")).expect("read a"),
+        "alpha\nbeta\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace_dir.join("b.txt")).expect("read b"),
+        "one\ntwo\n"
+    );
 }

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -264,3 +264,73 @@ async fn legacy_replace_lines_alias_still_routes_through_edit_file() {
     let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
     assert_eq!(updated, "ALPHA\nbeta\n");
 }
+
+#[tokio::test]
+async fn legacy_edit_file_insert_after_flag_still_works() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "legacy-edit-file-insert-after-flag";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "edits": [
+                    {
+                        "line": 0,
+                        "insertAfter": true,
+                        "new_value": "header"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("legacy insertAfter edit should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "header\nalpha\nbeta\n");
+}
+
+#[tokio::test]
+async fn legacy_edit_file_empty_new_value_still_deletes() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "legacy-edit-file-empty-new-value-delete";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let anchors = format_as_hashlines("alpha\nbeta\n");
+    let start_anchor = anchors
+        .lines()
+        .next()
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("start anchor");
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "edits": [
+                    {
+                        "line": 1,
+                        "anchor": start_anchor,
+                        "new_value": ""
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("legacy empty new_value delete should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "beta\n");
+}

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -342,7 +342,7 @@ async fn write_file_duplicate_resource_guidance_keeps_numbered_steps_clean() {
         "read guidance should be a clean numbered step: {text}"
     );
     assert!(
-        text.contains("4. Use editFile for targeted edits to \"art.html\" instead of rewriting the whole file."),
+        text.contains("4. Use editFiles for targeted edits to \"art.html\" instead of rewriting the whole file."),
         "edit guidance should be a clean numbered step: {text}"
     );
     assert!(

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -342,7 +342,7 @@ async fn write_file_duplicate_resource_guidance_keeps_numbered_steps_clean() {
         "read guidance should be a clean numbered step: {text}"
     );
     assert!(
-        text.contains("4. Use replaceLines, insertAfterLine, or deleteLines for targeted edits to \"art.html\" instead of rewriting the whole file."),
+        text.contains("4. Use editFile for targeted edits to \"art.html\" instead of rewriting the whole file."),
         "edit guidance should be a clean numbered step: {text}"
     );
     assert!(

--- a/src/lib/ai-service/__tests__/tool-schema-passthrough.test.ts
+++ b/src/lib/ai-service/__tests__/tool-schema-passthrough.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MCPTool } from '@/lib/mcp';
+
+import { OpenAIService } from '../openai';
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: vi.fn(),
+      },
+    },
+    models: {
+      list: vi.fn(),
+    },
+  })),
+}));
+
+vi.mock('../../logger', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../../llm-config-manager', () => ({
+  llmConfigManager: {
+    getModelsForProvider: vi.fn().mockReturnValue({}),
+    getModel: vi.fn().mockReturnValue(null),
+  },
+}));
+
+vi.mock('../model-capabilities', () => ({
+  supportsThinking: vi.fn().mockResolvedValue(false),
+  getContextWindow: vi.fn().mockResolvedValue(128000),
+}));
+
+describe('tool schema passthrough', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves nested oneOf contracts when converting OpenAI tools', () => {
+    const service = new OpenAIService('sk-test');
+    const tool: MCPTool = {
+      name: 'editFile',
+      description: 'Unified edit tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          edits: {
+            type: 'array',
+            items: {
+              type: 'object',
+              oneOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    op: { type: 'string', const: 'replace' },
+                    content: { type: 'string' },
+                  },
+                  required: ['op', 'content'],
+                  additionalProperties: false,
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    op: { type: 'string', const: 'delete' },
+                  },
+                  required: ['op'],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          },
+        },
+        required: ['edits'],
+      },
+    };
+
+    const converted = service.convertTools([tool]);
+    const parameters = converted[0].function.parameters as {
+      properties?: {
+        edits?: {
+          items?: {
+            oneOf?: Array<{ properties?: { op?: { const?: string } } }>;
+          };
+        };
+      };
+    };
+
+    const variants = parameters.properties?.edits?.items?.oneOf;
+    expect(variants).toHaveLength(2);
+    expect(variants?.[0]?.properties?.op?.const).toBe('replace');
+    expect(variants?.[1]?.properties?.op?.const).toBe('delete');
+  });
+});

--- a/src/lib/ai-service/__tests__/tool-schema-passthrough.test.ts
+++ b/src/lib/ai-service/__tests__/tool-schema-passthrough.test.ts
@@ -46,8 +46,8 @@ describe('tool schema passthrough', () => {
   it('preserves nested oneOf contracts when converting OpenAI tools', () => {
     const service = new OpenAIService('sk-test');
     const tool: MCPTool = {
-      name: 'editFile',
-      description: 'Unified edit tool',
+      name: 'editFiles',
+      description: 'Unified multi-file edit tool',
       inputSchema: {
         type: 'object',
         properties: {
@@ -59,18 +59,20 @@ describe('tool schema passthrough', () => {
                 {
                   type: 'object',
                   properties: {
+                    path: { type: 'string' },
                     op: { type: 'string', const: 'replace' },
                     content: { type: 'string' },
                   },
-                  required: ['op', 'content'],
+                  required: ['path', 'op', 'content'],
                   additionalProperties: false,
                 },
                 {
                   type: 'object',
                   properties: {
+                    path: { type: 'string' },
                     op: { type: 'string', const: 'delete' },
                   },
-                  required: ['op'],
+                  required: ['path', 'op'],
                   additionalProperties: false,
                 },
               ],

--- a/src/lib/ai-service/anthropic.ts
+++ b/src/lib/ai-service/anthropic.ts
@@ -39,6 +39,7 @@ import {
   createSerializableToolCallArgumentDelta,
   serializeToolCallArgumentDeltas,
 } from './stream-events';
+import { ensureSchemaTypeField } from './utils';
 
 const logger = getLogger('AnthropicService');
 
@@ -91,15 +92,9 @@ export class AnthropicService extends BaseAIService<
    */
   convertTools(mcpTools: MCPTool[]): AnthropicTool[] {
     const tools = mcpTools.map((mcpTool) => {
-      const properties = mcpTool.inputSchema.properties || {};
-      const required = mcpTool.inputSchema.required || [];
-
-      // Anthropic requires 'type' in schema
-      const input_schema = {
-        type: 'object' as const,
-        properties: properties,
-        required: required,
-      };
+      const input_schema = ensureSchemaTypeField(
+        mcpTool.inputSchema,
+      );
 
       return {
         name: mcpTool.name,

--- a/src/lib/ai-service/openai.ts
+++ b/src/lib/ai-service/openai.ts
@@ -104,14 +104,9 @@ export class OpenAIService extends BaseAIService<
    */
   convertTools(mcpTools: MCPTool[]): OpenAIChatCompletionTool[] {
     return mcpTools.map((mcpTool) => {
-      const properties = mcpTool.inputSchema.properties || {};
-      const required = mcpTool.inputSchema.required || [];
-
-      const parameters = ensureSchemaTypeField({
-        type: 'object' as const,
-        properties: properties,
-        required: required,
-      });
+      const parameters = ensureSchemaTypeField(
+        mcpTool.inputSchema,
+      );
 
       return {
         type: 'function',

--- a/src/lib/ai-service/utils/schema.ts
+++ b/src/lib/ai-service/utils/schema.ts
@@ -1,11 +1,11 @@
 export function ensureSchemaTypeField(
-  schema: Record<string, unknown>,
+  schema: object | Record<string, unknown>,
 ): Record<string, unknown> {
   if (!schema || typeof schema !== 'object') {
     return { type: 'object', properties: {} };
   }
 
-  const result = { ...schema };
+  const result = { ...(schema as Record<string, unknown>) };
 
   if (!result.type) {
     if (result.properties && typeof result.properties === 'object') {
@@ -48,6 +48,17 @@ export function ensureSchemaTypeField(
     } else if (typeof result.items === 'object' && result.items !== null) {
       result.items = ensureSchemaTypeField(
         result.items as Record<string, unknown>,
+      );
+    }
+  }
+
+  for (const key of ['oneOf', 'anyOf', 'allOf'] as const) {
+    const value = result[key];
+    if (Array.isArray(value)) {
+      result[key] = value.map((item) =>
+        typeof item === 'object' && item !== null
+          ? ensureSchemaTypeField(item as Record<string, unknown>)
+          : item,
       );
     }
   }

--- a/src/lib/mcp/schema/json-schema.ts
+++ b/src/lib/mcp/schema/json-schema.ts
@@ -34,6 +34,12 @@ export interface JSONSchemaBase {
   enum?: unknown[];
   /** A constant value that the schema must have. */
   const?: unknown;
+  /** Exactly one of these schemas must validate. */
+  oneOf?: JSONSchema[];
+  /** Any of these schemas may validate. */
+  anyOf?: JSONSchema[];
+  /** All of these schemas must validate. */
+  allOf?: JSONSchema[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- make `editFile` the single model-facing workspace edit tool while keeping legacy aliases as internal compatibility paths
- extend MCP schema support so op-specific edit variants are declared with `oneOf` and preserved through provider tool conversion
- validate `editFile` arguments against the declared schema and update workspace guidance/tests accordingly

## Validation
- `pnpm test:run src/lib/ai-service/__tests__/tool-schema-passthrough.test.ts`
- `cd src-tauri && cargo test --test workspace_hash_anchor_tests --test workspace_search_tests`
- `pnpm build`