### PR TITLE
⚗️ Distill: Optimize MCP response for listScheduledTasks

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -2,3 +2,6 @@
 
 **Learning:** Returning nested Markdown tables directly to LLM without explicitly declaring backticks for data constraints (such as `agent.id` and `sessionId`) reduces parsing stability and drops vital constraints.
 **Action:** When refactoring MCP Tools for tabular data, always explicitly quote ID fields and maintain strict structure without repeating conditional checks (`if !results.is_empty()`) for block-level additions.
+## 2024-05-24 - [Pagination context loss and markdown formatting]
+**Learning:** Returning unpaginated lists of complex entities without limits can easily bloat the LLM's context window. Additionally, when mapping lists to Markdown tables, ID fields must be explicitly wrapped in backticks to guarantee robust extraction by the LLM in subsequent chains.
+**Action:** Always add explicit `limit` and `offset` schema parameters to MCP list tools and use `.skip(offset).take(limit)` on iterators. Output explicit IDs wrapped in backticks when returning dense markdown tables.

--- a/src-tauri/src/mcp/builtin/scheduled_task/formatting.rs
+++ b/src-tauri/src/mcp/builtin/scheduled_task/formatting.rs
@@ -3,16 +3,16 @@ use serde_json::{json, Value};
 
 pub fn render_task_line(task: &ScheduledTaskModel) -> String {
     format!(
-        "- {} | {} | {} | next: {} | assistant: {}{}",
+        "| `{}` | {} | {} | {} | `{}` | {} |",
         task.id,
-        task.name,
+        task.name.replace('|', "\\|").replace('\n', " "),
         if task.enabled { "enabled" } else { "disabled" },
-        format_timestamp(task.next_run_at),
+        format_timestamp(task.next_run_at).replace('|', "\\|"),
         task.assistant_id,
         task.group_name
             .as_ref()
-            .map(|group| format!(" | group: {}", group))
-            .unwrap_or_default()
+            .map(|group| group.replace('|', "\\|").replace('\n', " "))
+            .unwrap_or_else(|| "-".to_string())
     )
 }
 

