### PR TITLE
🪨 Rosetta: Localize GeneralTab Font Settings & Expand KO

### DIFF
--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -58,12 +58,18 @@ function GeneralTabComponent({
                 onDisplaySettingsChange('fontFamily', e.target.value)
               }
             >
-              <option value="Pretendard">Pretendard (Standard Sans)</option>
-              <option value="Inter">Inter (Clean UI Sans)</option>
-              <option value="NanumSquare Neo">
-                NanumSquare Neo (Modern Geometric)
+              <option value="Pretendard">
+                {t('settings.display.fontFamilyOptions.pretendard', 'Pretendard (Standard Sans)')}
               </option>
-              <option value="D2Coding">D2Coding (Developer Mono)</option>
+              <option value="Inter">
+                {t('settings.display.fontFamilyOptions.inter', 'Inter (Clean UI Sans)')}
+              </option>
+              <option value="NanumSquare Neo">
+                {t('settings.display.fontFamilyOptions.nanumSquareNeo', 'NanumSquare Neo (Modern Geometric)')}
+              </option>
+              <option value="D2Coding">
+                {t('settings.display.fontFamilyOptions.d2coding', 'D2Coding (Developer Mono)')}
+              </option>
             </select>
             <p className="text-xs text-muted-foreground mt-1">
               {t(

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -326,6 +326,12 @@
       "diffContextLinesDescription": "Number of context lines to show in file edit diffs (1-10)."
     },
     "display": {
+      "fontFamilyOptions": {
+        "pretendard": "Pretendard (Standard Sans)",
+        "inter": "Inter (Clean UI Sans)",
+        "nanumSquareNeo": "NanumSquare Neo (Modern Geometric)",
+        "d2coding": "D2Coding (Developer Mono)"
+      },
       "metricsTitle": "Performance Metrics",
       "metricDisplayMode": "Metric Display Mode",
       "inline": "Inline (show in message)",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -305,6 +305,12 @@
       "diffContextLinesDescription": "파일 편집 diff에 표시할 컨텍스트 라인 수 (1-10)."
     },
     "display": {
+      "fontFamilyOptions": {
+        "pretendard": "프리텐다드 (표준 고딕)",
+        "inter": "인터 (깔끔한 UI 고딕)",
+        "nanumSquareNeo": "나눔스퀘어 네오 (모던 기하학)",
+        "d2coding": "D2Coding (개발자용 고정폭)"
+      },
       "metricsTitle": "성능 지표",
       "metricDisplayMode": "지표 표시 방식",
       "inline": "인라인 (메시지에 표시)",


### PR DESCRIPTION
🌐 Scope: GeneralTab font settings
🔑 Keys Added: fontFamilyOptions
🌍 Languages: EN, KO
⚠️ Visual QA: Verified longer text strings don't break layout

---
*PR created automatically by Jules for task [14697719317083046930](https://jules.google.com/task/14697719317083046930) started by @fritzprix*