### PR TITLE
fix: tighten history and knowledge builtin tools

### DIFF
--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -167,9 +167,9 @@ impl ErrorGuidance {
 
             // Knowledge tool errors
             (ErrorCategory::ResourceNotFound, ToolGroup::Knowledge) => vec![
-                "Use listKnowledge to see available knowledge entries".to_string(),
-                "Use searchKnowledge to find entries by keyword".to_string(),
-                "Verify the knowledge ID is correct".to_string(),
+                "Use search_knowledge to find relevant knowledge chunks and their IDs".to_string(),
+                "Use explore_context when you need graph context around a known entity".to_string(),
+                "Retry the request with IDs copied from prior knowledge results".to_string(),
             ],
 
             // UI tool errors

--- a/src-tauri/src/mcp/builtin/history/mod.rs
+++ b/src-tauri/src/mcp/builtin/history/mod.rs
@@ -65,7 +65,18 @@ impl BuiltinMCPServer for HistoryServer {
             "readSession" => handlers::read_session(self, args).await,
             "readMessage" => handlers::read_message(self, args).await,
             "search" => handlers::search_history(self, args, &caller_session_id).await,
-            _ => Err(format!("Unknown tool: {}", tool_name)),
+            _ => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Unknown history tool '{}'.", tool_name),
+                    ToolGroup::Agent,
+                )
+                .with_guidance(vec![
+                    "Use one of the available history tools: list, readSession, readMessage, or search."
+                        .to_string(),
+                ])
+                .to_mcp_result());
+            }
         };
 
         result.or_else(|e| {

--- a/src-tauri/src/mcp/builtin/history/tools.rs
+++ b/src-tauri/src/mcp/builtin/history/tools.rs
@@ -39,13 +39,14 @@ fn list_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Page number.")),
+                    integer_prop_with_default(Some(1), None, 1, Some("Page number.")),
                 ),
                 (
                     "pageSize".to_string(),
-                    integer_prop(
+                    integer_prop_with_default(
                         Some(1),
                         Some(100),
+                        20,
                         Some("Items per page."),
                     ),
                 ),
@@ -72,13 +73,19 @@ fn read_session_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Message list page number.")),
+                    integer_prop_with_default(
+                        Some(1),
+                        None,
+                        1,
+                        Some("Message list page number."),
+                    ),
                 ),
                 (
                     "pageSize".to_string(),
-                    integer_prop(
+                    integer_prop_with_default(
                         Some(1),
                         Some(100),
+                        50,
                         Some("Messages per page."),
                     ),
                 ),
@@ -113,9 +120,10 @@ fn read_message_tool() -> MCPTool {
                 ),
                 (
                     "maxChars".to_string(),
-                    integer_prop(
+                    integer_prop_with_default(
                         Some(1),
                         Some(3000),
+                        3000,
                         Some("Characters to return from the rendered message content."),
                     ),
                 ),
@@ -177,11 +185,11 @@ fn search_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Page number.")),
+                    integer_prop_with_default(Some(1), None, 1, Some("Page number.")),
                 ),
                 (
                     "pageSize".to_string(),
-                    integer_prop(Some(1), Some(100), Some("Items per page.")),
+                    integer_prop_with_default(Some(1), Some(100), 20, Some("Items per page.")),
                 ),
             ],
             vec!["query".to_string()],

--- a/src-tauri/src/mcp/builtin/history/tools.rs
+++ b/src-tauri/src/mcp/builtin/history/tools.rs
@@ -39,14 +39,14 @@ fn list_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Page number (default: 1).")),
+                    integer_prop(Some(1), None, Some("Page number.")),
                 ),
                 (
                     "pageSize".to_string(),
                     integer_prop(
                         Some(1),
                         Some(100),
-                        Some("Items per page (default: 20, max: 100)."),
+                        Some("Items per page."),
                     ),
                 ),
             ],
@@ -72,14 +72,14 @@ fn read_session_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Message list page number (default: 1).")),
+                    integer_prop(Some(1), None, Some("Message list page number.")),
                 ),
                 (
                     "pageSize".to_string(),
                     integer_prop(
                         Some(1),
                         Some(100),
-                        Some("Messages per page (default: 50, max: 100)."),
+                        Some("Messages per page."),
                     ),
                 ),
             ],
@@ -116,7 +116,7 @@ fn read_message_tool() -> MCPTool {
                     integer_prop(
                         Some(1),
                         Some(3000),
-                        Some("Maximum characters to return (hard-capped at 3000)."),
+                        Some("Characters to return from the rendered message content."),
                     ),
                 ),
             ],
@@ -177,15 +177,11 @@ fn search_tool() -> MCPTool {
                 ),
                 (
                     "page".to_string(),
-                    integer_prop(Some(1), None, Some("Page number (default: 1).")),
+                    integer_prop(Some(1), None, Some("Page number.")),
                 ),
                 (
                     "pageSize".to_string(),
-                    integer_prop(
-                        Some(1),
-                        Some(100),
-                        Some("Items per page (default: 20, max: 100)."),
-                    ),
+                    integer_prop(Some(1), Some(100), Some("Items per page.")),
                 ),
             ],
             vec!["query".to_string()],

