### PR TITLE
fix(agent): harden preflight overflow recovery

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3786,7 +3786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -12,7 +12,7 @@ pub use context::{
 };
 pub use request::{
     build_compact_context_selection_options, build_compact_summary_text,
-    merge_consecutive_user_messages, request_llm_completion,
+    merge_consecutive_user_messages, request_llm_completion, resolve_preserved_calibration_ratio,
 };
 
 // Crate-internal re-exports for intra-module visibility

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -731,13 +731,21 @@ pub async fn request_llm_completion(
             );
 
         if conservative_preflight_tokens >= safe_input_token_limit {
+            let selected_message_breakdown =
+                crate::agent::llm::token_utils::summarize_message_token_breakdown(&final_messages);
             log::info!(
-                "⛔ Rust preflight blocked LLM request: session={}, conservative_prompt_tokens={}, safe_input_token_limit={}, compact_summary_injected={}, selected_message_count={}",
+                "⛔ Rust preflight blocked LLM request: session={}, conservative_prompt_tokens={}, safe_input_token_limit={}, compact_summary_injected={}, selected_message_count={}, system_prompt_tokens={}, tools_tokens={}, preserved_calibration_ratio={}, selected_breakdown=[{}]",
                 session_id,
                 conservative_preflight_tokens,
                 safe_input_token_limit,
                 compact_summary_injected,
-                final_messages.len()
+                final_messages.len(),
+                system_prompt_tokens,
+                tools_tokens,
+                preserved_calibration_ratio
+                    .map(|ratio| format!("{:.4}", ratio))
+                    .unwrap_or_else(|| "none".to_string()),
+                selected_message_breakdown
             );
 
             if trigger_preflight_compaction_or_error(active_sessions, app_handle, &session_id)
@@ -761,6 +769,10 @@ pub async fn request_llm_completion(
                     "safeInputTokenLimit": safe_input_token_limit,
                     "compactSummaryInjected": compact_summary_injected,
                     "selectedMessageCount": final_messages.len(),
+                    "systemPromptTokens": system_prompt_tokens,
+                    "toolsTokens": tools_tokens,
+                    "preservedCalibrationRatio": preserved_calibration_ratio,
+                    "selectedBreakdown": selected_message_breakdown,
                 })),
             );
         }

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -59,6 +59,26 @@ pub fn build_compact_context_selection_options(
     }
 }
 
