### PR TITLE
refactor: tighten browser tool contract

### DIFF
--- a/src-tauri/src/mcp/builtin/browser/content.rs
+++ b/src-tauri/src/mcp/builtin/browser/content.rs
@@ -86,7 +86,7 @@ pub async fn extract_web_content(server: &BrowserServer, args: Value) -> Result<
                 vec![
                     "Verify the browser session is active",
                     "Ensure the page has fully loaded before extracting",
-                    "If you need a fresh navigation in this same session, use `goto` with a URL",
+                    "If you need a fresh navigation in this same session, use `navigateToUrl` with a URL",
                     "Try waiting a moment before retrying",
                 ],
             ))

--- a/src-tauri/src/mcp/builtin/browser/interaction.rs
+++ b/src-tauri/src/mcp/builtin/browser/interaction.rs
@@ -58,7 +58,7 @@ pub async fn click_element(server: &BrowserServer, args: Value) -> Result<MCPRes
                     &format!("Element with selector '{}' not found{}", selector, suggestions),
                     vec![
                         "Verify the selector is correct CSS syntax".to_string(),
-                        "The element might be lazy-loaded. Use `scroll` to load more content down the page.".to_string(),
+                        "The element might be lazy-loaded. Use `scrollPage` to load more content down the page.".to_string(),
                         "Use listInteractable to find valid selectors".to_string(),
                     ],
                     ToolGroup::Browser,
@@ -69,8 +69,8 @@ pub async fn click_element(server: &BrowserServer, args: Value) -> Result<MCPRes
                     "Click element",
                     &format!("Element with selector '{}' is not visible", selector),
                     vec![
-                        "The element exists but is hidden. Use `content` to analyze the page structure and find a parent container or toggle button.".to_string(),
-                        "The element might be lazy-loaded or off-screen. Use `scroll` to potentially trigger its visibility.".to_string(),
+                        "The element exists but is hidden. Use `getPageContent({})` to analyze the page structure and find a parent container or toggle button.".to_string(),
+                        "The element might be lazy-loaded or off-screen. Use `scrollPage` to potentially trigger its visibility.".to_string(),
                         "Use `listInteractable` to find visible elements that might reveal this target.".to_string(),
                     ],
                     ToolGroup::Browser,
@@ -87,7 +87,7 @@ pub async fn click_element(server: &BrowserServer, args: Value) -> Result<MCPRes
                 &e,
                 vec![
                     "Verify the selector is correct CSS syntax".to_string(),
-                    "Try using `scroll` to reveal lazy-loaded elements".to_string(),
+                    "Try using `scrollPage` to reveal lazy-loaded elements".to_string(),
                     "Use listInteractable to find valid selectors".to_string(),
                 ],
                 ToolGroup::Browser,
@@ -174,7 +174,7 @@ pub async fn input_text(server: &BrowserServer, args: Value) -> Result<MCPResult
                     &format!("Element with selector '{}' not found{}", selector, suggestions),
                     vec![
                         "Verify the selector targets an input/textarea element".to_string(),
-                        "The element might be lazy-loaded. Use `scroll` to load more content down the page.".to_string(),
+                        "The element might be lazy-loaded. Use `scrollPage` to load more content down the page.".to_string(),
                         "Use listInteractable to find valid selectors".to_string(),
                     ],
                     ToolGroup::Browser,
@@ -185,9 +185,9 @@ pub async fn input_text(server: &BrowserServer, args: Value) -> Result<MCPResult
                     "Input text",
                     &format!("Element with selector '{}' is not visible", selector),
                     vec![
-                        "The input is hidden. Use `content` to find the form section or toggle that contains it.".to_string(),
-                        "The element might be lazy-loaded or off-screen. Use `scroll` to potentially trigger its visibility.".to_string(),
-                        "Use `click` on the parent container or toggle to reveal the input.".to_string(),
+                        "The input is hidden. Use `getPageContent({})` to find the form section or toggle that contains it.".to_string(),
+                        "The element might be lazy-loaded or off-screen. Use `scrollPage` to potentially trigger its visibility.".to_string(),
+                        "Use `clickElement` on the parent container or toggle to reveal the input.".to_string(),
                     ],
                     ToolGroup::Browser,
                 ));
