### PR TITLE
Add global knowledge manager UI

### DIFF
--- a/scripts/run-rust-command.cjs
+++ b/scripts/run-rust-command.cjs
@@ -32,13 +32,18 @@ function getRecommendedBuildJobs() {
   return Math.min(cpuLimitedJobs, memoryLimitedJobs);
 }
 
-function getRecommendedTestThreads() {
-  const cpuCount = Math.max(1, getCpuCount());
-  const totalMemGiB = os.totalmem() / 1024 ** 3;
-  const cpuLimitedThreads = clamp(Math.floor(cpuCount / 2), 1, 4);
-  const memoryLimitedThreads = clamp(Math.floor(totalMemGiB / 4), 1, 4);
+function getDefaultBuildJobs(args) {
+  const recommendedJobs = getRecommendedBuildJobs();
 
-  return Math.min(cpuLimitedThreads, memoryLimitedThreads);
+  if (args[0] === 'test') {
+    return Math.min(recommendedJobs, 2);
+  }
+
+  return recommendedJobs;
+}
+
+function getDefaultTestThreads() {
+  return 1;
 }
 
 function hasFlag(args, flagNames) {
@@ -57,7 +62,7 @@ function hasFlag(args, flagNames) {
 const env = { ...process.env };
 
 if (!env.CARGO_BUILD_JOBS && !hasFlag(cargoArgs, ['-j', '--jobs'])) {
-  env.CARGO_BUILD_JOBS = String(getRecommendedBuildJobs());
+  env.CARGO_BUILD_JOBS = String(getDefaultBuildJobs(cargoArgs));
 }
 
 const isCargoTest = cargoArgs[0] === 'test';
@@ -66,7 +71,7 @@ if (
   !env.RUST_TEST_THREADS &&
   !hasFlag(cargoArgs, ['--test-threads'])
 ) {
-  const testThreads = String(getRecommendedTestThreads());
+  const testThreads = String(getDefaultTestThreads());
   const separatorIndex = cargoArgs.indexOf('--');
 
   if (separatorIndex === -1) {

--- a/src-tauri/src/commands/knowledge_commands.rs
+++ b/src-tauri/src/commands/knowledge_commands.rs
@@ -33,7 +33,6 @@ pub struct KnowledgeChunkListItemDto {
     pub id: i32,
     pub assistant_id: String,
     pub preview: String,
-    pub content: String,
     pub tags: Vec<String>,
     pub source: Option<String>,
     pub created_at: i64,
@@ -92,12 +91,37 @@ pub struct DeleteGlobalKnowledgeResponse {
 }
 
 fn build_preview(content: &str) -> String {
-    let normalized = content.split_whitespace().collect::<Vec<_>>().join(" ");
-    if normalized.chars().count() <= PREVIEW_LENGTH {
-        return normalized;
+    let mut preview = String::new();
+    let mut used_chars = 0;
+    let mut tokens = content.split_whitespace().peekable();
+
+    while let Some(token) = tokens.next() {
+        if !preview.is_empty() {
+            if used_chars >= PREVIEW_LENGTH {
+                preview.push_str("...");
+                return preview;
+            }
+            preview.push(' ');
+            used_chars += 1;
+        }
+
+        for ch in token.chars() {
+            if used_chars >= PREVIEW_LENGTH {
+                preview.push_str("...");
+                return preview;
+            }
+
+            preview.push(ch);
+            used_chars += 1;
+        }
+
+        if tokens.peek().is_some() && used_chars >= PREVIEW_LENGTH {
+            preview.push_str("...");
+            return preview;
+        }
     }
 
-    normalized.chars().take(PREVIEW_LENGTH).collect::<String>() + "..."
+    preview
 }
 
 impl From<KnowledgeGraphEntity> for KnowledgeGraphEntityDto {
@@ -191,7 +215,6 @@ pub async fn list_global_knowledge(
             id: chunk.id,
             assistant_id: chunk.assistant_id,
             preview: build_preview(&chunk.content),
-            content: chunk.content,
             tags: parse_db_tags(chunk.tags.as_ref()),
             source: chunk.source,
             created_at: chunk.created_at,

--- a/src-tauri/src/commands/knowledge_commands.rs
+++ b/src-tauri/src/commands/knowledge_commands.rs
@@ -1,0 +1,229 @@
+use crate::mcp::builtin::knowledge::helpers::parse_db_tags;
+use crate::repositories::{
+    KnowledgeChunkDetail, KnowledgeGraphEntity, KnowledgeGraphRelationship, KnowledgeListCursor,
+    KnowledgeV2Repository,
+};
+use crate::state::get_knowledge_v2_repository;
+use serde::{Deserialize, Serialize};
+use tauri::command;
+
+const DEFAULT_LIST_LIMIT: u64 = 200;
+const MAX_LIST_LIMIT: u64 = 500;
+const PREVIEW_LENGTH: usize = 220;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListGlobalKnowledgeRequest {
+    pub query: Option<String>,
+    pub assistant_id: Option<String>,
+    pub cursor: Option<KnowledgeListCursorDto>,
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct KnowledgeListCursorDto {
+    pub created_at: i64,
+    pub id: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnowledgeChunkListItemDto {
+    pub id: i32,
+    pub assistant_id: String,
+    pub preview: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub source: Option<String>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlobalKnowledgeListResponse {
+    pub items: Vec<KnowledgeChunkListItemDto>,
+    pub assistants: Vec<String>,
+    pub next_cursor: Option<KnowledgeListCursorDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnowledgeGraphEntityDto {
+    pub id: i32,
+    pub assistant_id: String,
+    pub name: String,
+    pub entity_type: Option<String>,
+    pub description: Option<String>,
+    pub is_primary: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnowledgeGraphRelationshipDto {
+    pub id: i32,
+    pub assistant_id: String,
+    pub source_entity_id: i32,
+    pub target_entity_id: i32,
+    pub relation_type: String,
+    pub weight: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KnowledgeChunkDetailDto {
+    pub id: i32,
+    pub assistant_id: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub source: Option<String>,
+    pub created_at: i64,
+    pub primary_entity_ids: Vec<i32>,
+    pub entities: Vec<KnowledgeGraphEntityDto>,
+    pub relationships: Vec<KnowledgeGraphRelationshipDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteGlobalKnowledgeResponse {
+    pub deleted_chunk_id: i32,
+    pub orphan_entity_count: u64,
+    pub orphan_relationship_count: u64,
+}
+
+fn build_preview(content: &str) -> String {
+    let normalized = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= PREVIEW_LENGTH {
+        return normalized;
+    }
+
+    normalized.chars().take(PREVIEW_LENGTH).collect::<String>() + "..."
+}
+
+impl From<KnowledgeGraphEntity> for KnowledgeGraphEntityDto {
+    fn from(value: KnowledgeGraphEntity) -> Self {
+        Self {
+            id: value.id,
+            assistant_id: value.assistant_id,
+            name: value.name,
+            entity_type: value.entity_type,
+            description: value.description,
+            is_primary: value.is_primary,
+        }
+    }
+}
+
+impl From<KnowledgeGraphRelationship> for KnowledgeGraphRelationshipDto {
+    fn from(value: KnowledgeGraphRelationship) -> Self {
+        Self {
+            id: value.id,
+            assistant_id: value.assistant_id,
+            source_entity_id: value.source_entity_id,
+            target_entity_id: value.target_entity_id,
+            relation_type: value.relation_type,
+            weight: value.weight,
+        }
+    }
+}
+
+impl From<KnowledgeChunkDetail> for KnowledgeChunkDetailDto {
+    fn from(value: KnowledgeChunkDetail) -> Self {
+        Self {
+            id: value.chunk.id,
+            assistant_id: value.chunk.assistant_id,
+            content: value.chunk.content,
+            tags: parse_db_tags(value.chunk.tags.as_ref()),
+            source: value.chunk.source,
+            created_at: value.chunk.created_at,
+            primary_entity_ids: value.primary_entity_ids,
+            entities: value.entities.into_iter().map(Into::into).collect(),
+            relationships: value.relationships.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<KnowledgeListCursor> for KnowledgeListCursorDto {
+    fn from(value: KnowledgeListCursor) -> Self {
+        Self {
+            created_at: value.created_at,
+            id: value.id,
+        }
+    }
+}
+
+impl From<KnowledgeListCursorDto> for KnowledgeListCursor {
+    fn from(value: KnowledgeListCursorDto) -> Self {
+        Self {
+            created_at: value.created_at,
+            id: value.id,
+        }
+    }
+}
+
+#[command]
+pub async fn list_global_knowledge(
+    request: Option<ListGlobalKnowledgeRequest>,
+) -> Result<GlobalKnowledgeListResponse, String> {
+    let request = request.unwrap_or(ListGlobalKnowledgeRequest {
+        query: None,
+        assistant_id: None,
+        cursor: None,
+        limit: None,
+    });
+    let limit = request
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .clamp(1, MAX_LIST_LIMIT);
+    let repo = get_knowledge_v2_repository();
+
+    let page = repo
+        .list_chunks(
+            request.assistant_id.as_deref(),
+            request.query.as_deref(),
+            request.cursor.map(Into::into),
+            limit,
+        )
+        .await?;
+    let items = page
+        .items
+        .into_iter()
+        .map(|chunk| KnowledgeChunkListItemDto {
+            id: chunk.id,
+            assistant_id: chunk.assistant_id,
+            preview: build_preview(&chunk.content),
+            content: chunk.content,
+            tags: parse_db_tags(chunk.tags.as_ref()),
+            source: chunk.source,
+            created_at: chunk.created_at,
+        })
+        .collect::<Vec<_>>();
+
+    let assistants = repo.list_assistant_ids().await?;
+
+    Ok(GlobalKnowledgeListResponse {
+        items,
+        assistants,
+        next_cursor: page.next_cursor.map(Into::into),
+    })
+}
+
+#[command]
+pub async fn get_global_knowledge_detail(id: i32) -> Result<KnowledgeChunkDetailDto, String> {
+    get_knowledge_v2_repository()
+        .get_chunk_detail(id)
+        .await
+        .map(Into::into)
+        .map_err(Into::into)
+}
+
+#[command]
+pub async fn delete_global_knowledge(id: i32) -> Result<DeleteGlobalKnowledgeResponse, String> {
+    let summary = get_knowledge_v2_repository()
+        .delete_chunk_global(id)
+        .await?;
+    Ok(DeleteGlobalKnowledgeResponse {
+        deleted_chunk_id: id,
+        orphan_entity_count: summary.orphan_entity_count,
+        orphan_relationship_count: summary.orphan_relationship_count,
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod attachments_commands;
 pub mod browser_commands;
 pub mod download_commands;
 pub mod file_commands;
+pub mod knowledge_commands;
 pub mod log_commands;
 pub mod mcp_commands;
 pub mod mcp_server_config_commands;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,9 @@ use commands::file_commands::{
     check_dropped_path_type, read_dropped_file, register_dropped_files, workspace_write_file,
     write_file,
 };
+use commands::knowledge_commands::{
+    delete_global_knowledge, get_global_knowledge_detail, list_global_knowledge,
+};
 use commands::log_commands::{
     backup_current_log, clear_current_log, get_launch_log_level, list_log_files, log_batch,
     log_debug, log_error_from_frontend, log_info, log_trace, log_warn,
@@ -195,6 +198,9 @@ pub fn run() {
                 read_dropped_file,
                 write_file,
                 workspace_write_file,
+                list_global_knowledge,
+                get_global_knowledge_detail,
+                delete_global_knowledge,
                 open_external_url,
                 open_workspace_file_with_default_app,
                 open_workspace_in_explorer,
@@ -351,7 +357,7 @@ pub fn run() {
             warn!("💡 Troubleshooting suggestions:");
             warn!("   1. Check WebKit/GTK installation: sudo apt install libwebkit2gtk-4.1-dev");
             warn!("   2. Update graphics drivers");
-            warn!("   3. Set WEBKIT_DISABLE_COMPOSITING_MODE=1");
+            warn!("   3. Retry with LIBRAGENT_LINUX_COMPATIBILITY_MODE=1");
             warn!("   4. Run in a desktop environment with proper display");
 
             std::process::exit(1);

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -393,7 +393,20 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     // Linux-specific checks
     #[cfg(target_os = "linux")]
     {
-        info!("🐧 Linux detected - WebKit compatibility flags already set in main.rs");
+        let compatibility_mode_enabled = matches!(
+            std::env::var("LIBRAGENT_LINUX_COMPATIBILITY_MODE"),
+            Ok(value)
+                if matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+        );
+
+        if compatibility_mode_enabled {
+            info!("🐧 Linux compatibility mode is active (software rendering + X11 fallback)");
+        } else {
+            info!("🐧 Linux detected - running with default WebKit rendering path");
+        }
         if std::env::var("container").is_ok() || std::env::var("DISPLAY").is_err() {
             warn!("⚠️  Warning: Running in limited graphics environment");
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@
 /// The main entry point for the LibrAgent application.
 ///
 /// This function is responsible for:
-/// 1. Setting Linux-specific WebKit compatibility environment variables (if on Linux)
+/// 1. Optionally enabling Linux-specific WebKit compatibility mode (if on Linux)
 /// 2. Loading environment variables from .env file (development mode only)
 /// 3. Determining the path for the SQLite database. It prioritizes the `LIBRAGENT_DB_PATH`
 ///    environment variable, falling back to a default location within the user's data directory.
@@ -12,21 +12,38 @@
 /// 5. Constructing the final SQLite connection URL.
 /// 6. Calling the main application runner (`run_with_sqlite_sync`) from the `tauri_mcp_agent_lib`
 ///    crate, passing it the database URL to initialize the application with database support.
+#[cfg(target_os = "linux")]
+fn linux_compatibility_mode_enabled() -> bool {
+    matches!(
+        std::env::var("LIBRAGENT_LINUX_COMPATIBILITY_MODE"),
+        Ok(value)
+            if matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+    )
+}
+
 fn main() {
-    // Set Linux-specific WebKit compatibility environment variables FIRST
-    // This must happen before any WebView initialization
+    // Set Linux-specific WebKit compatibility environment variables FIRST when explicitly enabled.
+    // This must happen before any WebView initialization.
     #[cfg(target_os = "linux")]
     {
-        println!("🐧 Linux detected - setting WebKit compatibility flags...");
+        if linux_compatibility_mode_enabled() {
+            println!("🐧 Linux compatibility mode enabled - applying WebKit fallback flags...");
 
-        // // Disable WebKit hardware acceleration to fix blank screen issues on Arch Linux
-        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            // Disable WebKit compositing and force software rendering for problematic Linux setups.
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            std::env::set_var("GDK_BACKEND", "x11");
+            std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
 
-        // Additional compatibility flags
-        std::env::set_var("GDK_BACKEND", "x11");
-        std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
-
-        println!("✅ WebKit compatibility flags set (software rendering enabled)");
+            println!("✅ Linux compatibility mode active (software rendering + X11 fallback)");
+        } else {
+            println!("🐧 Linux detected - using default WebKit rendering path");
+            println!(
+                "ℹ️  Set LIBRAGENT_LINUX_COMPATIBILITY_MODE=1 only if you hit blank screens or driver issues"
+            );
+        }
     }
 
     // Load environment variables from .env file

--- a/src-tauri/src/repositories/knowledge_v2_repository.rs
+++ b/src-tauri/src/repositories/knowledge_v2_repository.rs
@@ -461,18 +461,29 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
             .await
             .map_err(DbError::SeaOrmQueryFailed)?;
 
-        let mut orphan_entity_ids = Vec::new();
-        for entity_id in affected_entity_ids {
-            let remaining_links = knowledge_chunk_entity::Entity::find()
-                .filter(knowledge_chunk_entity::Column::EntityId.eq(entity_id))
-                .count(&txn)
+        let orphan_entity_ids = if affected_entity_ids.is_empty() {
+            Vec::new()
+        } else {
+            let affected_entity_id_list = affected_entity_ids.iter().copied().collect::<Vec<_>>();
+            let remaining_entity_ids = knowledge_chunk_entity::Entity::find()
+                .select_only()
+                .column(knowledge_chunk_entity::Column::EntityId)
+                .filter(
+                    knowledge_chunk_entity::Column::EntityId.is_in(affected_entity_id_list.clone()),
+                )
+                .group_by(knowledge_chunk_entity::Column::EntityId)
+                .into_tuple::<i32>()
+                .all(&txn)
                 .await
-                .map_err(DbError::SeaOrmQueryFailed)?;
+                .map_err(DbError::SeaOrmQueryFailed)?
+                .into_iter()
+                .collect::<HashSet<_>>();
 
-            if remaining_links == 0 {
-                orphan_entity_ids.push(entity_id);
-            }
-        }
+            affected_entity_id_list
+                .into_iter()
+                .filter(|entity_id| !remaining_entity_ids.contains(entity_id))
+                .collect::<Vec<_>>()
+        };
 
         let orphan_entity_count = orphan_entity_ids.len() as u64;
         let orphan_relationship_count = if orphan_entity_ids.is_empty() {
@@ -789,12 +800,13 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
             .await
             .map_err(DbError::SeaOrmQueryFailed)?;
 
-        let primary_entity_ids = chunk_links
+        let mut primary_entity_ids = chunk_links
             .iter()
             .map(|link| link.entity_id)
             .collect::<HashSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
+        primary_entity_ids.sort_unstable();
 
         if primary_entity_ids.is_empty() {
             return Ok(KnowledgeChunkDetail {

--- a/src-tauri/src/repositories/knowledge_v2_repository.rs
+++ b/src-tauri/src/repositories/knowledge_v2_repository.rs
@@ -7,6 +7,52 @@ use sea_orm::*;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
+#[derive(Debug, Clone)]
+pub struct KnowledgeGraphEntity {
+    pub id: i32,
+    pub assistant_id: String,
+    pub name: String,
+    pub entity_type: Option<String>,
+    pub description: Option<String>,
+    pub is_primary: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct KnowledgeGraphRelationship {
+    pub id: i32,
+    pub assistant_id: String,
+    pub source_entity_id: i32,
+    pub target_entity_id: i32,
+    pub relation_type: String,
+    pub weight: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct KnowledgeChunkDetail {
+    pub chunk: knowledge_chunk_v2::Model,
+    pub primary_entity_ids: Vec<i32>,
+    pub entities: Vec<KnowledgeGraphEntity>,
+    pub relationships: Vec<KnowledgeGraphRelationship>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct KnowledgeDeleteSummary {
+    pub orphan_entity_count: u64,
+    pub orphan_relationship_count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KnowledgeListCursor {
+    pub created_at: i64,
+    pub id: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct KnowledgeChunkPage {
+    pub items: Vec<knowledge_chunk_v2::Model>,
+    pub next_cursor: Option<KnowledgeListCursor>,
+}
+
 #[async_trait]
 pub trait KnowledgeV2Repository: Send + Sync {
     async fn record_chunk(
@@ -27,6 +73,18 @@ pub trait KnowledgeV2Repository: Send + Sync {
     ) -> Result<Vec<(knowledge_chunk_v2::Model, f32)>, DbError>;
 
     async fn delete_chunk(&self, id: i32, assistant_id: &str) -> Result<(), DbError>;
+
+    async fn delete_chunk_global(&self, id: i32) -> Result<KnowledgeDeleteSummary, DbError>;
+
+    async fn list_chunks(
+        &self,
+        assistant_id: Option<&str>,
+        query: Option<&str>,
+        cursor: Option<KnowledgeListCursor>,
+        limit: u64,
+    ) -> Result<KnowledgeChunkPage, DbError>;
+
+    async fn list_assistant_ids(&self) -> Result<Vec<String>, DbError>;
 
     async fn upsert_entity(
         &self,
@@ -52,6 +110,8 @@ pub trait KnowledgeV2Repository: Send + Sync {
         entity_name: &str,
         depth: u32,
     ) -> Result<serde_json::Value, DbError>;
+
+    async fn get_chunk_detail(&self, id: i32) -> Result<KnowledgeChunkDetail, DbError>;
 }
 
 #[derive(Debug)]
@@ -252,6 +312,76 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
         Ok(out)
     }
 
+    async fn list_chunks(
+        &self,
+        assistant_id: Option<&str>,
+        query: Option<&str>,
+        cursor: Option<KnowledgeListCursor>,
+        limit: u64,
+    ) -> Result<KnowledgeChunkPage, DbError> {
+        let normalized_limit = limit.clamp(1, 500);
+        let mut condition = Condition::all();
+
+        if let Some(assistant_id) = assistant_id.filter(|value| !value.is_empty()) {
+            condition = condition.add(knowledge_chunk_v2::Column::AssistantId.eq(assistant_id));
+        }
+
+        if let Some(query) = query.map(str::trim).filter(|value| !value.is_empty()) {
+            let like_query = format!("%{}%", query);
+            condition = condition.add(
+                Condition::any()
+                    .add(knowledge_chunk_v2::Column::Content.like(like_query.clone()))
+                    .add(knowledge_chunk_v2::Column::Tags.like(like_query.clone()))
+                    .add(knowledge_chunk_v2::Column::Source.like(like_query)),
+            );
+        }
+
+        if let Some(cursor) = cursor {
+            condition = condition.add(
+                Condition::any()
+                    .add(knowledge_chunk_v2::Column::CreatedAt.lt(cursor.created_at))
+                    .add(
+                        Condition::all()
+                            .add(knowledge_chunk_v2::Column::CreatedAt.eq(cursor.created_at))
+                            .add(knowledge_chunk_v2::Column::Id.lt(cursor.id)),
+                    ),
+            );
+        }
+
+        let mut items = knowledge_chunk_v2::Entity::find()
+            .filter(condition)
+            .order_by_desc(knowledge_chunk_v2::Column::CreatedAt)
+            .order_by_desc(knowledge_chunk_v2::Column::Id)
+            .limit(normalized_limit + 1)
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let next_cursor = if items.len() > normalized_limit as usize {
+            items.truncate(normalized_limit as usize);
+            items.last().map(|item| KnowledgeListCursor {
+                created_at: item.created_at,
+                id: item.id,
+            })
+        } else {
+            None
+        };
+
+        Ok(KnowledgeChunkPage { items, next_cursor })
+    }
+
+    async fn list_assistant_ids(&self) -> Result<Vec<String>, DbError> {
+        knowledge_chunk_v2::Entity::find()
+            .select_only()
+            .column(knowledge_chunk_v2::Column::AssistantId)
+            .distinct()
+            .order_by_asc(knowledge_chunk_v2::Column::AssistantId)
+            .into_tuple::<String>()
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)
+    }
+
     async fn delete_chunk(&self, id: i32, assistant_id: &str) -> Result<(), DbError> {
         let txn = self.db.begin().await.map_err(DbError::SeaOrmQueryFailed)?;
 
@@ -285,6 +415,101 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
 
         txn.commit().await.map_err(DbError::SeaOrmQueryFailed)?;
         Ok(())
+    }
+
+    async fn delete_chunk_global(&self, id: i32) -> Result<KnowledgeDeleteSummary, DbError> {
+        let txn = self.db.begin().await.map_err(DbError::SeaOrmQueryFailed)?;
+
+        let chunk = knowledge_chunk_v2::Entity::find_by_id(id)
+            .one(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?
+            .ok_or_else(|| DbError::NotFound(format!("Chunk {} not found", id)))?;
+
+        let chunk_links = knowledge_chunk_entity::Entity::find()
+            .filter(knowledge_chunk_entity::Column::ChunkId.eq(id))
+            .all(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let affected_entity_ids = chunk_links
+            .iter()
+            .map(|link| link.entity_id)
+            .collect::<HashSet<_>>();
+
+        let res = knowledge_chunk_v2::Entity::delete_many()
+            .filter(knowledge_chunk_v2::Column::Id.eq(id))
+            .exec(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        if res.rows_affected == 0 {
+            return Err(DbError::NotFound(format!("Chunk {} not found", id)));
+        }
+
+        txn.execute(Statement::from_sql_and_values(
+            self.db.get_database_backend(),
+            "DELETE FROM knowledge_vectors WHERE rowid = ?",
+            [id.into()],
+        ))
+        .await
+        .map_err(DbError::SeaOrmQueryFailed)?;
+
+        knowledge_chunk_entity::Entity::delete_many()
+            .filter(knowledge_chunk_entity::Column::ChunkId.eq(id))
+            .exec(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let mut orphan_entity_ids = Vec::new();
+        for entity_id in affected_entity_ids {
+            let remaining_links = knowledge_chunk_entity::Entity::find()
+                .filter(knowledge_chunk_entity::Column::EntityId.eq(entity_id))
+                .count(&txn)
+                .await
+                .map_err(DbError::SeaOrmQueryFailed)?;
+
+            if remaining_links == 0 {
+                orphan_entity_ids.push(entity_id);
+            }
+        }
+
+        let orphan_entity_count = orphan_entity_ids.len() as u64;
+        let orphan_relationship_count = if orphan_entity_ids.is_empty() {
+            0
+        } else {
+            let deleted_relationships = knowledge_relationship::Entity::delete_many()
+                .filter(knowledge_relationship::Column::AssistantId.eq(chunk.assistant_id))
+                .filter(
+                    Condition::any()
+                        .add(
+                            knowledge_relationship::Column::SourceEntityId
+                                .is_in(orphan_entity_ids.clone()),
+                        )
+                        .add(
+                            knowledge_relationship::Column::TargetEntityId
+                                .is_in(orphan_entity_ids.clone()),
+                        ),
+                )
+                .exec(&txn)
+                .await
+                .map_err(DbError::SeaOrmQueryFailed)?;
+
+            knowledge_entity::Entity::delete_many()
+                .filter(knowledge_entity::Column::Id.is_in(orphan_entity_ids))
+                .exec(&txn)
+                .await
+                .map_err(DbError::SeaOrmQueryFailed)?;
+
+            deleted_relationships.rows_affected
+        };
+
+        txn.commit().await.map_err(DbError::SeaOrmQueryFailed)?;
+
+        Ok(KnowledgeDeleteSummary {
+            orphan_entity_count,
+            orphan_relationship_count,
+        })
     }
 
     async fn upsert_entity(
@@ -549,5 +774,111 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
             "edges": relationships,
             "linked_chunks": linked_chunk_json
         }))
+    }
+
+    async fn get_chunk_detail(&self, id: i32) -> Result<KnowledgeChunkDetail, DbError> {
+        let chunk = knowledge_chunk_v2::Entity::find_by_id(id)
+            .one(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?
+            .ok_or_else(|| DbError::NotFound(format!("Chunk {} not found", id)))?;
+
+        let chunk_links = knowledge_chunk_entity::Entity::find()
+            .filter(knowledge_chunk_entity::Column::ChunkId.eq(id))
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let primary_entity_ids = chunk_links
+            .iter()
+            .map(|link| link.entity_id)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        if primary_entity_ids.is_empty() {
+            return Ok(KnowledgeChunkDetail {
+                chunk,
+                primary_entity_ids: Vec::new(),
+                entities: Vec::new(),
+                relationships: Vec::new(),
+            });
+        }
+
+        let relationship_rows = knowledge_relationship::Entity::find()
+            .filter(knowledge_relationship::Column::AssistantId.eq(&chunk.assistant_id))
+            .filter(
+                Condition::any()
+                    .add(
+                        knowledge_relationship::Column::SourceEntityId
+                            .is_in(primary_entity_ids.clone()),
+                    )
+                    .add(
+                        knowledge_relationship::Column::TargetEntityId
+                            .is_in(primary_entity_ids.clone()),
+                    ),
+            )
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let mut all_entity_ids = primary_entity_ids.iter().copied().collect::<HashSet<_>>();
+        for relationship in &relationship_rows {
+            all_entity_ids.insert(relationship.source_entity_id);
+            all_entity_ids.insert(relationship.target_entity_id);
+        }
+
+        let entity_rows = knowledge_entity::Entity::find()
+            .filter(
+                knowledge_entity::Column::Id.is_in(all_entity_ids.into_iter().collect::<Vec<_>>()),
+            )
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        let primary_entity_set = primary_entity_ids.iter().copied().collect::<HashSet<_>>();
+        let mut entities = entity_rows
+            .into_iter()
+            .map(|entity| KnowledgeGraphEntity {
+                id: entity.id,
+                assistant_id: entity.assistant_id,
+                name: entity.name,
+                entity_type: entity.entity_type,
+                description: entity.description,
+                is_primary: primary_entity_set.contains(&entity.id),
+            })
+            .collect::<Vec<_>>();
+        entities.sort_by(|left, right| {
+            right
+                .is_primary
+                .cmp(&left.is_primary)
+                .then_with(|| left.name.cmp(&right.name))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        let mut relationships = relationship_rows
+            .into_iter()
+            .map(|relationship| KnowledgeGraphRelationship {
+                id: relationship.id,
+                assistant_id: relationship.assistant_id,
+                source_entity_id: relationship.source_entity_id,
+                target_entity_id: relationship.target_entity_id,
+                relation_type: relationship.relation_type,
+                weight: relationship.weight,
+            })
+            .collect::<Vec<_>>();
+        relationships.sort_by(|left, right| {
+            left.relation_type
+                .cmp(&right.relation_type)
+                .then_with(|| left.source_entity_id.cmp(&right.source_entity_id))
+                .then_with(|| left.target_entity_id.cmp(&right.target_entity_id))
+        });
+
+        Ok(KnowledgeChunkDetail {
+            chunk,
+            primary_entity_ids,
+            entities,
+            relationships,
+        })
     }
 }

--- a/src-tauri/src/repositories/mod.rs
+++ b/src-tauri/src/repositories/mod.rs
@@ -24,7 +24,11 @@ pub use compact_context_repository::{
 pub use error::DbError;
 pub use in_memory_session_repository::InMemorySessionRepository;
 pub use knowledge_repository::{KnowledgeRepository, SqliteKnowledgeRepository};
-pub use knowledge_v2_repository::{KnowledgeV2Repository, SqliteKnowledgeV2Repository};
+pub use knowledge_v2_repository::{
+    KnowledgeChunkDetail, KnowledgeChunkPage, KnowledgeDeleteSummary, KnowledgeGraphEntity,
+    KnowledgeGraphRelationship, KnowledgeListCursor, KnowledgeV2Repository,
+    SqliteKnowledgeV2Repository,
+};
 pub use mcp_server_repository::{MCPServerRepository, SqliteMCPServerRepository};
 pub use message_repository::{MessageRepository, SqliteMessageRepository};
 pub use planning_repository::{PlanningRepository, SqlitePlanningRepository};

--- a/src-tauri/tests/knowledge_v2_repository_tests.rs
+++ b/src-tauri/tests/knowledge_v2_repository_tests.rs
@@ -1,7 +1,10 @@
 mod common;
 
-use sea_orm::EntityTrait;
+use sea_orm::{ConnectionTrait, EntityTrait, Statement};
 use tauri_mcp_agent_lib::entity::knowledge_chunk_entity;
+use tauri_mcp_agent_lib::entity::knowledge_chunk_v2;
+use tauri_mcp_agent_lib::entity::knowledge_entity;
+use tauri_mcp_agent_lib::entity::knowledge_relationship;
 use tauri_mcp_agent_lib::repositories::{KnowledgeV2Repository, SqliteKnowledgeV2Repository};
 
 #[tokio::test]
@@ -147,4 +150,183 @@ async fn knowledge_v2_graph_context_stays_scoped_to_assistant() {
         .await
         .expect("scoped lookup should succeed");
     assert_eq!(missing["error"], "Entity not found");
+}
+
+#[tokio::test]
+async fn delete_chunk_global_prunes_orphan_graph_state() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteKnowledgeV2Repository::new(db.clone());
+
+    let chunk_one_id = repo
+        .record_chunk(
+            "assistant-global".to_string(),
+            "Chunk one".to_string(),
+            Some(r#"["shared","orphan"]"#.to_string()),
+            Some("test".to_string()),
+            vec![0.3; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+    let chunk_two_id = repo
+        .record_chunk(
+            "assistant-global".to_string(),
+            "Chunk two".to_string(),
+            Some(r#"["shared"]"#.to_string()),
+            Some("test".to_string()),
+            vec![0.31; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+
+    let shared_entity_id = repo
+        .upsert_entity(
+            "assistant-global".to_string(),
+            "Shared".to_string(),
+            Some("Concept".to_string()),
+            None,
+        )
+        .await
+        .expect("upsert_entity should succeed");
+    let orphan_entity_id = repo
+        .upsert_entity(
+            "assistant-global".to_string(),
+            "Orphan".to_string(),
+            Some("Concept".to_string()),
+            None,
+        )
+        .await
+        .expect("upsert_entity should succeed");
+
+    repo.link_chunk_to_entity(chunk_one_id, shared_entity_id)
+        .await
+        .expect("link_chunk_to_entity should succeed");
+    repo.link_chunk_to_entity(chunk_one_id, orphan_entity_id)
+        .await
+        .expect("link_chunk_to_entity should succeed");
+    repo.link_chunk_to_entity(chunk_two_id, shared_entity_id)
+        .await
+        .expect("link_chunk_to_entity should succeed");
+    repo.create_relationship(
+        "assistant-global".to_string(),
+        shared_entity_id,
+        orphan_entity_id,
+        "RELATES_TO".to_string(),
+    )
+    .await
+    .expect("create_relationship should succeed");
+
+    let summary = repo
+        .delete_chunk_global(chunk_one_id)
+        .await
+        .expect("delete_chunk_global should succeed");
+
+    assert_eq!(summary.orphan_entity_count, 1);
+    assert_eq!(summary.orphan_relationship_count, 1);
+
+    let remaining_chunks = knowledge_chunk_v2::Entity::find().all(&db).await.unwrap();
+    assert_eq!(remaining_chunks.len(), 1);
+    assert_eq!(remaining_chunks[0].id, chunk_two_id);
+
+    let remaining_entities = knowledge_entity::Entity::find().all(&db).await.unwrap();
+    assert_eq!(remaining_entities.len(), 1);
+    assert_eq!(remaining_entities[0].id, shared_entity_id);
+
+    let remaining_relationships = knowledge_relationship::Entity::find()
+        .all(&db)
+        .await
+        .unwrap();
+    assert!(remaining_relationships.is_empty());
+
+    let remaining_links = knowledge_chunk_entity::Entity::find()
+        .all(&db)
+        .await
+        .unwrap();
+    assert_eq!(remaining_links.len(), 1);
+    assert_eq!(remaining_links[0].chunk_id, chunk_two_id);
+    assert_eq!(remaining_links[0].entity_id, shared_entity_id);
+}
+
+#[tokio::test]
+async fn knowledge_v2_repository_lists_chunks_with_cursor_pagination() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteKnowledgeV2Repository::new(db.clone());
+
+    let first_id = repo
+        .record_chunk(
+            "assistant-page".to_string(),
+            "First chunk".to_string(),
+            Some(r#"["page"]"#.to_string()),
+            Some("test".to_string()),
+            vec![0.2; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+    let second_id = repo
+        .record_chunk(
+            "assistant-page".to_string(),
+            "Second chunk".to_string(),
+            Some(r#"["page"]"#.to_string()),
+            Some("test".to_string()),
+            vec![0.21; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+    let third_id = repo
+        .record_chunk(
+            "assistant-page".to_string(),
+            "Third chunk".to_string(),
+            Some(r#"["page"]"#.to_string()),
+            Some("test".to_string()),
+            vec![0.22; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+
+    let backend = db.get_database_backend();
+    db.execute(Statement::from_sql_and_values(
+        backend,
+        "UPDATE knowledge_chunks_v2 SET created_at = ? WHERE id = ?",
+        [1003_i64.into(), first_id.into()],
+    ))
+    .await
+    .unwrap();
+    db.execute(Statement::from_sql_and_values(
+        backend,
+        "UPDATE knowledge_chunks_v2 SET created_at = ? WHERE id = ?",
+        [1002_i64.into(), second_id.into()],
+    ))
+    .await
+    .unwrap();
+    db.execute(Statement::from_sql_and_values(
+        backend,
+        "UPDATE knowledge_chunks_v2 SET created_at = ? WHERE id = ?",
+        [1001_i64.into(), third_id.into()],
+    ))
+    .await
+    .unwrap();
+
+    let first_page = repo
+        .list_chunks(Some("assistant-page"), None, None, 2)
+        .await
+        .expect("first page should load");
+    assert_eq!(first_page.items.len(), 2);
+    assert_eq!(
+        first_page
+            .items
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![first_id, second_id]
+    );
+    let next_cursor = first_page.next_cursor.expect("should include next cursor");
+    assert_eq!(next_cursor.id, second_id);
+    assert_eq!(next_cursor.created_at, 1002);
+
+    let second_page = repo
+        .list_chunks(Some("assistant-page"), None, Some(next_cursor), 2)
+        .await
+        .expect("second page should load");
+    assert_eq!(second_page.items.len(), 1);
+    assert_eq!(second_page.items[0].id, third_id);
+    assert!(second_page.next_cursor.is_none());
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -33,6 +33,7 @@ const SettingsPage = lazy(() => import('@/features/settings/SettingsPage'));
 const MCPServerPage = lazy(
   () => import('@/features/mcp-servers/MCPServerPage'),
 );
+const KnowledgePage = lazy(() => import('@/features/knowledge/KnowledgePage'));
 const ScheduledTasksPage = lazy(() =>
   import('@/features/scheduled-tasks/ScheduledTasksPage').then((m) => ({
     default: m.ScheduledTasksPage,
@@ -149,6 +150,10 @@ function App() {
                                     <Route
                                       path="/mcp-servers"
                                       element={<MCPServerPage />}
+                                    />
+                                    <Route
+                                      path="/knowledge"
+                                      element={<KnowledgePage />}
                                     />
                                     <Route
                                       path="/scheduled-tasks"

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Blocks,
   Circle,
   Clock,
+  Database,
 } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import {
@@ -188,6 +189,21 @@ export default function AppSidebar() {
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={location.pathname.startsWith('/knowledge')}
+                  tooltip={t('sidebar.knowledge', 'Knowledge')}
+                >
+                  <Link
+                    to="/knowledge"
+                    className="flex w-full items-center gap-2"
+                  >
+                    <Database className="shrink-0" />
+                    <span>{t('sidebar.knowledge', 'Knowledge')}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild

--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -42,6 +42,16 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/components/ui';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getLogger } from '@/lib/logger';
@@ -308,7 +318,7 @@ interface KnowledgeDetailDialogProps {
   isDeleting: boolean;
   isDetailLoading: boolean;
   onClose: () => void;
-  onDelete: () => void;
+  onRequestDelete: () => void;
   selectedItem: KnowledgeChunkListItem | null;
 }
 
@@ -319,7 +329,7 @@ const KnowledgeDetailDialog = memo(function KnowledgeDetailDialog({
   isDeleting,
   isDetailLoading,
   onClose,
-  onDelete,
+  onRequestDelete,
   selectedItem,
 }: KnowledgeDetailDialogProps) {
   const { t } = useTranslation('common');
@@ -355,7 +365,7 @@ const KnowledgeDetailDialog = memo(function KnowledgeDetailDialog({
               <Button
                 type="button"
                 variant="destructive"
-                onClick={onDelete}
+                onClick={onRequestDelete}
                 disabled={!selectedItem || isDeleting}
                 className="gap-2"
               >
@@ -577,6 +587,7 @@ export default function KnowledgePage() {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [listRefreshToken, setListRefreshToken] = useState(0);
   const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
     null,
@@ -698,6 +709,7 @@ export default function KnowledgePage() {
   }, []);
 
   const handleCloseDetail = useCallback(() => {
+    setIsDeleteDialogOpen(false);
     setSelectedId(null);
   }, []);
 
@@ -746,18 +758,15 @@ export default function KnowledgePage() {
     t,
   ]);
 
-  const handleDelete = useCallback(async () => {
+  const handleRequestDelete = useCallback(() => {
     if (!selectedItem || isDeleting) {
       return;
     }
+    setIsDeleteDialogOpen(true);
+  }, [isDeleting, selectedItem]);
 
-    const confirmed = window.confirm(
-      t(
-        'knowledge.confirmDelete',
-        'Delete this knowledge entry and clean up orphaned graph data?',
-      ),
-    );
-    if (!confirmed) {
+  const handleDelete = useCallback(async () => {
+    if (!selectedItem || isDeleting) {
       return;
     }
 
@@ -776,6 +785,7 @@ export default function KnowledgePage() {
       });
       setDetail(null);
       setSelectedId(null);
+      setIsDeleteDialogOpen(false);
       setListRefreshToken((current) => current + 1);
     } catch (error) {
       logger.error('Failed to delete knowledge entry', {
@@ -944,9 +954,43 @@ export default function KnowledgePage() {
         isDeleting={isDeleting}
         isDetailLoading={isDetailLoading}
         onClose={handleCloseDetail}
-        onDelete={handleDelete}
+        onRequestDelete={handleRequestDelete}
         selectedItem={selectedItem}
       />
+      <AlertDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={(open) => !isDeleting && setIsDeleteDialogOpen(open)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('knowledge.confirmDeleteTitle', 'Delete knowledge entry')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t(
+                'knowledge.confirmDelete',
+                'Delete this knowledge entry and clean up orphaned graph data?',
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>
+              {t('knowledge.cancel', 'Cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
+              disabled={isDeleting}
+              className="gap-2"
+            >
+              {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {t('knowledge.delete', 'Delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -1,0 +1,952 @@
+import {
+  memo,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Database,
+  FileText,
+  Loader2,
+  Network,
+  RefreshCw,
+  Search,
+  Trash2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getLogger } from '@/lib/logger';
+import {
+  deleteGlobalKnowledge,
+  getGlobalKnowledgeDetail,
+  listGlobalKnowledge,
+  type KnowledgeChunkDetail,
+  type KnowledgeChunkListItem,
+  type KnowledgeGraphEntity,
+  type KnowledgeListCursor,
+} from '@/lib/backend/knowledge';
+
+const logger = getLogger('KnowledgePage');
+const KNOWLEDGE_PAGE_SIZE = 60;
+const knowledgeDateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatTimestamp(timestamp: number): string {
+  return knowledgeDateFormatter.format(new Date(timestamp));
+}
+
+function getKnowledgeCardTitle(preview: string): string {
+  const normalizedPreview = preview.replace(/\s+/g, ' ').trim();
+  if (!normalizedPreview) {
+    return 'Untitled knowledge entry';
+  }
+
+  const sentenceMatch = normalizedPreview.match(/^(.{1,96}?[.!?])(?:\s|$)/);
+  if (sentenceMatch?.[1]) {
+    return sentenceMatch[1];
+  }
+
+  if (normalizedPreview.length <= 96) {
+    return normalizedPreview;
+  }
+
+  return `${normalizedPreview.slice(0, 93)}...`;
+}
+
+function layoutGraphNodes(entities: KnowledgeGraphEntity[]) {
+  const centerX = 180;
+  const centerY = 140;
+  const primary = entities.filter((entity) => entity.isPrimary);
+  const secondary = entities.filter((entity) => !entity.isPrimary);
+  const positions = new Map<number, { x: number; y: number }>();
+
+  if (primary.length === 1) {
+    positions.set(primary[0].id, { x: centerX, y: centerY });
+  } else {
+    primary.forEach((entity, index) => {
+      const angle = (Math.PI * 2 * index) / Math.max(primary.length, 1);
+      positions.set(entity.id, {
+        x: centerX + Math.cos(angle) * 68,
+        y: centerY + Math.sin(angle) * 68,
+      });
+    });
+  }
+
+  secondary.forEach((entity, index) => {
+    const angle = (Math.PI * 2 * index) / Math.max(secondary.length, 1);
+    positions.set(entity.id, {
+      x: centerX + Math.cos(angle) * 118,
+      y: centerY + Math.sin(angle) * 118,
+    });
+  });
+
+  return positions;
+}
+
+function KnowledgeGraphPreview({ detail }: { detail: KnowledgeChunkDetail }) {
+  const positions = useMemo(
+    () => layoutGraphNodes(detail.entities),
+    [detail.entities],
+  );
+
+  if (!detail.entities.length) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/60 p-8 text-center text-sm text-muted-foreground">
+        No graph data linked to this knowledge entry.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border bg-muted/20 p-3">
+        <svg viewBox="0 0 360 280" className="h-[280px] w-full">
+          {detail.relationships.map((relationship) => {
+            const source = positions.get(relationship.sourceEntityId);
+            const target = positions.get(relationship.targetEntityId);
+            if (!source || !target) {
+              return null;
+            }
+
+            const midX = (source.x + target.x) / 2;
+            const midY = (source.y + target.y) / 2;
+
+            return (
+              <g key={relationship.id}>
+                <line
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  stroke="currentColor"
+                  strokeOpacity="0.25"
+                  strokeWidth="1.5"
+                  className="text-muted-foreground"
+                />
+                <text
+                  x={midX}
+                  y={midY}
+                  textAnchor="middle"
+                  className="fill-muted-foreground text-[9px]"
+                >
+                  {relationship.relationType}
+                </text>
+              </g>
+            );
+          })}
+
+          {detail.entities.map((entity) => {
+            const position = positions.get(entity.id);
+            if (!position) {
+              return null;
+            }
+
+            return (
+              <g key={entity.id}>
+                <circle
+                  cx={position.x}
+                  cy={position.y}
+                  r={entity.isPrimary ? 20 : 16}
+                  className={
+                    entity.isPrimary
+                      ? 'fill-primary/80 stroke-primary'
+                      : 'fill-muted stroke-muted-foreground/40'
+                  }
+                  strokeWidth="1.5"
+                />
+                <text
+                  x={position.x}
+                  y={position.y + (entity.isPrimary ? 34 : 28)}
+                  textAnchor="middle"
+                  className="fill-foreground text-[10px] font-medium"
+                >
+                  {entity.name}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Badge variant="secondary" className="gap-1">
+          <span className="inline-block h-2 w-2 rounded-full bg-primary" />
+          Primary entity
+        </Badge>
+        <Badge variant="outline" className="gap-1">
+          <span className="inline-block h-2 w-2 rounded-full bg-muted-foreground/60" />
+          Related entity
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+interface KnowledgeListItemCardProps {
+  item: KnowledgeChunkListItem;
+  isActive: boolean;
+  onSelect: (id: number) => void;
+}
+
+const KnowledgeListItemCard = memo(function KnowledgeListItemCard({
+  item,
+  isActive,
+  onSelect,
+}: KnowledgeListItemCardProps) {
+  const title = getKnowledgeCardTitle(item.preview);
+  const visibleTags = item.tags.slice(0, 2);
+  const hiddenTagCount = Math.max(item.tags.length - visibleTags.length, 0);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      className={`w-full rounded-2xl border p-4 text-left shadow-sm transition-all [content-visibility:auto] ${
+        isActive
+          ? 'border-primary/70 bg-primary/5 shadow-primary/5'
+          : 'border-border/60 bg-card/80 hover:border-border hover:bg-muted/30'
+      }`}
+      style={{ containIntrinsicSize: '220px' }}
+    >
+      <div className="min-w-0 space-y-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <Badge
+            variant="secondary"
+            className="max-w-full min-w-0 shrink basis-full justify-start truncate sm:basis-auto"
+            title={item.assistantId}
+          >
+            {item.assistantId}
+          </Badge>
+          {item.source ? (
+            <Badge
+              variant="outline"
+              className="max-w-full min-w-0 shrink basis-full justify-start truncate sm:max-w-[18rem] sm:basis-auto"
+              title={item.source}
+            >
+              {item.source}
+            </Badge>
+          ) : null}
+        </div>
+
+        <h3
+          className="line-clamp-2 text-sm font-semibold leading-5 text-foreground"
+          title={title}
+        >
+          {title}
+        </h3>
+
+        <span className="block text-[11px] text-muted-foreground">
+          {formatTimestamp(item.createdAt)}
+        </span>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-border/40 bg-muted/20 p-3">
+        <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+          Excerpt
+        </div>
+        <p className="line-clamp-4 text-sm leading-6 text-foreground/90">
+          {item.preview}
+        </p>
+      </div>
+
+      <div className="mt-4 flex min-w-0 flex-wrap gap-2">
+        {visibleTags.map((tag) => (
+          <Badge
+            key={tag}
+            variant="outline"
+            className="max-w-full min-w-0 justify-start truncate"
+            title={tag}
+          >
+            #{tag}
+          </Badge>
+        ))}
+        {hiddenTagCount > 0 ? (
+          <Badge variant="outline" className="justify-start">
+            +{hiddenTagCount}
+          </Badge>
+        ) : null}
+      </div>
+    </button>
+  );
+});
+
+interface KnowledgeDetailDialogProps {
+  open: boolean;
+  detail: KnowledgeChunkDetail | null;
+  entityNameById: Map<number, string>;
+  isDeleting: boolean;
+  isDetailLoading: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  selectedItem: KnowledgeChunkListItem | null;
+}
+
+const KnowledgeDetailDialog = memo(function KnowledgeDetailDialog({
+  open,
+  detail,
+  entityNameById,
+  isDeleting,
+  isDetailLoading,
+  onClose,
+  onDelete,
+  selectedItem,
+}: KnowledgeDetailDialogProps) {
+  const { t } = useTranslation('common');
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent
+        showCloseButton={false}
+        className="grid h-[92vh] w-[calc(100vw-1.5rem)] max-w-[calc(100vw-1.5rem)] sm:!max-w-[min(1500px,calc(100vw-1.5rem))] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden border border-border/50 bg-background p-0 shadow-[0_28px_80px_-36px_rgba(0,0,0,0.45)]"
+      >
+        <DialogHeader className="border-b border-border/40 px-6 py-5 text-left">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <DialogTitle className="text-base">
+                {t('knowledge.detailTitle', 'Knowledge Detail')}
+              </DialogTitle>
+              <DialogDescription>
+                {t(
+                  'knowledge.detailDescription',
+                  'Inspect the selected entry, its evidence, and its local graph.',
+                )}
+              </DialogDescription>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" onClick={onClose}>
+                {t('knowledge.close', 'Close')}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={onDelete}
+                disabled={!selectedItem || isDeleting}
+                className="gap-2"
+              >
+                {isDeleting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4" />
+                )}
+                {t('knowledge.delete', 'Delete')}
+              </Button>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="min-h-0 overflow-hidden px-6 py-5">
+          {isDetailLoading || !detail ? (
+            <div className="space-y-4">
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-48 w-full" />
+            </div>
+          ) : (
+            <Tabs
+              defaultValue="overview"
+              className="flex h-full flex-col gap-4"
+            >
+              <TabsList className="grid w-full max-w-md grid-cols-2">
+                <TabsTrigger value="overview" className="gap-2">
+                  <FileText className="h-4 w-4" />
+                  {t('knowledge.tabs.overview', 'Overview')}
+                </TabsTrigger>
+                <TabsTrigger value="graph" className="gap-2">
+                  <Network className="h-4 w-4" />
+                  {t('knowledge.tabs.graph', 'Graph')}
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="overview" className="min-h-0 flex-1">
+                <div className="grid h-full gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+                  <Card className="min-h-0 py-4">
+                    <CardHeader className="px-4">
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant="secondary">{detail.assistantId}</Badge>
+                        {detail.source ? (
+                          <Badge variant="outline">{detail.source}</Badge>
+                        ) : null}
+                        {detail.tags.map((tag) => (
+                          <Badge key={tag} variant="outline">
+                            #{tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    </CardHeader>
+                    <CardContent className="min-h-0 px-4">
+                      <ScrollArea className="h-[420px] pr-4">
+                        <div className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
+                          {detail.content}
+                        </div>
+                      </ScrollArea>
+                    </CardContent>
+                  </Card>
+
+                  <div className="flex min-h-0 flex-col gap-4">
+                    <Card className="py-4">
+                      <CardHeader className="px-4">
+                        <CardTitle className="text-sm">
+                          {t('knowledge.metadataTitle', 'Metadata')}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="space-y-2 px-4 text-sm">
+                        <div>
+                          <span className="text-muted-foreground">
+                            {t('knowledge.fields.createdAt', 'Created')}
+                          </span>
+                          <div>{formatTimestamp(detail.createdAt)}</div>
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">
+                            {t(
+                              'knowledge.fields.primaryEntities',
+                              'Primary entities',
+                            )}
+                          </span>
+                          <div>{detail.primaryEntityIds.length}</div>
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">
+                            {t(
+                              'knowledge.fields.relationships',
+                              'Relationships',
+                            )}
+                          </span>
+                          <div>{detail.relationships.length}</div>
+                        </div>
+                      </CardContent>
+                    </Card>
+
+                    <Card className="min-h-0 flex-1 py-4">
+                      <CardHeader className="px-4">
+                        <CardTitle className="text-sm">
+                          {t('knowledge.entitiesTitle', 'Entities')}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="min-h-0 px-4">
+                        <ScrollArea className="h-[250px] pr-3">
+                          <div className="space-y-2">
+                            {detail.entities.length === 0 ? (
+                              <p className="text-sm text-muted-foreground">
+                                {t(
+                                  'knowledge.noEntities',
+                                  'No linked entities for this entry.',
+                                )}
+                              </p>
+                            ) : (
+                              detail.entities.map((entity) => (
+                                <div
+                                  key={entity.id}
+                                  className="rounded-lg border p-3 text-sm"
+                                >
+                                  <div className="flex items-center gap-2">
+                                    <span className="font-medium">
+                                      {entity.name}
+                                    </span>
+                                    {entity.isPrimary ? (
+                                      <Badge variant="secondary">
+                                        {t(
+                                          'knowledge.primaryEntity',
+                                          'Primary',
+                                        )}
+                                      </Badge>
+                                    ) : null}
+                                  </div>
+                                  {entity.entityType ? (
+                                    <div className="mt-1 text-xs text-muted-foreground">
+                                      {entity.entityType}
+                                    </div>
+                                  ) : null}
+                                  {entity.description ? (
+                                    <p className="mt-2 text-muted-foreground">
+                                      {entity.description}
+                                    </p>
+                                  ) : null}
+                                </div>
+                              ))
+                            )}
+                          </div>
+                        </ScrollArea>
+                      </CardContent>
+                    </Card>
+                  </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="graph" className="min-h-0 flex-1">
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+                  <KnowledgeGraphPreview detail={detail} />
+
+                  <Card className="py-4">
+                    <CardHeader className="px-4">
+                      <CardTitle className="text-sm">
+                        {t('knowledge.relationshipListTitle', 'Relationships')}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="px-4">
+                      <ScrollArea className="h-[320px] pr-3">
+                        <div className="space-y-2 text-sm">
+                          {detail.relationships.length === 0 ? (
+                            <p className="text-muted-foreground">
+                              {t(
+                                'knowledge.noRelationships',
+                                'No relationships linked to this entry.',
+                              )}
+                            </p>
+                          ) : (
+                            detail.relationships.map((relationship) => (
+                              <div
+                                key={relationship.id}
+                                className="rounded-lg border p-3"
+                              >
+                                <div className="font-medium">
+                                  {relationship.relationType}
+                                </div>
+                                <div className="mt-1 text-xs text-muted-foreground">
+                                  {entityNameById.get(
+                                    relationship.sourceEntityId,
+                                  ) ?? relationship.sourceEntityId}{' '}
+                                  -&gt;{' '}
+                                  {entityNameById.get(
+                                    relationship.targetEntityId,
+                                  ) ?? relationship.targetEntityId}
+                                </div>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </ScrollArea>
+                    </CardContent>
+                  </Card>
+                </div>
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+});
+
+export default function KnowledgePage() {
+  const { t } = useTranslation('common');
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [assistantFilter, setAssistantFilter] = useState('all');
+  const [items, setItems] = useState<KnowledgeChunkListItem[]>([]);
+  const [assistants, setAssistants] = useState<string[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<KnowledgeChunkDetail | null>(null);
+  const [isListLoading, setIsListLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [listRefreshToken, setListRefreshToken] = useState(0);
+  const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
+    null,
+  );
+  const deferredQuery = useDeferredValue(query);
+  const [, startSelectionTransition] = useTransition();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQuery(deferredQuery.trim());
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [deferredQuery]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsListLoading(true);
+      try {
+        const response = await listGlobalKnowledge({
+          query: debouncedQuery || undefined,
+          assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
+          limit: KNOWLEDGE_PAGE_SIZE,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        setItems(response.items);
+        setAssistants(response.assistants);
+        setNextCursor(response.nextCursor ?? null);
+        setSelectedId((current) => {
+          if (current && response.items.some((item) => item.id === current)) {
+            return current;
+          }
+          return null;
+        });
+      } catch (error) {
+        logger.error('Failed to load global knowledge list', error);
+        if (!cancelled) {
+          toast.error(
+            t(
+              'knowledge.loadListFailed',
+              'Failed to load global knowledge entries.',
+            ),
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsListLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantFilter, debouncedQuery, listRefreshToken, t]);
+
+  useEffect(() => {
+    if (selectedId === null) {
+      setDetail(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadDetail = async () => {
+      setIsDetailLoading(true);
+      try {
+        const response = await getGlobalKnowledgeDetail(selectedId);
+        if (!cancelled) {
+          setDetail(response);
+        }
+      } catch (error) {
+        logger.error('Failed to load knowledge detail', { selectedId, error });
+        if (!cancelled) {
+          toast.error(
+            t(
+              'knowledge.loadDetailFailed',
+              'Failed to load knowledge details.',
+            ),
+          );
+          setDetail(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsDetailLoading(false);
+        }
+      }
+    };
+
+    void loadDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, t]);
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.id === selectedId) ?? null,
+    [items, selectedId],
+  );
+  const isDetailOpen = selectedItem !== null;
+  const hasMoreItems = nextCursor !== null;
+  const entityNameById = useMemo(
+    () =>
+      new Map(detail?.entities.map((entity) => [entity.id, entity.name]) ?? []),
+    [detail?.entities],
+  );
+
+  const handleRefresh = useCallback(() => {
+    setListRefreshToken((current) => current + 1);
+  }, []);
+
+  const handleCloseDetail = useCallback(() => {
+    setSelectedId(null);
+  }, []);
+
+  const handleSelectItem = useCallback((id: number) => {
+    startSelectionTransition(() => {
+      setSelectedId(id);
+    });
+  }, []);
+
+  const handleLoadMore = useCallback(async () => {
+    if (isListLoading || isLoadingMore || nextCursor === null) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    try {
+      const response = await listGlobalKnowledge({
+        query: debouncedQuery || undefined,
+        assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
+        cursor: nextCursor,
+        limit: KNOWLEDGE_PAGE_SIZE,
+      });
+
+      setItems((current) => {
+        const seenIds = new Set(current.map((item) => item.id));
+        const appendedItems = response.items.filter(
+          (item) => !seenIds.has(item.id),
+        );
+        return [...current, ...appendedItems];
+      });
+      setNextCursor(response.nextCursor ?? null);
+    } catch (error) {
+      logger.error('Failed to load more global knowledge entries', error);
+      toast.error(
+        t('knowledge.loadMoreFailed', 'Failed to load more knowledge entries.'),
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    assistantFilter,
+    debouncedQuery,
+    isListLoading,
+    isLoadingMore,
+    nextCursor,
+    t,
+  ]);
+
+  const handleDelete = useCallback(async () => {
+    if (!selectedItem || isDeleting) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      t(
+        'knowledge.confirmDelete',
+        'Delete this knowledge entry and clean up orphaned graph data?',
+      ),
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const response = await deleteGlobalKnowledge(selectedItem.id);
+      toast.success(t('knowledge.deleteSuccess', 'Knowledge entry deleted.'), {
+        description: t(
+          'knowledge.deleteSuccessDescription',
+          'Removed {{entities}} orphan entities and {{relationships}} orphan relationships.',
+          {
+            entities: response.orphanEntityCount,
+            relationships: response.orphanRelationshipCount,
+          },
+        ),
+      });
+      setDetail(null);
+      setSelectedId(null);
+      setListRefreshToken((current) => current + 1);
+    } catch (error) {
+      logger.error('Failed to delete knowledge entry', {
+        id: selectedItem.id,
+        error,
+      });
+      toast.error(
+        t('knowledge.deleteFailed', 'Failed to delete knowledge entry.'),
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [isDeleting, selectedItem, t]);
+
+  return (
+    <div className="h-full bg-background p-6">
+      <div className="mx-auto flex h-full max-w-7xl flex-col gap-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center justify-center rounded-xl bg-primary/10 p-2.5 text-primary">
+              <Database size={28} />
+            </div>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+                {t('knowledge.pageTitle', 'Global Knowledge')}
+              </h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                {t(
+                  'knowledge.pageSubtitle',
+                  'Search shared memory, inspect evidence, and prune stale knowledge.',
+                )}
+              </p>
+            </div>
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleRefresh}
+            className="gap-2"
+          >
+            <RefreshCw className="h-4 w-4" />
+            {t('knowledge.refresh', 'Refresh')}
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1">
+          <Card className="min-h-0 gap-4 py-4">
+            <CardHeader className="px-4">
+              <CardTitle className="text-base">
+                {t('knowledge.browserTitle', 'Knowledge Browser')}
+              </CardTitle>
+              <CardDescription>
+                {t(
+                  'knowledge.browserDescription',
+                  'Find chunks first, then inspect their evidence and graph neighborhood.',
+                )}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex min-h-0 flex-1 flex-col gap-4 px-4">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={t(
+                    'knowledge.searchPlaceholder',
+                    'Search content, tags, or source...',
+                  )}
+                  className="pl-9"
+                />
+              </div>
+
+              <Select
+                value={assistantFilter}
+                onValueChange={setAssistantFilter}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={t(
+                      'knowledge.assistantFilterPlaceholder',
+                      'Filter by assistant',
+                    )}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">
+                    {t('knowledge.assistantFilterAll', 'All assistants')}
+                  </SelectItem>
+                  {assistants.map((assistantId) => (
+                    <SelectItem key={assistantId} value={assistantId}>
+                      {assistantId}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <ScrollArea className="min-h-0 flex-1">
+                <div className="space-y-4 pr-3">
+                  <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+                    {isListLoading ? (
+                      Array.from({ length: 6 }).map((_, index) => (
+                        <div
+                          key={index}
+                          className="space-y-2 rounded-xl border p-3"
+                        >
+                          <Skeleton className="h-4 w-24" />
+                          <Skeleton className="h-3 w-full" />
+                          <Skeleton className="h-3 w-4/5" />
+                        </div>
+                      ))
+                    ) : items.length === 0 ? (
+                      <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+                        {t(
+                          'knowledge.emptyState',
+                          'No knowledge entries match the current filters.',
+                        )}
+                      </div>
+                    ) : (
+                      items.map((item) => (
+                        <KnowledgeListItemCard
+                          key={item.id}
+                          item={item}
+                          isActive={item.id === selectedId}
+                          onSelect={handleSelectItem}
+                        />
+                      ))
+                    )}
+                  </div>
+
+                  {!isListLoading && items.length > 0 ? (
+                    <div className="flex flex-col items-center gap-3 py-2">
+                      {hasMoreItems ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => void handleLoadMore()}
+                          disabled={isLoadingMore}
+                          className="min-w-36 gap-2"
+                        >
+                          {isLoadingMore ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : null}
+                          {t('knowledge.loadMore', 'Load more')}
+                        </Button>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          {t(
+                            'knowledge.endOfResults',
+                            'You have reached the end of the current results.',
+                          )}
+                        </p>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      <KnowledgeDetailDialog
+        open={isDetailOpen}
+        detail={detail}
+        entityNameById={entityNameById}
+        isDeleting={isDeleting}
+        isDetailLoading={isDetailLoading}
+        onClose={handleCloseDetail}
+        onDelete={handleDelete}
+        selectedItem={selectedItem}
+      />
+    </div>
+  );
+}

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -90,6 +90,13 @@ export {
 // Session management
 export { removeSession, deleteAttachments } from './sessions';
 
+// Knowledge management
+export {
+  listGlobalKnowledge,
+  getGlobalKnowledgeDetail,
+  deleteGlobalKnowledge,
+} from './knowledge';
+
 // Utilities
 export {
   getAppLogsDir,

--- a/src/lib/backend/knowledge.ts
+++ b/src/lib/backend/knowledge.ts
@@ -4,7 +4,6 @@ export interface KnowledgeChunkListItem {
   id: number;
   assistantId: string;
   preview: string;
-  content: string;
   tags: string[];
   source?: string | null;
   createdAt: number;

--- a/src/lib/backend/knowledge.ts
+++ b/src/lib/backend/knowledge.ts
@@ -1,0 +1,89 @@
+import { safeInvoke } from './core';
+
+export interface KnowledgeChunkListItem {
+  id: number;
+  assistantId: string;
+  preview: string;
+  content: string;
+  tags: string[];
+  source?: string | null;
+  createdAt: number;
+}
+
+export interface GlobalKnowledgeListResponse {
+  items: KnowledgeChunkListItem[];
+  assistants: string[];
+  nextCursor?: KnowledgeListCursor | null;
+}
+
+export interface KnowledgeListCursor {
+  createdAt: number;
+  id: number;
+}
+
+export interface KnowledgeGraphEntity {
+  id: number;
+  assistantId: string;
+  name: string;
+  entityType?: string | null;
+  description?: string | null;
+  isPrimary: boolean;
+}
+
+export interface KnowledgeGraphRelationship {
+  id: number;
+  assistantId: string;
+  sourceEntityId: number;
+  targetEntityId: number;
+  relationType: string;
+  weight: number;
+}
+
+export interface KnowledgeChunkDetail {
+  id: number;
+  assistantId: string;
+  content: string;
+  tags: string[];
+  source?: string | null;
+  createdAt: number;
+  primaryEntityIds: number[];
+  entities: KnowledgeGraphEntity[];
+  relationships: KnowledgeGraphRelationship[];
+}
+
+export interface DeleteGlobalKnowledgeResponse {
+  deletedChunkId: number;
+  orphanEntityCount: number;
+  orphanRelationshipCount: number;
+}
+
+export interface ListGlobalKnowledgeRequest {
+  query?: string;
+  assistantId?: string;
+  cursor?: KnowledgeListCursor;
+  limit?: number;
+}
+
+export async function listGlobalKnowledge(
+  request: ListGlobalKnowledgeRequest = {},
+): Promise<GlobalKnowledgeListResponse> {
+  return safeInvoke<GlobalKnowledgeListResponse>('list_global_knowledge', {
+    request,
+  });
+}
+
+export async function getGlobalKnowledgeDetail(
+  id: number,
+): Promise<KnowledgeChunkDetail> {
+  return safeInvoke<KnowledgeChunkDetail>('get_global_knowledge_detail', {
+    id,
+  });
+}
+
+export async function deleteGlobalKnowledge(
+  id: number,
+): Promise<DeleteGlobalKnowledgeResponse> {
+  return safeInvoke<DeleteGlobalKnowledgeResponse>('delete_global_knowledge', {
+    id,
+  });
+}

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
- add a global Knowledge page in the sidebar with browse, search, detail, delete, and load-more pagination flows
- add backend list/detail/delete commands plus orphan graph cleanup and pagination coverage tests
- make Linux compatibility rendering opt-in and lower default Rust test parallelism to reduce memory pressure

## Validation
- pnpm build
- CARGO_BUILD_JOBS=2 pnpm rust:test knowledge_v2_repository_tests
- CARGO_BUILD_JOBS=2 pnpm rust:test knowledge_v2_repository_lists_chunks_with_cursor_pagination