### PR TITLE
⚡ Bolt: Add React.memo to ScheduledTaskRow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,8 @@
 
 **Learning:** Extracting inline `.reduce()` calls that count matching items (like enabled tasks or bookmarked sessions) into `useMemo` hooks or integrating them into existing `useMemo` blocks prevents O(N) recalculations on every component render.
 **Action:** When computing scalar counts or metrics from arrays, calculate and store them in `useMemo` or integrate the logic directly into existing list mappings to ensure referential stability and eliminate redundant layout thrashing.
+
+## 2026-10-27 - Bypassing React.memo with Sets
+
+**Learning:** `ScheduledTaskRow` was rendering unnecessarily on every toggling or deletion. The parent component (`ScheduledTasksPage`) was passing `togglingIds` and `deletingIds` (which are `Set`s) as props to the row components. Since these sets were frequently recreated or mutated by the `useScheduledTasks` hook, `React.memo`'s shallow comparison failed, causing an O(N) re-render of all task rows whenever a single task was modified.
+**Action:** When using `React.memo` to optimize child list components, avoid passing complex collection objects (like Sets or Maps) as props. Compute and pass primitive values (e.g., `isToggling={togglingIds.has(task.id)}`) directly within the parent's mapping loop. Also ensure all passed callbacks (`onEdit`, `onToggle`, `onDelete`) are referentially stable using `useCallback`.

--- a/src/features/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/src/features/scheduled-tasks/ScheduledTasksPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -85,43 +85,52 @@ export function ScheduledTasksPage() {
     await updateTask(editingTask.id, data);
   };
 
-  const handleToggle = async (task: ScheduledTask) => {
-    try {
-      await toggleTask(task);
-    } catch (error) {
-      logger.error('Failed to toggle scheduled task', error);
-      toast.error(
-        t('scheduledTasks.toggleFailed', 'Failed to update scheduled task'),
-      );
-    }
-  };
+  const handleToggle = useCallback(
+    async (task: ScheduledTask) => {
+      try {
+        await toggleTask(task);
+      } catch (error) {
+        logger.error('Failed to toggle scheduled task', error);
+        toast.error(
+          t('scheduledTasks.toggleFailed', 'Failed to update scheduled task'),
+        );
+      }
+    },
+    [toggleTask, t],
+  );
 
-  const handleDelete = async (id: string) => {
-    try {
-      await deleteTask(id);
-    } catch (error) {
-      logger.error('Failed to delete scheduled task', error);
-      toast.error(
-        t('scheduledTasks.deleteFailed', 'Failed to delete scheduled task'),
-      );
-    }
-  };
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await deleteTask(id);
+      } catch (error) {
+        logger.error('Failed to delete scheduled task', error);
+        toast.error(
+          t('scheduledTasks.deleteFailed', 'Failed to delete scheduled task'),
+        );
+      }
+    },
+    [deleteTask, t],
+  );
 
-  const openCreate = () => {
+  const openCreate = useCallback(() => {
     setEditingTask(null);
     setModalOpen(true);
-  };
+  }, []);
 
-  const openEdit = (task: ScheduledTask) => {
+  const openEdit = useCallback((task: ScheduledTask) => {
     setEditingTask(task);
     setModalOpen(true);
-  };
+  }, []);
 
-  const formatNextRun = (ms: number | null): string => {
-    if (!ms) return t('scheduledTasks.nextRunNone');
-    const d = new Date(ms);
-    return getDateTimeFormatter().format(d);
-  };
+  const formatNextRun = useCallback(
+    (ms: number | null): string => {
+      if (!ms) return t('scheduledTasks.nextRunNone');
+      const d = new Date(ms);
+      return getDateTimeFormatter().format(d);
+    },
+    [t],
+  );
 
   const groupedSections = useMemo<ScheduledTaskGroupSection[]>(() => {
     const groups = new Map<string, ScheduledTaskGroupSection>();
@@ -302,8 +311,8 @@ export function ScheduledTasksPage() {
                             onEdit={openEdit}
                             onToggle={handleToggle}
                             onDelete={handleDelete}
-                            togglingIds={togglingIds}
-                            deletingIds={deletingIds}
+                            isToggling={togglingIds.has(task.id)}
+                            isDeleting={deletingIds.has(task.id)}
                           />
                         ))}
                       </ul>