@@ -203,7 +203,7 @@ pub async fn input_text(server: &BrowserServer, args: Value) -> Result<MCPResult
                 &e,
                 vec![
                     "Verify the selector targets an input/textarea element".to_string(),
-                    "Try using `scroll` to reveal lazy-loaded elements".to_string(),
+                    "Try using `scrollPage` to reveal lazy-loaded elements".to_string(),
                     "Use listInteractable with filterType='semantic_input'".to_string(),
                 ],
                 ToolGroup::Browser,
@@ -329,7 +329,7 @@ pub async fn list_interactable(server: &BrowserServer, args: Value) -> Result<MC
                 vec![
                     "Verify the browser session is active".to_string(),
                     "Ensure the page has fully loaded".to_string(),
-                    "Try `content` first to see page structure".to_string(),
+                    "Try `getPageContent({})` first to see page structure".to_string(),
                 ],
                 ToolGroup::Browser,
             ))
@@ -345,8 +345,8 @@ pub async fn list_interactable(server: &BrowserServer, args: Value) -> Result<MC
                 &e,
                 vec![
                     "The page may have returned unexpected data".to_string(),
-                    "If the page is stale or broken, use `goto` with a URL to replace the current page in this session.".to_string(),
-                    "Use `content` to verify page structure".to_string(),
+                    "If the page is stale or broken, use `navigateToUrl` with a URL to replace the current page in this session.".to_string(),
+                    "Use `getPageContent({})` to verify page structure".to_string(),
                 ],
                 ToolGroup::Browser,
             ))
@@ -356,9 +356,10 @@ pub async fn list_interactable(server: &BrowserServer, args: Value) -> Result<MC
     let hint = SuccessHint::new(
         formatted_text,
         vec![
-            "Use `click` with the selector or index.".to_string(),
-            "If the target is off-screen, use `scroll` to bring it into the viewport.".to_string(),
-            "Use `content` to see the full page structure regardless of scroll position."
+            "Use `clickElement` with the selector.".to_string(),
+            "If the target is off-screen, use `scrollPage` to bring it into the viewport."
+                .to_string(),
+            "Use `getPageContent({})` to see the full page structure regardless of scroll position."
                 .to_string(),
         ],
     );
@@ -538,7 +539,7 @@ fn format_interactive_elements(
     }
 
     // Footer with usage hint
-    output.push_str("💡 Use the selector or index to interact with these elements.");
+    output.push_str("💡 Use the selector to interact with these elements.");
 
     Ok(output)
 }
@@ -564,9 +565,9 @@ pub async fn create_rich_response(
     let hint = SuccessHint::new(
         summary,
         vec![
-            "Use `content` to read the full page content.".to_string(),
-            "Use `click` to interact with elements.".to_string(),
-            "Use `fill` to type into forms.".to_string(),
+            "Use `getPageContent({})` to read the full page content.".to_string(),
+            "Use `clickElement` to interact with elements.".to_string(),
+            "Use `inputText` to type into forms.".to_string(),
         ],
     );
     Ok(hint.to_mcp_result())

--- a/src-tauri/src/mcp/builtin/browser/session.rs
+++ b/src-tauri/src/mcp/builtin/browser/session.rs
@@ -1,7 +1,7 @@
 use crate::mcp::builtin::browser::content::BROWSER_CONTENT_STORE;
 use crate::mcp::builtin::browser::BrowserServer;
 use crate::mcp::builtin::error_guidance::{
-    operation_failed_error, ErrorCategory, ErrorGuidance, SuccessHint, ToolGroup,
+    guided_error, operation_failed_error, ErrorCategory, SuccessHint, ToolGroup,
 };
 use crate::mcp::types::MCPResult;
 use serde_json::Value;
@@ -47,18 +47,17 @@ pub async fn close_session(server: &BrowserServer, _args: Value) -> Result<MCPRe
         );
         Ok(hint.to_mcp_result())
     } else {
-        let warning = ErrorGuidance::with_guidance(
+        Ok(guided_error(
             ErrorCategory::InvalidState,
             "No active browser session to close",
-            vec![
-                "The browser is already clean; no further close action is required".to_string(),
-                "Use createSession if you want to start a fresh browser session".to_string(),
-                "Use getCurrentUrl only after createSession has created an active session"
-                    .to_string(),
-            ],
             ToolGroup::Browser,
-        );
-        Ok(warning.to_mcp_result())
+        )
+        .with_guidance(vec![
+            "The browser is already clean; no further close action is required".to_string(),
+            "Use createSession if you want to start a fresh browser session".to_string(),
+            "Use getCurrentUrl only after createSession has created an active session".to_string(),
+        ])
+        .to_mcp_result())
     }
 }
 

