### PR TITLE
🕸️ Weaver: Refactor KnowledgePage using Declarative Data Fetching

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -144,3 +144,9 @@
 
 **Learning:** Extracting complex Drag-and-Drop subscription logic out of a monolithic component into a dedicated custom hook (`useSkillsDnD`) strictly separates presentation from side-effects, significantly improving component readability and reusability.
 **Action:** Continually hunt for "God useEffect" blocks handling disparate UI concerns (like file drop events) and encapsulate them inside specialized hooks.
+
+## 2026-04-20 - [KnowledgePage / useKnowledgeList / useKnowledgeDetail] **Eradicated:** [Cascading State Effect & Derived State] **Woven:** [Declarative Data Fetching (useSWR / useSWRInfinite)]
+
+- **KnowledgePage:** Eradicated the anti-pattern where `useState` and `useEffect` were manually orchestrating pagination (`nextCursor`, `isLoadingMore`, `items`), detail fetching, and query debouncing via imperative blocks.
+- **Woven (useKnowledgeList / useKnowledgeDetail):** Encapsulated side-effects, cursor tracking, error handling, and derived loading states into dedicated SWR data fetching hooks.
+- **Benefits:** Decoupled data fetching from UI presentation, avoided the "State Duplicator" and "Action-Effect Chain", and greatly improved component readability by relying on SWR's cache (`mutateList`, `mutateDetail`) for post-mutation synchronization.

--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -602,8 +602,7 @@ export default function KnowledgePage() {
     mutateList,
   } = useKnowledgeList(debouncedQuery, assistantFilter, KNOWLEDGE_PAGE_SIZE);
 
-  const { detail, isDetailLoading, mutateDetail } =
-    useKnowledgeDetail(selectedId);
+  const { detail, isDetailLoading } = useKnowledgeDetail(selectedId);
 
   const selectedItem = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,