@@ -328,8 +337,8 @@ export function ScheduledTasksPage() {
                     onEdit={openEdit}
                     onToggle={handleToggle}
                     onDelete={handleDelete}
-                    togglingIds={togglingIds}
-                    deletingIds={deletingIds}
+                    isToggling={togglingIds.has(task.id)}
+                    isDeleting={deletingIds.has(task.id)}
                   />
                 ))}
               </ul>
@@ -371,22 +380,25 @@ function SummaryCard({
   );
 }
 
-function ScheduledTaskRow({
+// Memoized to prevent all task rows from re-rendering when a single task is toggled or deleted.
+// Requires stable function references (useCallback) and primitive boolean props (isToggling/isDeleting)
+// instead of Sets to ensure shallow equality checks pass.
+const ScheduledTaskRow = React.memo(function ScheduledTaskRow({
   task,
   formatNextRun,
   onEdit,
   onToggle,
   onDelete,
-  togglingIds,
-  deletingIds,
+  isToggling,
+  isDeleting,
 }: {
   task: ScheduledTask;
   formatNextRun: (ms: number | null) => string;
   onEdit: (task: ScheduledTask) => void;
   onToggle: (task: ScheduledTask) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
-  togglingIds: Set<string>;
-  deletingIds: Set<string>;
+  isToggling: boolean;
+  isDeleting: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -396,7 +408,7 @@ function ScheduledTaskRow({
         checked={task.enabled}
         onCheckedChange={() => void onToggle(task)}
         className="mt-0.5 shrink-0"
-        disabled={togglingIds.has(task.id) || deletingIds.has(task.id)}
+        disabled={isToggling || isDeleting}
       />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
@@ -483,9 +495,9 @@ function ScheduledTaskRow({
               aria-label={t('scheduledTasks.deleteTaskAria', {
                 name: task.name,
               })}
-              disabled={deletingIds.has(task.id) || togglingIds.has(task.id)}
+              disabled={isDeleting || isToggling}
             >
-              {deletingIds.has(task.id) ? (
+              {isDeleting ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : (
                 <Trash2 className="w-4 h-4" />
@@ -497,7 +509,7 @@ function ScheduledTaskRow({
       </div>
     </li>
   );
-}
+});
 
 function compareScheduledTasks(left: ScheduledTask, right: ScheduledTask) {
   if (left.enabled !== right.enabled) {


### PR DESCRIPTION
💡 **What**:
- Wrapped `ScheduledTaskRow` component in `React.memo()`.
- Added `useCallback` to `openCreate`, `openEdit`, `handleToggle`, `handleDelete`, and `formatNextRun` in `ScheduledTasksPage` to ensure referential stability.
- Modified `ScheduledTaskRow` to accept primitive boolean properties (`isToggling`, `isDeleting`) instead of the entire `togglingIds` and `deletingIds` `Set` objects.

🎯 **Why**:
When a single task was toggled or deleted, the parent component (`ScheduledTasksPage`) updated its state (`togglingIds` or `deletingIds`). Because these were passed down as Set objects and callbacks were recreated on every render, all `ScheduledTaskRow` items re-rendered. By passing stable function references and primitive booleans instead of entire Sets, we guarantee that `React.memo`'s shallow equality check works correctly.

📉 **Impact**: 
Reduces list item re-renders from O(N) to O(1) when a single task is toggled or deleted, improving application snappiness on the Scheduled Tasks page as the automation list grows.

🔬 **Measurement**:
Using the React Developer Tools Profiler, verify that toggling a scheduled task only re-renders the toggled row component itself, rather than re-rendering the entire group or list.

---
*PR created automatically by Jules for task [14429354951964596757](https://jules.google.com/task/14429354951964596757) started by @fritzprix*