--- a/src-tauri/src/mcp/builtin/browser/session.rs
+++ b/src-tauri/src/mcp/builtin/browser/session.rs
@@ -47,9 +47,15 @@ pub async fn close_session(server: &BrowserServer, _args: Value) -> Result<MCPRe
         );
         Ok(hint.to_mcp_result())
     } else {
-        let warning = ErrorGuidance::new(
+        let warning = ErrorGuidance::with_guidance(
             ErrorCategory::InvalidState,
             "No active browser session to close",
+            vec![
+                "The browser is already clean; no further close action is required".to_string(),
+                "Use createSession if you want to start a fresh browser session".to_string(),
+                "Use getCurrentUrl only after createSession has created an active session"
+                    .to_string(),
+            ],
             ToolGroup::Browser,
         );
         Ok(warning.to_mcp_result())
@@ -123,7 +129,8 @@ pub async fn create_session(server: &BrowserServer, args: Value) -> Result<MCPRe
                 vec![
                     "Page load timed out, but the session is ready and page may be usable."
                         .to_string(),
-                    "Try `content` to see if content loaded despite the timeout.".to_string(),
+                    "Try `getPageContent({})` to see if content loaded despite the timeout."
+                        .to_string(),
                     "If the page is blank, navigate to a different URL.".to_string(),
                 ],
             )
@@ -188,7 +195,7 @@ pub async fn create_session(server: &BrowserServer, args: Value) -> Result<MCPRe
                     url
                 ),
                 vec![
-                    "Use `content` to read the current page content".to_string(),
+                    "Use `getPageContent({})` to read the current page content".to_string(),
                     "Use listInteractable to see interactive elements".to_string(),
                 ],
             )
