### PR TITLE
Fix agent/tool audit guardrails

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -161,8 +161,31 @@ pub async fn load_accessible_delegated_session(
     target_session_id: &str,
     tool_name: &str,
 ) -> Result<SessionMetadata, MCPResult> {
-    let sessions = match manager.get_all_sessions().await {
-        Ok(sessions) => sessions,
+    let caller_exists = match manager.get_session(caller_session_id).await {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
+        Err(error) => {
+            return Err(guided_error(
+                ErrorCategory::InternalError,
+                format!(
+                    "Failed to load caller session metadata for {}: {}",
+                    tool_name, error
+                ),
+                ToolGroup::Agent,
+            )
+            .with_guidance(vec![
+                "Retry the operation once session metadata is available again".to_string(),
+                "If the issue persists, inspect the session repository health".to_string(),
+            ])
+            .to_mcp_result())
+        }
+    };
+    if !caller_exists {
+        return Err(caller_session_not_found_result(caller_session_id));
+    }
+
+    let Some(target_session) = (match manager.get_session(target_session_id).await {
+        Ok(session) => session,
         Err(error) => {
             return Err(guided_error(
                 ErrorCategory::InternalError,
@@ -178,44 +201,61 @@ pub async fn load_accessible_delegated_session(
             ])
             .to_mcp_result())
         }
-    };
-
-    let session_index = sessions
-        .into_iter()
-        .map(|session| (session.id.clone(), session))
-        .collect::<HashMap<_, _>>();
-
-    let Some(target_session) = session_index.get(target_session_id).cloned() else {
+    }) else {
         return Err(
             crate::mcp::builtin::error_guidance::missing_agent_session_error(target_session_id),
         );
     };
 
-    if !is_delegated_descendant_session(&session_index, caller_session_id, target_session_id) {
-        return Err(
-            guided_error(
-                ErrorCategory::PermissionDenied,
-                format!(
-                    "Session '{}' is not a delegated descendant of the current session '{}'.",
-                    target_session_id, caller_session_id
-                ),
-                ToolGroup::Agent,
-            )
-            .with_guidance(vec![
-                format!(
-                    "Use {} only with delegated child/descendant sessions started from the current session",
-                    tool_name
-                ),
-                "Use list(type=\"sessions\") to inspect the delegated sessions you can control directly"
-                    .to_string(),
-                "Start a new delegated session with startSession(...) if you need fresh child work"
-                    .to_string(),
-            ])
-            .to_mcp_result(),
-        );
+    let mut next_parent = target_session.parent_session_id.clone();
+    let mut seen = HashSet::new();
+    while let Some(parent_id) = next_parent {
+        if !seen.insert(parent_id.clone()) {
+            break;
+        }
+        if parent_id == caller_session_id {
+            return Ok(target_session);
+        }
+        next_parent = match manager.get_session(&parent_id).await {
+            Ok(Some(session)) => session.parent_session_id,
+            Ok(None) => None,
+            Err(error) => {
+                return Err(guided_error(
+                    ErrorCategory::InternalError,
+                    format!(
+                        "Failed to load delegated session lineage for {}: {}",
+                        tool_name, error
+                    ),
+                    ToolGroup::Agent,
+                )
+                .with_guidance(vec![
+                    "Retry the operation once session metadata is available again".to_string(),
+                    "If the issue persists, inspect the session repository health".to_string(),
+                ])
+                .to_mcp_result())
+            }
+        };
     }
 
-    Ok(target_session)
+    Err(guided_error(
+        ErrorCategory::PermissionDenied,
+        format!(
+            "Session '{}' is not a delegated descendant of the current session '{}'.",
+            target_session_id, caller_session_id
+        ),
+        ToolGroup::Agent,
+    )
+    .with_guidance(vec![
+        format!(
+            "Use {} only with delegated child/descendant sessions started from the current session",
+            tool_name
+        ),
+        "Use list(type=\"sessions\") to inspect the delegated sessions you can control directly"
+            .to_string(),
+        "Start a new delegated session with startSession(...) if you need fresh child work"
+            .to_string(),
+    ])
+    .to_mcp_result())
 }
 
 fn recovery_action_for_session(session_id: &str, status: &str, reason: &str) -> Value {

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
 
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::builtin::session_api::formatting::{
@@ -8,7 +9,7 @@ use crate::mcp::builtin::session_api::utils::{
     build_agent_session_tool_data, build_agent_tool_data,
 };
 use crate::mcp::types::{MCPContent, MCPResult};
-use crate::repositories::message_repository::MessageRepository;
+use crate::repositories::{message_repository::MessageRepository, SessionMetadata};
 
 fn read_optional_string(args: &Value, key: &str) -> Result<Option<String>, String> {
     match args.get(key) {
@@ -123,6 +124,98 @@ fn invalid_explicit_org_result(org_id: &str) -> MCPResult {
         "Use list(type=\"sessions\") to inspect the current delegated lineage".to_string(),
     ])
     .to_mcp_result()
+}
+
+pub fn is_delegated_descendant_session(
+    sessions: &HashMap<String, SessionMetadata>,
+    caller_session_id: &str,
+    target_session_id: &str,
+) -> bool {
+    if caller_session_id == target_session_id {
+        return false;
+    }
+
+    let mut next_parent = sessions
+        .get(target_session_id)
+        .and_then(|session| session.parent_session_id.clone());
+    let mut seen = HashSet::new();
+
+    while let Some(parent_id) = next_parent {
+        if !seen.insert(parent_id.clone()) {
+            return false;
+        }
+        if parent_id == caller_session_id {
+            return true;
+        }
+        next_parent = sessions
+            .get(&parent_id)
+            .and_then(|session| session.parent_session_id.clone());
+    }
+
+    false
+}
+
+pub async fn load_accessible_delegated_session(
+    manager: &crate::agent::AgentSessionManager,
+    caller_session_id: &str,
+    target_session_id: &str,
+    tool_name: &str,
+) -> Result<SessionMetadata, MCPResult> {
+    let sessions = match manager.get_all_sessions().await {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            return Err(guided_error(
+                ErrorCategory::InternalError,
+                format!(
+                    "Failed to load session metadata for {}: {}",
+                    tool_name, error
+                ),
+                ToolGroup::Agent,
+            )
+            .with_guidance(vec![
+                "Retry the operation once session metadata is available again".to_string(),
+                "If the issue persists, inspect the session repository health".to_string(),
+            ])
+            .to_mcp_result())
+        }
+    };
+
+    let session_index = sessions
+        .into_iter()
+        .map(|session| (session.id.clone(), session))
+        .collect::<HashMap<_, _>>();
+
+    let Some(target_session) = session_index.get(target_session_id).cloned() else {
+        return Err(
+            crate::mcp::builtin::error_guidance::missing_agent_session_error(target_session_id),
+        );
+    };
+
+    if !is_delegated_descendant_session(&session_index, caller_session_id, target_session_id) {
+        return Err(
+            guided_error(
+                ErrorCategory::PermissionDenied,
+                format!(
+                    "Session '{}' is not a delegated descendant of the current session '{}'.",
+                    target_session_id, caller_session_id
+                ),
+                ToolGroup::Agent,
+            )
+            .with_guidance(vec![
+                format!(
+                    "Use {} only with delegated child/descendant sessions started from the current session",
+                    tool_name
+                ),
+                "Use list(type=\"sessions\") to inspect the delegated sessions you can control directly"
+                    .to_string(),
+                "Start a new delegated session with startSession(...) if you need fresh child work"
+                    .to_string(),
+            ])
+            .to_mcp_result(),
+        );
+    }
+
+    Ok(target_session)
 }
 
 fn recovery_action_for_session(session_id: &str, status: &str, reason: &str) -> Value {

--- a/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 
-use crate::mcp::builtin::error_guidance::missing_agent_session_error;
 use crate::mcp::builtin::error_guidance::SuccessHint;
 use crate::mcp::builtin::session_api::formatting::{extract_session_status, is_terminal_status};
 use crate::mcp::builtin::session_api::utils::{
@@ -10,7 +9,10 @@ use crate::mcp::builtin::session_api::utils::{
 use crate::mcp::types::MCPResult;
 
 use super::super::AgentServer;
-use super::{build_paused_check_session_result, build_terminal_check_session_result};
+use super::{
+    build_paused_check_session_result, build_terminal_check_session_result,
+    load_accessible_delegated_session,
+};
 
 /// checkSession handler (from awaitAgent / getAgentStatus)
 pub async fn check_session(
@@ -25,9 +27,16 @@ pub async fn check_session(
     let wait = args.get("wait").and_then(|v| v.as_bool()).unwrap_or(false);
     let timeout_secs = args.get("timeout").and_then(|v| v.as_u64()).unwrap_or(3600);
 
-    let current_session_meta = match manager.get_session(&session_id).await? {
-        Some(session) => session,
-        None => return Ok(missing_agent_session_error(&session_id)),
+    let current_session_meta = match load_accessible_delegated_session(
+        manager,
+        caller_session_id,
+        &session_id,
+        "checkSession",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(result) => return Ok(result),
     };
     let current_status = format!("{:?}", current_session_meta.status).to_lowercase();
     let current_turn_count = count_session_turns(&session_id).await;

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -12,8 +12,8 @@ use crate::mcp::types::MCPResult;
 use crate::repositories::SessionStatus;
 
 use super::super::AgentServer;
-use super::caller_session_not_found_result;
 use super::check_session::check_session;
+use super::{caller_session_not_found_result, load_accessible_delegated_session};
 
 fn self_target_session_action_result(
     tool_name: &str,
@@ -219,6 +219,16 @@ pub async fn message_to_session(
         .ok_or("AgentSessionManager not available")?;
     let session_id = read_required_string(&args, "sessionId")?;
     let message_text = read_required_string(&args, "message")?;
+    if let Err(result) = load_accessible_delegated_session(
+        manager,
+        _caller_session_id,
+        &session_id,
+        "messageToSession",
+    )
+    .await
+    {
+        return Ok(result);
+    }
     let response = match crate::services::AgentService::send_message_to_session(
         manager,
         &session_id,
@@ -279,6 +289,13 @@ pub async fn stop_session(
         ));
     }
 
+    if let Err(result) =
+        load_accessible_delegated_session(manager, caller_session_id, &session_id, "stopSession")
+            .await
+    {
+        return Ok(result);
+    }
+
     if let Err(error) = manager.terminate_session(session_id.clone()).await {
         if error.contains("not found") {
             return Ok(missing_agent_session_error(&session_id));
@@ -336,12 +353,19 @@ pub async fn compact_session_context(
                 "Use this tool only when you want to refresh another delegated session's compact summary"
                     .to_string(),
                 ],
-            ));
+        ));
     }
 
-    let target_session = match manager.get_session(&session_id).await? {
-        Some(session) => session,
-        None => return Ok(missing_agent_session_error(&session_id)),
+    let target_session = match load_accessible_delegated_session(
+        manager,
+        caller_session_id,
+        &session_id,
+        "compactSessionContext",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(result) => return Ok(result),
     };
 
     if target_session.status == SessionStatus::Busy {

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -212,7 +212,7 @@ pub async fn start_session(
 pub async fn message_to_session(
     server: &AgentServer,
     args: Value,
-    _caller_session_id: &str,
+    caller_session_id: &str,
 ) -> Result<MCPResult, String> {
     let manager = server
         .get_manager()
@@ -221,7 +221,7 @@ pub async fn message_to_session(
     let message_text = read_required_string(&args, "message")?;
     if let Err(result) = load_accessible_delegated_session(
         manager,
-        _caller_session_id,
+        caller_session_id,
         &session_id,
         "messageToSession",
     )

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -103,6 +103,26 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
         .to_mcp_result());
     }
 
+    if let Ok(Some(_)) = get_server_config(&name).await {
+        return Ok(guided_error(
+            ErrorCategory::DuplicateResource,
+            format!("Server name '{}' already exists", name),
+            ToolGroup::Tool,
+        )
+        .with_guidance(vec![
+            format!(
+                "Use update(name=\"{}\", transport=...) to change the existing server configuration",
+                name
+            ),
+            format!(
+                "Use list(query=\"{}\") to inspect the existing server before modifying it",
+                name
+            ),
+            "Choose a different unique name if you want to register a separate server".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
     let transport_val = match args.get("transport") {
         Some(t) => t,
         Option::None => return Ok(missing_param_error("transport", ToolGroup::Tool)),
@@ -788,5 +808,38 @@ pub async fn list_tools(args: Value, session_id: Option<&str>) -> Result<MCPResu
         );
     }
 
-    Ok(SuccessHint::new(format!("{}{}{}", header, body, external_action), hints).to_mcp_result())
+    let structured_results = paginated_tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "source": tool.source,
+                "name": tool.name,
+                "status": tool.status,
+                "description": tool.description,
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut external_servers = found_external_ids
+        .iter()
+        .map(|(name, id)| json!({ "name": name, "id": id }))
+        .collect::<Vec<_>>();
+    external_servers.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+    external_servers.dedup_by(|left, right| left["id"] == right["id"]);
+
+    Ok(
+        SuccessHint::new(format!("{}{}{}", header, body, external_action), hints)
+            .to_mcp_result_with_data(Some(json!({
+                "query": query,
+                "scope": scope,
+                "availability": availability,
+                "forceVerify": force_verify,
+                "offset": offset,
+                "limit": limit,
+                "totalResults": total_results,
+                "totalTools": total_tools,
+                "totalServerRows": total_server_rows,
+                "results": structured_results,
+                "externalServers": external_servers,
+            }))),
+    )
 }

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -103,24 +103,43 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
         .to_mcp_result());
     }
 
-    if let Ok(Some(_)) = get_server_config(&name).await {
-        return Ok(guided_error(
-            ErrorCategory::DuplicateResource,
-            format!("Server name '{}' already exists", name),
-            ToolGroup::Tool,
-        )
-        .with_guidance(vec![
-            format!(
-                "Use update(name=\"{}\", transport=...) to change the existing server configuration",
-                name
-            ),
-            format!(
-                "Use list(query=\"{}\") to inspect the existing server before modifying it",
-                name
-            ),
-            "Choose a different unique name if you want to register a separate server".to_string(),
-        ])
-        .to_mcp_result());
+    match get_server_config(&name).await {
+        Ok(Some(_)) => {
+            return Ok(guided_error(
+                ErrorCategory::DuplicateResource,
+                format!("Server name '{}' already exists", name),
+                ToolGroup::Tool,
+            )
+            .with_guidance(vec![
+                format!(
+                    "Use update(name=\"{}\", transport=...) to change the existing server configuration",
+                    name
+                ),
+                format!(
+                    "Use list(query=\"{}\") to inspect the existing server before modifying it",
+                    name
+                ),
+                "Choose a different unique name if you want to register a separate server"
+                    .to_string(),
+            ])
+            .to_mcp_result());
+        }
+        Ok(None) => {}
+        Err(error) => {
+            return Ok(guided_error(
+                ErrorCategory::DatabaseError,
+                format!(
+                    "Failed to check whether server '{}' already exists: {}",
+                    name, error
+                ),
+                ToolGroup::Tool,
+            )
+            .with_guidance(vec![
+                "The server registry could not be queried, so registration was aborted to avoid mutating an existing server by mistake".to_string(),
+                "Retry the operation after the database/service issue is resolved".to_string(),
+            ])
+            .to_mcp_result());
+        }
     }
 
     let transport_val = match args.get("transport") {

--- a/src-tauri/tests/agent_delegation_access_tests.rs
+++ b/src-tauri/tests/agent_delegation_access_tests.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::is_delegated_descendant_session;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+
+fn session(id: &str, parent_session_id: Option<&str>) -> SessionMetadata {
+    SessionMetadata {
+        id: id.to_string(),
+        name: Some(id.to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: parent_session_id.map(str::to_string),
+        lineage_id: Some("root".to_string()),
+        depth: Some(match parent_session_id {
+            None => 0,
+            Some("root") => 1,
+            _ => 2,
+        }),
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: 0,
+        updated_at: 0,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[test]
+fn descendant_access_allows_nested_child_sessions() {
+    let sessions = HashMap::from([
+        ("root".to_string(), session("root", None)),
+        ("child-a".to_string(), session("child-a", Some("root"))),
+        (
+            "grandchild-a1".to_string(),
+            session("grandchild-a1", Some("child-a")),
+        ),
+    ]);
+
+    assert!(is_delegated_descendant_session(
+        &sessions,
+        "root",
+        "grandchild-a1"
+    ));
+    assert!(is_delegated_descendant_session(
+        &sessions,
+        "child-a",
+        "grandchild-a1"
+    ));
+}
+
+#[test]
+fn descendant_access_rejects_self_and_sibling_sessions() {
+    let sessions = HashMap::from([
+        ("root".to_string(), session("root", None)),
+        ("child-a".to_string(), session("child-a", Some("root"))),
+        ("child-b".to_string(), session("child-b", Some("root"))),
+    ]);
+
+    assert!(!is_delegated_descendant_session(
+        &sessions, "child-a", "child-a"
+    ));
+    assert!(!is_delegated_descendant_session(
+        &sessions, "child-a", "child-b"
+    ));
+    assert!(!is_delegated_descendant_session(
+        &sessions, "child-b", "child-a"
+    ));
+}

--- a/src-tauri/tests/tool_contract_tests.rs
+++ b/src-tauri/tests/tool_contract_tests.rs
@@ -1,0 +1,189 @@
+mod common;
+
+use migration::MigratorTrait;
+use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
+use serde_json::{json, Value};
+use std::str::FromStr;
+use tauri_mcp_agent_lib::mcp::builtin::tool::ToolServer;
+use tauri_mcp_agent_lib::mcp::builtin::BuiltinMCPServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::migration::Migrator;
+use tauri_mcp_agent_lib::repositories::{MCPServerRepository, SqliteMCPServerRepository};
+use tauri_mcp_agent_lib::set_mcp_server_repository;
+use tauri_mcp_agent_lib::utils::sqlite::format_sqlite_url;
+use tempfile::TempDir;
+use tokio::sync::OnceCell;
+
+struct TestContext {
+    _temp_dir: TempDir,
+    _db: DatabaseConnection,
+    repo: SqliteMCPServerRepository,
+}
+
+static TEST_CONTEXT: OnceCell<TestContext> = OnceCell::const_new();
+
+async fn repo() -> SqliteMCPServerRepository {
+    TEST_CONTEXT
+        .get_or_init(|| async {
+            common::register_sqlite_vec();
+            let temp_dir = tempfile::tempdir().expect("temp dir should create");
+            let db_path = temp_dir.path().join("tool-contract-tests.db");
+            let url = format_sqlite_url(&db_path.to_string_lossy());
+            let options = SqliteConnectOptions::from_str(&url)
+                .expect("sqlite url should be valid")
+                .create_if_missing(true);
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(options)
+                .await
+                .expect("sqlite pool should connect");
+            let db = SqlxSqliteConnector::from_sqlx_sqlite_pool(pool);
+            Migrator::up(&db, None)
+                .await
+                .expect("migrations should run");
+            let repo = SqliteMCPServerRepository::new(db.clone());
+            set_mcp_server_repository(repo.clone());
+            TestContext {
+                _temp_dir: temp_dir,
+                _db: db,
+                repo,
+            }
+        })
+        .await
+        .repo
+        .clone()
+}
+
+fn extract_text(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn register_rejects_duplicate_server_names_without_mutating_existing_config() {
+    let repo = repo().await;
+    let server = ToolServer::new();
+
+    let existing = repo
+        .create(
+            "github-duplicate-check",
+            json!({
+                "name": "github-duplicate-check",
+                "transport": {
+                    "type": "http",
+                    "url": "https://example.com/original"
+                }
+            }),
+        )
+        .await
+        .expect("existing server should insert");
+
+    let result = server
+        .call_tool(
+            "register",
+            json!({
+                "name": "github-duplicate-check",
+                "description": "Replacement config that should be rejected",
+                "transport": {
+                    "type": "http",
+                    "url": "https://127.0.0.1:1/should-not-run"
+                }
+            }),
+            None,
+        )
+        .await
+        .expect("register should return an MCP result");
+
+    let text = extract_text(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(text.contains("already exists"));
+    assert!(text.contains("update(name=\"github-duplicate-check\""));
+
+    let reloaded = repo
+        .get(&existing.id)
+        .await
+        .expect("existing server should reload")
+        .expect("existing server should still exist");
+    let config: Value =
+        serde_json::from_str(&reloaded.config).expect("stored config should remain valid JSON");
+    assert_eq!(
+        config["transport"]["url"].as_str(),
+        Some("https://example.com/original")
+    );
+}
+
+#[tokio::test]
+async fn list_returns_structured_results_for_ui_consumers() {
+    let repo = repo().await;
+    let server = ToolServer::new();
+
+    let created = repo
+        .create(
+            "github-structured-list",
+            json!({
+                "name": "github-structured-list",
+                "transport": {
+                    "type": "http",
+                    "url": "https://example.com/mcp"
+                }
+            }),
+        )
+        .await
+        .expect("server should insert");
+
+    repo.update_cached_tools(
+        &created.id,
+        1,
+        json!([
+            {
+                "name": "search_issues",
+                "description": "Search repository issues"
+            }
+        ])
+        .to_string(),
+    )
+    .await
+    .expect("cached tools should update");
+
+    let result = server
+        .call_tool(
+            "list",
+            json!({
+                "query": "search_issues",
+                "scope": "external",
+                "availability": "inventory"
+            }),
+            None,
+        )
+        .await
+        .expect("list should return an MCP result");
+
+    let structured = result
+        .structured_content
+        .clone()
+        .expect("structured content should be present");
+    let results = structured["results"]
+        .as_array()
+        .expect("results should be an array");
+    let external_servers = structured["externalServers"]
+        .as_array()
+        .expect("externalServers should be an array");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["name"].as_str(), Some("search_issues"));
+    assert_eq!(structured["totalResults"].as_u64(), Some(1));
+    assert!(external_servers.iter().any(|entry| {
+        entry["id"].as_str() == Some(created.id.as_str())
+            && entry["name"].as_str() == Some("github-structured-list")
+    }));
+}

--- a/src-tauri/tests/tool_contract_tests.rs
+++ b/src-tauri/tests/tool_contract_tests.rs
@@ -2,7 +2,9 @@ mod common;
 
 use migration::MigratorTrait;
 use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseConnection, SqlxSqliteConnector, Statement,
+};
 use serde_json::{json, Value};
 use std::str::FromStr;
 use tauri_mcp_agent_lib::mcp::builtin::tool::ToolServer;
@@ -17,7 +19,7 @@ use tokio::sync::OnceCell;
 
 struct TestContext {
     _temp_dir: TempDir,
-    _db: DatabaseConnection,
+    db: DatabaseConnection,
     repo: SqliteMCPServerRepository,
 }
 
@@ -46,12 +48,20 @@ async fn repo() -> SqliteMCPServerRepository {
             set_mcp_server_repository(repo.clone());
             TestContext {
                 _temp_dir: temp_dir,
-                _db: db,
+                db,
                 repo,
             }
         })
         .await
         .repo
+        .clone()
+}
+
+async fn db() -> DatabaseConnection {
+    TEST_CONTEXT
+        .get()
+        .expect("test context should be initialized")
+        .db
         .clone()
 }
 
@@ -120,6 +130,65 @@ async fn register_rejects_duplicate_server_names_without_mutating_existing_confi
         config["transport"]["url"].as_str(),
         Some("https://example.com/original")
     );
+}
+
+#[tokio::test]
+async fn register_aborts_when_existing_server_config_cannot_be_loaded() {
+    let repo = repo().await;
+    let db = db().await;
+    let server = ToolServer::new();
+
+    let existing = repo
+        .create(
+            "github-broken-config-check",
+            json!({
+                "name": "github-broken-config-check",
+                "transport": {
+                    "type": "http",
+                    "url": "https://example.com/original"
+                }
+            }),
+        )
+        .await
+        .expect("existing server should insert");
+
+    db.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
+        "UPDATE mcp_servers SET config = ? WHERE id = ?",
+        ["{".into(), existing.id.clone().into()],
+    ))
+    .await
+    .expect("test setup should corrupt existing config");
+
+    let result = server
+        .call_tool(
+            "register",
+            json!({
+                "name": "github-broken-config-check",
+                "description": "Replacement config that should be rejected on lookup error",
+                "transport": {
+                    "type": "http",
+                    "url": "https://127.0.0.1:1/should-not-run"
+                }
+            }),
+            None,
+        )
+        .await
+        .expect("register should return an MCP result");
+
+    let text = extract_text(&result);
+    assert_eq!(result.is_error, Some(false));
+    assert!(
+        text.contains("Failed to check whether server 'github-broken-config-check' already exists")
+    );
+    assert!(text.contains("registration was aborted"));
+
+    let reloaded = repo
+        .get(&existing.id)
+        .await
+        .expect("existing server should reload")
+        .expect("existing server should still exist");
+    assert_eq!(reloaded.config, "{");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- enforce descendant-only access for delegated session control tools
- make tool register reject duplicate server names instead of mutating existing configs
- return structured payloads from tool list and add regression coverage

## Testing
- pnpm refactor:validate