### PR TITLE
⚡ Bolt: Memoize derived array metrics to prevent O(N) recalculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -92,3 +92,6 @@
 
 **Learning:** `ScheduledTasksPage` was creating intermediate arrays using `.filter(...)` and then sorting them using `.sort(...)` repeatedly in the render loop just to calculate `nextGroupRun` (the earliest next run time among enabled tasks). Since the source array `group.tasks` was already correctly sorted upstream (enabled first, then by `nextRunAt`), this eager downstream sorting was entirely redundant and caused unnecessary array allocations and O(N log N) computation per group render.
 **Action:** When extracting a single item (like a min/max or "next" item) from an already-sorted array, do not re-sort. Use an O(1) traversal like `.find(...)` to locate the first item matching your criteria. Similarly, avoid intermediate arrays from `.filter().length` and prefer `.reduce()` when just counting specific items in a hot path.
+## 2026-04-18 - Memoizing Derived Array Metrics
+**Learning:** Extracting inline `.reduce()` calls that count matching items (like enabled tasks or bookmarked sessions) into `useMemo` hooks or integrating them into existing `useMemo` blocks prevents O(N) recalculations on every component render.
+**Action:** When computing scalar counts or metrics from arrays, calculate and store them in `useMemo` or integrate the logic directly into existing list mappings to ensure referential stability and eliminate redundant layout thrashing.

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -336,6 +336,13 @@ export function SessionHistoryPanel({
     t,
   ]);
 
+  const bookmarkedCount = useMemo(() => {
+    return baseSessions.reduce(
+      (acc, session) => (session.isBookmarked ? acc + 1 : acc),
+      0,
+    );
+  }, [baseSessions]);
+
   const statusCounts = useMemo(() => {
     const counts = {
       all: baseSessions.length,
@@ -401,10 +408,7 @@ export function SessionHistoryPanel({
             <TabsTrigger value="bookmarked" className="flex-1">
               <Bookmark className="mr-1.5 h-3.5 w-3.5" />
               {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} (
-              {baseSessions.reduce(
-                (acc, session) => (session.isBookmarked ? acc + 1 : acc),
-                0,
-              )}
+              {bookmarkedCount}
               )
             </TabsTrigger>
           </TabsList>

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -54,6 +54,7 @@ interface ScheduledTaskGroupSection {
   groupId: string | null;
   groupName: string;
   tasks: ScheduledTask[];
+  enabledCount: number;
 }
 
 export function ScheduledTasksPage() {
@@ -142,6 +143,7 @@ export function ScheduledTasksPage() {
         groupId: task.groupId,
         groupName: task.groupName,
         tasks: [task],
+        enabledCount: 0, // correctly assigned below
       });
     }
 

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -146,10 +146,17 @@ export function ScheduledTasksPage() {
     }
 
     return Array.from(groups.values())
-      .map((group) => ({
-        ...group,
-        tasks: [...group.tasks].sort(compareScheduledTasks),
-      }))
+      .map((group) => {
+        const sortedTasks = [...group.tasks].sort(compareScheduledTasks);
+        return {
+          ...group,
+          tasks: sortedTasks,
+          enabledCount: sortedTasks.reduce(
+            (count, task) => (task.enabled ? count + 1 : count),
+            0,
+          ),
+        };
+      })
       .sort((left, right) => left.groupName.localeCompare(right.groupName));
   }, [tasks]);
 
@@ -158,9 +165,9 @@ export function ScheduledTasksPage() {
     [tasks],
   );
 
-  const enabledTaskCount = tasks.reduce(
-    (acc, task) => (task.enabled ? acc + 1 : acc),
-    0,
+  const enabledTaskCount = useMemo(
+    () => tasks.reduce((acc, task) => (task.enabled ? acc + 1 : acc), 0),
+    [tasks],
   );
 
   if (loading) {
@@ -250,10 +257,6 @@ export function ScheduledTasksPage() {
                 </h2>
               </div>
               {groupedSections.map((group) => {
-                const groupEnabledCount = group.tasks.reduce(
-                  (count, task) => (task.enabled ? count + 1 : count),
-                  0,
-                );
                 // group.tasks is already sorted via compareScheduledTasks.
                 // This lookup relies on that ordering, so the first enabled task
                 // with a non-null nextRunAt is the group's earliest upcoming run.
@@ -275,7 +278,7 @@ export function ScheduledTasksPage() {
                         </Badge>
                         <Badge variant="outline" className="text-xs">
                           {t('scheduledTasks.groupEnabledCount', {
-                            count: groupEnabledCount,
+                            count: group.enabledCount,
                             defaultValue: '{{count}} enabled',
                           })}
                         </Badge>


### PR DESCRIPTION
💡 What: Extracted inline `.reduce()` computations used for counting (e.g., bookmarked sessions and enabled tasks) and memoized them using `useMemo` hooks or integrated them into existing memoized map operations.
🎯 Why: Inline `reduce` calls directly within the JSX render loop forced the component to recount items on every render, causing O(N) array iterations unnecessarily.
📊 Impact: Eliminates unneeded calculations on each re-render, ensuring smooth layout and minimizing CPU thrashing for list-heavy views (Session History, Scheduled Tasks).
🔬 Measurement: Verified with `pnpm lint` and `pnpm test`. CPU usage during component state updates like typing in search or clicking tabs should be noticeably lower.

---
*PR created automatically by Jules for task [6336134329747970820](https://jules.google.com/task/6336134329747970820) started by @fritzprix*