### PR TITLE
🚪 Airlock: Extract session orphaning logic to Rust backend

### DIFF
--- a/src-tauri/src/agent/lifecycle/deletion.rs
+++ b/src-tauri/src/agent/lifecycle/deletion.rs
@@ -94,7 +94,7 @@ pub async fn delete_session_only(
     proxy_manager: &Arc<MCPServiceProxyManager>,
     app_handle: &AppHandle,
     session_id: String,
-) -> Result<(), String> {
+) -> Result<(String, Vec<String>), String> {
     // 1. Terminate workflow if running (this session only)
     let _ = crate::agent::workflow::terminate_session(
         session_repo,
@@ -109,11 +109,11 @@ pub async fn delete_session_only(
     active_sessions.write().await.remove(&session_id);
 
     // 3. Delete workspace and db
-    crate::services::SessionCleanupService::delete_session_data_only(&session_id).await?;
+    let orphaned_ids = crate::services::SessionCleanupService::delete_session_data_only(&session_id).await?;
 
     log::info!(
         "✅ Deleted session only (children orphaned): {}",
         session_id
     );
-    Ok(())
+    Ok((session_id, orphaned_ids))
 }

--- a/src-tauri/src/agent/lifecycle/deletion.rs
+++ b/src-tauri/src/agent/lifecycle/deletion.rs
@@ -109,7 +109,8 @@ pub async fn delete_session_only(
     active_sessions.write().await.remove(&session_id);
 
     // 3. Delete workspace and db
-    let orphaned_ids = crate::services::SessionCleanupService::delete_session_data_only(&session_id).await?;
+    let orphaned_ids =
+        crate::services::SessionCleanupService::delete_session_data_only(&session_id).await?;
 
     log::info!(
         "✅ Deleted session only (children orphaned): {}",

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -593,7 +593,10 @@ impl AgentSessionManager {
     /// - Direct children have their `parent_session_id` set to NULL (become top-level)
     /// - Only this session's workspace and search index are removed
     /// - No cascade to descendants
-    pub async fn delete_session_only(&self, session_id: String) -> Result<(String, Vec<String>), String> {
+    pub async fn delete_session_only(
+        &self,
+        session_id: String,
+    ) -> Result<(String, Vec<String>), String> {
         crate::agent::lifecycle::delete_session_only(
             &self.session_repo,
             &self.active_sessions,

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -593,7 +593,7 @@ impl AgentSessionManager {
     /// - Direct children have their `parent_session_id` set to NULL (become top-level)
     /// - Only this session's workspace and search index are removed
     /// - No cascade to descendants
-    pub async fn delete_session_only(&self, session_id: String) -> Result<(), String> {
+    pub async fn delete_session_only(&self, session_id: String) -> Result<(String, Vec<String>), String> {
         crate::agent::lifecycle::delete_session_only(
             &self.session_repo,
             &self.active_sessions,

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -744,7 +744,7 @@ pub async fn agent_delete_session_only(
 
     Ok(AgentResponse {
         success: true,
-        message: format!("Session deleted (children orphaned): {}", session_id),
+        message: format!("Session deleted (children orphaned): {}", deleted_id),
         data: Some(serde_json::json!({
             "deletedId": deleted_id,
             "orphanedIds": orphaned_ids

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -740,12 +740,15 @@ pub async fn agent_delete_session_only(
     manager: State<'_, AgentSessionManager>,
     session_id: String,
 ) -> Result<AgentResponse, String> {
-    manager.delete_session_only(session_id.clone()).await?;
+    let (deleted_id, orphaned_ids) = manager.delete_session_only(session_id.clone()).await?;
 
     Ok(AgentResponse {
         success: true,
         message: format!("Session deleted (children orphaned): {}", session_id),
-        data: None,
+        data: Some(serde_json::json!({
+            "deletedId": deleted_id,
+            "orphanedIds": orphaned_ids
+        })),
     })
 }
 

--- a/src-tauri/src/services/session_cleanup_service.rs
+++ b/src-tauri/src/services/session_cleanup_service.rs
@@ -141,7 +141,7 @@ impl SessionCleanupService {
     }
 
     /// Delete only this session data, leaving children as orphaned top-level sessions.
-    pub async fn delete_session_data_only(session_id: &str) -> Result<(), String> {
+    pub async fn delete_session_data_only(session_id: &str) -> Result<Vec<String>, String> {
         Self::delete_session_workspace(session_id).await?;
 
         if let Err(e) = delete_index(session_id) {
@@ -153,11 +153,17 @@ impl SessionCleanupService {
         }
 
         let session_repo = crate::state::get_session_repository();
+
+        let orphaned_ids = session_repo
+            .get_child_session_ids(session_id)
+            .await
+            .map_err(|e| format!("Failed to get child session ids: {}", e))?;
+
         session_repo
             .orphan_and_delete_session(session_id)
             .await
             .map_err(|e| format!("Failed to delete session metadata: {}", e))?;
 
-        Ok(())
+        Ok(orphaned_ids)
     }
 }

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -453,18 +453,22 @@ export function AgentSessionListProvider({
       logger.info('Deleting session only (orphaning children)', { sessionId });
 
       try {
-        await safeInvoke<AgentResponse>('agent_delete_session_only', {
+        const response = await safeInvoke<
+          AgentResponse<{ deletedId: string; orphanedIds: string[] }>
+        >('agent_delete_session_only', {
           sessionId,
         });
 
         clearSessionState(sessionId);
 
-        // Remove the session; update direct children to have no parent
+        const orphanedIds = new Set(response?.data?.orphanedIds || []);
+
+        // Remove the session; update explicitly orphaned children to have no parent
         setSessions((prev) =>
           prev
             .filter((s) => s.id !== sessionId)
             .map((s) =>
-              s.parentSessionId === sessionId
+              orphanedIds.has(s.id)
                 ? { ...s, parentSessionId: undefined }
                 : s,
             ),

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -459,18 +459,17 @@ export function AgentSessionListProvider({
           sessionId,
         });
 
-        clearSessionState(sessionId);
+        const actualDeletedId = response?.data?.deletedId || sessionId;
+        clearSessionState(actualDeletedId);
 
         const orphanedIds = new Set(response?.data?.orphanedIds || []);
 
         // Remove the session; update explicitly orphaned children to have no parent
         setSessions((prev) =>
           prev
-            .filter((s) => s.id !== sessionId)
+            .filter((s) => s.id !== actualDeletedId)
             .map((s) =>
-              orphanedIds.has(s.id)
-                ? { ...s, parentSessionId: undefined }
-                : s,
+              orphanedIds.has(s.id) ? { ...s, parentSessionId: undefined } : s,
             ),
         );
 

--- a/src/context/__tests__/AgentSessionListContext-delete.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-delete.test.tsx
@@ -143,7 +143,7 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
                     { id: 'parent', name: 'Parent', status: 'idle', createdAt: Date.now() },
                     { id: 'child', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'parent' },
                 ]);
-            if (cmd === 'agent_delete_session_only') return Promise.resolve();
+            if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'parent', orphanedIds: ['child'] } });
             return Promise.resolve();
         });
 
@@ -176,7 +176,7 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
                     { id: 'p', name: 'Parent', status: 'idle', createdAt: Date.now(), parentSessionId: 'gp' },
                     { id: 'c', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'p' },
                 ]);
-            if (cmd === 'agent_delete_session_only') return Promise.resolve();
+            if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'p', orphanedIds: ['c'] } });
             return Promise.resolve();
         });
 

--- a/src/context/__tests__/AgentSessionListContext-delete.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-delete.test.tsx
@@ -167,6 +167,41 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
         expect(safeInvoke).toHaveBeenCalledWith('agent_delete_session_only', { sessionId: 'parent' });
     });
 
+    it('deleteSessionOnly: uses deletedId from backend response when different from sessionId', async () => {
+        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
+            if (cmd === 'agent_get_all_sessions')
+                return Promise.resolve([
+                    { id: 'alias-id', name: 'Alias', status: 'idle', createdAt: Date.now() },
+                    { id: 'canonical-id', name: 'Parent', status: 'idle', createdAt: Date.now() },
+                    { id: 'child', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'canonical-id' },
+                ]);
+            // Mock backend resolving 'alias-id' to 'canonical-id'
+            if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'canonical-id', orphanedIds: ['child'] } });
+            return Promise.resolve();
+        });
+
+        const { result } = renderHook(
+            () => ({ state: useAgentSessionListState(), actions: useAgentSessionListActions() }),
+            { wrapper: TestWrapper },
+        );
+
+        await waitFor(() => expect(result.current.state.sessions).toHaveLength(3));
+
+        await act(async () => {
+            await result.current.actions.deleteSessionOnly('alias-id');
+        });
+
+        await waitFor(() => expect(result.current.state.sessions).toHaveLength(2));
+
+        const remainingIds = result.current.state.sessions.map(s => s.id);
+        // Canonical ID should be removed, alias should remain
+        expect(remainingIds).not.toContain('canonical-id');
+        expect(remainingIds).toContain('alias-id');
+        
+        const orphanedChild = result.current.state.sessions.find((s) => s.id === 'child');
+        expect(orphanedChild?.parentSessionId).toBeUndefined();
+    });
+
     it('deleteSessionOnly: grandchild still linked to its own parent after orphan', async () => {
         // Tree: gp → p → c. Delete p with deleteSessionOnly.
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
💡 What: Migrated the logic for identifying which child sessions to orphan during a delete-only operation from the React frontend to the Rust backend.
🎯 Why: Prevents the view layer from recomputing mutation side-effects and enforces the backend as the sole source of truth for cascading changes.
📊 Impact: Thin React client that only filters state based on explicit DTOs from Rust.
🔬 Verification: Run `pnpm test` and `cargo test`.

---
*PR created automatically by Jules for task [12831781078944304497](https://jules.google.com/task/12831781078944304497) started by @fritzprix*