### PR TITLE
🎨 Palette: Improve keyboard focus visibility for preset actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,6 +57,8 @@
 
 **Learning:** For Radix UI tooltips wrapping a trigger with `asChild`, ensuring `asChild` propagates the event up the DOM needs proper usage of Radix primitive, particularly combining `DropdownMenuTrigger` with `TooltipTrigger` on `Button`. Also `forwardRef` warnings show up if the inner button is not using forwardRef correctly, but in `SessionNotificationsBell` combining them with `asChild` creates refs warning if not nested correctly. `TooltipTrigger asChild` around `DropdownMenuTrigger asChild` is needed.
 **Action:** When nesting Tooltips around Radix `DropdownMenuTrigger`, ensure both have `asChild` property so the original `<Button>` element receives both tooltip and dropdown aria/ref properties.
+
 ## 2023-10-26 - [Interactive elements with group-hover opacity]
+
 **Learning:** Container elements using `group-hover:opacity-100` alongside a low base opacity (e.g. `opacity-60`) will obscure their internally focusable elements during keyboard navigation (tabbing). This degrades the experience for keyboard users who cannot easily perceive the focused element.
 **Action:** Always append `group-focus-within:opacity-100` to containers that use `group-hover:opacity-100` to expose interactive child elements (like buttons or TooltipTriggers).

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,6 @@
 
 **Learning:** For Radix UI tooltips wrapping a trigger with `asChild`, ensuring `asChild` propagates the event up the DOM needs proper usage of Radix primitive, particularly combining `DropdownMenuTrigger` with `TooltipTrigger` on `Button`. Also `forwardRef` warnings show up if the inner button is not using forwardRef correctly, but in `SessionNotificationsBell` combining them with `asChild` creates refs warning if not nested correctly. `TooltipTrigger asChild` around `DropdownMenuTrigger asChild` is needed.
 **Action:** When nesting Tooltips around Radix `DropdownMenuTrigger`, ensure both have `asChild` property so the original `<Button>` element receives both tooltip and dropdown aria/ref properties.
+## 2023-10-26 - [Interactive elements with group-hover opacity]
+**Learning:** Container elements using `group-hover:opacity-100` alongside a low base opacity (e.g. `opacity-60`) will obscure their internally focusable elements during keyboard navigation (tabbing). This degrades the experience for keyboard users who cannot easily perceive the focused element.
+**Action:** Always append `group-focus-within:opacity-100` to containers that use `group-hover:opacity-100` to expose interactive child elements (like buttons or TooltipTriggers).

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -115,7 +115,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
                 </p>
               </div>
               {!isInstalled && (
-                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 transition-opacity">
+                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <code className="text-[10px] bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">
                     {preset.command} {preset.args?.[0]}
                   </code>


### PR DESCRIPTION
### 💡 What
Added `group-focus-within:opacity-100` to the container of the install button inside the Recommended MCP Server Presets card.

### 🎯 Why
Previously, the download action button and preset command details were visually suppressed with `opacity-60` and only became fully visible (`opacity-100`) via mouse hover (`group-hover:opacity-100`). This made the UI inaccessible for keyboard users navigating via Tab, as the focused element remained semi-transparent and difficult to read.

### 📸 Before/After
*Before:* Tabbing to the install button kept the surrounding text and button at 60% opacity.
*After:* Tabbing to the install button smoothly transitions the group's opacity to 100%, matching the mouse hover experience.

### ♿ Accessibility
Improves WCAG compliance by ensuring focus indicators and related contextual text have sufficient contrast and visibility when accessed via keyboard.

---
*PR created automatically by Jules for task [13290165062833020153](https://jules.google.com/task/13290165062833020153) started by @fritzprix*