### PR TITLE
feat(history): add delete capability to OrgCard and fix toaster position

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { lazy, Suspense, useEffect } from 'react';
 import { emit } from '@tauri-apps/api/event';
-import { Toaster } from 'sonner';
+import { Toaster } from '../components/ui/sonner';
 import AppSidebar from '../components/layout/AppSidebar';
 import { ThemeToggle } from '../components/common/ThemeToggle';
 import { AppHeader } from '../components/layout/AppHeader';
@@ -165,7 +165,7 @@ function App() {
                             </div>
                           </DnDContextProvider>
                         </SidebarProvider>
-                        <Toaster />
+                        <Toaster position="top-right" />
                       </AgentSessionListProvider>
                     </AssistantContextProvider>
                   </MCPServerProvider>

--- a/src/features/history/OrgCard.tsx
+++ b/src/features/history/OrgCard.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Building2, Play } from 'lucide-react';
+import { Building2, Play, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -10,12 +11,28 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { formatSessionTimestamp } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
+import { useAgentSessionListActions } from '@/context/AgentSessionListContext';
+import { toast } from 'sonner';
+import { getLogger } from '@/lib/logger';
 import type { OrgSummary } from './org-sessions';
 import { getStatusBadgeConfig } from './org-status';
 import { OrgStatTiles } from './OrgStatTiles';
 import { OrgLineageSnapshot } from './OrgLineageSnapshot';
+
+const logger = getLogger('OrgCard');
 
 interface OrgCardProps {
   org: OrgSummary;
@@ -24,14 +41,31 @@ interface OrgCardProps {
 export function OrgCard({ org }: OrgCardProps) {
   const navigate = useNavigate();
   const { t } = useTranslation('common');
+  const { deleteSession } = useAgentSessionListActions();
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const ts = formatSessionTimestamp(org.updatedAt);
   const rootBadge = getStatusBadgeConfig(org.rootSession.status);
 
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      await deleteSession(org.orgRootSessionId);
+      toast.success(t('orgHistory.toasts.deleted', 'Organization deleted'));
+    } catch (error) {
+      logger.error('Failed to delete organization', error);
+      toast.error(
+        t('orgHistory.toasts.deleteFailed', 'Failed to delete organization'),
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   return (
     <Card className="overflow-hidden border-border/70 bg-card shadow-sm shadow-black/5 transition-shadow hover:shadow-md">
-      <CardHeader className="gap-4 overflow-hidden border-b bg-muted/20">
-        <div className="min-w-0 space-y-3">
+      <CardHeader className="flex-row items-start justify-between gap-4 overflow-hidden border-b bg-muted/20 pb-4">
+        <div className="min-w-0 flex-1 space-y-3">
           <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             {t('orgHistory.cardLabel', 'Explicit Org')}
           </p>
@@ -73,6 +107,44 @@ export function OrgCard({ org }: OrgCardProps) {
             </div>
           </div>
         </div>
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="mt-1 h-8 w-8 shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+              disabled={isDeleting}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">
+                {t('orgHistory.delete', 'Delete Organization')}
+              </span>
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {t('orgHistory.deleteConfirm.title', 'Delete Organization?')}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {t(
+                  'orgHistory.deleteConfirm.description',
+                  'This will permanently delete this organization and all of its associated member sessions, including all files and histories. This action cannot be undone.',
+                )}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {t('common.delete')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </CardHeader>
 
       <CardContent className="space-y-5 pt-6">

--- a/src/features/history/OrgCard.tsx
+++ b/src/features/history/OrgCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Building2, Play, Trash2 } from 'lucide-react';
+import { Building2, Play, Trash2, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -43,15 +43,23 @@ export function OrgCard({ org }: OrgCardProps) {
   const { t } = useTranslation('common');
   const { deleteSession } = useAgentSessionListActions();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const ts = formatSessionTimestamp(org.updatedAt);
   const rootBadge = getStatusBadgeConfig(org.rootSession.status);
 
-  async function handleDelete() {
+  async function handleDelete(e: React.MouseEvent) {
+    // Prevent the dialog from closing automatically if we were using a simple trigger,
+    // but since we are using AlertDialogAction which usually closes, we need to handle it.
+    // However, Shadcn AlertDialogAction calls onOpenChange(false) internally.
+    // To prevent this, we manage the 'open' state of the AlertDialog manually.
+    e.preventDefault();
+
     setIsDeleting(true);
     try {
       await deleteSession(org.orgRootSessionId);
       toast.success(t('orgHistory.toasts.deleted', 'Organization deleted'));
+      setIsDialogOpen(false); // Only close on success
     } catch (error) {
       logger.error('Failed to delete organization', error);
       toast.error(
@@ -108,7 +116,7 @@ export function OrgCard({ org }: OrgCardProps) {
           </div>
         </div>
 
-        <AlertDialog>
+        <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
@@ -135,12 +143,22 @@ export function OrgCard({ org }: OrgCardProps) {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>
+                {t('common.cancel')}
+              </AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDelete}
+                disabled={isDeleting}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
-                {t('common.delete')}
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t('common.delete', 'Delete')}
+                  </>
+                ) : (
+                  t('common.delete', 'Delete')
+                )}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/features/history/__tests__/OrgCard.test.tsx
+++ b/src/features/history/__tests__/OrgCard.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OrgCard } from '../OrgCard';
+import type { OrgSummary } from '../org-sessions';
+import { toast } from 'sonner';
+import type { AgentSession } from '@/models/agent';
+
+const mockNavigate = vi.fn();
+const mockDeleteSession = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/context/AgentSessionListContext', () => ({
+  useAgentSessionListActions: () => ({
+    deleteSession: mockDeleteSession,
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultString?: string) => defaultString || key,
+  }),
+}));
+
+// Mock ResizeObserver which is needed by some Radix components
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+const mockOrg: OrgSummary = {
+  orgId: 'org-1',
+  orgName: 'Research Org',
+  orgRootSessionId: 'root-1',
+  rootSession: {
+    id: 'root-1',
+    name: 'Root Session',
+    status: 'idle',
+    model: 'gpt-4',
+    provider: 'openai',
+    createdAt: new Date('2026-04-05T00:00:00Z'),
+    updatedAt: new Date('2026-04-05T01:00:00Z'),
+    orgId: 'org-1',
+    orgName: 'Research Org',
+    orgRootSessionId: 'root-1',
+    yoloMode: false,
+  } as unknown as AgentSession,
+  members: [],
+  memberCount: 5,
+  busyCount: 1,
+  updatedAt: new Date('2026-04-05T01:00:00Z'),
+};
+
+describe('OrgCard', () => {
+  it('renders organization information correctly', () => {
+    render(<OrgCard org={mockOrg} />);
+
+    expect(screen.getByText('Research Org')).toBeInTheDocument();
+    // Use getAllByText because 'Root Session' appears in the title and the value
+    expect(screen.getAllByText('Root Session').length).toBeGreaterThan(0);
+    expect(screen.getByText('5')).toBeInTheDocument(); // Member count
+  });
+
+  it('navigates to root session when resume button is clicked', () => {
+    render(<OrgCard org={mockOrg} />);
+
+    fireEvent.click(screen.getByText('Resume Root Session'));
+    expect(mockNavigate).toHaveBeenCalledWith('/agent/root-1');
+  });
+
+  it('opens confirmation dialog and handles successful deletion', async () => {
+    mockDeleteSession.mockResolvedValueOnce(undefined);
+    render(<OrgCard org={mockOrg} />);
+
+    // Click trash icon
+    const deleteButton = screen.getByRole('button', { name: 'Delete Organization' });
+    fireEvent.click(deleteButton);
+
+    // Dialog should be open
+    expect(screen.getByText('Delete Organization?')).toBeInTheDocument();
+
+    // Click confirm delete - the button text is 'common.delete' or 'Delete' depending on mock
+    const confirmButton = screen.getByRole('button', { name: 'Delete' });
+    fireEvent.click(confirmButton);
+
+    expect(mockDeleteSession).toHaveBeenCalledWith('root-1');
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Organization deleted');
+      expect(screen.queryByText('Delete Organization?')).not.toBeInTheDocument();
+    });
+  });
+
+  it('handles deletion failure and keeps dialog open', async () => {
+    mockDeleteSession.mockRejectedValueOnce(new Error('Delete failed'));
+    render(<OrgCard org={mockOrg} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to delete organization');
+      // Dialog should still be open
+      expect(screen.getByText('Delete Organization?')).toBeInTheDocument();
+    });
+  });
+
+  it('disables buttons while deleting', async () => {
+    // Mock a slow deletion
+    let resolveDelete: (value: void | PromiseLike<void>) => void;
+    const deletePromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    mockDeleteSession.mockReturnValue(deletePromise);
+
+    render(<OrgCard org={mockOrg} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Organization' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    // Buttons should be disabled
+    // Note: AlertDialogCancel uses t('common.cancel') which returns 'common.cancel' in our mock
+    expect(screen.getByRole('button', { name: 'common.cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+    // Complete the deletion
+    resolveDelete!(undefined);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Organization?')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -248,6 +248,27 @@
       "subtitle": "Start a conversation to create your first session"
     }
   },
+  "orgHistory": {
+    "heading": "Org View",
+    "description": "Explicit org-created lineages only. One-off delegated sessions stay in ordinary history.",
+    "cardLabel": "Explicit Org",
+    "rootLabel": "Root Session",
+    "updatedLabel": "Updated",
+    "resumeRoot": "Resume Root Session",
+    "delete": "Delete Organization",
+    "deleteConfirm": {
+      "title": "Delete Organization?",
+      "description": "This will permanently delete this organization and all of its associated member sessions, including all files and histories. This action cannot be undone."
+    },
+    "toasts": {
+      "deleted": "Organization deleted",
+      "deleteFailed": "Failed to delete organization"
+    },
+    "emptyState": {
+      "title": "No org lineages yet",
+      "subtitle": "Create an org explicitly, then spawn org members through the org-aware tools. Plain sub-agent lineage does not belong here."
+    }
+  },
   "settings": {
     "title": "Settings",
     "versionLabel": "{{appName}} v{{version}}",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -227,6 +227,27 @@
       "subtitle": "대화를 시작하여 첫 번째 세션을 만드세요"
     }
   },
+  "orgHistory": {
+    "heading": "조직 뷰",
+    "description": "명시적으로 생성된 조직 리니지만 표시됩니다. 일회성 위임 세션은 일반 기록에 남습니다.",
+    "cardLabel": "명시적 조직",
+    "rootLabel": "루트 세션",
+    "updatedLabel": "업데이트됨",
+    "resumeRoot": "루트 세션 재개",
+    "delete": "조직 삭제",
+    "deleteConfirm": {
+      "title": "조직을 삭제하시겠습니까?",
+      "description": "이 조직과 관련된 모든 구성원 세션(파일 및 기록 포함)이 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+    },
+    "toasts": {
+      "deleted": "조직이 삭제되었습니다",
+      "deleteFailed": "조직 삭제에 실패했습니다"
+    },
+    "emptyState": {
+      "title": "아직 조직 리니지가 없습니다",
+      "subtitle": "조직을 명시적으로 만든 다음, 조직 인식 도구를 통해 조직 구성원을 생성하세요. 일반 서브 에이전트 리니지는 여기에 포함되지 않습니다."
+    }
+  },
   "settings": {
     "title": "설정",
     "versionLabel": "{{appName}} v{{version}}",


### PR DESCRIPTION
This pull request adds the ability to delete organizations from the organization history view, including a confirmation dialog and user feedback. It also improves the user interface and internationalization for organization management. The most important changes are grouped below:

**Organization Deletion Feature:**

* Added a delete button to the `OrgCard` component, which opens a confirmation dialog before allowing users to permanently delete an organization and all its sessions. The deletion process provides success and error toasts for user feedback. [[1]](diffhunk://#diff-2a3d98193e2f941aae41a415b6d3e4073d6814bf41ccb4bda87e4428136fe077R1-R4) [[2]](diffhunk://#diff-2a3d98193e2f941aae41a415b6d3e4073d6814bf41ccb4bda87e4428136fe077R14-R68) [[3]](diffhunk://#diff-2a3d98193e2f941aae41a415b6d3e4073d6814bf41ccb4bda87e4428136fe077R110-R147)
* Integrated the deletion logic with the agent session context and added logging for error handling. [[1]](diffhunk://#diff-2a3d98193e2f941aae41a415b6d3e4073d6814bf41ccb4bda87e4428136fe077R1-R4) [[2]](diffhunk://#diff-2a3d98193e2f941aae41a415b6d3e4073d6814bf41ccb4bda87e4428136fe077R14-R68)

**Internationalization and UI Updates:**

* Added English and Korean translations for all new organization history UI elements, including confirmation dialogs, toast messages, and empty state descriptions. [[1]](diffhunk://#diff-90cc22e42d25a866b056a59abd1eb6b7ad4ce4ea8fa42c729eed6aadb4f91653R251-R271) [[2]](diffhunk://#diff-92ce093068dd792da6e7c0e170250968dd34717d8a98de9720976612807f0821R230-R250)
* Updated the import for the `Toaster` component and set its position to `top-right` for better visibility of notifications. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L4-R4) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L168-R168)