--- a/src-tauri/src/mcp/builtin/knowledge/mod.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/mod.rs
@@ -8,6 +8,7 @@ use crate::mcp::builtin::BuiltinMCPServer;
 use crate::mcp::types::{
     BuiltinServerMetadata, ContextVolatility, MCPResult, MCPTool, ServiceContext,
 };
+use crate::repositories::SqliteKnowledgeV2Repository;
 
 pub mod embed;
 pub mod extraction;
@@ -43,6 +44,10 @@ impl KnowledgeServer {
                 .to_string(),
             icon: None,
         }
+    }
+
+    pub(crate) fn repository(&self) -> SqliteKnowledgeV2Repository {
+        SqliteKnowledgeV2Repository::new(self.db.as_ref().clone())
     }
 }
 

--- a/src-tauri/src/mcp/builtin/knowledge/operations.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/operations.rs
@@ -357,31 +357,34 @@ pub async fn prune_knowledge(
         Err(result) => return Ok(result),
     };
 
-    let repo = server.repository();
-
     match action {
         "delete" => {
-            let mut validated_ids = Vec::with_capacity(parsed_target_ids.len());
-            let mut missing_ids = Vec::new();
-
-            for id in &parsed_target_ids {
-                match repo.get_chunk_detail(*id).await {
-                    Ok(detail) if detail.chunk.assistant_id == assistant_id => {
-                        validated_ids.push(*id);
-                    }
-                    Ok(_) | Err(DbError::NotFound(_)) | Err(DbError::ResourceNotFound(_)) => {
-                        missing_ids.push(*id);
-                    }
-                    Err(error) => {
-                        return Ok(guided_error(
-                            ErrorCategory::DatabaseError,
-                            format!("Failed to validate knowledge chunk {}: {}", id, error),
-                            ToolGroup::Knowledge,
-                        )
-                        .to_mcp_result());
-                    }
+            let repo = server.repository();
+            let existing_ids = match repo
+                .find_existing_chunk_ids(assistant_id, &parsed_target_ids)
+                .await
+            {
+                Ok(ids) => ids,
+                Err(error) => {
+                    return Ok(guided_error(
+                        ErrorCategory::DatabaseError,
+                        format!("Failed to validate requested knowledge chunks: {}", error),
+                        ToolGroup::Knowledge,
+                    )
+                    .to_mcp_result());
                 }
-            }
+            };
+            let existing_id_set = existing_ids.iter().copied().collect::<HashSet<_>>();
+            let validated_ids = parsed_target_ids
+                .iter()
+                .copied()
+                .filter(|id| existing_id_set.contains(id))
+                .collect::<Vec<_>>();
+            let missing_ids = parsed_target_ids
+                .iter()
+                .copied()
+                .filter(|id| !existing_id_set.contains(id))
+                .collect::<Vec<_>>();
 
             if !missing_ids.is_empty() {
                 let mut result = guided_error(
@@ -401,38 +404,92 @@ pub async fn prune_knowledge(
                 .to_mcp_result();
                 result.structured_content = Some(json!({
                     "action": action,
-                    "requestedIds": parsed_target_ids,
+                    "requestedIds": target_ids,
+                    "normalizedIds": parsed_target_ids,
                     "validatedIds": validated_ids,
                     "missingIds": missing_ids,
                 }));
                 return Ok(result);
             }
 
-            let mut deleted_ids = Vec::with_capacity(validated_ids.len());
-            for id in &validated_ids {
-                match repo.delete_chunk(*id, assistant_id).await {
-                    Ok(()) => deleted_ids.push(*id),
-                    Err(error) => {
-                        return Ok(guided_error(
-                            ErrorCategory::DatabaseError,
-                            format!("Failed to delete knowledge chunk {}: {}", id, error),
-                            ToolGroup::Knowledge,
-                        )
-                        .to_mcp_result());
-                    }
+            match repo
+                .delete_chunks_atomic(&validated_ids, assistant_id)
+                .await
+            {
+                Ok(()) => {}
+                Err(DbError::NotFound(_) | DbError::ResourceNotFound(_)) => {
+                    let current_existing = match repo
+                        .find_existing_chunk_ids(assistant_id, &validated_ids)
+                        .await
+                    {
+                        Ok(ids) => ids,
+                        Err(error) => {
+                            return Ok(guided_error(
+                                ErrorCategory::DatabaseError,
+                                format!(
+                                    "Failed to re-check requested knowledge chunks after delete conflict: {}",
+                                    error
+                                ),
+                                ToolGroup::Knowledge,
+                            )
+                            .to_mcp_result());
+                        }
+                    };
+                    let current_existing_set =
+                        current_existing.iter().copied().collect::<HashSet<_>>();
+                    let current_missing = validated_ids
+                        .iter()
+                        .copied()
+                        .filter(|id| !current_existing_set.contains(id))
+                        .collect::<Vec<_>>();
+
+                    let mut result = guided_error(
+                        ErrorCategory::ResourceNotFound,
+                        format!(
+                            "Knowledge chunk IDs changed before deletion completed: {}. No chunks were deleted.",
+                            format_chunk_id_list(&current_missing)
+                        ),
+                        ToolGroup::Knowledge,
+                    )
+                    .with_guidance(vec![
+                        "Another request modified these chunks during pruning.".to_string(),
+                        "Use search_knowledge to refresh chunk IDs.".to_string(),
+                        "Retry prune_knowledge with IDs copied from fresh search_knowledge results."
+                            .to_string(),
+                    ])
+                    .to_mcp_result();
+                    result.structured_content = Some(json!({
+                        "action": action,
+                        "requestedIds": target_ids,
+                        "normalizedIds": parsed_target_ids,
+                        "validatedIds": validated_ids,
+                        "missingIds": current_missing,
+                        "deletedIds": Vec::<i32>::new(),
+                    }));
+                    return Ok(result);
+                }
+                Err(error) => {
+                    return Ok(guided_error(
+                        ErrorCategory::DatabaseError,
+                        format!("Failed to delete requested knowledge chunks: {}", error),
+                        ToolGroup::Knowledge,
+                    )
+                    .to_mcp_result());
                 }
             }
 
             Ok(SuccessHint::new(
                 format!(
                     "Deleted knowledge chunks: {}.",
-                    format_chunk_id_list(&deleted_ids)
+                    format_chunk_id_list(&validated_ids)
                 ),
                 vec!["Use search_knowledge to confirm the remaining entries.".to_string()],
             )
             .to_mcp_result_with_data(Some(json!({
                 "action": action,
-                "deletedIds": deleted_ids,
+                "requestedIds": target_ids,
+                "normalizedIds": parsed_target_ids,
+                "deletedIds": validated_ids,
                 "deletedCount": validated_ids.len(),
             }))))
         }

--- a/src-tauri/src/mcp/builtin/knowledge/operations.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/operations.rs
@@ -7,13 +7,13 @@ use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, ErrorCategory, SuccessHint, ToolGroup,
 };
 use crate::mcp::types::MCPResult;
-use crate::repositories::KnowledgeV2Repository;
+use crate::repositories::{DbError, KnowledgeV2Repository};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Record new knowledge into the local vector DB and graph.
 pub async fn record_knowledge(
-    _server: &KnowledgeServer,
+    server: &KnowledgeServer,
     args: Value,
     assistant_id: &str,
 ) -> Result<MCPResult, String> {
@@ -132,7 +132,7 @@ pub async fn record_knowledge(
     };
 
     // 2. Save to DB via Repository
-    let repo = crate::state::get_knowledge_v2_repository();
+    let repo = server.repository();
     let tags_json = tags.as_ref().map(serde_json::to_string).transpose();
     let tags_json = match tags_json {
         Ok(serialized_tags) => serialized_tags,
@@ -170,7 +170,7 @@ pub async fn record_knowledge(
                 || !extraction_plan.relationships.is_empty()
             {
                 match persist_extraction_plan(
-                    repo,
+                    &repo,
                     assistant_id,
                     chunk_id,
                     &extraction_plan,
@@ -338,7 +338,7 @@ async fn persist_extraction_plan(
 
 /// Prune or manage existing knowledge.
 pub async fn prune_knowledge(
-    _server: &KnowledgeServer,
+    server: &KnowledgeServer,
     args: Value,
     assistant_id: &str,
 ) -> Result<MCPResult, String> {
@@ -352,27 +352,89 @@ pub async fn prune_knowledge(
         None => return Ok(missing_param_error("target_ids", ToolGroup::Knowledge)),
     };
 
-    let repo = crate::state::get_knowledge_v2_repository();
-    let mut deleted_count = 0;
+    let parsed_target_ids = match parse_prune_target_ids(target_ids) {
+        Ok(ids) => ids,
+        Err(result) => return Ok(result),
+    };
+
+    let repo = server.repository();
 
     match action {
         "delete" => {
-            for id_val in target_ids {
-                if let Some(id) = id_val.as_i64() {
-                    if repo.delete_chunk(id as i32, assistant_id).await.is_ok() {
-                        deleted_count += 1;
+            let mut validated_ids = Vec::with_capacity(parsed_target_ids.len());
+            let mut missing_ids = Vec::new();
+
+            for id in &parsed_target_ids {
+                match repo.get_chunk_detail(*id).await {
+                    Ok(detail) if detail.chunk.assistant_id == assistant_id => {
+                        validated_ids.push(*id);
+                    }
+                    Ok(_) | Err(DbError::NotFound(_)) | Err(DbError::ResourceNotFound(_)) => {
+                        missing_ids.push(*id);
+                    }
+                    Err(error) => {
+                        return Ok(guided_error(
+                            ErrorCategory::DatabaseError,
+                            format!("Failed to validate knowledge chunk {}: {}", id, error),
+                            ToolGroup::Knowledge,
+                        )
+                        .to_mcp_result());
                     }
                 }
             }
+
+            if !missing_ids.is_empty() {
+                let mut result = guided_error(
+                    ErrorCategory::ResourceNotFound,
+                    format!(
+                        "Knowledge chunk IDs not found for this assistant: {}",
+                        format_chunk_id_list(&missing_ids)
+                    ),
+                    ToolGroup::Knowledge,
+                )
+                .with_guidance(vec![
+                    "Use search_knowledge to find valid chunk IDs.".to_string(),
+                    "Retry prune_knowledge with IDs copied from search_knowledge results."
+                        .to_string(),
+                    "Knowledge chunk IDs are assistant-scoped.".to_string(),
+                ])
+                .to_mcp_result();
+                result.structured_content = Some(json!({
+                    "action": action,
+                    "requestedIds": parsed_target_ids,
+                    "validatedIds": validated_ids,
+                    "missingIds": missing_ids,
+                }));
+                return Ok(result);
+            }
+
+            let mut deleted_ids = Vec::with_capacity(validated_ids.len());
+            for id in &validated_ids {
+                match repo.delete_chunk(*id, assistant_id).await {
+                    Ok(()) => deleted_ids.push(*id),
+                    Err(error) => {
+                        return Ok(guided_error(
+                            ErrorCategory::DatabaseError,
+                            format!("Failed to delete knowledge chunk {}: {}", id, error),
+                            ToolGroup::Knowledge,
+                        )
+                        .to_mcp_result());
+                    }
+                }
+            }
+
             Ok(SuccessHint::new(
                 format!(
-                    "Deleted {}/{} knowledge chunks.",
-                    deleted_count,
-                    target_ids.len()
+                    "Deleted knowledge chunks: {}.",
+                    format_chunk_id_list(&deleted_ids)
                 ),
-                vec![],
+                vec!["Use search_knowledge to confirm the remaining entries.".to_string()],
             )
-            .to_mcp_result_with_data(Some(json!({ "deleted": deleted_count }))))
+            .to_mcp_result_with_data(Some(json!({
+                "action": action,
+                "deletedIds": deleted_ids,
+                "deletedCount": validated_ids.len(),
+            }))))
         }
         _ => Ok(guided_error(
             ErrorCategory::InvalidInput,
@@ -384,4 +446,66 @@ pub async fn prune_knowledge(
         ])
         .to_mcp_result()),
     }
+}
+
+fn parse_prune_target_ids(target_ids: &[Value]) -> Result<Vec<i32>, MCPResult> {
+    if target_ids.is_empty() {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            "Parameter 'target_ids' must contain at least one knowledge chunk ID.".to_string(),
+            ToolGroup::Knowledge,
+        )
+        .with_guidance(vec![
+            "Use search_knowledge to find chunk IDs before pruning.".to_string(),
+            "Provide target_ids as an array of integers.".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    let mut parsed_ids = Vec::with_capacity(target_ids.len());
+    let mut seen_ids = HashSet::new();
+
+    for value in target_ids {
+        let Some(raw_id) = value.as_i64() else {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                "Parameter 'target_ids' must contain only integer chunk IDs.".to_string(),
+                ToolGroup::Knowledge,
+            )
+            .with_guidance(vec![
+                "Use search_knowledge to copy valid chunk IDs.".to_string(),
+                "Remove non-integer values from target_ids and retry prune_knowledge.".to_string(),
+            ])
+            .to_mcp_result());
+        };
+
+        let Ok(chunk_id) = i32::try_from(raw_id) else {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Knowledge chunk ID '{}' is outside the supported integer range.",
+                    raw_id
+                ),
+                ToolGroup::Knowledge,
+            )
+            .with_guidance(vec![
+                "Copy chunk IDs directly from search_knowledge results.".to_string(),
+                "Retry prune_knowledge with valid integer IDs.".to_string(),
+            ])
+            .to_mcp_result());
+        };
+
+        if seen_ids.insert(chunk_id) {
+            parsed_ids.push(chunk_id);
+        }
+    }
+
+    Ok(parsed_ids)
+}
+
+fn format_chunk_id_list(ids: &[i32]) -> String {
+    ids.iter()
+        .map(i32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/src-tauri/src/mcp/builtin/knowledge/queries.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/queries.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 /// Search knowledge using hybrid approach
 pub async fn search_knowledge(
-    _server: &KnowledgeServer,
+    server: &KnowledgeServer,
     args: Value,
     assistant_id: &str,
 ) -> Result<MCPResult, String> {
@@ -63,7 +63,7 @@ pub async fn search_knowledge(
         None
     };
 
-    let repo = crate::state::get_knowledge_v2_repository();
+    let repo = server.repository();
     let text_query = if matches!(mode, "keyword" | "hybrid") {
         Some(query)
     } else {
@@ -123,7 +123,7 @@ pub async fn search_knowledge(
 
 /// Explore graph context
 pub async fn explore_context(
-    _server: &KnowledgeServer,
+    server: &KnowledgeServer,
     args: Value,
     assistant_id: &str,
 ) -> Result<MCPResult, String> {
@@ -134,7 +134,7 @@ pub async fn explore_context(
 
     let depth = args.get("depth").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
 
-    let repo = crate::state::get_knowledge_v2_repository();
+    let repo = server.repository();
     match repo
         .get_graph_context(assistant_id, entity_name, depth)
         .await

--- a/src-tauri/src/mcp/builtin/knowledge/tools.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/tools.rs
@@ -6,7 +6,7 @@ pub fn record_knowledge_tool() -> MCPTool {
     MCPTool {
         name: "record_knowledge".to_string(),
         title: Some("Record Knowledge".to_string()),
-        description: "Save a knowledge entry to the local knowledge base. Prefer caller-supplied entities and relationships; local heuristic extraction only fills gaps when structured graph data is missing. Use concise entity names (recommended: natural-language names under 10 words).".to_string(),
+        description: "Save a knowledge entry to the local knowledge base. Prefer caller-supplied entities and relationships; heuristic extraction only fills gaps when structured graph data is missing.".to_string(),
         input_schema: object_prop(
             vec![
                 (
@@ -27,7 +27,7 @@ pub fn record_knowledge_tool() -> MCPTool {
                             vec![
                                 (
                                     "name".to_string(),
-                                    string_prop_required("Entity name as understood by the calling agent. Use a concise natural-language name (up to 10 words recommended)."),
+                                    string_prop_required("Entity name as understood by the calling agent. Use a concise natural-language name with 10 words or fewer."),
                                 ),
                                 (
                                     "entity_type".to_string(),
@@ -59,11 +59,11 @@ pub fn record_knowledge_tool() -> MCPTool {
                             vec![
                                 (
                                     "source".to_string(),
-                                    string_prop_required("Source entity name. Use the same concise entity naming style as entities[].name."),
+                                    string_prop_required("Source entity name. Match entities[].name when the entity is supplied explicitly."),
                                 ),
                                 (
                                     "target".to_string(),
-                                    string_prop_required("Target entity name. Use the same concise entity naming style as entities[].name."),
+                                    string_prop_required("Target entity name. Match entities[].name when the entity is supplied explicitly."),
                                 ),
                                 (
                                     "relation_type".to_string(),
@@ -122,7 +122,7 @@ pub fn search_knowledge_tool() -> MCPTool {
                         Some(1),
                         Some(50),
                         5,
-                        Some("Maximum number of results to return (default: 5)."),
+                        Some("Maximum number of results to return."),
                     ),
                 ),
                 (
@@ -130,7 +130,7 @@ pub fn search_knowledge_tool() -> MCPTool {
                     enum_prop(
                         vec!["keyword", "semantic", "hybrid"],
                         "hybrid",
-                        Some("Search mode. Defaults to 'hybrid'."),
+                        Some("'keyword' uses FTS, 'semantic' uses embeddings, and 'hybrid' fuses both rankings."),
                     ),
                 ),
             ],
@@ -162,7 +162,7 @@ pub fn explore_context_tool() -> MCPTool {
                         Some(1),
                         Some(3),
                         1,
-                        Some("The depth of the graph traversal. Defaults to 1."),
+                        Some("Number of relationship hops to traverse from the root entity."),
                     ),
                 ),
             ],
@@ -186,14 +186,14 @@ pub fn prune_knowledge_tool() -> MCPTool {
                     "target_ids".to_string(),
                     array_schema(
                         integer_prop(None, None, None),
-                        Some("List of knowledge chunk IDs to target."),
+                        Some("Knowledge chunk IDs to delete. Copy these IDs from search_knowledge results."),
                     ),
                 ),
                 (
                     "action".to_string(),
                     enum_prop_required(
                         vec!["delete"],
-                        "The action to perform. Currently only 'delete' is supported.",
+                        "Delete the targeted knowledge chunks.",
                     ),
                 ),
             ],

--- a/src-tauri/src/repositories/knowledge_v2_repository.rs
+++ b/src-tauri/src/repositories/knowledge_v2_repository.rs
@@ -74,6 +74,8 @@ pub trait KnowledgeV2Repository: Send + Sync {
 
     async fn delete_chunk(&self, id: i32, assistant_id: &str) -> Result<(), DbError>;
 
+    async fn delete_chunks_atomic(&self, ids: &[i32], assistant_id: &str) -> Result<(), DbError>;
+
     async fn delete_chunk_global(&self, id: i32) -> Result<KnowledgeDeleteSummary, DbError>;
 
     async fn list_chunks(
@@ -110,6 +112,12 @@ pub trait KnowledgeV2Repository: Send + Sync {
         entity_name: &str,
         depth: u32,
     ) -> Result<serde_json::Value, DbError>;
+
+    async fn find_existing_chunk_ids(
+        &self,
+        assistant_id: &str,
+        ids: &[i32],
+    ) -> Result<Vec<i32>, DbError>;
 
     async fn get_chunk_detail(&self, id: i32) -> Result<KnowledgeChunkDetail, DbError>;
 }
@@ -409,6 +417,63 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
         // Also cleanup chunk-entity links
         knowledge_chunk_entity::Entity::delete_many()
             .filter(knowledge_chunk_entity::Column::ChunkId.eq(id))
+            .exec(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        txn.commit().await.map_err(DbError::SeaOrmQueryFailed)?;
+        Ok(())
+    }
+
+    async fn delete_chunks_atomic(&self, ids: &[i32], assistant_id: &str) -> Result<(), DbError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let txn = self.db.begin().await.map_err(DbError::SeaOrmQueryFailed)?;
+        let requested_ids = ids.to_vec();
+        let expected_count = requested_ids.len() as u64;
+
+        let existing_count = knowledge_chunk_v2::Entity::find()
+            .filter(knowledge_chunk_v2::Column::AssistantId.eq(assistant_id))
+            .filter(knowledge_chunk_v2::Column::Id.is_in(requested_ids.clone()))
+            .count(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        if existing_count != expected_count {
+            return Err(DbError::NotFound(format!(
+                "One or more chunks are missing for assistant '{}'",
+                assistant_id
+            )));
+        }
+
+        let delete_result = knowledge_chunk_v2::Entity::delete_many()
+            .filter(knowledge_chunk_v2::Column::AssistantId.eq(assistant_id))
+            .filter(knowledge_chunk_v2::Column::Id.is_in(requested_ids.clone()))
+            .exec(&txn)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        if delete_result.rows_affected != expected_count {
+            return Err(DbError::NotFound(format!(
+                "One or more chunks changed while deleting for assistant '{}'",
+                assistant_id
+            )));
+        }
+
+        for id in &requested_ids {
+            txn.execute(Statement::from_sql_and_values(
+                self.db.get_database_backend(),
+                "DELETE FROM knowledge_vectors WHERE rowid = ?",
+                [(*id).into()],
+            ))
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+        }
+
+        knowledge_chunk_entity::Entity::delete_many()
+            .filter(knowledge_chunk_entity::Column::ChunkId.is_in(requested_ids))
             .exec(&txn)
             .await
             .map_err(DbError::SeaOrmQueryFailed)?;
@@ -785,6 +850,28 @@ impl KnowledgeV2Repository for SqliteKnowledgeV2Repository {
             "edges": relationships,
             "linked_chunks": linked_chunk_json
         }))
+    }
+
+    async fn find_existing_chunk_ids(
+        &self,
+        assistant_id: &str,
+        ids: &[i32],
+    ) -> Result<Vec<i32>, DbError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut existing_ids = knowledge_chunk_v2::Entity::find()
+            .select_only()
+            .column(knowledge_chunk_v2::Column::Id)
+            .filter(knowledge_chunk_v2::Column::AssistantId.eq(assistant_id))
+            .filter(knowledge_chunk_v2::Column::Id.is_in(ids.iter().copied()))
+            .into_tuple::<i32>()
+            .all(&self.db)
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+        existing_ids.sort_unstable();
+        Ok(existing_ids)
     }
 
     async fn get_chunk_detail(&self, id: i32) -> Result<KnowledgeChunkDetail, DbError> {

--- a/src-tauri/tests/history_builtin_tests.rs
+++ b/src-tauri/tests/history_builtin_tests.rs
@@ -295,6 +295,70 @@ fn history_list_tool_status_filter_has_no_default() {
     );
 }
 
+#[test]
+fn history_tool_schemas_expose_runtime_defaults() {
+    let tools = HistoryServer::tools_static();
+
+    let list_tool = tools
+        .iter()
+        .find(|tool| tool.name == "list")
+        .expect("list tool should exist");
+    let read_session_tool = tools
+        .iter()
+        .find(|tool| tool.name == "readSession")
+        .expect("readSession tool should exist");
+    let read_message_tool = tools
+        .iter()
+        .find(|tool| tool.name == "readMessage")
+        .expect("readMessage tool should exist");
+    let search_tool = tools
+        .iter()
+        .find(|tool| tool.name == "search")
+        .expect("search tool should exist");
+
+    let list_properties = match &list_tool.input_schema.schema_type {
+        JSONSchemaType::Object {
+            properties: Some(properties),
+            ..
+        } => properties,
+        other => panic!("expected list object schema, got {other:?}"),
+    };
+    assert_eq!(list_properties["page"].default, Some(json!(1)));
+    assert_eq!(list_properties["pageSize"].default, Some(json!(20)));
+
+    let read_session_properties = match &read_session_tool.input_schema.schema_type {
+        JSONSchemaType::Object {
+            properties: Some(properties),
+            ..
+        } => properties,
+        other => panic!("expected readSession object schema, got {other:?}"),
+    };
+    assert_eq!(read_session_properties["page"].default, Some(json!(1)));
+    assert_eq!(read_session_properties["pageSize"].default, Some(json!(50)));
+
+    let read_message_properties = match &read_message_tool.input_schema.schema_type {
+        JSONSchemaType::Object {
+            properties: Some(properties),
+            ..
+        } => properties,
+        other => panic!("expected readMessage object schema, got {other:?}"),
+    };
+    assert_eq!(
+        read_message_properties["maxChars"].default,
+        Some(json!(3000))
+    );
+
+    let search_properties = match &search_tool.input_schema.schema_type {
+        JSONSchemaType::Object {
+            properties: Some(properties),
+            ..
+        } => properties,
+        other => panic!("expected search object schema, got {other:?}"),
+    };
+    assert_eq!(search_properties["page"].default, Some(json!(1)));
+    assert_eq!(search_properties["pageSize"].default, Some(json!(20)));
+}
+
 #[tokio::test]
 async fn history_list_filters_sessions_and_exposes_ids() {
     let _guard = TEST_GUARD.lock().await;

--- a/src-tauri/tests/knowledge_builtin_tool_tests.rs
+++ b/src-tauri/tests/knowledge_builtin_tool_tests.rs
@@ -48,7 +48,7 @@ async fn knowledge_prune_blocks_partial_delete_when_any_id_is_missing() {
         .call_tool(
             "prune_knowledge",
             json!({
-                "target_ids": [existing_chunk_id, missing_chunk_id],
+                "target_ids": [existing_chunk_id, existing_chunk_id, missing_chunk_id],
                 "action": "delete"
             }),
             None,
@@ -66,6 +66,10 @@ async fn knowledge_prune_blocks_partial_delete_when_any_id_is_missing() {
         .expect("structured content expected on validation failure");
     assert_eq!(
         structured["requestedIds"],
+        json!([existing_chunk_id, existing_chunk_id, missing_chunk_id])
+    );
+    assert_eq!(
+        structured["normalizedIds"],
         json!([existing_chunk_id, missing_chunk_id])
     );
     assert_eq!(structured["validatedIds"], json!([existing_chunk_id]));
@@ -118,6 +122,8 @@ async fn knowledge_prune_success_reports_deleted_ids_in_text_and_json() {
     let structured = result
         .structured_content
         .expect("structured content expected on success");
+    assert_eq!(structured["requestedIds"], json!([chunk_id]));
+    assert_eq!(structured["normalizedIds"], json!([chunk_id]));
     assert_eq!(structured["deletedIds"], json!([chunk_id]));
     assert_eq!(structured["deletedCount"], 1);
 
@@ -141,4 +147,41 @@ fn knowledge_not_found_guidance_uses_real_tool_names() {
     assert!(text.contains("explore_context"));
     assert!(!text.contains("searchKnowledge"));
     assert!(!text.contains("listKnowledge"));
+}
+
+#[tokio::test]
+async fn knowledge_repository_atomic_delete_rejects_partial_deletes() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteKnowledgeV2Repository::new(db.clone());
+    let assistant_id = "assistant-prune-atomic";
+
+    let existing_chunk_id = repo
+        .record_chunk(
+            assistant_id.to_string(),
+            "Knowledge chunk that should survive repository-level atomic delete failure."
+                .to_string(),
+            None,
+            Some("test".to_string()),
+            vec![0.24; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+    let missing_chunk_id = existing_chunk_id + 50_000;
+
+    let error = repo
+        .delete_chunks_atomic(&[existing_chunk_id, missing_chunk_id], assistant_id)
+        .await
+        .expect_err("atomic delete should fail when any chunk is missing");
+
+    assert!(
+        matches!(
+            error,
+            tauri_mcp_agent_lib::repositories::DbError::NotFound(_)
+        ),
+        "expected NotFound error, got: {error:?}"
+    );
+    assert!(
+        repo.get_chunk_detail(existing_chunk_id).await.is_ok(),
+        "existing chunk should remain because delete_chunks_atomic must not partially delete"
+    );
 }

--- a/src-tauri/tests/knowledge_builtin_tool_tests.rs
+++ b/src-tauri/tests/knowledge_builtin_tool_tests.rs
@@ -1,0 +1,144 @@
+mod common;
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
+use tauri_mcp_agent_lib::mcp::builtin::knowledge::KnowledgeServer;
+use tauri_mcp_agent_lib::mcp::builtin::BuiltinMCPServer;
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::repositories::{KnowledgeV2Repository, SqliteKnowledgeV2Repository};
+
+fn extract_text_content(result: &tauri_mcp_agent_lib::mcp::types::MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn knowledge_prune_blocks_partial_delete_when_any_id_is_missing() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteKnowledgeV2Repository::new(db.clone());
+    let assistant_id = "assistant-prune-block";
+
+    let existing_chunk_id = repo
+        .record_chunk(
+            assistant_id.to_string(),
+            "Knowledge chunk that should survive validation failure.".to_string(),
+            None,
+            Some("test".to_string()),
+            vec![0.42; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+    let missing_chunk_id = existing_chunk_id + 999;
+
+    let server = KnowledgeServer::new(assistant_id.to_string(), Arc::new(db))
+        .await
+        .expect("knowledge server should initialize");
+
+    let result = server
+        .call_tool(
+            "prune_knowledge",
+            json!({
+                "target_ids": [existing_chunk_id, missing_chunk_id],
+                "action": "delete"
+            }),
+            None,
+        )
+        .await
+        .expect("prune_knowledge should return an MCP error result");
+
+    assert_eq!(result.is_error, Some(true));
+    let text = extract_text_content(&result);
+    assert!(text.contains(&missing_chunk_id.to_string()));
+    assert!(text.contains("search_knowledge"));
+
+    let structured = result
+        .structured_content
+        .expect("structured content expected on validation failure");
+    assert_eq!(
+        structured["requestedIds"],
+        json!([existing_chunk_id, missing_chunk_id])
+    );
+    assert_eq!(structured["validatedIds"], json!([existing_chunk_id]));
+    assert_eq!(structured["missingIds"], json!([missing_chunk_id]));
+
+    assert!(
+        repo.get_chunk_detail(existing_chunk_id).await.is_ok(),
+        "existing chunk should remain because validation must happen before deletion"
+    );
+}
+
+#[tokio::test]
+async fn knowledge_prune_success_reports_deleted_ids_in_text_and_json() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteKnowledgeV2Repository::new(db.clone());
+    let assistant_id = "assistant-prune-success";
+
+    let chunk_id = repo
+        .record_chunk(
+            assistant_id.to_string(),
+            "Knowledge chunk that should be deleted.".to_string(),
+            None,
+            Some("test".to_string()),
+            vec![0.11; 384],
+        )
+        .await
+        .expect("record_chunk should succeed");
+
+    let server = KnowledgeServer::new(assistant_id.to_string(), Arc::new(db))
+        .await
+        .expect("knowledge server should initialize");
+
+    let result = server
+        .call_tool(
+            "prune_knowledge",
+            json!({
+                "target_ids": [chunk_id],
+                "action": "delete"
+            }),
+            None,
+        )
+        .await
+        .expect("prune_knowledge should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(text.contains(&chunk_id.to_string()));
+    assert!(text.contains("search_knowledge"));
+
+    let structured = result
+        .structured_content
+        .expect("structured content expected on success");
+    assert_eq!(structured["deletedIds"], json!([chunk_id]));
+    assert_eq!(structured["deletedCount"], 1);
+
+    assert!(
+        repo.get_chunk_detail(chunk_id).await.is_err(),
+        "chunk should be deleted after successful prune_knowledge"
+    );
+}
+
+#[test]
+fn knowledge_not_found_guidance_uses_real_tool_names() {
+    let result = guided_error(
+        ErrorCategory::ResourceNotFound,
+        "Knowledge chunk 123 not found",
+        ToolGroup::Knowledge,
+    )
+    .to_mcp_result();
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("search_knowledge"));
+    assert!(text.contains("explore_context"));
+    assert!(!text.contains("searchKnowledge"));
+    assert!(!text.contains("listKnowledge"));
+}

--- a/src-tauri/tests/knowledge_v2_extraction_tests.rs
+++ b/src-tauri/tests/knowledge_v2_extraction_tests.rs
@@ -211,7 +211,7 @@ fn record_knowledge_tool_schema_exposes_structured_graph_inputs() {
         .get("name")
         .and_then(|schema| schema.description.as_deref())
         .expect("entity name field should describe naming guidance");
-    assert!(entity_name_description.contains("up to 10 words recommended"));
+    assert!(entity_name_description.contains("10 words or fewer"));
 
     let relationships_schema = properties
         .get("relationships")
@@ -248,5 +248,5 @@ fn record_knowledge_tool_schema_exposes_structured_graph_inputs() {
         .get("source")
         .and_then(|schema| schema.description.as_deref())
         .expect("relationship source field should describe naming guidance");
-    assert!(relationship_source_description.contains("concise entity naming style"));
+    assert!(relationship_source_description.contains("Match entities[].name"));
 }


### PR DESCRIPTION
## Summary
- harden knowledge prune_knowledge so chunk IDs are validated before deletion and results report deleted/missing IDs explicitly
- fix Knowledge resource-not-found guidance to reference real builtin tool names
- remove schema-duplicated description text from history/knowledge tool schemas and add regression tests for knowledge prune and guidance behavior

## Testing
- cargo test --tests --profile ci-test --test knowledge_builtin_tool_tests --test knowledge_v2_extraction_tests --test history_builtin_tests --test error_contract_guards
- pnpm refactor:validate