+pub fn resolve_preserved_calibration_ratio(
+    raw_messages: &[Message],
+    prompt_messages: &[Message],
+    system_prompt_tokens: usize,
+    tools_tokens: usize,
+) -> Option<f64> {
+    crate::agent::llm::token_utils::try_derive_bpe_calibration_ratio(
+        prompt_messages,
+        system_prompt_tokens,
+        tools_tokens,
+    )
+    .or_else(|| {
+        crate::agent::llm::token_utils::try_derive_bpe_calibration_ratio(
+            raw_messages,
+            system_prompt_tokens,
+            tools_tokens,
+        )
+    })
+}
+
 pub fn build_compact_summary_message(session_id: &str, text: String, created_at: i64) -> Message {
     Message {
         id: format!("compact-summary-{}", session_id),
@@ -498,12 +518,7 @@ pub async fn request_llm_completion(
         .as_ref()
         .map(|json| crate::agent::llm::token_utils::estimate_text_tokens(json))
         .unwrap_or(0);
-    let preserved_calibration_ratio =
-        crate::agent::llm::token_utils::try_derive_bpe_calibration_ratio(
-            &messages,
-            system_prompt_tokens,
-            tools_tokens,
-        );
+    let raw_messages = messages.clone();
 
     // --- Step A: Inject compact summary (if a valid record is cached) ---
     // Clone Arc refs while holding the outer read lock, then release it immediately.
@@ -585,6 +600,12 @@ pub async fn request_llm_completion(
             (messages, false)
         }
     };
+    let preserved_calibration_ratio = resolve_preserved_calibration_ratio(
+        &raw_messages,
+        &messages,
+        system_prompt_tokens,
+        tools_tokens,
+    );
 
     log::info!(
         "🧱 Prompt prefix composition: session={}, compact_summary_injected={}, message_count={}, preserved_calibration_ratio={}",

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -43,6 +43,7 @@ pub fn build_compact_context_selection_options(
     tools_json: Option<String>,
     provider: &str,
     tool_call_group_visible_count: usize,
+    fallback_calibration_ratio: Option<f64>,
 ) -> crate::agent::llm::context_selector::SelectionOptions {
     crate::agent::llm::context_selector::SelectionOptions {
         system_prompt,
@@ -54,6 +55,7 @@ pub fn build_compact_context_selection_options(
             tool_call_group_visible_count
         }),
         pin_first_user_message: false,
+        fallback_calibration_ratio,
     }
 }
 
@@ -479,6 +481,29 @@ pub async fn request_llm_completion(
     let max_input_context = context_settings.max_input_context;
     let tool_call_group_visible_count = context_settings.tool_call_group_visible_count;
     let model_max_limit = context_settings.model_max_limit;
+    let tools_json = available_tools
+        .as_ref()
+        .map(|tools| serde_json::to_string(tools).unwrap_or_default());
+    let combined_system_prompt = match (&system_prompt, &session_context) {
+        (Some(sp), Some(sc)) => Some(format!("{}\n\n{}", sp, sc)),
+        (Some(sp), None) => Some(sp.clone()),
+        (None, Some(sc)) => Some(sc.clone()),
+        (None, None) => None,
+    };
+    let system_prompt_tokens = combined_system_prompt
+        .as_ref()
+        .map(|prompt| crate::agent::llm::token_utils::estimate_text_tokens(prompt))
+        .unwrap_or(0);
+    let tools_tokens = tools_json
+        .as_ref()
+        .map(|json| crate::agent::llm::token_utils::estimate_text_tokens(json))
+        .unwrap_or(0);
+    let preserved_calibration_ratio =
+        crate::agent::llm::token_utils::try_derive_bpe_calibration_ratio(
+            &messages,
+            system_prompt_tokens,
+            tools_tokens,
+        );
 
     // --- Step A: Inject compact summary (if a valid record is cached) ---
     // Clone Arc refs while holding the outer read lock, then release it immediately.
@@ -562,22 +587,16 @@ pub async fn request_llm_completion(
     };
 
     log::info!(
-        "🧱 Prompt prefix composition: session={}, compact_summary_injected={}, message_count={}",
+        "🧱 Prompt prefix composition: session={}, compact_summary_injected={}, message_count={}, preserved_calibration_ratio={}",
         session_id,
         compact_summary_injected,
-        messages.len()
+        messages.len(),
+        preserved_calibration_ratio
+            .map(|ratio| format!("{:.4}", ratio))
+            .unwrap_or_else(|| "none".to_string())
     );
 
     let mut final_messages = messages.clone();
-    let tools_json = available_tools
-        .as_ref()
-        .map(|tools| serde_json::to_string(tools).unwrap_or_default());
-    let combined_system_prompt = match (&system_prompt, &session_context) {
-        (Some(sp), Some(sc)) => Some(format!("{}\n\n{}", sp, sc)),
-        (Some(sp), None) => Some(sp.clone()),
-        (None, Some(sc)) => Some(sc.clone()),
-        (None, None) => None,
-    };
 
     if uses_compaction_strategy(&context_strategy) {
         let safe_input_token_limit = std::cmp::min(max_input_context, model_max_limit);
@@ -586,6 +605,7 @@ pub async fn request_llm_completion(
             tools_json.clone(),
             &provider,
             tool_call_group_visible_count,
+            preserved_calibration_ratio,
         );
 
         final_messages = crate::agent::llm::context_selector::select_messages_within_context(
@@ -647,19 +667,46 @@ pub async fn request_llm_completion(
 
     if uses_compaction_strategy(&context_strategy) {
         let safe_input_token_limit = std::cmp::min(max_input_context, model_max_limit);
-        let system_prompt_tokens = combined_system_prompt
-            .as_ref()
-            .map(|prompt| crate::agent::llm::token_utils::estimate_text_tokens(prompt))
-            .unwrap_or(0);
-        let tools_tokens = tools_json
-            .as_ref()
-            .map(|json| crate::agent::llm::token_utils::estimate_text_tokens(json))
-            .unwrap_or(0);
+        final_messages =
+            crate::agent::llm::context_selector::trim_messages_to_fit_conservative_limit(
+                &final_messages,
+                &provider,
+                safe_input_token_limit,
+                system_prompt_tokens,
+                tools_tokens,
+                preserved_calibration_ratio,
+            );
+
+        final_messages = crate::agent::llm::context_selector::truncate_single_oversized_message_to_fit_conservative_limit(
+            &final_messages,
+            safe_input_token_limit,
+            system_prompt_tokens,
+            tools_tokens,
+            preserved_calibration_ratio,
+        );
+
+        if final_messages.is_empty() {
+            if trigger_preflight_compaction_or_error(active_sessions, app_handle, &session_id)
+                .await?
+            {
+                return Ok(());
+            }
+
+            return Err(
+                AgentRuntimeError::new(
+                    AgentRuntimeErrorType::EmptySelectionError,
+                    "No messages fit within the effective context window after overflow trimming. Increase the context limit or reduce the newest message size and retry.",
+                )
+                .with_code("EMPTY_MESSAGE_SELECTION"),
+            );
+        }
+
         let conservative_preflight_tokens =
             crate::agent::llm::token_utils::calculate_conservative_preflight_prompt_tokens(
                 &final_messages,
                 system_prompt_tokens,
                 tools_tokens,
+                preserved_calibration_ratio,
             );
 
         if conservative_preflight_tokens >= safe_input_token_limit {
@@ -682,7 +729,7 @@ pub async fn request_llm_completion(
                 AgentRuntimeError::new(
                     AgentRuntimeErrorType::ContextLimitError,
                     format!(
-                        "Prepared payload exceeds the effective context limit before send ({} >= {} conservative tokens).",
+                        "Prepared payload exceeds the effective context limit before send ({} >= {} conservative tokens). Compaction/overflow trimming could not shrink the remaining message further.",
                         conservative_preflight_tokens, safe_input_token_limit
                     ),
                 )

--- a/src-tauri/src/agent/llm/context_selector.rs
+++ b/src-tauri/src/agent/llm/context_selector.rs
@@ -499,8 +499,7 @@ fn can_truncate_message_for_context_fit(message: &Message) -> bool {
 }
 
 fn truncate_text_middle(text: &str, keep_ratio: f64) -> Option<String> {
-    let chars: Vec<char> = text.chars().collect();
-    let total_chars = chars.len();
+    let total_chars = text.chars().count();
     let notice_chars = CONTEXT_FIT_TRUNCATION_NOTICE.chars().count();
     let requested_chars = ((total_chars as f64) * keep_ratio).floor() as usize;
     let min_visible_chars = MIN_CONTEXT_FIT_SIDE_CHARS.saturating_mul(2);
@@ -512,11 +511,23 @@ fn truncate_text_middle(text: &str, keep_ratio: f64) -> Option<String> {
 
     let head_chars = visible_chars / 2;
     let tail_chars = visible_chars.saturating_sub(head_chars);
-    let head: String = chars.iter().take(head_chars).collect();
-    let tail_start = total_chars.saturating_sub(tail_chars);
-    let tail: String = chars.iter().skip(tail_start).collect();
+    let head_end = byte_index_after_n_chars(text, head_chars);
+    let tail_start = byte_index_after_n_chars(text, total_chars.saturating_sub(tail_chars));
+    let head = &text[..head_end];
+    let tail = &text[tail_start..];
 
     Some(format!("{}{}{}", head, CONTEXT_FIT_TRUNCATION_NOTICE, tail))
+}
+
+fn byte_index_after_n_chars(text: &str, char_count: usize) -> usize {
+    if char_count == 0 {
+        return 0;
+    }
+
+    text.char_indices()
+        .nth(char_count)
+        .map(|(index, _)| index)
+        .unwrap_or(text.len())
 }
 
 fn truncate_message_for_context_fit(message: &Message, keep_ratio: f64) -> Option<Message> {

--- a/src-tauri/src/agent/llm/context_selector.rs
+++ b/src-tauri/src/agent/llm/context_selector.rs
@@ -583,6 +583,8 @@ pub fn truncate_single_oversized_message_to_fit_conservative_limit(
             continue;
         };
         let candidate_messages = vec![candidate];
+        let original_bpe = token_utils::estimate_tokens_bpe(original_message);
+        let candidate_bpe = token_utils::estimate_tokens_bpe(&candidate_messages[0]);
         let conservative_total = token_utils::calculate_conservative_preflight_prompt_tokens(
             &candidate_messages,
             system_prompt_tokens,
@@ -591,9 +593,11 @@ pub fn truncate_single_oversized_message_to_fit_conservative_limit(
         );
 
         log::info!(
-            "✂️ Truncated oversized single message for context fit: role={}, keep_ratio={:.2}, conservative_total={}, limit={}",
+            "✂️ Truncated oversized single message for context fit: role={}, keep_ratio={:.2}, original_bpe={}, candidate_bpe={}, conservative_total={}, limit={}",
             original_message.role,
             keep_ratio,
+            original_bpe,
+            candidate_bpe,
             conservative_total,
             safe_input_token_limit
         );

--- a/src-tauri/src/agent/llm/context_selector.rs
+++ b/src-tauri/src/agent/llm/context_selector.rs
@@ -14,6 +14,7 @@ pub struct SelectionOptions {
     pub max_messages: Option<usize>,
     pub max_tool_calls_per_message: Option<usize>,
     pub pin_first_user_message: bool,
+    pub fallback_calibration_ratio: Option<f64>,
 }
 
 impl Default for SelectionOptions {
@@ -24,6 +25,7 @@ impl Default for SelectionOptions {
             max_messages: None,
             max_tool_calls_per_message: None,
             pin_first_user_message: true,
+            fallback_calibration_ratio: None,
         }
     }
 }
@@ -32,6 +34,26 @@ impl Default for SelectionOptions {
 #[derive(Debug)]
 pub struct SelectedContext {
     pub messages: Vec<Message>,
+}
+
+const CONTEXT_FIT_TRUNCATION_NOTICE: &str = "\n\n...[truncated for context fit]...\n\n";
+const CONTEXT_FIT_TRUNCATION_SCALES: [f64; 6] = [0.5, 0.35, 0.25, 0.15, 0.1, 0.05];
+const MIN_CONTEXT_FIT_SIDE_CHARS: usize = 48;
+
+fn provider_requires_tool_chain_cleanup(provider_id: &str) -> bool {
+    ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
+}
+
+fn resolve_calibration_ratio(
+    messages: &[Message],
+    system_prompt_tokens: usize,
+    tools_tokens: usize,
+    fallback_calibration_ratio: Option<f64>,
+) -> f64 {
+    token_utils::try_derive_bpe_calibration_ratio(messages, system_prompt_tokens, tools_tokens)
+        .or(fallback_calibration_ratio)
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0)
+        .unwrap_or(1.0)
 }
 
 /// Calculates the split index for compaction.
@@ -307,6 +329,7 @@ pub fn select_messages_within_context(
     let max_tool_calls = options
         .and_then(|o| o.max_tool_calls_per_message)
         .unwrap_or(4);
+    let fallback_calibration_ratio = options.and_then(|o| o.fallback_calibration_ratio);
     let batched_messages = batch_tool_calls_in_messages(messages, max_tool_calls);
 
     let context_window = model_info.map(|m| m.context_window).unwrap_or(128_000);
@@ -342,10 +365,11 @@ pub fn select_messages_within_context(
         }
     }
 
-    let calibration_ratio = token_utils::derive_bpe_calibration_ratio(
+    let calibration_ratio = resolve_calibration_ratio(
         &batched_messages,
         system_prompt_tokens,
         tools_tokens,
+        fallback_calibration_ratio,
     );
 
     log::debug!(
@@ -373,7 +397,7 @@ pub fn select_messages_within_context(
         let calibrated_tokens = (tokens as f64 * calibration_ratio).ceil() as usize;
 
         if total_tokens + calibrated_tokens > token_limit {
-            if ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id) {
+            if provider_requires_tool_chain_cleanup(provider_id) {
                 let adjusted = remove_incomplete_tool_chains(Vec::from(selected));
                 return build_selected_with_optional_pinned(
                     pinned_message.clone(),
@@ -396,7 +420,7 @@ pub fn select_messages_within_context(
                 if selected.is_empty() {
                     selected.push_front(msg.clone());
                 }
-                if ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id) {
+                if provider_requires_tool_chain_cleanup(provider_id) {
                     let adjusted = remove_incomplete_tool_chains(Vec::from(selected));
                     return build_selected_with_optional_pinned(
                         pinned_message.clone(),
@@ -414,8 +438,7 @@ pub fn select_messages_within_context(
     }
 
     let final_selected = Vec::from(selected);
-    let adjusted = if ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
-    {
+    let adjusted = if provider_requires_tool_chain_cleanup(provider_id) {
         remove_incomplete_tool_chains(final_selected)
     } else {
         final_selected
@@ -427,6 +450,150 @@ pub fn select_messages_within_context(
         pinned_message_budget,
         adjusted,
     )
+}
+
+pub fn trim_messages_to_fit_conservative_limit(
+    messages: &[Message],
+    provider_id: &str,
+    safe_input_token_limit: usize,
+    system_prompt_tokens: usize,
+    tools_tokens: usize,
+    fallback_calibration_ratio: Option<f64>,
+) -> Vec<Message> {
+    let mut trimmed = messages.to_vec();
+
+    while !trimmed.is_empty() {
+        let conservative_total = token_utils::calculate_conservative_preflight_prompt_tokens(
+            &trimmed,
+            system_prompt_tokens,
+            tools_tokens,
+            fallback_calibration_ratio,
+        );
+
+        if conservative_total < safe_input_token_limit {
+            break;
+        }
+
+        if trimmed.len() == 1 {
+            break;
+        }
+
+        trimmed.remove(0);
+
+        if provider_requires_tool_chain_cleanup(provider_id) {
+            trimmed = remove_incomplete_tool_chains(trimmed);
+        }
+    }
+
+    trimmed
+}
+
+fn can_truncate_message_for_context_fit(message: &Message) -> bool {
+    matches!(message.role.as_str(), "user" | "tool")
+        && message.content.iter().any(|part| {
+            matches!(
+                part,
+                crate::mcp::types::MCPContent::Text { text, .. } if !text.trim().is_empty()
+            )
+        })
+}
+
+fn truncate_text_middle(text: &str, keep_ratio: f64) -> Option<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let total_chars = chars.len();
+    let notice_chars = CONTEXT_FIT_TRUNCATION_NOTICE.chars().count();
+    let requested_chars = ((total_chars as f64) * keep_ratio).floor() as usize;
+    let min_visible_chars = MIN_CONTEXT_FIT_SIDE_CHARS.saturating_mul(2);
+    let visible_chars = requested_chars.max(min_visible_chars).min(total_chars);
+
+    if total_chars <= visible_chars.saturating_add(notice_chars) {
+        return None;
+    }
+
+    let head_chars = visible_chars / 2;
+    let tail_chars = visible_chars.saturating_sub(head_chars);
+    let head: String = chars.iter().take(head_chars).collect();
+    let tail_start = total_chars.saturating_sub(tail_chars);
+    let tail: String = chars.iter().skip(tail_start).collect();
+
+    Some(format!("{}{}{}", head, CONTEXT_FIT_TRUNCATION_NOTICE, tail))
+}
+
+fn truncate_message_for_context_fit(message: &Message, keep_ratio: f64) -> Option<Message> {
+    if !can_truncate_message_for_context_fit(message) {
+        return None;
+    }
+
+    let mut truncated_message = message.clone();
+    let mut changed = false;
+
+    truncated_message.content = message
+        .content
+        .iter()
+        .map(|part| match part {
+            crate::mcp::types::MCPContent::Text { text, is_error } => {
+                if let Some(truncated_text) = truncate_text_middle(text, keep_ratio) {
+                    changed = true;
+                    crate::mcp::types::MCPContent::Text {
+                        text: truncated_text,
+                        is_error: *is_error,
+                    }
+                } else {
+                    part.clone()
+                }
+            }
+            _ => part.clone(),
+        })
+        .collect();
+
+    changed.then_some(truncated_message)
+}
+
+pub fn truncate_single_oversized_message_to_fit_conservative_limit(
+    messages: &[Message],
+    safe_input_token_limit: usize,
+    system_prompt_tokens: usize,
+    tools_tokens: usize,
+    fallback_calibration_ratio: Option<f64>,
+) -> Vec<Message> {
+    if messages.len() != 1 {
+        return messages.to_vec();
+    }
+
+    let original_message = &messages[0];
+    if !can_truncate_message_for_context_fit(original_message) {
+        return messages.to_vec();
+    }
+
+    let mut best_candidate = messages.to_vec();
+
+    for keep_ratio in CONTEXT_FIT_TRUNCATION_SCALES {
+        let Some(candidate) = truncate_message_for_context_fit(original_message, keep_ratio) else {
+            continue;
+        };
+        let candidate_messages = vec![candidate];
+        let conservative_total = token_utils::calculate_conservative_preflight_prompt_tokens(
+            &candidate_messages,
+            system_prompt_tokens,
+            tools_tokens,
+            fallback_calibration_ratio,
+        );
+
+        log::info!(
+            "✂️ Truncated oversized single message for context fit: role={}, keep_ratio={:.2}, conservative_total={}, limit={}",
+            original_message.role,
+            keep_ratio,
+            conservative_total,
+            safe_input_token_limit
+        );
+
+        best_candidate = candidate_messages;
+        if conservative_total < safe_input_token_limit {
+            break;
+        }
+    }
+
+    best_candidate
 }
 
 fn prepend_pinned_message(pinned_msg: Message, mut selected_msgs: Vec<Message>) -> Vec<Message> {

--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -85,6 +85,33 @@ async fn defer_for_post_response_compaction_if_needed(
     .await
 }
 
+pub fn validate_expected_response_id(
+    session_id: &str,
+    expected_response_id: Option<&str>,
+    received_message_id: &str,
+) -> Result<(), String> {
+    let Some(expected_response_id) = expected_response_id else {
+        log::info!(
+            "Ignoring stray LLM response for session {} (received_message_id={}, expected_response_id=<none>)",
+            session_id,
+            received_message_id
+        );
+        return Err("LLM response superseded".to_string());
+    };
+
+    if received_message_id != expected_response_id {
+        log::info!(
+            "Ignoring superseded LLM response for session {} (expected_response_id={}, received_message_id={})",
+            session_id,
+            expected_response_id,
+            received_message_id
+        );
+        return Err("LLM response superseded".to_string());
+    }
+
+    Ok(())
+}
+
 /// Handle an LLM response from the frontend
 pub async fn handle_llm_response(
     session_repo: &Arc<dyn SessionRepository>,
@@ -166,9 +193,12 @@ pub async fn handle_llm_response(
         let sessions = active_sessions.read().await;
         if let Some(session) = sessions.get(&session_id) {
             let mut expected_id = session.expected_response_id.write().await;
-            if let Some(id) = expected_id.take() {
-                assistant_message.id = id;
-            }
+            validate_expected_response_id(
+                &session_id,
+                expected_id.as_deref(),
+                &assistant_message.id,
+            )?;
+            expected_id.take();
         }
     }
 

--- a/src-tauri/src/agent/llm/token_utils.rs
+++ b/src-tauri/src/agent/llm/token_utils.rs
@@ -40,6 +40,12 @@ pub fn calculate_context_safety_margin(effective_limit: usize) -> usize {
 }
 
 const CONSERVATIVE_DELTA_SAFETY_MULTIPLIER: f64 = 1.05;
+// Cross-tokenizer providers like Gemini can legitimately report promptTokens
+// around ~0.63 of the equivalent cl100k_base estimate, so the acceptance band
+// must stay wide enough to preserve those grounded anchors.
+pub const PROMPT_ANCHOR_RATIO_MIN: f64 = 0.50;
+pub const PROMPT_ANCHOR_RATIO_MAX: f64 = 1.50;
+const MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE: usize = 2_048;
 
 fn usage_metric_as_usize(usage: &serde_json::Value, key: &str) -> Option<usize> {
     usage
@@ -77,20 +83,84 @@ fn get_prompt_anchor_ratio(
     system_prompt_tokens: usize,
     tools_tokens: usize,
 ) -> Option<(usize, usize, f64)> {
-    let (anchor_index, prompt_tokens) =
-        find_latest_assistant_usage_anchor(messages, "promptTokens")?;
-    let bpe_input: usize = messages[..anchor_index]
-        .iter()
-        .map(estimate_tokens_bpe)
-        .sum::<usize>()
-        + system_prompt_tokens
-        + tools_tokens;
-    let ratio = if bpe_input > 0 {
-        prompt_tokens as f64 / bpe_input as f64
-    } else {
-        1.0
-    };
-    Some((anchor_index, prompt_tokens, ratio))
+    for (anchor_index, anchor_message) in messages.iter().enumerate().rev() {
+        if anchor_message.role != "assistant" {
+            continue;
+        }
+
+        let Some(usage) = anchor_message.usage.as_ref() else {
+            continue;
+        };
+        let Some(prompt_tokens) = usage_metric_as_usize(usage, "promptTokens") else {
+            continue;
+        };
+        if prompt_tokens == 0 {
+            continue;
+        }
+
+        let prefix_messages = &messages[..anchor_index];
+        let prefix_message_bpe = prefix_messages
+            .iter()
+            .map(estimate_tokens_bpe)
+            .sum::<usize>();
+        let bpe_input = prefix_message_bpe + system_prompt_tokens + tools_tokens;
+        let ratio = if bpe_input > 0 {
+            prompt_tokens as f64 / bpe_input as f64
+        } else {
+            1.0
+        };
+        let message_breakdown = summarize_message_token_breakdown(prefix_messages);
+        log::debug!(
+            "promptTokens anchor ratio: anchor_index={}, anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
+            anchor_index,
+            anchor_message.id,
+            anchor_message.role,
+            prompt_tokens,
+            prefix_message_bpe,
+            system_prompt_tokens,
+            tools_tokens,
+            bpe_input,
+            ratio,
+            message_breakdown
+        );
+
+        if prefix_message_bpe < MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE {
+            log::warn!(
+                "Rejecting promptTokens anchor with insufficient message prefix: anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, minimum_prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
+                anchor_message.id,
+                anchor_message.role,
+                prompt_tokens,
+                prefix_message_bpe,
+                MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE,
+                system_prompt_tokens,
+                tools_tokens,
+                bpe_input,
+                ratio,
+                message_breakdown
+            );
+            continue;
+        }
+
+        if !(PROMPT_ANCHOR_RATIO_MIN..=PROMPT_ANCHOR_RATIO_MAX).contains(&ratio) {
+            log::warn!(
+                "Suspicious promptTokens calibration ratio: anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
+                anchor_message.id,
+                anchor_message.role,
+                prompt_tokens,
+                prefix_message_bpe,
+                system_prompt_tokens,
+                tools_tokens,
+                bpe_input,
+                ratio,
+                message_breakdown
+            );
+            continue;
+        }
+
+        return Some((anchor_index, prompt_tokens, ratio));
+    }
+
+    None
 }
 
 fn normalize_calibration_ratio(ratio: f64) -> Option<f64> {
@@ -151,6 +221,34 @@ pub fn estimate_tokens_bpe(message: &Message) -> usize {
 
     let text = format!("{}: {}", message.role, parts.join(" "));
     estimate_text_tokens(&text)
+}
+
+pub fn summarize_message_token_breakdown(messages: &[Message]) -> String {
+    if messages.is_empty() {
+        return "none".to_string();
+    }
+
+    messages
+        .iter()
+        .map(|message| {
+            format!(
+                "{}:{}:bpe={}",
+                message.role,
+                shorten_message_id(&message.id),
+                estimate_tokens_bpe(message)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn shorten_message_id(message_id: &str) -> &str {
+    const SHORT_ID_LEN: usize = 12;
+    if message_id.len() <= SHORT_ID_LEN {
+        message_id
+    } else {
+        &message_id[..SHORT_ID_LEN]
+    }
 }
 
 /// Calculates a grounded token estimate by finding the last assistant message with
@@ -329,11 +427,17 @@ pub fn calculate_conservative_preflight_prompt_tokens(
         let conservative_total =
             (calibrated_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
         log::debug!(
-            "conservative preflight fallback (preserved calibration): base={}, ratio={:.4}, calibrated={}, total={}",
+            "conservative preflight fallback (preserved calibration): message_bpe={}, system_prompt_tokens={}, tools_tokens={}, base={}, ratio={:.4}, calibrated={}, total={}, breakdown=[{}]",
+            full_estimate
+                .saturating_sub(system_prompt_tokens)
+                .saturating_sub(tools_tokens),
+            system_prompt_tokens,
+            tools_tokens,
             full_estimate,
             ratio,
             calibrated_estimate,
-            conservative_total
+            conservative_total,
+            summarize_message_token_breakdown(messages)
         );
         return conservative_total;
     }

--- a/src-tauri/src/agent/llm/token_utils.rs
+++ b/src-tauri/src/agent/llm/token_utils.rs
@@ -93,6 +93,14 @@ fn get_prompt_anchor_ratio(
     Some((anchor_index, prompt_tokens, ratio))
 }
 
+fn normalize_calibration_ratio(ratio: f64) -> Option<f64> {
+    if ratio.is_finite() && ratio > 0.0 {
+        Some(ratio)
+    } else {
+        None
+    }
+}
+
 /// Estimates the token count for a given message using BPE or character fallback.
 /// Translates `estimateTokensBPE` from TS.
 pub fn estimate_tokens_bpe(message: &Message) -> usize {
@@ -199,17 +207,25 @@ pub fn calculate_grounded_total_tokens(
 /// swings wildly per turn and would add noise to the ratio.
 ///
 /// Returns 1.0 when no valid anchor exists (no calibration possible on first turn).
+pub fn try_derive_bpe_calibration_ratio(
+    messages: &[Message],
+    system_prompt_tokens: usize,
+    tools_tokens: usize,
+) -> Option<f64> {
+    if let Some((_anchor_index, _prompt_tokens, ratio)) =
+        get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
+    {
+        return normalize_calibration_ratio(ratio);
+    }
+    None
+}
+
 pub fn derive_bpe_calibration_ratio(
     messages: &[Message],
     system_prompt_tokens: usize,
     tools_tokens: usize,
 ) -> f64 {
-    if let Some((_anchor_index, _prompt_tokens, ratio)) =
-        get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
-    {
-        return ratio;
-    }
-    1.0
+    try_derive_bpe_calibration_ratio(messages, system_prompt_tokens, tools_tokens).unwrap_or(1.0)
 }
 
 /// Estimates the current context token count anchored on the API-reported
@@ -283,6 +299,7 @@ pub fn calculate_conservative_preflight_prompt_tokens(
     messages: &[Message],
     system_prompt_tokens: usize,
     tools_tokens: usize,
+    fallback_calibration_ratio: Option<f64>,
 ) -> usize {
     if let Some((anchor_index, prompt_tokens, ratio)) =
         get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
@@ -307,6 +324,20 @@ pub fn calculate_conservative_preflight_prompt_tokens(
     let full_estimate = messages.iter().map(estimate_tokens_bpe).sum::<usize>()
         + system_prompt_tokens
         + tools_tokens;
+    if let Some(ratio) = fallback_calibration_ratio.and_then(normalize_calibration_ratio) {
+        let calibrated_estimate = (full_estimate as f64 * ratio).ceil() as usize;
+        let conservative_total =
+            (calibrated_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
+        log::debug!(
+            "conservative preflight fallback (preserved calibration): base={}, ratio={:.4}, calibrated={}, total={}",
+            full_estimate,
+            ratio,
+            calibrated_estimate,
+            conservative_total
+        );
+        return conservative_total;
+    }
+
     let conservative_total =
         (full_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
     log::debug!(

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -713,17 +713,24 @@ fn test_grounded_total_tokens_keeps_summary_aware_anchor_after_compaction() {
 
 #[test]
 fn test_prompt_anchor_calibration_keeps_summary_aware_anchor_after_compaction() {
-    let summary =
-        make_compact_summary_message("compact-summary-123", "assistant", "Compacted summary");
+    let summary = make_compact_summary_message(
+        "compact-summary-123",
+        "assistant",
+        &"Compacted summary ".repeat(1500),
+    );
 
-    let intro = make_message_simple("user", "Existing tail before grounded response");
-    let mut grounded = make_message_simple("assistant", "Grounded assistant output");
-    grounded.usage = Some(json!({ "promptTokens": 200 }));
+    let intro = make_message_simple(
+        "user",
+        &"Existing tail before grounded response ".repeat(1000),
+    );
+    let grounded = make_message_simple("assistant", "Grounded assistant output");
 
     let messages = vec![summary.clone(), intro.clone(), grounded];
 
     let bpe_input = estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&intro) + 10 + 5;
-    let expected_ratio = 200.0 / bpe_input as f64;
+    let expected_ratio = (bpe_input as f64 * 0.9).ceil() / bpe_input as f64;
+    let mut messages = messages;
+    messages[2].usage = Some(json!({ "promptTokens": (bpe_input as f64 * 0.9).ceil() as usize }));
 
     let ratio = derive_bpe_calibration_ratio(&messages, 10, 5);
     assert!((ratio - expected_ratio).abs() < 1e-9);
@@ -731,15 +738,20 @@ fn test_prompt_anchor_calibration_keeps_summary_aware_anchor_after_compaction() 
 
 #[test]
 fn test_prompt_anchored_total_tokens_keeps_summary_aware_anchor_after_compaction() {
-    let summary =
-        make_compact_summary_message("compact-summary-123", "assistant", "Compacted summary");
+    let summary = make_compact_summary_message(
+        "compact-summary-123",
+        "assistant",
+        &"Compacted summary ".repeat(1500),
+    );
 
-    let intro = make_message_simple("user", "Existing tail before grounded response");
+    let intro = make_message_simple(
+        "user",
+        &"Existing tail before grounded response ".repeat(1000),
+    );
     let mut grounded = make_message_simple("assistant", "Grounded assistant output");
-    grounded.usage = Some(json!({ "promptTokens": 200 }));
     let tail = make_message_simple("user", "Fresh delta after anchor");
 
-    let messages = vec![
+    let mut messages = vec![
         summary.clone(),
         intro.clone(),
         grounded.clone(),
@@ -747,9 +759,12 @@ fn test_prompt_anchored_total_tokens_keeps_summary_aware_anchor_after_compaction
     ];
 
     let bpe_input = estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&intro) + 10 + 5;
-    let ratio = 200.0 / bpe_input as f64;
+    let prompt_tokens = (bpe_input as f64 * 0.9).ceil() as usize;
+    messages[2].usage = Some(json!({ "promptTokens": prompt_tokens }));
+    grounded.usage = Some(json!({ "promptTokens": prompt_tokens }));
+    let ratio = prompt_tokens as f64 / bpe_input as f64;
     let bpe_output = estimate_tokens_bpe(&grounded) + estimate_tokens_bpe(&tail);
-    let expected = 200 + (bpe_output as f64 * ratio).ceil() as usize;
+    let expected = prompt_tokens + (bpe_output as f64 * ratio).ceil() as usize;
 
     let tokens = calculate_prompt_anchored_total_tokens(&messages, 10, 5);
     assert_eq!(tokens, expected);
@@ -757,24 +772,29 @@ fn test_prompt_anchored_total_tokens_keeps_summary_aware_anchor_after_compaction
 
 #[test]
 fn test_conservative_preflight_prompt_tokens_biases_anchor_delta_upward() {
-    let summary =
-        make_compact_summary_message("compact-summary-1", "assistant", "Compacted summary");
-    let intro = make_message("intro", "user", "Stable tail before anchor");
+    let summary = make_compact_summary_message(
+        "compact-summary-1",
+        "assistant",
+        &"Compacted summary ".repeat(1500),
+    );
+    let intro = make_message("intro", "user", &"Stable tail before anchor ".repeat(1000));
     let mut grounded = make_message("assistant-anchor", "assistant", "Grounded output");
-    grounded.usage = Some(json!({ "promptTokens": 240 }));
     let tail = make_message("tail", "user", "Fresh delta after anchor");
 
-    let messages = vec![
+    let mut messages = vec![
         summary.clone(),
         intro.clone(),
         grounded.clone(),
         tail.clone(),
     ];
     let bpe_input = estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&intro) + 10 + 5;
-    let ratio = 240.0 / bpe_input as f64;
+    let prompt_tokens = (bpe_input as f64 * 0.9).ceil() as usize;
+    messages[2].usage = Some(json!({ "promptTokens": prompt_tokens }));
+    grounded.usage = Some(json!({ "promptTokens": prompt_tokens }));
+    let ratio = prompt_tokens as f64 / bpe_input as f64;
     let delta_bpe = estimate_tokens_bpe(&grounded) + estimate_tokens_bpe(&tail);
-    let anchored_total = 240 + (delta_bpe as f64 * ratio).ceil() as usize;
-    let expected = 240 + (delta_bpe as f64 * ratio * 1.05).ceil() as usize;
+    let anchored_total = prompt_tokens + (delta_bpe as f64 * ratio).ceil() as usize;
+    let expected = prompt_tokens + (delta_bpe as f64 * ratio * 1.05).ceil() as usize;
 
     let conservative = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5, None);
     assert_eq!(conservative, expected);
@@ -795,18 +815,20 @@ fn test_conservative_preflight_prompt_tokens_fallback_biases_full_estimate_upwar
 
 #[test]
 fn test_conservative_preflight_prompt_tokens_uses_latest_prompt_anchor() {
-    let earlier_user = make_message("u1", "user", "Earlier context");
+    let earlier_user = make_message("u1", "user", &"Earlier context ".repeat(1200));
     let older_anchor_clone_for_bpe;
-    let mut older_anchor = make_message("a1", "assistant", "Older grounded output");
-    older_anchor.usage = Some(json!({ "promptTokens": 120 }));
+    let older_anchor = make_message("a1", "assistant", "Older grounded output");
     older_anchor_clone_for_bpe = older_anchor.clone();
 
-    let newer_user = make_message("u2", "user", "Newer context that should define the anchor");
+    let newer_user = make_message(
+        "u2",
+        "user",
+        &"Newer context that should define the anchor ".repeat(1000),
+    );
     let mut latest_anchor = make_message("a2", "assistant", "Latest grounded output");
-    latest_anchor.usage = Some(json!({ "promptTokens": 260 }));
 
     let tail = make_message("u3", "user", "Tail delta after latest anchor");
-    let messages = vec![
+    let mut messages = vec![
         earlier_user.clone(),
         older_anchor,
         newer_user.clone(),
@@ -819,11 +841,16 @@ fn test_conservative_preflight_prompt_tokens_uses_latest_prompt_anchor() {
         + estimate_tokens_bpe(&newer_user)
         + 10
         + 5;
-    let ratio = 260.0 / bpe_input as f64;
+    let prompt_tokens = (bpe_input as f64 * 0.92).ceil() as usize;
+    messages[3].usage = Some(json!({ "promptTokens": prompt_tokens }));
+    latest_anchor.usage = Some(json!({ "promptTokens": prompt_tokens }));
+    let ratio = prompt_tokens as f64 / bpe_input as f64;
     let delta_bpe = estimate_tokens_bpe(&latest_anchor) + estimate_tokens_bpe(&tail);
-    let expected = 260 + (delta_bpe as f64 * ratio * 1.05).ceil() as usize;
-    let stale_anchor_ratio = 120.0 / (estimate_tokens_bpe(&earlier_user) + 10 + 5) as f64;
-    let stale_anchor_estimate = 120
+    let expected = prompt_tokens + (delta_bpe as f64 * ratio * 1.05).ceil() as usize;
+    let stale_denominator = estimate_tokens_bpe(&earlier_user) + 10 + 5;
+    let stale_prompt_tokens = (stale_denominator as f64 * 0.92).ceil() as usize;
+    let stale_anchor_ratio = stale_prompt_tokens as f64 / stale_denominator as f64;
+    let stale_anchor_estimate = stale_prompt_tokens
         + ((estimate_tokens_bpe(&older_anchor_clone_for_bpe)
             + estimate_tokens_bpe(&newer_user)
             + estimate_tokens_bpe(&latest_anchor)
@@ -850,12 +877,16 @@ fn test_try_derive_bpe_calibration_ratio_returns_none_without_anchor() {
 #[test]
 fn test_conservative_preflight_prompt_tokens_uses_preserved_ratio_when_compaction_loses_anchor() {
     let preserved_context = vec![
-        make_message("u1", "user", "Large earlier context"),
-        make_message("a1", "assistant", "Older grounded output"),
+        make_message("u1", "user", &"Large earlier context ".repeat(1200)),
+        make_message("a1", "assistant", &"Older grounded output ".repeat(1000)),
     ];
     let mut grounded_anchor = make_message("a2", "assistant", "Latest grounded output");
-    grounded_anchor.usage = Some(json!({ "promptTokens": 180 }));
     let mut full_messages = preserved_context.clone();
+    let grounded_denominator =
+        full_messages.iter().map(estimate_tokens_bpe).sum::<usize>() + 10 + 5;
+    grounded_anchor.usage = Some(json!({
+        "promptTokens": (grounded_denominator as f64 * 0.9).ceil() as usize
+    }));
     full_messages.push(grounded_anchor.clone());
     let preserved_ratio = try_derive_bpe_calibration_ratio(&full_messages, 10, 5)
         .expect("expected grounded promptTokens anchor");
@@ -886,27 +917,106 @@ fn test_conservative_preflight_prompt_tokens_uses_preserved_ratio_when_compactio
 
 #[test]
 fn test_resolve_preserved_calibration_ratio_prefers_post_compaction_layout() {
-    let raw_prefix = make_message("u1", "user", "large raw prefix before compaction");
+    let raw_prefix = make_message(
+        "u1",
+        "user",
+        &"large raw prefix before compaction ".repeat(1200),
+    );
     let mut raw_anchor = make_message("a1", "assistant", "grounded output");
-    raw_anchor.usage = Some(json!({ "promptTokens": 120 }));
+    let raw_denominator = estimate_tokens_bpe(&raw_prefix) + 10 + 5;
+    raw_anchor.usage = Some(json!({
+      "promptTokens": (raw_denominator as f64 * 0.95).ceil() as usize
+    }));
     let raw_messages = vec![raw_prefix.clone(), raw_anchor];
 
-    let summary =
-        make_compact_summary_message("compact-summary-1", "assistant", "compacted summary");
-    let tail_user = make_message("u2", "user", "tail before anchor");
+    let summary = make_compact_summary_message(
+        "compact-summary-1",
+        "assistant",
+        &"compacted summary ".repeat(1500),
+    );
+    let tail_user = make_message("u2", "user", &"tail before anchor ".repeat(1000));
     let mut tail_anchor = make_message("a2", "assistant", "tail grounded output");
-    tail_anchor.usage = Some(json!({ "promptTokens": 90 }));
+    let prompt_denominator =
+        estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&tail_user) + 10 + 5;
+    tail_anchor.usage = Some(json!({
+      "promptTokens": (prompt_denominator as f64 * 0.9).ceil() as usize
+    }));
     let prompt_messages = vec![summary.clone(), tail_user.clone(), tail_anchor];
 
     let resolved = resolve_preserved_calibration_ratio(&raw_messages, &prompt_messages, 10, 5)
         .expect("expected calibration ratio");
 
-    let expected_post_ratio =
-        90.0 / (estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&tail_user) + 10 + 5) as f64;
-    let stale_raw_ratio = 120.0 / (estimate_tokens_bpe(&raw_prefix) + 10 + 5) as f64;
+    let expected_post_ratio = (prompt_denominator as f64 * 0.9).ceil() / prompt_denominator as f64;
+    let stale_raw_ratio = (raw_denominator as f64 * 0.95).ceil() / raw_denominator as f64;
 
     assert!((resolved - expected_post_ratio).abs() < 1e-9);
     assert_ne!(resolved, stale_raw_ratio);
+}
+
+#[test]
+fn test_try_derive_bpe_calibration_ratio_skips_short_prefix_anchor_and_uses_older_valid_anchor() {
+    let earlier_user = make_message("u1", "user", &"stable prefix ".repeat(1500));
+    let mut earlier_anchor = make_message("a1", "assistant", "older grounded output");
+    let earlier_denominator = estimate_tokens_bpe(&earlier_user) + 10 + 5;
+    earlier_anchor.usage = Some(json!({
+        "promptTokens": (earlier_denominator as f64 * 0.92).ceil() as usize
+    }));
+
+    let short_summary = make_compact_summary_message("compact-summary-1", "assistant", "tiny");
+    let mut latest_anchor = make_message("a2", "assistant", "latest but unstable anchor");
+    let latest_denominator = estimate_tokens_bpe(&earlier_user)
+        + estimate_tokens_bpe(&earlier_anchor)
+        + estimate_tokens_bpe(&short_summary)
+        + 10
+        + 5;
+    latest_anchor.usage = Some(json!({
+        "promptTokens": (latest_denominator as f64 * 1.6).ceil() as usize
+    }));
+
+    let messages = vec![
+        earlier_user,
+        earlier_anchor.clone(),
+        short_summary,
+        latest_anchor,
+    ];
+    let ratio = try_derive_bpe_calibration_ratio(&messages, 10, 5)
+        .expect("expected earlier valid anchor to be used");
+
+    let expected = (earlier_denominator as f64 * 0.92).ceil() / earlier_denominator as f64;
+    assert!((ratio - expected).abs() < 1e-9);
+}
+
+#[test]
+fn test_try_derive_bpe_calibration_ratio_accepts_valid_low_ratio_anchor() {
+    let prefix = make_message("u1", "user", &"cross tokenizer prefix ".repeat(1500));
+    let mut anchor = make_message("a1", "assistant", "grounded output");
+    let denominator = estimate_tokens_bpe(&prefix) + 10 + 5;
+    let valid_ratio = (PROMPT_ANCHOR_RATIO_MIN + 1.0) / 2.0;
+    let prompt_tokens = (denominator as f64 * valid_ratio).ceil() as usize;
+    anchor.usage = Some(json!({
+        "promptTokens": prompt_tokens
+    }));
+
+    let messages = vec![prefix, anchor];
+    let ratio = try_derive_bpe_calibration_ratio(&messages, 10, 5)
+        .expect("expected valid low grounded anchor to be accepted");
+
+    let expected = prompt_tokens as f64 / denominator as f64;
+    assert!((ratio - expected).abs() < 1e-9);
+}
+
+#[test]
+fn test_try_derive_bpe_calibration_ratio_rejects_extreme_low_ratio_anchor() {
+    let prefix = make_message("u1", "user", &"extreme ratio prefix ".repeat(1500));
+    let mut anchor = make_message("a1", "assistant", "grounded output");
+    let denominator = estimate_tokens_bpe(&prefix) + 10 + 5;
+    let invalid_ratio = PROMPT_ANCHOR_RATIO_MIN / 2.0;
+    anchor.usage = Some(json!({
+        "promptTokens": (denominator as f64 * invalid_ratio).ceil() as usize
+    }));
+
+    let messages = vec![prefix, anchor];
+    assert_eq!(try_derive_bpe_calibration_ratio(&messages, 10, 5), None);
 }
 
 #[test]

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_text,
     find_preflight_compaction_split_index, merge_consecutive_user_messages,
-    resolve_context_management_settings, should_skip_same_tail_compaction,
-    should_trigger_background_compaction, uses_compaction_strategy,
+    resolve_context_management_settings, resolve_preserved_calibration_ratio,
+    should_skip_same_tail_compaction, should_trigger_background_compaction,
+    uses_compaction_strategy,
 };
 use tauri_mcp_agent_lib::agent::llm::context_selector::*;
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
@@ -881,6 +882,31 @@ fn test_conservative_preflight_prompt_tokens_uses_preserved_ratio_when_compactio
         conservative,
         ((base as f64 * preserved_ratio).ceil() as f64 * 1.05).ceil() as usize
     );
+}
+
+#[test]
+fn test_resolve_preserved_calibration_ratio_prefers_post_compaction_layout() {
+    let raw_prefix = make_message("u1", "user", "large raw prefix before compaction");
+    let mut raw_anchor = make_message("a1", "assistant", "grounded output");
+    raw_anchor.usage = Some(json!({ "promptTokens": 120 }));
+    let raw_messages = vec![raw_prefix.clone(), raw_anchor];
+
+    let summary =
+        make_compact_summary_message("compact-summary-1", "assistant", "compacted summary");
+    let tail_user = make_message("u2", "user", "tail before anchor");
+    let mut tail_anchor = make_message("a2", "assistant", "tail grounded output");
+    tail_anchor.usage = Some(json!({ "promptTokens": 90 }));
+    let prompt_messages = vec![summary.clone(), tail_user.clone(), tail_anchor];
+
+    let resolved = resolve_preserved_calibration_ratio(&raw_messages, &prompt_messages, 10, 5)
+        .expect("expected calibration ratio");
+
+    let expected_post_ratio =
+        90.0 / (estimate_tokens_bpe(&summary) + estimate_tokens_bpe(&tail_user) + 10 + 5) as f64;
+    let stale_raw_ratio = 120.0 / (estimate_tokens_bpe(&raw_prefix) + 10 + 5) as f64;
+
+    assert!((resolved - expected_post_ratio).abs() < 1e-9);
+    assert_ne!(resolved, stale_raw_ratio);
 }
 
 #[test]

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -518,6 +518,7 @@ fn test_compact_mode_selection_options_disable_first_user_pinning() {
         Some("tools".to_string()),
         "openai",
         7,
+        Some(0.63),
     );
 
     assert_eq!(options.system_prompt.as_deref(), Some("system"));
@@ -525,11 +526,12 @@ fn test_compact_mode_selection_options_disable_first_user_pinning() {
     assert_eq!(options.max_messages, None);
     assert_eq!(options.max_tool_calls_per_message, Some(7));
     assert!(!options.pin_first_user_message);
+    assert_eq!(options.fallback_calibration_ratio, Some(0.63));
 }
 
 #[test]
 fn test_compact_mode_selection_options_keep_gemini_tool_visibility_contract() {
-    let options = build_compact_context_selection_options(None, None, "gemini", 7);
+    let options = build_compact_context_selection_options(None, None, "gemini", 7, None);
 
     assert_eq!(options.max_tool_calls_per_message, Some(100));
     assert!(!options.pin_first_user_message);
@@ -773,7 +775,7 @@ fn test_conservative_preflight_prompt_tokens_biases_anchor_delta_upward() {
     let anchored_total = 240 + (delta_bpe as f64 * ratio).ceil() as usize;
     let expected = 240 + (delta_bpe as f64 * ratio * 1.05).ceil() as usize;
 
-    let conservative = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5);
+    let conservative = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5, None);
     assert_eq!(conservative, expected);
     assert!(conservative >= anchored_total);
 }
@@ -785,7 +787,7 @@ fn test_conservative_preflight_prompt_tokens_fallback_biases_full_estimate_upwar
         make_message("m2", "assistant", "No grounded usage yet"),
     ];
     let base = messages.iter().map(estimate_tokens_bpe).sum::<usize>() + 10 + 5;
-    let conservative = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5);
+    let conservative = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5, None);
 
     assert_eq!(conservative, (base as f64 * 1.05).ceil() as usize);
 }
@@ -829,9 +831,197 @@ fn test_conservative_preflight_prompt_tokens_uses_latest_prompt_anchor() {
             * 1.05)
             .ceil() as usize;
 
-    let actual = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5);
+    let actual = calculate_conservative_preflight_prompt_tokens(&messages, 10, 5, None);
     assert_eq!(actual, expected);
     assert_ne!(actual, stale_anchor_estimate);
+}
+
+#[test]
+fn test_try_derive_bpe_calibration_ratio_returns_none_without_anchor() {
+    let messages = vec![
+        make_message("m1", "user", "hello"),
+        make_message("m2", "assistant", "no usage here"),
+    ];
+
+    assert_eq!(try_derive_bpe_calibration_ratio(&messages, 10, 5), None);
+}
+
+#[test]
+fn test_conservative_preflight_prompt_tokens_uses_preserved_ratio_when_compaction_loses_anchor() {
+    let preserved_context = vec![
+        make_message("u1", "user", "Large earlier context"),
+        make_message("a1", "assistant", "Older grounded output"),
+    ];
+    let mut grounded_anchor = make_message("a2", "assistant", "Latest grounded output");
+    grounded_anchor.usage = Some(json!({ "promptTokens": 180 }));
+    let mut full_messages = preserved_context.clone();
+    full_messages.push(grounded_anchor.clone());
+    let preserved_ratio = try_derive_bpe_calibration_ratio(&full_messages, 10, 5)
+        .expect("expected grounded promptTokens anchor");
+
+    let compacted_messages = vec![
+        make_compact_summary_message("compact-summary-1", "assistant", "Compacted summary"),
+        make_message("u-tail", "user", "Fresh request after compaction"),
+    ];
+    let base = compacted_messages
+        .iter()
+        .map(estimate_tokens_bpe)
+        .sum::<usize>()
+        + 10
+        + 5;
+
+    let conservative = calculate_conservative_preflight_prompt_tokens(
+        &compacted_messages,
+        10,
+        5,
+        Some(preserved_ratio),
+    );
+
+    assert_eq!(
+        conservative,
+        ((base as f64 * preserved_ratio).ceil() as f64 * 1.05).ceil() as usize
+    );
+}
+
+#[test]
+fn test_select_messages_within_context_uses_preserved_calibration_after_compaction() {
+    let oversized_summary =
+        make_compact_summary_message("compact-summary-1", "assistant", &"summary ".repeat(800));
+    let tail = make_message("u-tail", "user", "Keep this newest turn");
+
+    let options = SelectionOptions {
+        system_prompt: Some("system prompt".to_string()),
+        tools_json: Some("[]".to_string()),
+        max_messages: None,
+        max_tool_calls_per_message: Some(4),
+        pin_first_user_message: false,
+        fallback_calibration_ratio: Some(0.25),
+    };
+
+    let selected = select_messages_within_context(
+        &[oversized_summary.clone(), tail.clone()],
+        "gemini",
+        Some(600),
+        Some(&options),
+        Some(&ModelContextInfo {
+            context_window: 128_000,
+        }),
+    );
+
+    assert_eq!(selected.len(), 2);
+    assert_eq!(selected[0].id, oversized_summary.id);
+    assert_eq!(selected[1].id, tail.id);
+}
+
+#[test]
+fn test_trim_messages_to_fit_conservative_limit_drops_oldest_messages_until_fit() {
+    let summary =
+        make_compact_summary_message("compact-summary-1", "assistant", &"summary ".repeat(700));
+    let older = make_message("older", "assistant", &"older context ".repeat(250));
+    let newest = make_message("newest", "user", "Newest actionable turn");
+    let preserved_ratio = Some(0.25);
+    let limit = 250;
+
+    let trimmed = trim_messages_to_fit_conservative_limit(
+        &[summary.clone(), older, newest.clone()],
+        "gemini",
+        limit,
+        10,
+        5,
+        preserved_ratio,
+    );
+
+    assert_eq!(trimmed.len(), 2);
+    assert_eq!(trimmed[0].id, "older");
+    assert_eq!(trimmed[1].id, newest.id);
+    assert!(
+        calculate_conservative_preflight_prompt_tokens(&trimmed, 10, 5, preserved_ratio) < limit
+    );
+}
+
+#[test]
+fn test_trim_messages_to_fit_conservative_limit_preserves_resolved_tool_chain() {
+    let mut assistant = make_message("assistant", "assistant", "Calling tool");
+    assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "call_1".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "toolA".to_string(),
+            arguments: "{}".to_string(),
+        },
+    }]);
+    let mut tool_result = make_message("tool", "tool", "Tool result");
+    tool_result.tool_call_id = Some("call_1".to_string());
+    let newest = make_message("newest", "user", "Newest user turn");
+
+    let trimmed = trim_messages_to_fit_conservative_limit(
+        &[assistant.clone(), tool_result.clone(), newest.clone()],
+        "gemini",
+        usize::MAX,
+        10,
+        5,
+        None,
+    );
+
+    assert_eq!(trimmed.len(), 3);
+    assert_eq!(trimmed[0].id, assistant.id);
+    assert_eq!(trimmed[1].id, tool_result.id);
+    assert_eq!(trimmed[2].id, newest.id);
+}
+
+#[test]
+fn test_truncate_single_oversized_message_to_fit_conservative_limit_truncates_user_text() {
+    let oversized = make_message("user-1", "user", &"very large latest request ".repeat(600));
+    let limit = 600;
+
+    let truncated = truncate_single_oversized_message_to_fit_conservative_limit(
+        &[oversized.clone()],
+        limit,
+        10,
+        5,
+        None,
+    );
+
+    assert_eq!(truncated.len(), 1);
+    assert_ne!(
+        estimate_tokens_bpe(&truncated[0]),
+        estimate_tokens_bpe(&oversized)
+    );
+    let MCPContent::Text { text, .. } = &truncated[0].content[0] else {
+        panic!("expected text content");
+    };
+    assert!(text.contains("...[truncated for context fit]..."));
+    assert!(calculate_conservative_preflight_prompt_tokens(&truncated, 10, 5, None) < limit);
+}
+
+#[test]
+fn test_truncate_single_oversized_message_to_fit_conservative_limit_skips_assistant_tool_call_message(
+) {
+    let mut assistant = make_message("assistant-1", "assistant", "Calling tool");
+    assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "call_1".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "toolA".to_string(),
+            arguments: "{}".to_string(),
+        },
+    }]);
+
+    let truncated = truncate_single_oversized_message_to_fit_conservative_limit(
+        &[assistant.clone()],
+        100,
+        10,
+        5,
+        None,
+    );
+
+    assert_eq!(truncated.len(), 1);
+    assert_eq!(
+        estimate_tokens_bpe(&truncated[0]),
+        estimate_tokens_bpe(&assistant)
+    );
+    assert!(truncated[0].tool_calls.is_some());
+    assert_eq!(truncated[0].role, assistant.role);
 }
 
 #[test]

--- a/src-tauri/tests/llm_response_guard_tests.rs
+++ b/src-tauri/tests/llm_response_guard_tests.rs
@@ -1,0 +1,23 @@
+use tauri_mcp_agent_lib::agent::llm::validate_expected_response_id;
+
+#[test]
+fn rejects_response_when_expected_response_id_is_missing() {
+    let error = validate_expected_response_id("session-1", None, "response-1")
+        .expect_err("missing expected response id should reject stray responses");
+
+    assert_eq!(error, "LLM response superseded");
+}
+
+#[test]
+fn rejects_response_when_expected_response_id_mismatches() {
+    let error = validate_expected_response_id("session-1", Some("response-1"), "response-2")
+        .expect_err("mismatched response id should reject superseded responses");
+
+    assert_eq!(error, "LLM response superseded");
+}
+
+#[test]
+fn accepts_response_when_expected_response_id_matches() {
+    validate_expected_response_id("session-1", Some("response-1"), "response-1")
+        .expect("matching response id should be accepted");
+}

--- a/src/context/LLMServiceContext.tsx
+++ b/src/context/LLMServiceContext.tsx
@@ -120,7 +120,6 @@ export function LLMServiceProvider({ children }: LLMServiceProviderProps) {
     setAwaitingCompact,
   } = useLLMExecution({
     settingsRef,
-    streamingMessages,
     setStreamingMessages,
     updateSessionStatus,
   });

--- a/src/context/__tests__/AgentChatContext.test.tsx
+++ b/src/context/__tests__/AgentChatContext.test.tsx
@@ -314,6 +314,7 @@ describe('AgentChatContext', () => {
       await act(async () => {
         promise = result.current.llm.executeCompletionRequest(
           'test-session',
+          'response-msg-agent-1',
           mockMessages,
           'test-model',
           'openai',

--- a/src/context/__tests__/LLMServiceContext.test.tsx
+++ b/src/context/__tests__/LLMServiceContext.test.tsx
@@ -215,6 +215,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         promise = result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-1',
           messages,
           'gpt-4',
           'openai',
@@ -270,6 +271,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         resultMessage = await result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-2',
           messages,
           'gpt-4',
           'openai',
@@ -324,6 +326,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         resultMessage = (await result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-3',
           messages,
           'gpt-4',
           'openai',
@@ -391,6 +394,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         promise = result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-4',
           messages,
           'gpt-4',
           'openai',
@@ -475,6 +479,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         promise = result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-5',
           messages,
           'gpt-4',
           'openai',
@@ -535,6 +540,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         promise = result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-6',
           messages,
           'gpt-4',
           'openai',
@@ -583,6 +589,7 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         resultMessage = (await result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-7',
           messages,
           'gpt-4',
           'openai',
@@ -622,6 +629,7 @@ describe('LLMServiceContext – Core', () => {
       await expect(
         result.current.executeCompletionRequest(
           'test-session',
+          'response-msg-8',
           messages,
           'gpt-4',
           'openai',
@@ -656,6 +664,7 @@ describe('LLMServiceContext – Core', () => {
 
       await result.current.executeCompletionRequest(
         'test-session',
+        'response-msg-9',
         messages,
         'gpt-4',
         'openai',

--- a/src/context/llm/__tests__/cancel.test.ts
+++ b/src/context/llm/__tests__/cancel.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isAbortError } from '../types';
+import {
+  isAbortError,
+  isSupersededRequestError,
+  isWorkflowCancelledError,
+} from '../types';
 
 // ---------------------------------------------------------------------------
 // isAbortError utility
@@ -62,6 +66,31 @@ describe('isAbortError', () => {
 
   it('returns false for a non-null primitive (number)', () => {
     expect(isAbortError(42)).toBe(false);
+  });
+});
+
+describe('request lifecycle helper errors', () => {
+  it('returns true for Request superseded', () => {
+    expect(isSupersededRequestError(new Error('Request superseded'))).toBe(true);
+  });
+
+  it('returns false for non-superseded error', () => {
+    expect(isSupersededRequestError(new Error('Network error'))).toBe(false);
+  });
+
+  it('returns true for workflow cancelled shaped errors', () => {
+    expect(isWorkflowCancelledError(new Error('Workflow was cancelled'))).toBe(
+      true,
+    );
+    expect(
+      isWorkflowCancelledError({ displayMessage: 'LLM response superseded' }),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated workflow errors', () => {
+    expect(
+      isWorkflowCancelledError(new Error('Workflow failed unexpectedly')),
+    ).toBe(false);
   });
 });
 
@@ -145,7 +174,11 @@ describe('useLLMListener: handleLLMError must NOT be called on abort', () => {
     error: unknown,
     sessionId: string,
   ) => {
-    if (isAbortError(error)) {
+    if (
+      isAbortError(error) ||
+      isSupersededRequestError(error) ||
+      isWorkflowCancelledError(error)
+    ) {
       return; // ← correct: do NOT call handleLLMError / report to Rust
     }
     await mockHandleLLMError(sessionId, String(error));
@@ -168,6 +201,18 @@ describe('useLLMListener: handleLLMError must NOT be called on abort', () => {
     const err = new Error('API quota exceeded');
     await handleCatchInListener(err, 'session-1');
     expect(mockHandleLLMError).toHaveBeenCalledWith('session-1', 'Error: API quota exceeded');
+  });
+
+  it('does NOT call handleLLMError when request was superseded', async () => {
+    const err = new Error('Request superseded');
+    await handleCatchInListener(err, 'session-3');
+    expect(mockHandleLLMError).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call handleLLMError for workflow cancelled backend rejection', async () => {
+    const err = new Error('Workflow was cancelled');
+    await handleCatchInListener(err, 'session-4');
+    expect(mockHandleLLMError).not.toHaveBeenCalled();
   });
 });
 

--- a/src/context/llm/types.ts
+++ b/src/context/llm/types.ts
@@ -20,6 +20,34 @@ export function isAbortError(error: unknown): boolean {
   );
 }
 
+export function isSupersededRequestError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false;
+  const e = error as Record<string, unknown>;
+  return (
+    typeof e['message'] === 'string' && e['message'] === 'Request superseded'
+  );
+}
+
+export function isWorkflowCancelledError(error: unknown): boolean {
+  if (typeof error === 'string') {
+    return (
+      error === 'Workflow was cancelled' || error === 'LLM response superseded'
+    );
+  }
+
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+
+  const e = error as Record<string, unknown>;
+  return (
+    e['message'] === 'Workflow was cancelled' ||
+    e['message'] === 'LLM response superseded' ||
+    e['displayMessage'] === 'Workflow was cancelled' ||
+    e['displayMessage'] === 'LLM response superseded'
+  );
+}
+
 /**
  * Request from Rust backend to execute an LLM completion
  */
@@ -98,6 +126,7 @@ export interface LLMServiceContextValue {
    */
   executeCompletionRequest: (
     sessionId: string,
+    responseMessageId: string,
     messages: Message[],
     model: string,
     provider: string,

--- a/src/context/llm/useExecuteCompletion.ts
+++ b/src/context/llm/useExecuteCompletion.ts
@@ -30,6 +30,7 @@ import {
   applyServiceRuntimeConfig,
   buildServiceRuntimeConfig,
 } from './service-runtime-config';
+import { isSupersededRequestError } from './types';
 
 const logger = getLogger('useExecuteCompletion');
 
@@ -53,7 +54,6 @@ function createExecutionError(
 
 interface UseExecuteCompletionProps {
   settingsRef: React.MutableRefObject<Settings>;
-  streamingMessages: Map<string, Partial<Message>>;
   setStreamingMessages: React.Dispatch<
     React.SetStateAction<Map<string, Partial<Message>>>
   >;
@@ -62,7 +62,6 @@ interface UseExecuteCompletionProps {
 
 export function useExecuteCompletion({
   settingsRef,
-  streamingMessages,
   setStreamingMessages,
   updateSessionStatus,
 }: UseExecuteCompletionProps) {
@@ -76,6 +75,8 @@ export function useExecuteCompletion({
   const timeoutsRef = useRef<Map<string, number>>(new Map());
   // Track last streaming UI update time per session (throttle to ~20fps)
   const lastStreamingUpdateRef = useRef<Map<string, number>>(new Map());
+  // Track the latest request identity per session to suppress stale stream updates/results
+  const activeRequestIdsRef = useRef<Map<string, string>>(new Map());
 
   // Context window usage per session for gauge display
 
@@ -92,12 +93,20 @@ export function useExecuteCompletion({
 
       activeServicesRef.current.forEach((svc) => svc.dispose());
       activeServicesRef.current.clear();
+      activeRequestIdsRef.current.clear();
     };
   }, []);
+
+  const isCurrentRequest = useCallback(
+    (sessionId: string, responseMessageId: string) =>
+      activeRequestIdsRef.current.get(sessionId) === responseMessageId,
+    [],
+  );
 
   const executeCompletionRequest = useCallback(
     async (
       sessionId: string,
+      responseMessageId: string,
       messages: Message[],
       model: string,
       provider: string,
@@ -129,6 +138,12 @@ export function useExecuteCompletion({
       if (previousService) {
         previousService.dispose();
       }
+      const previousTimeoutId = timeoutsRef.current.get(sessionId);
+      if (previousTimeoutId) {
+        clearTimeout(previousTimeoutId);
+        timeoutsRef.current.delete(sessionId);
+      }
+      activeRequestIdsRef.current.set(sessionId, responseMessageId);
 
       // Create abort controller for this request
       const abortController = new AbortController();
@@ -151,9 +166,8 @@ export function useExecuteCompletion({
       activeServicesRef.current.set(sessionId, service);
 
       // Get existing streaming message (already set by event listener)
-      const existingStreamingMessage = streamingMessages.get(sessionId);
-      const streamingMessage: Partial<Message> = existingStreamingMessage || {
-        id: `msg_${Date.now()}`,
+      const streamingMessage: Partial<Message> = {
+        id: responseMessageId,
         sessionId,
         threadId: sessionId,
         role: 'assistant',
@@ -193,7 +207,7 @@ export function useExecuteCompletion({
         setStreamingMessages((prev) => {
           const next = new Map(prev);
           next.set(sessionId, {
-            id: `msg_${Date.now()}`,
+            id: responseMessageId,
             sessionId,
             threadId: sessionId,
             role: 'assistant',
@@ -237,6 +251,14 @@ export function useExecuteCompletion({
         });
 
         for await (const rawChunk of streamGenerator) {
+          if (!isCurrentRequest(sessionId, responseMessageId)) {
+            logger.info('Dropping stream for superseded request', {
+              sessionId,
+              responseMessageId,
+            });
+            throw new Error('Request superseded');
+          }
+
           if (firstChunkTime === undefined) {
             firstChunkTime = performance.now();
           }
@@ -388,6 +410,9 @@ export function useExecuteCompletion({
           if (hasToolCallUpdate || nowMs - lastUpdateMs >= 50) {
             lastStreamingUpdateRef.current.set(sessionId, nowMs);
             setStreamingMessages((prev) => {
+              if (!isCurrentRequest(sessionId, responseMessageId)) {
+                return prev;
+              }
               const next = new Map(prev);
               const toolCalls: ToolCall[] = content
                 .filter((c) => c.type === 'tool_call')
@@ -421,6 +446,9 @@ export function useExecuteCompletion({
         // Always flush final streaming state after loop ends
         lastStreamingUpdateRef.current.delete(sessionId);
         setStreamingMessages((prev) => {
+          if (!isCurrentRequest(sessionId, responseMessageId)) {
+            return prev;
+          }
           const next = new Map(prev);
           const toolCalls: ToolCall[] = content
             .filter((c) => c.type === 'tool_call')
@@ -487,7 +515,7 @@ export function useExecuteCompletion({
           .join('\n');
 
         const finalMessage: Message = {
-          id: streamingMessage.id ?? `msg_${Date.now()}`,
+          id: responseMessageId,
           sessionId,
           threadId: sessionId,
           role: 'assistant',
@@ -567,6 +595,9 @@ export function useExecuteCompletion({
 
         // 1. Update with isStreaming: false IMMEDIATELY
         setStreamingMessages((prev) => {
+          if (!isCurrentRequest(sessionId, responseMessageId)) {
+            return prev;
+          }
           const next = new Map(prev);
           next.set(sessionId, finalMessage);
           return next;
@@ -575,6 +606,9 @@ export function useExecuteCompletion({
         // 2. Schedule cleanup with 500ms delay to allow backend event to arrive
         const timeoutId = window.setTimeout(() => {
           setStreamingMessages((prev) => {
+            if (!isCurrentRequest(sessionId, responseMessageId)) {
+              return prev;
+            }
             const next = new Map(prev);
             // Only delete if it's still the same message (same ID)
             const current = next.get(sessionId);
@@ -589,6 +623,9 @@ export function useExecuteCompletion({
 
         updateSessionStatus(sessionId, 'idle');
 
+        if (activeRequestIdsRef.current.get(sessionId) === responseMessageId) {
+          activeRequestIdsRef.current.delete(sessionId);
+        }
         if (abortControllersRef.current.get(sessionId) === abortController) {
           abortControllersRef.current.delete(sessionId);
         }
@@ -599,17 +636,23 @@ export function useExecuteCompletion({
         return finalMessage;
       } catch (error) {
         const isAborted = isAbortError(error);
+        const isSuperseded = isSupersededRequestError(error);
 
-        if (isAborted) {
-          logger.info('Completion request was aborted by cancellation', {
+        if (isAborted || isSuperseded) {
+          logger.info('Completion request ended without surfacing an error', {
             sessionId,
+            responseMessageId,
+            reason: isSuperseded ? 'superseded' : 'aborted',
           });
         } else {
           logger.error('Completion request failed', error);
         }
 
-        if (abortControllersRef.current.get(sessionId) === abortController) {
-          updateSessionStatus(sessionId, isAborted ? 'idle' : 'error');
+        if (isCurrentRequest(sessionId, responseMessageId)) {
+          updateSessionStatus(
+            sessionId,
+            isAborted || isSuperseded ? 'idle' : 'error',
+          );
 
           setStreamingMessages((prev) => {
             const next = new Map(prev);
@@ -624,6 +667,7 @@ export function useExecuteCompletion({
           }
 
           abortControllersRef.current.delete(sessionId);
+          activeRequestIdsRef.current.delete(sessionId);
         }
         if (activeServicesRef.current.get(sessionId) === service) {
           activeServicesRef.current.delete(sessionId);
@@ -632,7 +676,7 @@ export function useExecuteCompletion({
         throw error;
       }
     },
-    [updateSessionStatus, settingsRef, streamingMessages, setStreamingMessages],
+    [isCurrentRequest, updateSessionStatus, settingsRef, setStreamingMessages],
   );
 
   const cancelCompletionRequest = useCallback((sessionId: string) => {

--- a/src/context/llm/useLLMExecution.ts
+++ b/src/context/llm/useLLMExecution.ts
@@ -9,7 +9,6 @@ import { useExecuteCompletion } from './useExecuteCompletion';
 
 interface UseLLMExecutionProps {
   settingsRef: React.MutableRefObject<Settings>;
-  streamingMessages: Map<string, Partial<Message>>;
   setStreamingMessages: React.Dispatch<
     React.SetStateAction<Map<string, Partial<Message>>>
   >;

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -33,7 +33,11 @@ import type {
   CompactedRange,
   CompletionRequest,
 } from './types';
-import { isAbortError } from './types';
+import {
+  isAbortError,
+  isSupersededRequestError,
+  isWorkflowCancelledError,
+} from './types';
 import {
   applyServiceRuntimeConfig,
   buildServiceRuntimeConfig,
@@ -135,6 +139,7 @@ interface UseLLMListenerProps {
   settingsRef: React.MutableRefObject<Settings>;
   executeCompletionRequest: (
     sessionId: string,
+    responseMessageId: string,
     messages: Message[],
     model: string,
     provider: string,
@@ -306,6 +311,7 @@ export function useLLMListener({
                 try {
                   return await executeCompletionRequest(
                     sessionId,
+                    responseMessageId,
                     messages,
                     targetModel,
                     targetProvider,
@@ -380,6 +386,7 @@ export function useLLMListener({
                 // One shot with fallback — no further retries
                 result = await executeCompletionRequest(
                   sessionId,
+                  responseMessageId,
                   messages,
                   fallbackModel.model,
                   fallbackModel.provider,
@@ -431,13 +438,20 @@ export function useLLMListener({
             // state transition to Idle. Reporting it would cause a race where Rust
             // transitions: Idle (cancel) → Error (stale abort) in wrong order.
             const isAborted = isAbortError(error);
+            const isSuperseded = isSupersededRequestError(error);
+            const isWorkflowCancelled = isWorkflowCancelledError(error);
 
-            if (isAborted) {
+            if (isAborted || isSuperseded || isWorkflowCancelled) {
               clearCompactionPressureForSession(sessionId);
-              logger.info(
-                'LLM request aborted due to cancellation, skipping error report to Rust',
-                { sessionId },
-              );
+              logger.info('Skipping benign LLM request error report to Rust', {
+                sessionId,
+                reason: isAborted
+                  ? 'aborted'
+                  : isSuperseded
+                    ? 'superseded'
+                    : 'workflow-cancelled',
+                error,
+              });
               return;
             }
 

--- a/src/lib/__tests__/date-utils.test.ts
+++ b/src/lib/__tests__/date-utils.test.ts
@@ -36,6 +36,11 @@ describe('date-utils', () => {
       writable: true,
       configurable: true,
     });
+
+    // Warm ICU-backed formatter initialization once so the first assertion
+    // doesn't pay the full cold-start cost on slower Windows CI runners.
+    new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+    new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short' });
   });
 
   afterAll(() => {
@@ -52,21 +57,25 @@ describe('date-utils', () => {
   });
 
   describe('deterministic cache key (getDateFormatter)', () => {
-    it('returns the same formatter instance for options with different key insertion orders', () => {
-      const options1: Intl.DateTimeFormatOptions = {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      };
-      const options2: Intl.DateTimeFormatOptions = {
-        day: 'numeric',
-        year: 'numeric',
-        month: 'short',
-      };
-      const formatter1 = getDateFormatter('en', options1);
-      const formatter2 = getDateFormatter('en', options2);
-      expect(formatter1).toBe(formatter2);
-    });
+    it(
+      'returns the same formatter instance for options with different key insertion orders',
+      () => {
+        const options1: Intl.DateTimeFormatOptions = {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        };
+        const options2: Intl.DateTimeFormatOptions = {
+          day: 'numeric',
+          year: 'numeric',
+          month: 'short',
+        };
+        const formatter1 = getDateFormatter('en', options1);
+        const formatter2 = getDateFormatter('en', options2);
+        expect(formatter1).toBe(formatter2);
+      },
+      15000,
+    );
   });
 
   describe('formatRelativeTime', () => {

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
- preserve preflight calibration across compaction instead of falling back to raw BPE after anchor loss
- trim old selected messages before send and truncate a single oversized latest user/tool message with head-tail compression
- add regression tests for preserved calibration, overflow trimming, and single-message truncation

## Validation
- pnpm rust:test -- llm_context_tests
- pnpm refactor:validate