### PR TITLE
🪨 Rosetta: Localize Settings Page & Expand KO

### DIFF
--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -573,7 +573,10 @@ export default function SettingsPage() {
                 {t('settings.title', 'Settings')}
               </h1>
               <p className="text-sm text-muted-foreground mt-0.5">
-                LibrAgent v{__APP_VERSION__}
+                {t('settings.versionLabel', '{{appName}} v{{version}}', {
+                  appName: t('appName', 'LibrAgent'),
+                  version: __APP_VERSION__,
+                })}
               </p>
             </div>
           </div>

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -573,7 +573,8 @@ export default function SettingsPage() {
                 {t('settings.title', 'Settings')}
               </h1>
               <p className="text-sm text-muted-foreground mt-0.5">
-                {t('settings.versionLabel', '{{appName}} v{{version}}', {
+                {t('settings.versionLabel', {
+                  defaultValue: '{{appName}} v{{version}}',
                   appName: t('appName', 'LibrAgent'),
                   version: __APP_VERSION__,
                 })}

--- a/src/features/settings/components/AboutSection.tsx
+++ b/src/features/settings/components/AboutSection.tsx
@@ -39,7 +39,9 @@ export function AboutSection() {
         {/* Version row */}
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-foreground">LibrAgent</p>
+            <p className="text-sm font-medium text-foreground">
+              {t('appName', 'LibrAgent')}
+            </p>
             <p className="text-xs text-muted-foreground">
               {t('settings.about.version', 'Version')} {__APP_VERSION__}
             </p>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "appName": "LibrAgent",
   "assistant": {
     "nameLabel": "Assistant Name *",
     "namePlaceholder": "Enter assistant name...",
@@ -249,6 +250,7 @@
   },
   "settings": {
     "title": "Settings",
+    "versionLabel": "{{appName}} v{{version}}",
     "unsaved": "Unsaved",
     "saved": "Settings saved successfully",
     "saving": "Saving...",
@@ -364,6 +366,8 @@
       "maxConcurrentActiveProcessesDescription": "Maximum number of shell/code processes running simultaneously across all agent sessions.",
       "maxSuspendedProcesses": "Max Suspended Shell Processes",
       "maxSuspendedProcessesDescription": "Maximum number of processes that can be paused waiting on pollProcess. Should be ≥ active processes.",
+      "toolResultInlineLimit": "Tool Result Inline Limit (KB)",
+      "toolResultInlineLimitDescription": "Controls how much tool output stays inline before LibrAgent spills the full result to a workspace file. Lower values keep the agent context leaner.",
       "shellIsolation": "Shell Isolation Level",
       "shellIsolationModes": {
         "basic": "Basic - Full PATH access (less secure)",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -1,4 +1,5 @@
 {
+  "appName": "LibrAgent",
   "assistant": {
     "nameLabel": "어시스턴트 이름 *",
     "namePlaceholder": "어시스턴트 이름을 입력하세요...",
@@ -228,6 +229,7 @@
   },
   "settings": {
     "title": "설정",
+    "versionLabel": "{{appName}} v{{version}}",
     "unsaved": "미저장",
     "saved": "설정이 저장되었습니다",
     "saving": "저장 중...",
@@ -343,6 +345,8 @@
       "maxConcurrentActiveProcessesDescription": "모든 에이전트 세션에서 동시에 실행되는 셸/코드 프로세스의 최대 수입니다.",
       "maxSuspendedProcesses": "최대 일시 중지된 셸 프로세스",
       "maxSuspendedProcessesDescription": "pollProcess 대기 중에 일시 중지될 수 있는 프로세스의 최대 수입니다. 활성 프로세스 수보다 크거나 같아야 합니다.",
+      "toolResultInlineLimit": "Tool Result Inline Limit (KB)",
+      "toolResultInlineLimitDescription": "Controls how much tool output stays inline before LibrAgent spills the full result to a workspace file. Lower values keep the agent context leaner.",
       "shellIsolation": "셸 격리 수준",
       "shellIsolationModes": {
         "basic": "기본 - 전체 PATH 접근 (보안 낮음)",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -345,8 +345,8 @@
       "maxConcurrentActiveProcessesDescription": "모든 에이전트 세션에서 동시에 실행되는 셸/코드 프로세스의 최대 수입니다.",
       "maxSuspendedProcesses": "최대 일시 중지된 셸 프로세스",
       "maxSuspendedProcessesDescription": "pollProcess 대기 중에 일시 중지될 수 있는 프로세스의 최대 수입니다. 활성 프로세스 수보다 크거나 같아야 합니다.",
-      "toolResultInlineLimit": "Tool Result Inline Limit (KB)",
-      "toolResultInlineLimitDescription": "Controls how much tool output stays inline before LibrAgent spills the full result to a workspace file. Lower values keep the agent context leaner.",
+      "toolResultInlineLimit": "도구 결과 인라인 제한 (KB)",
+      "toolResultInlineLimitDescription": "LibrAgent가 전체 결과를 워크스페이스 파일로 넘기기 전에 인라인으로 유지할 도구 출력의 양을 조절합니다. 낮은 값일수록 에이전트 컨텍스트를 가볍게 유지합니다.",
       "shellIsolation": "셸 격리 수준",
       "shellIsolationModes": {
         "basic": "기본 - 전체 PATH 접근 (보안 낮음)",


### PR DESCRIPTION
🪨 Rosetta: Localize Settings Page & Expand KO

🌐 Scope:
- `src/features/settings/components/AboutSection.tsx`
- `src/features/settings/SettingsPage.tsx`
- `src/locales/en/common.json`
- `src/locales/ko/common.json`

🔑 Keys Added:
- `appName`
- `settings.versionLabel`
- `advanced.toolResultInlineLimit`
- `advanced.toolResultInlineLimitDescription`

🌍 Languages:
- Synced `en.json` and `ko.json`.
- Used English placeholders for new advanced settings strings in `ko.json` pending translation.

⚠️ Visual QA:
- Ensured formatting correctly uses templates `{{appName}} v{{version}}` instead of concatenation, avoiding layout breaks for different language orderings.

---
*PR created automatically by Jules for task [2035701786614505077](https://jules.google.com/task/2035701786614505077) started by @fritzprix*