--- a/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
+++ b/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
@@ -28,6 +28,8 @@ pub struct CreateScheduledTaskArgs {
 pub struct ListScheduledTasksArgs {
     assistant_id: Option<String>,
     enabled: Option<bool>,
+    limit: Option<usize>,
+    offset: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -153,45 +155,73 @@ pub async fn handle_list_scheduled_tasks(
         tasks.retain(|task| task.enabled == enabled);
     }
 
+    let total = tasks.len();
+    let limit = args.limit.unwrap_or(20);
+    let offset = args.offset.unwrap_or(0);
+
+    let paged_tasks: Vec<_> = tasks.into_iter().skip(offset).take(limit).collect();
+
     let header = match (args.assistant_id.as_deref(), args.enabled) {
         (Some(assistant_id), Some(enabled)) => format!(
-            "Found {} scheduled task(s) for assistant '{}' with enabled={}:",
-            tasks.len(),
+            "Found {} scheduled task(s) for assistant '{}' with enabled={}:\n\n",
+            total,
             assistant_id,
             enabled
         ),
         (Some(assistant_id), None) => format!(
-            "Found {} scheduled task(s) for assistant '{}':",
-            tasks.len(),
+            "Found {} scheduled task(s) for assistant '{}':\n\n",
+            total,
             assistant_id
         ),
         (None, Some(enabled)) => format!(
-            "Found {} scheduled task(s) with enabled={}:",
-            tasks.len(),
+            "Found {} scheduled task(s) with enabled={}:\n\n",
+            total,
             enabled
         ),
-        (None, None) => format!("Found {} scheduled task(s):", tasks.len()),
+        (None, None) => format!("Found {} scheduled task(s):\n\n", total),
     };
 
-    let body = if tasks.is_empty() {
-        "No scheduled tasks matched the filter.".to_string()
+    let mut body = String::new();
+    if paged_tasks.is_empty() {
+        if total > 0 {
+            body.push_str(&format!("No results for this page (offset {}, limit {}). Try a smaller offset.\n", offset, limit));
+        } else {
+            body.push_str("No scheduled tasks matched the filter.\n");
+        }
     } else {
-        tasks
+        body.push_str("| ID | Name | Status | Next Run | Assistant | Group |\n");
+        body.push_str("|---|---|---|---|---|---|\n");
+        body.push_str(&paged_tasks
             .iter()
-            .map(render_task_line)
+            .map(|t| render_task_line(t))
             .collect::<Vec<_>>()
-            .join("\n")
-    };
+            .join("\n"));
+        body.push('\n');
+    }
+
+    if offset.saturating_add(limit) < total {
+        body.push_str(&format!(
+            "\n*(Showing {} to {} of {} total results. Call this tool again with offset: {} to see more)*",
+            offset + 1,
+            offset + paged_tasks.len(),
+            total,
+            offset.saturating_add(limit)
+        ));
+    }
 
     Ok(SuccessHint::new(
         format!(
-            "{header}\n\n{body}\n\n💡 Use getScheduledTask(\"...\") for full detail before updating or deleting."
+            "{header}{body}\n\n💡 Use getScheduledTask(\"...\") for full detail before updating or deleting."
         ),
         vec!["Use getScheduledTask(\"...\") to inspect one task in detail".to_string()],
     )
     .to_mcp_result_with_data(Some(json!({
-        "tasks": tasks.iter().map(task_to_json).collect::<Vec<_>>(),
-        "total": tasks.len()
+        "query": args.assistant_id,
+        "enabled": args.enabled,
+        "offset": offset,
+        "limit": limit,
+        "totalResults": total,
+        "tasks": paged_tasks.iter().map(task_to_json).collect::<Vec<_>>(),
     }))))
 }
 

--- a/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
+++ b/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
@@ -193,7 +193,7 @@ pub async fn handle_list_scheduled_tasks(
         body.push_str("|---|---|---|---|---|---|\n");
         body.push_str(&paged_tasks
             .iter()
-            .map(|t| render_task_line(t))
+            .map(render_task_line)
             .collect::<Vec<_>>()
             .join("\n"));
         body.push('\n');

--- a/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
+++ b/src-tauri/src/mcp/builtin/scheduled_task/handlers.rs
@@ -164,19 +164,15 @@ pub async fn handle_list_scheduled_tasks(
     let header = match (args.assistant_id.as_deref(), args.enabled) {
         (Some(assistant_id), Some(enabled)) => format!(
             "Found {} scheduled task(s) for assistant '{}' with enabled={}:\n\n",
-            total,
-            assistant_id,
-            enabled
+            total, assistant_id, enabled
         ),
         (Some(assistant_id), None) => format!(
             "Found {} scheduled task(s) for assistant '{}':\n\n",
-            total,
-            assistant_id
+            total, assistant_id
         ),
         (None, Some(enabled)) => format!(
             "Found {} scheduled task(s) with enabled={}:\n\n",
-            total,
-            enabled
+            total, enabled
         ),
         (None, None) => format!("Found {} scheduled task(s):\n\n", total),
     };
@@ -184,18 +180,23 @@ pub async fn handle_list_scheduled_tasks(
     let mut body = String::new();
     if paged_tasks.is_empty() {
         if total > 0 {
-            body.push_str(&format!("No results for this page (offset {}, limit {}). Try a smaller offset.\n", offset, limit));
+            body.push_str(&format!(
+                "No results for this page (offset {}, limit {}). Try a smaller offset.\n",
+                offset, limit
+            ));
         } else {
             body.push_str("No scheduled tasks matched the filter.\n");
         }
     } else {
         body.push_str("| ID | Name | Status | Next Run | Assistant | Group |\n");
         body.push_str("|---|---|---|---|---|---|\n");
-        body.push_str(&paged_tasks
-            .iter()
-            .map(render_task_line)
-            .collect::<Vec<_>>()
-            .join("\n"));
+        body.push_str(
+            &paged_tasks
+                .iter()
+                .map(render_task_line)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         body.push('\n');
     }
 

--- a/src-tauri/src/mcp/builtin/scheduled_task/tools.rs
+++ b/src-tauri/src/mcp/builtin/scheduled_task/tools.rs
@@ -113,6 +113,24 @@ fn list_scheduled_tasks_tool() -> MCPTool {
                     "enabled".to_string(),
                     boolean_prop(Some("Optional enabled-state filter.")),
                 ),
+                (
+                    "limit".to_string(),
+                    integer_prop_with_default(
+                        Some(1),
+                        Some(100),
+                        20,
+                        Some("Maximum number of items to return."),
+                    ),
+                ),
+                (
+                    "offset".to_string(),
+                    integer_prop_with_default(
+                        Some(0),
+                        None,
+                        0,
+                        Some("Pagination offset (0-based)."),
+                    ),
+                ),
             ],
             vec![],
             None,


### PR DESCRIPTION
💡 What: Added `limit` and `offset` arguments to the `listScheduledTasks` tool and reformatted the list output into a dense Markdown table. Explicitly added backticks around task IDs and assistant IDs.  
🎯 Why: Without limits and tabular output, listing a large number of scheduled tasks bloats the context window with raw text lines, and lacks explicit ID quotation needed for LLMs to easily extract IDs for subsequent actions. 
📉 Token Impact: Reduces output size for large numbers of tasks by paginating at 20 tasks max by default and formatting into a highly compressed table. 
🛠️ Error Recovery: Added a specific pagination hint string at the bottom of the list when more items are available, prompting the LLM to call the tool again with the updated offset.

---
*PR created automatically by Jules for task [3248561605424510949](https://jules.google.com/task/3248561605424510949) started by @fritzprix*