@@ -671,7 +670,6 @@ export default function KnowledgePage() {
       setSelectedId(null);
       setIsDeleteDialogOpen(false);
       void mutateList();
-      void mutateDetail();
     } catch (error) {
       logger.error('Failed to delete knowledge entry', {
         id: selectedItem.id,
@@ -683,7 +681,7 @@ export default function KnowledgePage() {
     } finally {
       setIsDeleting(false);
     }
-  }, [isDeleting, selectedItem, t]);
+  }, [isDeleting, mutateList, selectedItem, t]);
 
   return (
     <div className="h-full bg-background p-6">

--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -57,13 +57,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { getLogger } from '@/lib/logger';
 import {
   deleteGlobalKnowledge,
-  getGlobalKnowledgeDetail,
-  listGlobalKnowledge,
   type KnowledgeChunkDetail,
   type KnowledgeChunkListItem,
   type KnowledgeGraphEntity,
-  type KnowledgeListCursor,
 } from '@/lib/backend/knowledge';
+import { useKnowledgeList } from './hooks/useKnowledgeList';
+import { useKnowledgeDetail } from './hooks/useKnowledgeDetail';
 
 const logger = getLogger('KnowledgePage');
 const KNOWLEDGE_PAGE_SIZE = 60;
@@ -579,19 +578,9 @@ export default function KnowledgePage() {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [assistantFilter, setAssistantFilter] = useState('all');
-  const [items, setItems] = useState<KnowledgeChunkListItem[]>([]);
-  const [assistants, setAssistants] = useState<string[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
-  const [detail, setDetail] = useState<KnowledgeChunkDetail | null>(null);
-  const [isListLoading, setIsListLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [listRefreshToken, setListRefreshToken] = useState(0);
-  const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
-    null,
-  );
   const deferredQuery = useDeferredValue(query);
   const [, startSelectionTransition] = useTransition();
 
@@ -603,99 +592,34 @@ export default function KnowledgePage() {
     return () => window.clearTimeout(timeout);
   }, [deferredQuery]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const {
+    items,
+    assistants,
+    nextCursor,
+    isListLoading,
+    isLoadingMore,
+    loadMore: handleLoadMore,
+    mutateList,
+  } = useKnowledgeList(debouncedQuery, assistantFilter, KNOWLEDGE_PAGE_SIZE);
 
-    const load = async () => {
-      setIsListLoading(true);
-      try {
-        const response = await listGlobalKnowledge({
-          query: debouncedQuery || undefined,
-          assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
-          limit: KNOWLEDGE_PAGE_SIZE,
-        });
-
-        if (cancelled) {
-          return;
-        }
-
-        setItems(response.items);
-        setAssistants(response.assistants);
-        setNextCursor(response.nextCursor ?? null);
-        setSelectedId((current) => {
-          if (current && response.items.some((item) => item.id === current)) {
-            return current;
-          }
-          return null;
-        });
-      } catch (error) {
-        logger.error('Failed to load global knowledge list', error);
-        if (!cancelled) {
-          toast.error(
-            t(
-              'knowledge.loadListFailed',
-              'Failed to load global knowledge entries.',
-            ),
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setIsListLoading(false);
-        }
-      }
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [assistantFilter, debouncedQuery, listRefreshToken, t]);
-
-  useEffect(() => {
-    if (selectedId === null) {
-      setDetail(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadDetail = async () => {
-      setIsDetailLoading(true);
-      try {
-        const response = await getGlobalKnowledgeDetail(selectedId);
-        if (!cancelled) {
-          setDetail(response);
-        }
-      } catch (error) {
-        logger.error('Failed to load knowledge detail', { selectedId, error });
-        if (!cancelled) {
-          toast.error(
-            t(
-              'knowledge.loadDetailFailed',
-              'Failed to load knowledge details.',
-            ),
-          );
-          setDetail(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsDetailLoading(false);
-        }
-      }
-    };
-
-    void loadDetail();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedId, t]);
+  const { detail, isDetailLoading, mutateDetail } =
+    useKnowledgeDetail(selectedId);
 
   const selectedItem = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,
     [items, selectedId],
   );
+
+  // Weaver Pattern: Adjusting State During Render
+  // Deselect if the item goes away from the list to prevent accessing a non-existent item detail.
+  // We check that isListLoading is false to avoid deselecting while the list is momentarily empty during the very first load or un-cached filter change.
+  if (
+    selectedId !== null &&
+    !isListLoading &&
+    !items.some((item) => item.id === selectedId)
+  ) {
+    setSelectedId(null);
+  }
   const isDetailOpen = selectedItem !== null;
   const hasMoreItems = nextCursor !== null;
   const entityNameById = useMemo(
@@ -705,8 +629,8 @@ export default function KnowledgePage() {
   );
 
   const handleRefresh = useCallback(() => {
-    setListRefreshToken((current) => current + 1);
-  }, []);
+    void mutateList();
+  }, [mutateList]);
 
   const handleCloseDetail = useCallback(() => {
     setIsDeleteDialogOpen(false);
@@ -718,45 +642,6 @@ export default function KnowledgePage() {
       setSelectedId(id);
     });
   }, []);
-
-  const handleLoadMore = useCallback(async () => {
-    if (isListLoading || isLoadingMore || nextCursor === null) {
-      return;
-    }
-
-    setIsLoadingMore(true);
-    try {
-      const response = await listGlobalKnowledge({
-        query: debouncedQuery || undefined,
-        assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
-        cursor: nextCursor,
-        limit: KNOWLEDGE_PAGE_SIZE,
-      });
-
-      setItems((current) => {
-        const seenIds = new Set(current.map((item) => item.id));
-        const appendedItems = response.items.filter(
-          (item) => !seenIds.has(item.id),
-        );
-        return [...current, ...appendedItems];
-      });
-      setNextCursor(response.nextCursor ?? null);
-    } catch (error) {
-      logger.error('Failed to load more global knowledge entries', error);
-      toast.error(
-        t('knowledge.loadMoreFailed', 'Failed to load more knowledge entries.'),
-      );
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [
-    assistantFilter,
-    debouncedQuery,
-    isListLoading,
-    isLoadingMore,
-    nextCursor,
-    t,
-  ]);
 
   const handleRequestDelete = useCallback(() => {
     if (!selectedItem || isDeleting) {
@@ -783,10 +668,10 @@ export default function KnowledgePage() {
           },
         ),
       });
-      setDetail(null);
       setSelectedId(null);
       setIsDeleteDialogOpen(false);
-      setListRefreshToken((current) => current + 1);
+      void mutateList();
+      void mutateDetail();
     } catch (error) {
       logger.error('Failed to delete knowledge entry', {
         id: selectedItem.id,

--- a/src/features/knowledge/hooks/useKnowledgeDetail.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDetail.ts
@@ -6,23 +6,26 @@ import { getGlobalKnowledgeDetail } from '@/lib/backend/knowledge';
 
 const logger = getLogger('useKnowledgeDetail');
 
+type KnowledgeDetailKey = readonly ['knowledgeDetail', number];
+
 export function useKnowledgeDetail(selectedId: number | null) {
   const { t } = useTranslation('common');
 
   const { data, error, isLoading, mutate } = useSWR(
-    selectedId ? ['knowledgeDetail', selectedId] : null,
-    async ([, id]) => {
-      return getGlobalKnowledgeDetail(id as number);
+    selectedId ? (['knowledgeDetail', selectedId] as const) : null,
+    async ([, id]: KnowledgeDetailKey) => {
+      return getGlobalKnowledgeDetail(id);
     },
     {
       revalidateOnFocus: false,
+      shouldRetryOnError: false,
       onError: (err) => {
         logger.error('Failed to load knowledge detail', { selectedId, err });
         toast.error(
           t('knowledge.loadDetailFailed', 'Failed to load knowledge details.'),
         );
       },
-    }
+    },
   );
 
   return {

--- a/src/features/knowledge/hooks/useKnowledgeDetail.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDetail.ts
@@ -1,0 +1,34 @@
+import useSWR from 'swr';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { getLogger } from '@/lib/logger';
+import { getGlobalKnowledgeDetail } from '@/lib/backend/knowledge';
+
+const logger = getLogger('useKnowledgeDetail');
+
+export function useKnowledgeDetail(selectedId: number | null) {
+  const { t } = useTranslation('common');
+
+  const { data, error, isLoading, mutate } = useSWR(
+    selectedId ? ['knowledgeDetail', selectedId] : null,
+    async ([, id]) => {
+      return getGlobalKnowledgeDetail(id as number);
+    },
+    {
+      revalidateOnFocus: false,
+      onError: (err) => {
+        logger.error('Failed to load knowledge detail', { selectedId, err });
+        toast.error(
+          t('knowledge.loadDetailFailed', 'Failed to load knowledge details.'),
+        );
+      },
+    }
+  );
+
+  return {
+    detail: data || null,
+    isDetailLoading: isLoading,
+    error,
+    mutateDetail: mutate,
+  };
+}

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -76,7 +76,10 @@ export function useKnowledgeList(
       onError: (err) => {
         logger.error('Failed to load global knowledge list', err);
         toast.error(
-          t('knowledge.loadListFailed', 'Failed to load global knowledge entries.'),
+          t(
+            'knowledge.loadListFailed',
+            'Failed to load global knowledge entries.',
+          ),
         );
       },
     },

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -32,12 +32,12 @@ export function useKnowledgeList(
       pageIndex: number,
       previousPageData: GlobalKnowledgeListResponse | null,
     ): FetcherArgs | null => {
-      const keyBase: [string, string, string, number] = [
+      const keyBase = [
         'globalKnowledge',
         debouncedQuery,
         assistantFilter,
         limit,
-      ];
+      ] as const;
 
       if (pageIndex === 0) return [...keyBase, null];
 
@@ -72,13 +72,14 @@ export function useKnowledgeList(
     {
       revalidateOnFocus: false,
       revalidateFirstPage: false,
+      shouldRetryOnError: false,
       onError: (err) => {
         logger.error('Failed to load global knowledge list', err);
         toast.error(
           t('knowledge.loadListFailed', 'Failed to load global knowledge entries.'),
         );
       },
-    }
+    },
   );
 
   const items = useMemo(() => {
@@ -113,8 +114,8 @@ export function useKnowledgeList(
 
   const loadMore = useCallback(() => {
     if (isLoadingMore || !nextCursor || isListLoading) return;
-    setSize(size + 1);
-  }, [isLoadingMore, nextCursor, isListLoading, setSize, size]);
+    setSize((previousSize) => previousSize + 1);
+  }, [isLoadingMore, nextCursor, isListLoading, setSize]);
 
   return {
     items,

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -1,0 +1,128 @@
+import useSWRInfinite from 'swr/infinite';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { getLogger } from '@/lib/logger';
+import {
+  listGlobalKnowledge,
+  type KnowledgeChunkListItem,
+  type GlobalKnowledgeListResponse,
+  type KnowledgeListCursor,
+} from '@/lib/backend/knowledge';
+import { useCallback, useMemo } from 'react';
+
+const logger = getLogger('useKnowledgeList');
+
+type FetcherArgs = [
+  key: string,
+  query: string,
+  assistantId: string,
+  limit: number,
+  cursor: KnowledgeListCursor | null,
+];
+
+export function useKnowledgeList(
+  debouncedQuery: string,
+  assistantFilter: string,
+  limit: number,
+) {
+  const { t } = useTranslation('common');
+
+  const getKey = useCallback(
+    (
+      pageIndex: number,
+      previousPageData: GlobalKnowledgeListResponse | null,
+    ): FetcherArgs | null => {
+      const keyBase: [string, string, string, number] = [
+        'globalKnowledge',
+        debouncedQuery,
+        assistantFilter,
+        limit,
+      ];
+
+      if (pageIndex === 0) return [...keyBase, null];
+
+      if (!previousPageData?.nextCursor) return null;
+
+      return [...keyBase, previousPageData.nextCursor];
+    },
+    [debouncedQuery, assistantFilter, limit],
+  );
+
+  const fetcher = useCallback(
+    async ([
+      ,
+      query,
+      assistantId,
+      lim,
+      cursor,
+    ]: FetcherArgs): Promise<GlobalKnowledgeListResponse> => {
+      return listGlobalKnowledge({
+        query: query || undefined,
+        assistantId: assistantId === 'all' ? undefined : assistantId,
+        limit: lim,
+        cursor: cursor ?? undefined,
+      });
+    },
+    [],
+  );
+
+  const { data, error, size, setSize, isValidating, mutate } = useSWRInfinite(
+    getKey,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateFirstPage: false,
+      onError: (err) => {
+        logger.error('Failed to load global knowledge list', err);
+        toast.error(
+          t('knowledge.loadListFailed', 'Failed to load global knowledge entries.'),
+        );
+      },
+    }
+  );
+
+  const items = useMemo(() => {
+    if (!data) return [];
+    const allItems: KnowledgeChunkListItem[] = [];
+    const seenIds = new Set<number>();
+
+    for (const page of data) {
+      for (const item of page.items) {
+        if (!seenIds.has(item.id)) {
+          seenIds.add(item.id);
+          allItems.push(item);
+        }
+      }
+    }
+    return allItems;
+  }, [data]);
+
+  const assistants = useMemo(() => {
+    if (!data || data.length === 0) return [];
+    return data[0].assistants || [];
+  }, [data]);
+
+  const nextCursor = useMemo(() => {
+    if (!data || data.length === 0) return null;
+    return data[data.length - 1].nextCursor ?? null;
+  }, [data]);
+
+  const isLoadingMore =
+    isValidating && size > 1 && data && typeof data[size - 1] === 'undefined';
+  const isListLoading = !data && !error && isValidating;
+
+  const loadMore = useCallback(() => {
+    if (isLoadingMore || !nextCursor || isListLoading) return;
+    setSize(size + 1);
+  }, [isLoadingMore, nextCursor, isListLoading, setSize, size]);
+
+  return {
+    items,
+    assistants,
+    nextCursor,
+    isListLoading,
+    isLoadingMore,
+    loadMore,
+    mutateList: mutate,
+  };
+}


### PR DESCRIPTION
**🚫 Eradicated:**
- Eradicated manual imperative state orchestration (`useEffect` coupled with `useState` loops) inside `KnowledgePage`.
- Removed Action-Effect Chains used to toggle loading, cursor states, and data mutations.

**✨ Woven:**
- Introduced `useKnowledgeList` (utilizing `useSWRInfinite`) and `useKnowledgeDetail` (`useSWR`) to encapsulate knowledge list retrieval, detail fetching, error handling, and cursors.
- Successfully applied **Adjusting State During Render** to instantly clean up dangling detail selections when a list updates, avoiding delayed cascading updates entirely.

**📉 Impact:**
- Predictable declarative data fetching reduces infinite re-render possibilities on filter changes.
- Significant reduction in the `KnowledgePage` UI codebase. SWR cache acts as the SSOT for active queries, enabling decoupled mutation functions without prop-drilling or Context.

---
*PR created automatically by Jules for task [14003041355275914794](https://jules.google.com/task/14003041355275914794) started by @fritzprix*