### PR TITLE
Fix sub-session LLM inheritance

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,11 @@ src/**/*.test.tsx
 src-tauri/
 public/
 .venv/
+.gemini/
+.cargo/
+.agent/
+.editorconfig
+.gitattributes
 
 # Handlebars templates (preserve formatting and doctype)
 *.hbs

--- a/scripts/run-rust-command.cjs
+++ b/scripts/run-rust-command.cjs
@@ -43,7 +43,9 @@ function getRecommendedTestBuildJobs() {
 
 function getDefaultBuildJobs(args) {
   const recommendedJobs =
-    args[0] === 'test' ? getRecommendedTestBuildJobs() : getRecommendedBuildJobs();
+    args[0] === 'test'
+      ? getRecommendedTestBuildJobs()
+      : getRecommendedBuildJobs();
 
   return recommendedJobs;
 }

--- a/src-tauri/src/agent/types.rs
+++ b/src-tauri/src/agent/types.rs
@@ -18,6 +18,8 @@ pub struct ToolCallFunction {
 pub struct CreateSessionRequest {
     pub name: Option<String>,
     pub assistant_id: String, // Replaces agent_config
+    pub model: Option<String>,
+    pub provider: Option<String>,
     pub workspace_path: Option<String>,
     pub request: String,
     pub parent_session_id: Option<String>,

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -111,6 +111,8 @@ async fn start_session_impl(
     let body: crate::agent::types::CreateSessionRequest = serde_json::from_value(json!({
         "parentSessionId": caller_session_id,
         "assistantId": read_required_string(&args, "agentId")?,
+        "model": args.get("model").and_then(|v| v.as_str()),
+        "provider": args.get("provider").and_then(|v| v.as_str()),
         "request": read_required_string(&args, "task")?,
         "workspacePath": effective_workspace_path.as_deref(),
         "maxDepth": args.get("maxDepth").and_then(|v| v.as_u64()),

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -131,6 +131,8 @@ fn start_session_tool() -> MCPTool {
                 ("agentId".to_string(), string_prop_required("Exact agent configuration ID to use. Call `list(type='configs')` first, then copy the returned ID. Do not put the agent name here.")),
                 ("task".to_string(), string_prop_required("The specific task description for the sub-agent.")),
                 ("workspaceOverride".to_string(), string_prop(None, None, Some("Absolute workspace path for the child session. If omitted, a plain child uses its default isolated workspace; an org child inherits the explicit org root workspace by default."))),
+                ("model".to_string(), string_prop(None, None, Some("Optional model override for the child session. If omitted, the child inherits the caller session model."))),
+                ("provider".to_string(), string_prop(None, None, Some("Optional provider override for the child session. If omitted, the child inherits the caller session provider."))),
                 ("maxDepth".to_string(), integer_prop(Some(0), None, Some("Override the delegation depth limit for this child session. If omitted, inherit the caller's maxDepth when present; otherwise leave the depth limit unset."))),
                 ("maxFanout".to_string(), integer_prop(Some(0), None, Some("Override the delegation fanout limit for this child session. If omitted, inherit the caller's maxFanout when present; otherwise leave the fanout limit unset."))),
                 ("includeCurrentOrg".to_string(), boolean_prop(Some("Optional explicit override for org inheritance. When omitted, children automatically inherit the caller's explicit org membership; set false to keep a delegated child out of Org view."))),

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -82,6 +82,14 @@ pub async fn handle_tool_call(
                 body["workspacePath"] = Value::String(path.to_string());
             }
 
+            if let Some(model) = args.get("model").and_then(|v| v.as_str()) {
+                body["model"] = Value::String(model.to_string());
+            }
+
+            if let Some(provider) = args.get("provider").and_then(|v| v.as_str()) {
+                body["provider"] = Value::String(provider.to_string());
+            }
+
             let await_completion = args
                 .get("awaitCompletion")
                 .and_then(|v| v.as_bool())

--- a/src-tauri/src/mcp/builtin/session_api/tools.rs
+++ b/src-tauri/src/mcp/builtin/session_api/tools.rs
@@ -59,6 +59,22 @@ pub fn create_child_session_tool() -> MCPTool {
                     ),
                 ),
                 (
+                    "model".to_string(),
+                    string_prop(
+                        None,
+                        None,
+                        Some("Optional model override for the child session. If omitted, the child inherits the parent session model."),
+                    ),
+                ),
+                (
+                    "provider".to_string(),
+                    string_prop(
+                        None,
+                        None,
+                        Some("Optional provider override for the child session. If omitted, the child inherits the parent session provider."),
+                    ),
+                ),
+                (
                     "awaitCompletion".to_string(),
                     boolean_prop(Some("If true (default), block until the child finishes and return its final result. Set false to spawn and return immediately — then use awaitAgent(sessionId) to collect results.")),
                 ),

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -150,14 +150,21 @@ pub fn resolve_child_session_model_provider(
     requested_model: Option<String>,
     requested_provider: Option<String>,
     parent_session: Option<&SessionMetadata>,
-) -> (Option<String>, Option<String>) {
+) -> Result<(Option<String>, Option<String>), String> {
     let inherited_model = parent_session.map(|session| session.model.clone());
     let inherited_provider = parent_session.map(|session| session.provider.clone());
 
-    (
+    if parent_session.is_none() && (requested_model.is_some() != requested_provider.is_some()) {
+        return Err(
+            "Child session model/provider override must include both model and provider when no parent session is available for inheritance"
+                .to_string(),
+        );
+    }
+
+    Ok((
         requested_model.or(inherited_model),
         requested_provider.or(inherited_provider),
-    )
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -236,7 +243,7 @@ impl AgentService {
             body.model.clone(),
             body.provider.clone(),
             parent_session.as_ref(),
-        );
+        )?;
 
         let lineage_meta = if let Some(parent_id) = parent_session_id.clone() {
             let store = lineage_store().read().await;

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -2,6 +2,7 @@ use crate::agent::types::{CreateSessionRequest, CreateSessionResponse, SessionLi
 use crate::agent::AgentSessionManager;
 use crate::mcp::types::MCPContent;
 use crate::models::chat::Message;
+use crate::repositories::SessionMetadata;
 use crate::session::get_session_manager;
 use std::collections::HashMap;
 use std::fs;
@@ -145,6 +146,20 @@ pub fn normalize_explicit_org(
     }
 }
 
+pub fn resolve_child_session_model_provider(
+    requested_model: Option<String>,
+    requested_provider: Option<String>,
+    parent_session: Option<&SessionMetadata>,
+) -> (Option<String>, Option<String>) {
+    let inherited_model = parent_session.map(|session| session.model.clone());
+    let inherited_provider = parent_session.map(|session| session.provider.clone());
+
+    (
+        requested_model.or(inherited_model),
+        requested_provider.or(inherited_provider),
+    )
+}
+
 #[derive(Debug, Clone)]
 pub struct SendSessionMessageResponse {
     pub message_id: String,
@@ -188,11 +203,13 @@ impl AgentService {
 
         // 3. Resolve lineage metadata
         let parent_session_id = body.parent_session_id.clone();
+        let mut parent_session = None;
         let requested_max_depth = body.max_depth;
         let requested_max_fanout = body.max_fanout;
 
         if let Some(ref parent_id) = parent_session_id {
-            if manager.get_session(parent_id).await?.is_none() {
+            parent_session = manager.get_session(parent_id).await?;
+            if parent_session.is_none() {
                 return Err(format!("Parent session not found: {}", parent_id));
             }
         }
@@ -214,6 +231,12 @@ impl AgentService {
             body.org_name.clone(),
             body.org_root_session_id.clone(),
         )?;
+
+        let (resolved_model, resolved_provider) = resolve_child_session_model_provider(
+            body.model.clone(),
+            body.provider.clone(),
+            parent_session.as_ref(),
+        );
 
         let lineage_meta = if let Some(parent_id) = parent_session_id.clone() {
             let store = lineage_store().read().await;
@@ -348,7 +371,13 @@ impl AgentService {
         }
 
         let session = manager
-            .create_session(session_id.clone(), session_name, None, None, agent_config)
+            .create_session(
+                session_id.clone(),
+                session_name,
+                resolved_model,
+                resolved_provider,
+                agent_config,
+            )
             .await?;
 
         lineage_store()

--- a/src-tauri/tests/subsession_llm_inheritance_tests.rs
+++ b/src-tauri/tests/subsession_llm_inheritance_tests.rs
@@ -1,0 +1,70 @@
+use tauri_mcp_agent_lib::agent::types::CreateSessionRequest;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+use tauri_mcp_agent_lib::services::agent_service::resolve_child_session_model_provider;
+
+fn build_parent_session(model: &str, provider: &str) -> SessionMetadata {
+    let now = chrono::Utc::now().timestamp_millis();
+    SessionMetadata {
+        id: "parent-session".to_string(),
+        name: Some("Parent".to_string()),
+        status: SessionStatus::Idle,
+        model: model.to_string(),
+        provider: provider.to_string(),
+        agent_config: Some(r#"{"name":"Parent"}"#.to_string()),
+        parent_session_id: None,
+        lineage_id: Some("parent-session".to_string()),
+        depth: Some(0),
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[test]
+fn child_sessions_inherit_parent_model_and_provider_by_default() {
+    let parent = build_parent_session("gpt-5.4", "openai");
+
+    let (model, provider) = resolve_child_session_model_provider(None, None, Some(&parent));
+
+    assert_eq!(model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(provider.as_deref(), Some("openai"));
+}
+
+#[test]
+fn child_sessions_allow_explicit_override_without_losing_unspecified_parent_field() {
+    let parent = build_parent_session("gpt-5.4", "openai");
+
+    let (model, provider) = resolve_child_session_model_provider(
+        Some("claude-sonnet-4.5".to_string()),
+        None,
+        Some(&parent),
+    );
+
+    assert_eq!(model.as_deref(), Some("claude-sonnet-4.5"));
+    assert_eq!(provider.as_deref(), Some("openai"));
+}
+
+#[test]
+fn create_session_request_deserializes_optional_model_and_provider() {
+    let request: CreateSessionRequest = serde_json::from_value(serde_json::json!({
+        "assistantId": "assistant-1",
+        "request": "delegate this",
+        "model": "claude-sonnet-4.5",
+        "provider": "anthropic"
+    }))
+    .expect("request should deserialize");
+
+    assert_eq!(request.model.as_deref(), Some("claude-sonnet-4.5"));
+    assert_eq!(request.provider.as_deref(), Some("anthropic"));
+}

--- a/src-tauri/tests/subsession_llm_inheritance_tests.rs
+++ b/src-tauri/tests/subsession_llm_inheritance_tests.rs
@@ -35,7 +35,8 @@ fn build_parent_session(model: &str, provider: &str) -> SessionMetadata {
 fn child_sessions_inherit_parent_model_and_provider_by_default() {
     let parent = build_parent_session("gpt-5.4", "openai");
 
-    let (model, provider) = resolve_child_session_model_provider(None, None, Some(&parent));
+    let (model, provider) =
+        resolve_child_session_model_provider(None, None, Some(&parent)).unwrap();
 
     assert_eq!(model.as_deref(), Some("gpt-5.4"));
     assert_eq!(provider.as_deref(), Some("openai"));
@@ -49,7 +50,8 @@ fn child_sessions_allow_explicit_override_without_losing_unspecified_parent_fiel
         Some("claude-sonnet-4.5".to_string()),
         None,
         Some(&parent),
-    );
+    )
+    .unwrap();
 
     assert_eq!(model.as_deref(), Some("claude-sonnet-4.5"));
     assert_eq!(provider.as_deref(), Some("openai"));

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
- make child session creation inherit the parent session model/provider by default
- allow optional model/provider overrides through spawnAgent and startSession request plumbing
- add regression coverage for inheritance and override resolution

## Testing
- cargo test --tests --profile ci-test --test subsession_llm_inheritance_tests
- pnpm refactor:validate