@@ -197,7 +204,7 @@ pub async fn create_session(server: &BrowserServer, args: Value) -> Result<MCPRe
         (
             format!("Browser session created. {}", status_msg),
             vec![
-                "Use `goto` to navigate this active session to a webpage".to_string(),
+                "Use `navigateToUrl` to navigate this active session to a webpage".to_string(),
                 "Or call createSession with a `url` next time to open the first page immediately"
                     .to_string(),
             ],

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -73,8 +73,8 @@ impl ErrorGuidance {
             // Browser tool errors
             (ErrorCategory::ResourceNotFound, ToolGroup::Browser) => vec![
                 "Use createSession to start a new browser session".to_string(),
-                "Use listSessions to see available sessions (if available)".to_string(),
-                "Verify the session_id parameter is correct".to_string(),
+                "Use getPageContent({}) to extract fresh content from the current page".to_string(),
+                "Use listInteractable to inspect the current page before interacting".to_string(),
             ],
             (ErrorCategory::InvalidInput, ToolGroup::Browser) => vec![
                 "Verify the URL format is valid (must include http:// or https://)".to_string(),
@@ -82,7 +82,7 @@ impl ErrorGuidance {
                 "Use listInteractable to see available elements first".to_string(),
             ],
             (ErrorCategory::OperationFailed, ToolGroup::Browser) => vec![
-                "Try extractWebContent to view page structure".to_string(),
+                "Try getPageContent to view page structure".to_string(),
                 "Use navigateToUrl to reload the page".to_string(),
                 "Verify the target element is visible and interactable".to_string(),
             ],
@@ -345,19 +345,19 @@ impl SuccessHint {
             // Browser tools
             ("createSession", ToolGroup::Browser) => vec![
                 "Use navigateToUrl to load a webpage".to_string(),
-                "Use extractWebContent to see the initial page".to_string(),
+                "Use getPageContent to see the initial page".to_string(),
             ],
             ("navigateToUrl", ToolGroup::Browser) => vec![
-                "Use extractWebContent to see page content".to_string(),
+                "Use getPageContent to see page content".to_string(),
                 "Use listInteractable to see clickable elements".to_string(),
             ],
-            ("extractWebContent", ToolGroup::Browser) => vec![
+            ("getPageContent", ToolGroup::Browser) => vec![
                 "Use listInteractable to see interactive elements".to_string(),
                 "Use clickElement to interact with the page".to_string(),
             ],
             ("listInteractable", ToolGroup::Browser) => vec![
-                "Use clickElement with the selector or index".to_string(),
-                "Use extractWebContent to see full page content".to_string(),
+                "Use clickElement with the selector".to_string(),
+                "Use getPageContent to see full page content".to_string(),
             ],
 
             // Planning tools

--- a/src-tauri/tests/browser_guidance_contract_tests.rs
+++ b/src-tauri/tests/browser_guidance_contract_tests.rs
@@ -1,0 +1,74 @@
+use tauri_mcp_agent_lib::mcp::builtin::error_guidance::{
+    ErrorCategory, ErrorGuidance, SuccessHint, ToolGroup,
+};
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+
+fn result_text(result: MCPResult) -> String {
+    result
+        .content
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn browser_resource_not_found_guidance_matches_single_session_workflow() {
+    let message = result_text(
+        ErrorGuidance::new(
+            ErrorCategory::ResourceNotFound,
+            "No active browser session found for this agent",
+            ToolGroup::Browser,
+        )
+        .to_mcp_result(),
+    );
+
+    assert!(message.contains("Use createSession to start a new browser session"));
+    assert!(
+        message.contains("Use getPageContent({}) to extract fresh content from the current page")
+    );
+    assert!(message.contains("Use listInteractable to inspect the current page before interacting"));
+    assert!(!message.contains("listSessions"));
+    assert!(!message.contains("session_id"));
+}
+
+#[test]
+fn browser_operation_failed_guidance_uses_get_page_content_name() {
+    let message = result_text(
+        ErrorGuidance::new(
+            ErrorCategory::OperationFailed,
+            "Click element failed",
+            ToolGroup::Browser,
+        )
+        .to_mcp_result(),
+    );
+
+    assert!(message.contains("Try getPageContent to view page structure"));
+    assert!(!message.contains("extractWebContent"));
+}
+
+#[test]
+fn browser_success_hint_next_steps_use_canonical_tool_names() {
+    let create_session = SuccessHint::for_tool("createSession", ToolGroup::Browser).join("\n");
+    assert!(create_session.contains("Use getPageContent to see the initial page"));
+    assert!(!create_session.contains("extractWebContent"));
+
+    let navigate = SuccessHint::for_tool("navigateToUrl", ToolGroup::Browser).join("\n");
+    assert!(navigate.contains("Use getPageContent to see page content"));
+    assert!(!navigate.contains("extractWebContent"));
+
+    let get_page_content = SuccessHint::for_tool("getPageContent", ToolGroup::Browser).join("\n");
+    assert!(get_page_content.contains("Use listInteractable to see interactive elements"));
+    assert!(!get_page_content.contains("extractWebContent"));
+
+    let list_interactable =
+        SuccessHint::for_tool("listInteractable", ToolGroup::Browser).join("\n");
+    assert!(list_interactable.contains("Use clickElement with the selector"));
+    assert!(list_interactable.contains("Use getPageContent to see full page content"));
+    assert!(!list_interactable.contains("index"));
+    assert!(!list_interactable.contains("extractWebContent"));
+}


### PR DESCRIPTION
## Summary
- remove remaining browser contract drift between schema, runtime, and guidance
- refine browser tool descriptions around the stateful single-session model
- add regression coverage for browser description, guidance, and schema expectations

## Testing
- pnpm sync-builtin-services
- pnpm format
- cargo test --test browser_guidance_contract_tests
- cargo test --test browser_tool_description_tests