### PR TITLE
Optimize agent session loading

### DIFF
--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -465,10 +465,9 @@ pub async fn request_llm_completion(
     let system_prompt = Some(stable_prompt);
 
     // Collect available tools
-    let available_tools =
-        crate::agent::tools::collect_available_tools(&session_id, &agent_config, proxy_manager)
-            .await
-            .ok();
+    let available_tools = crate::agent::tools::collect_available_tools(&session_id, proxy_manager)
+        .await
+        .ok();
 
     // Resolve @type:arg references in user messages (Late Binding).
     // The stored messages are NOT modified — only the CompletionRequest payload is enriched.

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -257,6 +257,7 @@ impl AgentSessionManager {
         session_id: String,
         user_message: Message,
     ) -> Result<(), String> {
+        self.ensure_session_active(&session_id).await?;
         crate::agent::workflow::start_workflow(
             &self.session_repo,
             &self.active_sessions,
@@ -319,6 +320,7 @@ impl AgentSessionManager {
 
     /// Resume a paused workflow
     pub async fn resume_workflow(&self, session_id: String) -> Result<(), String> {
+        self.ensure_session_active(&session_id).await?;
         crate::agent::workflow::resume_workflow(
             &self.session_repo,
             &self.active_sessions,
@@ -365,6 +367,7 @@ impl AgentSessionManager {
         session_id: String,
         messages: Vec<Message>,
     ) -> Result<bool, String> {
+        self.ensure_session_active(&session_id).await?;
         let should_trigger_workflow = {
             let sessions = self.active_sessions.read().await;
             let session = sessions
@@ -443,6 +446,21 @@ impl AgentSessionManager {
         }
 
         Ok(should_trigger_workflow)
+    }
+
+    pub async fn ensure_session_active(&self, session_id: &str) -> Result<(), String> {
+        let is_active = {
+            let active = self.active_sessions.read().await;
+            active.contains_key(session_id)
+        };
+
+        if is_active {
+            return Ok(());
+        }
+
+        self.resume_session(session_id).await?;
+        self.init_session_with_messages(session_id).await?;
+        Ok(())
     }
 
     pub async fn inject_channel_notification(

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -628,21 +628,9 @@ impl AgentSessionManager {
         &self,
         session_id: &str,
     ) -> Result<Vec<crate::mcp::types::MCPTool>, String> {
-        let active = self.active_sessions.read().await;
-        let session = active
-            .get(session_id)
-            .ok_or_else(|| format!("Session not found: {}", session_id))?;
-
-        let agent_config = session
-            .metadata
-            .agent_config
-            .as_ref()
-            .ok_or_else(|| "Agent configuration is required".to_string())
-            .and_then(|json| {
-                crate::agent::AgentConfig::from_json(json).map_err(|e| e.to_string())
-            })?;
-
-        drop(active); // Release the read lock before async call
+        self.proxy_manager
+            .ensure_configured_proxy(session_id, Some(self.app_handle.clone()))
+            .await?;
 
         // Wait for background tool loading to finish (stdio/HTTP servers are spawned
         // asynchronously during proxy creation). Use a short timeout here (10 s) because
@@ -663,8 +651,7 @@ impl AgentSessionManager {
         }
 
         // Use existing collect_available_tools function (same as LLM request)
-        crate::agent::tools::collect_available_tools(session_id, &agent_config, &self.proxy_manager)
-            .await
+        crate::agent::tools::collect_available_tools(session_id, &self.proxy_manager).await
     }
 
     /// Get available tools for a session based on its config
@@ -672,34 +659,7 @@ impl AgentSessionManager {
         &self,
         session_id: &str,
     ) -> Result<Vec<crate::mcp::types::MCPTool>, String> {
-        // 1. Get session config
-        // Try active first
-        let config = {
-            let active = self.active_sessions.read().await;
-            if let Some(session) = active.get(session_id) {
-                if let Some(config_str) = &session.metadata.agent_config {
-                    crate::agent::AgentConfig::from_json(config_str)?
-                } else {
-                    return Err("Session has no config".to_string());
-                }
-            } else {
-                // Try DB
-                let session_opt =
-                    crate::agent::lifecycle::get_session(&self.session_repo, session_id).await?;
-                if let Some(session) = session_opt {
-                    if let Some(config_str) = &session.agent_config {
-                        crate::agent::AgentConfig::from_json(config_str)?
-                    } else {
-                        return Err("Session has no config".to_string());
-                    }
-                } else {
-                    return Err("Session not found".to_string());
-                }
-            }
-        };
-
-        // 2. Call collect_available_tools
-        crate::agent::tools::collect_available_tools(session_id, &config, &self.proxy_manager).await
+        self.get_available_tools(session_id).await
     }
 
     /// Remove a message from the in-memory cache

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -93,10 +93,9 @@ pub fn classify_tool_result(
     ToolResultAcceptance::Accept
 }
 
-/// Collect available tools for a session based on agent configuration
+/// Collect available tools for a session from its configured proxy.
 pub async fn collect_available_tools(
     session_id: &str,
-    agent_config: &crate::agent::AgentConfig,
     proxy_manager: &Arc<MCPServiceProxyManager>,
 ) -> Result<Vec<crate::mcp::types::MCPTool>, String> {
     let mut all_tools = Vec::new();
@@ -129,35 +128,26 @@ pub async fn collect_available_tools(
             session_id
         );
 
-        // 2. Collect external MCP tools
-        if !agent_config.mcp_server_ids.is_empty() {
-            log::debug!(
-                "Agent config allows {} external MCP servers",
-                agent_config.mcp_server_ids.len()
-            );
+        // 2. Collect external MCP tools from the session-isolated proxy state.
+        let session_stdio_tools = proxy.get_session_stdio_tools().await;
 
-            // 2a. Get SESSION-ISOLATED stdio server tools (spawned per-session)
-            let session_stdio_tools = proxy.get_session_stdio_tools().await;
+        log::info!(
+            "Collected {} SESSION-ISOLATED stdio tools for session {}",
+            session_stdio_tools.len(),
+            session_id
+        );
 
-            log::info!(
-                "Collected {} SESSION-ISOLATED stdio tools for session {}",
-                session_stdio_tools.len(),
-                session_id
-            );
+        all_tools.extend(session_stdio_tools);
 
-            all_tools.extend(session_stdio_tools);
+        let session_http_tools = proxy.get_session_http_tools().await;
 
-            // 2b. Get SESSION-ISOLATED HTTP server tools (connected per-session)
-            let session_http_tools = proxy.get_session_http_tools().await;
+        log::info!(
+            "Collected {} SESSION-ISOLATED HTTP tools for session {}",
+            session_http_tools.len(),
+            session_id
+        );
 
-            log::info!(
-                "Collected {} SESSION-ISOLATED HTTP tools for session {}",
-                session_http_tools.len(),
-                session_id
-            );
-
-            all_tools.extend(session_http_tools);
-        }
+        all_tools.extend(session_http_tools);
     } else {
         log::warn!(
             "No proxy found for session {}, cannot collect tools",

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -177,43 +177,27 @@ pub(crate) async fn ensure_proxy_exists(
         session_id
     );
 
-    let session_repo = crate::state::get_session_repository();
-    if let Some(session) = session_repo
-        .get_session(session_id)
+    match proxy_manager
+        .ensure_configured_proxy(session_id, Some(app_handle.clone()))
         .await
-        .map_err(|e| format!("Failed to get session for proxy recreation: {}", e))?
     {
-        if let Some(config_json) = session.agent_config {
-            let agent_config = crate::agent::AgentConfig::from_json(&config_json)
-                .map_err(|e| format!("Failed to parse agent config: {}", e))?;
-
-            let tool_ids = crate::agent::tools::extract_builtin_tool_ids(&agent_config);
-            let mcp_server_ids = agent_config.mcp_server_ids.clone();
-
-            proxy_manager
-                .create_proxy(
-                    session_id.to_string(),
-                    tool_ids,
-                    mcp_server_ids,
-                    Some(app_handle.clone()),
-                )
-                .await?;
-
+        Ok(_) => {
             log::info!(
-                "✅ Successfully recreated MCP proxy for session: {}",
-                session_id
-            );
-        } else {
-            log::error!(
-                "Cannot recreate proxy: Session {} has no agent config",
+                "Successfully ensured configured MCP proxy for session: {}",
                 session_id
             );
         }
-    } else {
-        log::error!(
-            "Cannot recreate proxy: Session {} not found in DB",
-            session_id
-        );
+        Err(error)
+            if error == format!("Session not found: {}", session_id)
+                || error == "Session has no config" =>
+        {
+            log::error!(
+                "Cannot recreate proxy during workflow start for session {}: {}",
+                session_id,
+                error
+            );
+        }
+        Err(error) => return Err(error),
     }
 
     Ok(())

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -1,7 +1,9 @@
 use crate::agent::AgentSessionManager;
+use crate::commands::messages_commands::MessageSlice;
 use crate::mcp::types::ChannelNotification;
 use crate::mcp::types::ChannelPermissionVerdict;
 use crate::mcp::types::ServiceContext;
+use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::{CompactContextRecord, SessionMetadata, SessionRepository};
 use crate::state::get_session_repository;
 use serde::{Deserialize, Serialize};
@@ -118,6 +120,23 @@ pub struct AgentResponse {
     pub success: bool,
     pub message: String,
     pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentOpenSessionResponse {
+    pub session: SessionMetadata,
+    pub messages: MessageSlice,
+    #[serde(default)]
+    pub pending_approvals: Vec<PendingApprovalSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingApprovalSnapshot {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub arguments: String,
 }
 
 fn default_ui_action_params() -> serde_json::Value {
@@ -266,6 +285,52 @@ pub async fn agent_resume_session(
     session_id: String,
 ) -> Result<SessionMetadata, String> {
     manager.resume_session(&session_id).await
+}
+
+/// Resume a session and return only the recent transcript slice needed for initial UI rendering.
+#[command]
+pub async fn agent_open_session(
+    manager: State<'_, AgentSessionManager>,
+    session_id: String,
+    initial_message_limit: Option<u64>,
+) -> Result<AgentOpenSessionResponse, String> {
+    const DEFAULT_INITIAL_MESSAGE_LIMIT: u64 = 40;
+
+    let session = manager
+        .get_session(&session_id)
+        .await?
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+    let repo = crate::state::get_message_repository();
+    let message_slice = repo
+        .get_recent_slice(
+            &session_id,
+            initial_message_limit.unwrap_or(DEFAULT_INITIAL_MESSAGE_LIMIT),
+        )
+        .await
+        .map_err(|e| format!("Failed to load recent session messages: {}", e))?;
+    let pending_approvals = {
+        let active = manager.active_sessions_arc();
+        let sessions = active.read().await;
+        if let Some(active_session) = sessions.get(&session_id) {
+            let approvals = active_session.pending_approvals.read().await;
+            approvals
+                .iter()
+                .map(|(tool_call_id, data)| PendingApprovalSnapshot {
+                    tool_call_id: tool_call_id.clone(),
+                    tool_name: data.tool_name.clone(),
+                    arguments: data.arguments.clone(),
+                })
+                .collect()
+        } else {
+            Vec::new()
+        }
+    };
+
+    Ok(AgentOpenSessionResponse {
+        session,
+        messages: message_slice.into(),
+        pending_approvals,
+    })
 }
 
 /// Initialize session with messages from database

--- a/src-tauri/src/commands/messages_commands.rs
+++ b/src-tauri/src/commands/messages_commands.rs
@@ -1,10 +1,14 @@
 use crate::agent::session_manager::AgentSessionManager;
 use crate::models::chat::Message;
+use crate::repositories::message_repository::{
+    MessagePaginationCursor as RepositoryMessageCursor, MessageSlicePage as RepositoryMessageSlice,
+};
 use crate::repositories::MessageRepository;
 use crate::search::message_index::SearchResult;
 use crate::services::MessageService;
 use crate::state::get_message_repository;
 use crate::utils::pagination::Page;
+use serde::{Deserialize, Serialize};
 use tauri::command;
 use tauri::State;
 
@@ -14,6 +18,40 @@ use tauri::State;
 // ========================================
 // Tauri Commands
 // ========================================
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageCursor {
+    pub created_at: i64,
+    pub row_id: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageSlice {
+    pub items: Vec<Message>,
+    pub has_more_before: bool,
+    pub oldest_cursor: Option<MessageCursor>,
+}
+
+impl From<RepositoryMessageCursor> for MessageCursor {
+    fn from(value: RepositoryMessageCursor) -> Self {
+        Self {
+            created_at: value.created_at,
+            row_id: value.row_id,
+        }
+    }
+}
+
+impl From<RepositoryMessageSlice> for MessageSlice {
+    fn from(value: RepositoryMessageSlice) -> Self {
+        Self {
+            items: value.items,
+            has_more_before: value.has_more_before,
+            oldest_cursor: value.oldest_cursor.map(Into::into),
+        }
+    }
+}
 
 /// Get a paginated list of messages for a session.
 #[command]
@@ -26,6 +64,38 @@ pub async fn messages_get_page(
     repo.get_page(&session_id, page, page_size)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// Get the most recent messages for a session in ascending chronological order.
+#[command]
+pub async fn messages_get_recent_slice(
+    session_id: String,
+    limit: u64,
+) -> Result<MessageSlice, String> {
+    let repo = get_message_repository();
+    let slice = repo
+        .get_recent_slice(&session_id, limit)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(slice.into())
+}
+
+/// Get messages older than a cursor for a session in ascending chronological order.
+#[command]
+pub async fn messages_get_messages_before(
+    session_id: String,
+    before_created_at: i64,
+    before_row_id: i64,
+    limit: u64,
+) -> Result<MessageSlice, String> {
+    let repo = get_message_repository();
+    let slice = repo
+        .get_messages_before(&session_id, before_created_at, before_row_id, limit)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(slice.into())
 }
 
 /// Insert or update multiple messages at once.

--- a/src-tauri/src/commands/messages_commands.rs
+++ b/src-tauri/src/commands/messages_commands.rs
@@ -66,21 +66,6 @@ pub async fn messages_get_page(
         .map_err(|e| e.to_string())
 }
 
-/// Get the most recent messages for a session in ascending chronological order.
-#[command]
-pub async fn messages_get_recent_slice(
-    session_id: String,
-    limit: u64,
-) -> Result<MessageSlice, String> {
-    let repo = get_message_repository();
-    let slice = repo
-        .get_recent_slice(&session_id, limit)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    Ok(slice.into())
-}
-
 /// Get messages older than a cursor for a session in ascending chronological order.
 #[command]
 pub async fn messages_get_messages_before(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,10 +37,10 @@ use commands::agent_commands::{
     agent_handle_compact_error, agent_handle_compact_response, agent_handle_llm_error,
     agent_handle_llm_response, agent_handle_tool_result, agent_init_session_with_messages,
     agent_inject_channel_message, agent_inject_channel_message_auto, agent_inject_messages,
-    agent_mark_session_viewed, agent_pause_workflow, agent_respond_channel_permission,
-    agent_respond_tool_approval, agent_resume_session, agent_resume_workflow,
-    agent_save_compact_context, agent_send_message, agent_set_yolo_mode, agent_terminate_workflow,
-    agent_toggle_session_bookmark, agent_update_session_config,
+    agent_mark_session_viewed, agent_open_session, agent_pause_workflow,
+    agent_respond_channel_permission, agent_respond_tool_approval, agent_resume_session,
+    agent_resume_workflow, agent_save_compact_context, agent_send_message, agent_set_yolo_mode,
+    agent_terminate_workflow, agent_toggle_session_bookmark, agent_update_session_config,
 };
 use commands::assistant_crud_commands::{
     batch_upsert_assistants, create_assistant, delete_assistant, get_assistant, list_assistants,
@@ -72,8 +72,9 @@ use commands::mcp_server_config_commands::{
     list_mcp_server_presets, update_mcp_server_config,
 };
 use commands::messages_commands::{
-    messages_delete, messages_delete_all_for_session, messages_get_page, messages_search,
-    messages_upsert, messages_upsert_many,
+    messages_delete, messages_delete_all_for_session, messages_get_messages_before,
+    messages_get_page, messages_get_recent_slice, messages_search, messages_upsert,
+    messages_upsert_many,
 };
 use commands::playbook_commands::{
     create_playbook, delete_playbook, get_playbook, list_playbooks, toggle_playbook_bookmark,
@@ -226,6 +227,8 @@ pub fn run() {
                 revoke_oauth_token,
                 // Message management commands
                 messages_get_page,
+                messages_get_recent_slice,
+                messages_get_messages_before,
                 messages_upsert_many,
                 messages_upsert,
                 messages_delete,
@@ -234,6 +237,7 @@ pub fn run() {
                 // Agent workflow commands
                 agent_create_session,
                 agent_resume_session,
+                agent_open_session,
                 agent_init_session_with_messages,
                 agent_send_message,
                 agent_execute_ui_tauri_action,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,8 +73,7 @@ use commands::mcp_server_config_commands::{
 };
 use commands::messages_commands::{
     messages_delete, messages_delete_all_for_session, messages_get_messages_before,
-    messages_get_page, messages_get_recent_slice, messages_search, messages_upsert,
-    messages_upsert_many,
+    messages_get_page, messages_search, messages_upsert, messages_upsert_many,
 };
 use commands::playbook_commands::{
     create_playbook, delete_playbook, get_playbook, list_playbooks, toggle_playbook_bookmark,
@@ -227,7 +226,6 @@ pub fn run() {
                 revoke_oauth_token,
                 // Message management commands
                 messages_get_page,
-                messages_get_recent_slice,
                 messages_get_messages_before,
                 messages_upsert_many,
                 messages_upsert,

--- a/src-tauri/src/mcp/service_proxy_manager/creation.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/creation.rs
@@ -700,6 +700,41 @@ impl MCPServiceProxyManager {
         Ok(proxy_arc)
     }
 
+    /// Ensure a session has a proxy that matches its persisted agent configuration.
+    ///
+    /// Unlike `ensure_builtin_proxy`, this path is config-aware: it loads the session's
+    /// stored `agent_config`, derives both builtin and external MCP requirements, and then
+    /// delegates to `create_proxy()`. That means an existing builtin-only lazy proxy will
+    /// be recreated when the session configuration requires stdio/HTTP MCP servers.
+    pub async fn ensure_configured_proxy(
+        &self,
+        session_id: &str,
+        app_handle: Option<AppHandle>,
+    ) -> Result<Arc<MCPServiceProxy>, String> {
+        use crate::agent::tools::extract_builtin_tool_ids;
+        use crate::repositories::session_repository::SessionRepository;
+
+        let session_repo = crate::state::get_session_repository();
+        let session = session_repo
+            .get_session(session_id)
+            .await
+            .map_err(|e| format!("Failed to load session {}: {}", session_id, e))?
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+        let config_json = session
+            .agent_config
+            .ok_or_else(|| "Session has no config".to_string())?;
+        let agent_config = crate::agent::AgentConfig::from_json(&config_json)?;
+        let tool_ids = extract_builtin_tool_ids(&agent_config);
+
+        self.create_proxy(
+            session_id.to_string(),
+            tool_ids,
+            agent_config.mcp_server_ids,
+            app_handle,
+        )
+        .await
+    }
+
     /// Lazily initialise a builtin-only proxy for a session that has no active proxy.
     ///
     /// Called by [`crate::mcp::service_proxy_manager::MCPServiceProxyManager::call_tool`] when a builtin tool is requested for a session whose proxy

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -226,7 +226,21 @@ impl SqliteMessageRepository {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn build_slice_page(mut rows: Vec<MessageRowWithCursor>, limit: u64) -> MessageSlicePage {
+    fn validate_slice_limit(limit: u64) -> Result<i64, DbError> {
+        if limit == 0 {
+            return Err(DbError::InvalidInput(
+                "Message slice limit must be greater than zero".to_string(),
+            ));
+        }
+
+        i64::try_from(limit.saturating_add(1))
+            .map_err(|_| DbError::InvalidInput("Message slice limit is too large".to_string()))
+    }
+
+    fn build_slice_page(
+        mut rows: Vec<MessageRowWithCursor>,
+        limit: u64,
+    ) -> Result<MessageSlicePage, DbError> {
         let has_more_before = rows.len() as u64 > limit;
         if has_more_before {
             rows.truncate(limit as usize);
@@ -239,11 +253,11 @@ impl SqliteMessageRepository {
             .map(|row| Self::model_to_message(row.model))
             .collect();
 
-        MessageSlicePage {
+        Ok(MessageSlicePage {
             items,
             has_more_before,
             oldest_cursor,
-        }
+        })
     }
 
     /// Convert SeaORM message model to Message type
@@ -584,7 +598,7 @@ impl MessageRepository for SqliteMessageRepository {
         session_id: &str,
         limit: u64,
     ) -> Result<MessageSlicePage, DbError> {
-        let fetch_limit = limit.saturating_add(1);
+        let fetch_limit = Self::validate_slice_limit(limit)?;
         let rows = self
             .query_slice_rows(
                 "SELECT rowid AS cursor_rowid, id, session_id, role, content, tool_calls, tool_call_id, is_streaming, thinking, thinking_signature, assistant_id, attachments, tool_use, created_at, updated_at, source, error, usage \
@@ -592,11 +606,11 @@ impl MessageRepository for SqliteMessageRepository {
                  WHERE session_id = ? \
                  ORDER BY created_at DESC, rowid DESC \
                  LIMIT ?",
-                vec![session_id.into(), (fetch_limit as i64).into()],
+                vec![session_id.into(), fetch_limit.into()],
             )
             .await?;
 
-        Ok(Self::build_slice_page(rows, limit))
+        Self::build_slice_page(rows, limit)
     }
 
     async fn get_messages_before(
@@ -606,7 +620,7 @@ impl MessageRepository for SqliteMessageRepository {
         before_row_id: i64,
         limit: u64,
     ) -> Result<MessageSlicePage, DbError> {
-        let fetch_limit = limit.saturating_add(1);
+        let fetch_limit = Self::validate_slice_limit(limit)?;
         let rows = self
             .query_slice_rows(
                 "SELECT rowid AS cursor_rowid, id, session_id, role, content, tool_calls, tool_call_id, is_streaming, thinking, thinking_signature, assistant_id, attachments, tool_use, created_at, updated_at, source, error, usage \
@@ -620,12 +634,12 @@ impl MessageRepository for SqliteMessageRepository {
                     before_created_at.into(),
                     before_created_at.into(),
                     before_row_id.into(),
-                    (fetch_limit as i64).into(),
+                    fetch_limit.into(),
                 ],
             )
             .await?;
 
-        Ok(Self::build_slice_page(rows, limit))
+        Self::build_slice_page(rows, limit)
     }
 
     async fn get_recent_messages(&self, limit: u64) -> Result<Vec<Message>, DbError> {

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -3,13 +3,32 @@ use crate::models::chat::Message;
 use crate::utils::pagination::Page;
 use async_trait::async_trait;
 use sea_orm::{
-    sea_query::Expr, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, QuerySelect, Set,
+    sea_query::Expr, ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection,
+    EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, Set, Statement,
 };
 
 use crate::entity::prelude::{Message as MessageEntity, MessageIndexMeta};
 use crate::entity::{message, message_index_meta, session};
 use crate::utils::json::{from_json_option, from_json_or_default, to_json_option};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessagePaginationCursor {
+    pub created_at: i64,
+    pub row_id: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageSlicePage {
+    pub items: Vec<Message>,
+    pub has_more_before: bool,
+    pub oldest_cursor: Option<MessagePaginationCursor>,
+}
+
+#[derive(Debug)]
+struct MessageRowWithCursor {
+    model: message::Model,
+    cursor: MessagePaginationCursor,
+}
 
 /// Message repository trait for abstraction and testability
 #[async_trait]
@@ -65,6 +84,24 @@ pub trait MessageRepository: Send + Sync {
         limit: u64,
     ) -> Result<Vec<Message>, DbError>;
 
+    /// Get the most recent messages for a session in ascending chronological order.
+    /// Returns `limit + 1` internally so callers can infer whether older messages exist.
+    async fn get_recent_slice(
+        &self,
+        session_id: &str,
+        limit: u64,
+    ) -> Result<MessageSlicePage, DbError>;
+
+    /// Get messages older than a cursor for a session in ascending chronological order.
+    /// Cursor is exclusive and uses `(created_at, row_id)` for stable keyset pagination.
+    async fn get_messages_before(
+        &self,
+        session_id: &str,
+        before_created_at: i64,
+        before_row_id: i64,
+        limit: u64,
+    ) -> Result<MessageSlicePage, DbError>;
+
     /// Get recent messages across all sessions with limit
     async fn get_recent_messages(&self, limit: u64) -> Result<Vec<Message>, DbError>;
 
@@ -95,6 +132,118 @@ impl SqliteMessageRepository {
     /// Create a new SQLite message repository with the given database connection
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
+    }
+
+    fn row_to_message_model(row: &QueryResult) -> Result<message::Model, DbError> {
+        Ok(message::Model {
+            id: row.try_get("", "id").map_err(DbError::SeaOrmQueryFailed)?,
+            session_id: row
+                .try_get("", "session_id")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            role: row
+                .try_get("", "role")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            content: row
+                .try_get("", "content")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            tool_calls: row
+                .try_get("", "tool_calls")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            tool_call_id: row
+                .try_get("", "tool_call_id")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            is_streaming: row
+                .try_get("", "is_streaming")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            thinking: row
+                .try_get("", "thinking")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            thinking_signature: row
+                .try_get("", "thinking_signature")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            assistant_id: row
+                .try_get("", "assistant_id")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            attachments: row
+                .try_get("", "attachments")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            tool_use: row
+                .try_get("", "tool_use")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            created_at: row
+                .try_get("", "created_at")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            updated_at: row
+                .try_get("", "updated_at")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            source: row
+                .try_get("", "source")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            error: row
+                .try_get("", "error")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            usage: row
+                .try_get("", "usage")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+        })
+    }
+
+    fn row_to_cursor(row: &QueryResult) -> Result<MessagePaginationCursor, DbError> {
+        Ok(MessagePaginationCursor {
+            created_at: row
+                .try_get("", "created_at")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+            row_id: row
+                .try_get("", "cursor_rowid")
+                .map_err(DbError::SeaOrmQueryFailed)?,
+        })
+    }
+
+    fn row_to_message_with_cursor(row: &QueryResult) -> Result<MessageRowWithCursor, DbError> {
+        Ok(MessageRowWithCursor {
+            model: Self::row_to_message_model(row)?,
+            cursor: Self::row_to_cursor(row)?,
+        })
+    }
+
+    async fn query_slice_rows(
+        &self,
+        sql: &str,
+        values: Vec<sea_orm::Value>,
+    ) -> Result<Vec<MessageRowWithCursor>, DbError> {
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await
+            .map_err(DbError::SeaOrmQueryFailed)?;
+
+        rows.iter()
+            .map(Self::row_to_message_with_cursor)
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn build_slice_page(mut rows: Vec<MessageRowWithCursor>, limit: u64) -> MessageSlicePage {
+        let has_more_before = rows.len() as u64 > limit;
+        if has_more_before {
+            rows.truncate(limit as usize);
+        }
+        rows.reverse();
+
+        let oldest_cursor = rows.first().map(|row| row.cursor.clone());
+        let items = rows
+            .into_iter()
+            .map(|row| Self::model_to_message(row.model))
+            .collect();
+
+        MessageSlicePage {
+            items,
+            has_more_before,
+            oldest_cursor,
+        }
     }
 
     /// Convert SeaORM message model to Message type
@@ -428,6 +577,55 @@ impl MessageRepository for SqliteMessageRepository {
             .get_message_models_by_session(session_id, limit)
             .await?;
         Ok(models.into_iter().map(Self::model_to_message).collect())
+    }
+
+    async fn get_recent_slice(
+        &self,
+        session_id: &str,
+        limit: u64,
+    ) -> Result<MessageSlicePage, DbError> {
+        let fetch_limit = limit.saturating_add(1);
+        let rows = self
+            .query_slice_rows(
+                "SELECT rowid AS cursor_rowid, id, session_id, role, content, tool_calls, tool_call_id, is_streaming, thinking, thinking_signature, assistant_id, attachments, tool_use, created_at, updated_at, source, error, usage \
+                 FROM messages \
+                 WHERE session_id = ? \
+                 ORDER BY created_at DESC, rowid DESC \
+                 LIMIT ?",
+                vec![session_id.into(), (fetch_limit as i64).into()],
+            )
+            .await?;
+
+        Ok(Self::build_slice_page(rows, limit))
+    }
+
+    async fn get_messages_before(
+        &self,
+        session_id: &str,
+        before_created_at: i64,
+        before_row_id: i64,
+        limit: u64,
+    ) -> Result<MessageSlicePage, DbError> {
+        let fetch_limit = limit.saturating_add(1);
+        let rows = self
+            .query_slice_rows(
+                "SELECT rowid AS cursor_rowid, id, session_id, role, content, tool_calls, tool_call_id, is_streaming, thinking, thinking_signature, assistant_id, attachments, tool_use, created_at, updated_at, source, error, usage \
+                 FROM messages \
+                 WHERE session_id = ? \
+                   AND (created_at < ? OR (created_at = ? AND rowid < ?)) \
+                 ORDER BY created_at DESC, rowid DESC \
+                 LIMIT ?",
+                vec![
+                    session_id.into(),
+                    before_created_at.into(),
+                    before_created_at.into(),
+                    before_row_id.into(),
+                    (fetch_limit as i64).into(),
+                ],
+            )
+            .await?;
+
+        Ok(Self::build_slice_page(rows, limit))
     }
 
     async fn get_recent_messages(&self, limit: u64) -> Result<Vec<Message>, DbError> {

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -817,6 +817,10 @@ impl AgentService {
 
         let proxy_manager = get_mcp_service_proxy_manager();
 
+        proxy_manager
+            .ensure_configured_proxy(&session_id, crate::state::get_app_handle().cloned())
+            .await?;
+
         let proxy = proxy_manager
             .get_proxy(&session_id)
             .await

--- a/src-tauri/tests/message_cursor_pagination_tests.rs
+++ b/src-tauri/tests/message_cursor_pagination_tests.rs
@@ -1,0 +1,117 @@
+mod common;
+
+use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::repositories::{
+    MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
+    SqliteSessionRepository,
+};
+
+fn build_session_metadata(session_id: &str) -> SessionMetadata {
+    let now = chrono::Utc::now().timestamp_millis();
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Message pagination regression".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+fn build_message(session_id: &str, id: &str, created_at: i64) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: session_id.to_string(),
+        role: "assistant".to_string(),
+        content: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        created_at,
+        updated_at: created_at,
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn message_history_pagination_uses_rowid_for_same_timestamp_ties() {
+    let db = common::setup_test_db_with_migrations().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let message_repo = SqliteMessageRepository::new(db.clone());
+    let session_id = format!("pagination-{}", uuid::Uuid::new_v4());
+
+    session_repo
+        .upsert_session(&build_session_metadata(&session_id))
+        .await
+        .expect("session should be created");
+
+    let created_at = 1_712_345_678_900_i64;
+    let inserted_ids = ["msg-z", "msg-a", "msg-m", "msg-b"];
+    for id in inserted_ids {
+        message_repo
+            .insert(&build_message(&session_id, id, created_at))
+            .await
+            .expect("message insert should succeed");
+    }
+
+    let first_slice = message_repo
+        .get_recent_slice(&session_id, 2)
+        .await
+        .expect("recent slice should load");
+
+    let first_ids: Vec<String> = first_slice
+        .items
+        .iter()
+        .map(|message| message.id.clone())
+        .collect();
+    assert_eq!(first_ids, vec!["msg-m".to_string(), "msg-b".to_string()]);
+    assert!(first_slice.has_more_before);
+
+    let oldest_cursor = first_slice
+        .oldest_cursor
+        .clone()
+        .expect("recent slice should expose oldest cursor");
+
+    let older_slice = message_repo
+        .get_messages_before(
+            &session_id,
+            oldest_cursor.created_at,
+            oldest_cursor.row_id,
+            2,
+        )
+        .await
+        .expect("older slice should load");
+
+    let older_ids: Vec<String> = older_slice
+        .items
+        .iter()
+        .map(|message| message.id.clone())
+        .collect();
+    assert_eq!(older_ids, vec!["msg-z".to_string(), "msg-a".to_string()]);
+    assert!(!older_slice.has_more_before);
+}

--- a/src-tauri/tests/message_cursor_pagination_tests.rs
+++ b/src-tauri/tests/message_cursor_pagination_tests.rs
@@ -2,8 +2,8 @@ mod common;
 
 use tauri_mcp_agent_lib::models::chat::Message;
 use tauri_mcp_agent_lib::repositories::{
-    MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
-    SqliteSessionRepository,
+    DbError, MessageRepository, SessionMetadata, SessionRepository, SessionStatus,
+    SqliteMessageRepository, SqliteSessionRepository,
 };
 
 fn build_session_metadata(session_id: &str) -> SessionMetadata {
@@ -114,4 +114,33 @@ async fn message_history_pagination_uses_rowid_for_same_timestamp_ties() {
         .collect();
     assert_eq!(older_ids, vec!["msg-z".to_string(), "msg-a".to_string()]);
     assert!(!older_slice.has_more_before);
+}
+
+#[tokio::test]
+async fn message_slice_queries_reject_zero_limit() {
+    let db = common::setup_test_db_with_migrations().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let message_repo = SqliteMessageRepository::new(db.clone());
+    let session_id = format!("pagination-zero-{}", uuid::Uuid::new_v4());
+
+    session_repo
+        .upsert_session(&build_session_metadata(&session_id))
+        .await
+        .expect("session should be created");
+    message_repo
+        .insert(&build_message(&session_id, "msg-1", 1_712_345_678_900_i64))
+        .await
+        .expect("message insert should succeed");
+
+    let recent_error = message_repo
+        .get_recent_slice(&session_id, 0)
+        .await
+        .expect_err("zero limit should be rejected for recent slices");
+    assert!(matches!(recent_error, DbError::InvalidInput(_)));
+
+    let before_error = message_repo
+        .get_messages_before(&session_id, 1_712_345_678_900_i64, i64::MAX, 0)
+        .await
+        .expect_err("zero limit should be rejected for older slices");
+    assert!(matches!(before_error, DbError::InvalidInput(_)));
 }

--- a/src/context/AgentSessionContext.tsx
+++ b/src/context/AgentSessionContext.tsx
@@ -1,9 +1,4 @@
 import React, { createContext, useContext, useMemo, useCallback } from 'react';
-import { getLogger } from '@/lib/logger';
-import { safeInvoke } from '@/lib/backend/core';
-import type { Page } from '@/lib/db/types';
-import type { RustMessage, Message } from '@/models/chat';
-import { rustMessageToMessage } from '@/models/chat';
 import { useAgentSessionListActions } from './AgentSessionListContext';
 import { useAgentSessionState as useAgentSessionStateLogic } from './agent-session/useAgentSessionState';
 import { useAgentSessionEvents } from './agent-session/useAgentSessionEvents';
@@ -16,8 +11,6 @@ import type {
 
 // Re-export types so we don't break existing imports
 export * from './agent-session/types';
-
-const logger = getLogger('AgentSessionContext');
 
 const AgentSessionStateContext = createContext<
   AgentSessionStateContextValue | undefined
@@ -59,27 +52,7 @@ export function AgentSessionProvider({
     [persistViewedAt],
   );
 
-  const loadMessages = useCallback(
-    async (sid: string) => {
-      try {
-        const page = await safeInvoke<Page<RustMessage>>('messages_get_page', {
-          sessionId: sid,
-          page: 1,
-          pageSize: 1000,
-        });
-
-        const msgs: Message[] = page.items.map(rustMessageToMessage);
-
-        stateProps.setters.setMessages(msgs);
-      } catch (err) {
-        logger.error('Failed to load messages', err);
-      }
-    },
-    [stateProps.setters],
-  );
-
   useAgentSessionEvents(sessionId, stateProps, {
-    loadMessages,
     persistViewedAt,
   });
 
@@ -93,6 +66,8 @@ export function AgentSessionProvider({
       session: stateProps.state.session,
       messages: stateProps.state.messages,
       isSessionLoading: stateProps.state.isSessionLoading,
+      isLoadingOlderMessages: stateProps.state.isLoadingOlderMessages,
+      hasOlderMessages: stateProps.state.hasOlderMessages,
       error: stateProps.state.error,
       llmError: stateProps.state.llmError,
       workflowStatus: stateProps.state.workflowStatus,
@@ -105,6 +80,8 @@ export function AgentSessionProvider({
       stateProps.state.session,
       stateProps.state.messages,
       stateProps.state.isSessionLoading,
+      stateProps.state.isLoadingOlderMessages,
+      stateProps.state.hasOlderMessages,
       stateProps.state.error,
       stateProps.state.llmError,
       stateProps.state.workflowStatus,

--- a/src/context/__tests__/AgentSessionContext.test.tsx
+++ b/src/context/__tests__/AgentSessionContext.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '../AgentSessionContext';
 import { listen } from '@tauri-apps/api/event';
 import { safeInvoke } from '@/lib/backend/core';
-import * as messagesBackend from '@/lib/backend/messages';
+import * as agentCommandsBackend from '@/lib/backend/agent-commands';
 import type { Message } from '@/models/chat';
 
 const mockMarkSessionViewed = vi.fn();
@@ -33,9 +33,8 @@ vi.mock('@/lib/logger', () => ({
     }),
 }));
 
-// Mock backend messages API
-vi.mock('@/lib/backend/messages', () => ({
-    getMessagesPageForSession: vi.fn(),
+vi.mock('@/lib/backend/agent-commands', () => ({
+    openAgentSession: vi.fn(),
 }));
 
 vi.mock('../AgentSessionListContext', () => ({
@@ -84,24 +83,23 @@ describe('AgentSessionContext (Local)', () => {
         mockMarkSessionViewed.mockResolvedValue(undefined);
         mockRefreshCompactedRange.mockResolvedValue(undefined);
         (listen as ReturnType<typeof vi.fn>).mockResolvedValue(mockUnlisten);
-        // Mock getMessagesPageForSession to return empty list by default
-        (messagesBackend.getMessagesPageForSession as ReturnType<typeof vi.fn>).mockResolvedValue({
-            items: [],
-            total: 0,
-            page: 1,
-            pageSize: 50,
-            totalPages: 0,
+        (agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+            session: {
+                id: TEST_SESSION_ID,
+                name: 'Test Session',
+                status: 'idle',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                yoloMode: false,
+            },
+            messages: {
+                items: [],
+                hasMoreBefore: false,
+                oldestCursor: null,
+            },
+            pendingApprovals: [],
         });
-
-        // Mock get_session interaction for initialization
-        (safeInvoke as ReturnType<typeof vi.fn>).mockResolvedValue({
-            id: TEST_SESSION_ID,
-            name: 'Test Session',
-            status: 'idle',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-            yoloMode: false,
-        });
+        (safeInvoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     });
 
     it('should initialize with session state', async () => {
@@ -121,7 +119,7 @@ describe('AgentSessionContext (Local)', () => {
         expect(result.current.workflowStatus).toBe('idle');
         expect(result.current.messages).toEqual([]);
 
-        expect(safeInvoke).toHaveBeenCalledWith('agent_get_session', { sessionId: TEST_SESSION_ID });
+        expect(agentCommandsBackend.openAgentSession).toHaveBeenCalledWith(TEST_SESSION_ID);
         expect(mockRefreshCompactedRange).toHaveBeenCalledWith(TEST_SESSION_ID);
     });
 
@@ -136,37 +134,24 @@ describe('AgentSessionContext (Local)', () => {
     });
 
     it('does not reinitialize the session when rerendered with the same sessionId', async () => {
-        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((command, args) => {
-            if (command === 'agent_get_session') {
-                return Promise.resolve({
-                    id: args.sessionId,
-                    name: `Session ${args.sessionId}`,
+        (agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>).mockImplementation(
+            async (sessionId: string) => ({
+                session: {
+                    id: sessionId,
+                    name: `Session ${sessionId}`,
                     status: 'idle',
                     createdAt: Date.now(),
                     updatedAt: Date.now(),
                     yoloMode: false,
-                });
-            }
-
-            if (command === 'messages_get_page') {
-                return Promise.resolve({
+                },
+                messages: {
                     items: [],
-                    total: 0,
-                    page: 1,
-                    pageSize: 1000,
-                    totalPages: 0,
-                });
-            }
-
-            if (
-                command === 'agent_resume_session' ||
-                command === 'agent_init_session_with_messages'
-            ) {
-                return Promise.resolve({});
-            }
-
-            return Promise.resolve(undefined);
-        });
+                    hasMoreBefore: false,
+                    oldestCursor: null,
+                },
+                pendingApprovals: [],
+            })
+        );
 
         const { result, rerender } = renderHook(() => useAgentSessionState(), {
             wrapper: ({ children }) => (
@@ -184,61 +169,38 @@ describe('AgentSessionContext (Local)', () => {
         expect(mockRefreshCompactedRange).toHaveBeenCalledTimes(1);
         expect(mockMarkSessionViewed).toHaveBeenCalledTimes(1);
 
-        const initialGetSessionCalls = (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-            ([command]) => command === 'agent_get_session'
-        ).length;
-        const initialMessagePageCalls = (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-            ([command]) => command === 'messages_get_page'
-        ).length;
+        const initialOpenSessionCalls = (
+            agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>
+        ).mock.calls.length;
 
         rerender();
 
-        expect(
-            (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-                ([command]) => command === 'agent_get_session'
-            )
-        ).toHaveLength(initialGetSessionCalls);
-        expect(
-            (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-                ([command]) => command === 'messages_get_page'
-            )
-        ).toHaveLength(initialMessagePageCalls);
+        expect(agentCommandsBackend.openAgentSession).toHaveBeenCalledTimes(
+            initialOpenSessionCalls
+        );
         expect(mockRefreshCompactedRange).toHaveBeenCalledTimes(1);
         expect(mockMarkSessionViewed).toHaveBeenCalledTimes(1);
     });
 
     it('reinitializes exactly once when the active sessionId changes', async () => {
-        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((command, args) => {
-            if (command === 'agent_get_session') {
-                return Promise.resolve({
-                    id: args.sessionId,
-                    name: `Session ${args.sessionId}`,
+        (agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>).mockImplementation(
+            async (sessionId: string) => ({
+                session: {
+                    id: sessionId,
+                    name: `Session ${sessionId}`,
                     status: 'idle',
                     createdAt: Date.now(),
                     updatedAt: Date.now(),
                     yoloMode: false,
-                });
-            }
-
-            if (command === 'messages_get_page') {
-                return Promise.resolve({
+                },
+                messages: {
                     items: [],
-                    total: 0,
-                    page: 1,
-                    pageSize: 1000,
-                    totalPages: 0,
-                });
-            }
-
-            if (
-                command === 'agent_resume_session' ||
-                command === 'agent_init_session_with_messages'
-            ) {
-                return Promise.resolve({});
-            }
-
-            return Promise.resolve(undefined);
-        });
+                    hasMoreBefore: false,
+                    oldestCursor: null,
+                },
+                pendingApprovals: [],
+            })
+        );
 
         let activeSessionId = 'session-1';
         const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -267,18 +229,7 @@ describe('AgentSessionContext (Local)', () => {
         expect(mockRefreshCompactedRange).toHaveBeenNthCalledWith(1, 'session-1');
         expect(mockRefreshCompactedRange).toHaveBeenNthCalledWith(2, 'session-2');
 
-        expect(
-            (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-                ([command, args]) =>
-                    command === 'agent_get_session' && args.sessionId === 'session-2'
-            )
-        ).toHaveLength(1);
-        expect(
-            (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
-                ([command, args]) =>
-                    command === 'messages_get_page' && args.sessionId === 'session-2'
-            )
-        ).toHaveLength(1);
+        expect(agentCommandsBackend.openAgentSession).toHaveBeenCalledWith('session-2');
         expect(mockMarkSessionViewed).toHaveBeenNthCalledWith(
             2,
             'session-2',

--- a/src/context/agent-session/types.ts
+++ b/src/context/agent-session/types.ts
@@ -79,6 +79,8 @@ export interface AgentSessionStateContextValue {
   session: AgentSession | null;
   messages: Message[];
   isSessionLoading: boolean;
+  isLoadingOlderMessages: boolean;
+  hasOlderMessages: boolean;
   error: MessageError | null;
   llmError: MessageError | null;
   workflowStatus: 'idle' | 'busy' | 'paused' | 'error';
@@ -96,6 +98,7 @@ export interface AgentSessionActionsContextValue {
   stopSession: () => Promise<void>;
   setError: (error: string | AgentRuntimeError | null) => void;
   addMessage: (message: Message) => void;
+  loadOlderMessages: () => Promise<void>;
   resumeSession: () => Promise<void>;
   respondToToolApproval: (
     toolCallId: string,

--- a/src/context/agent-session/useAgentSessionActions.ts
+++ b/src/context/agent-session/useAgentSessionActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { safeInvoke } from '@/lib/backend/core';
+import { getMessagesBeforeCursor } from '@/lib/backend/messages';
 import { getLogger } from '@/lib/logger';
 import type { Message, RustMessage } from '@/models/chat';
 import type { AgentResponse, SendUserMessageRequest } from '@/models/agent-ipc';
@@ -82,6 +83,42 @@ export function useAgentSessionActionsLogic(
       logger.error('Failed to stop session', err);
     }
   }, [state.session]);
+
+  const loadOlderMessages = useCallback(async () => {
+    if (
+      !state.session ||
+      state.isLoadingOlderMessages ||
+      !state.hasOlderMessages ||
+      !state.oldestMessageCursor
+    ) {
+      return;
+    }
+
+    try {
+      setters.setIsLoadingOlderMessages(true);
+
+      const olderSlice = await getMessagesBeforeCursor(
+        state.session.id,
+        state.oldestMessageCursor,
+        50,
+      );
+
+      setters.prependMessages(olderSlice.items);
+      setters.setHasOlderMessages(olderSlice.hasMoreBefore);
+      setters.setOldestMessageCursor(olderSlice.oldestCursor ?? null);
+    } catch (err) {
+      logger.error('Failed to load older messages', err);
+      throw err;
+    } finally {
+      setters.setIsLoadingOlderMessages(false);
+    }
+  }, [
+    setters,
+    state.hasOlderMessages,
+    state.isLoadingOlderMessages,
+    state.oldestMessageCursor,
+    state.session,
+  ]);
 
   const resumeSession = useCallback(async () => {
     if (!state.session) return;
@@ -171,6 +208,7 @@ export function useAgentSessionActionsLogic(
   return {
     sendMessage,
     stopSession,
+    loadOlderMessages,
     resumeSession,
     respondToToolApproval,
     toggleYoloMode,

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { safeInvoke } from '@/lib/backend/core';
+import { openAgentSession } from '@/lib/backend/agent-commands';
 import { getLogger } from '@/lib/logger';
 import { rustMessageToMessage } from '@/models/chat';
 import type { AgentSession } from '@/models/agent';
-import type { AgentResponse, AgentSessionMetadata } from '@/models/agent-ipc';
+import type { AgentResponse } from '@/models/agent-ipc';
 import type { AgentEventPayload } from './types';
 import { buildMessageError } from './utils';
 import type { useAgentSessionState } from './useAgentSessionState';
@@ -15,7 +16,6 @@ export function useAgentSessionEvents(
   sessionId: string,
   stateProps: ReturnType<typeof useAgentSessionState>,
   actions: {
-    loadMessages: (sid: string) => Promise<void>;
     persistViewedAt: (viewedAt?: Date) => Promise<void>;
   },
 ) {
@@ -264,62 +264,51 @@ export function useAgentSessionEvents(
           }
         });
 
-        const response = await safeInvoke<AgentSessionMetadata | null>(
-          'agent_get_session',
-          { sessionId },
-        );
-
-        if (!response) {
-          throw new Error(`Session not found: ${sessionId}`);
-        }
+        const response = await openAgentSession(sessionId);
+        const sessionMetadata = response.session;
 
         if (!isMounted) return;
 
         let assistant: import('@/models/chat').Assistant | undefined;
-        if (response.agentConfig) {
+        if (sessionMetadata.agentConfig) {
           try {
-            assistant = JSON.parse(response.agentConfig);
+            assistant = JSON.parse(sessionMetadata.agentConfig);
           } catch (e) {
             logger.error('Failed to parse agent config', e);
           }
         }
 
         const sessionData: AgentSession = {
-          id: response.id,
-          name: response.name,
-          status: response.status,
-          model: response.model,
-          provider: response.provider,
+          id: sessionMetadata.id,
+          name: sessionMetadata.name,
+          status: sessionMetadata.status,
+          model: sessionMetadata.model,
+          provider: sessionMetadata.provider,
           assistant,
-          createdAt: new Date(response.createdAt),
-          updatedAt: response.updatedAt
-            ? new Date(response.updatedAt)
+          createdAt: new Date(sessionMetadata.createdAt),
+          updatedAt: sessionMetadata.updatedAt
+            ? new Date(sessionMetadata.updatedAt)
             : undefined,
-          lastViewedAt: response.lastViewedAt
-            ? new Date(response.lastViewedAt)
+          lastViewedAt: sessionMetadata.lastViewedAt
+            ? new Date(sessionMetadata.lastViewedAt)
             : undefined,
-          lastMessageAt: response.lastMessageAt
-            ? new Date(response.lastMessageAt)
+          lastMessageAt: sessionMetadata.lastMessageAt
+            ? new Date(sessionMetadata.lastMessageAt)
             : undefined,
-          lastAttentionAt: response.lastAttentionAt
-            ? new Date(response.lastAttentionAt)
+          lastAttentionAt: sessionMetadata.lastAttentionAt
+            ? new Date(sessionMetadata.lastAttentionAt)
             : undefined,
-          lastAttentionReason: response.lastAttentionReason,
-          yoloMode: response.yoloMode,
+          lastAttentionReason: sessionMetadata.lastAttentionReason,
+          yoloMode: sessionMetadata.yoloMode,
         };
 
         setters.setSession(sessionData);
         setters.setWorkflowStatus(sessionData.status);
         setters.setYoloModeEnabled(sessionData.yoloMode);
-
-        await safeInvoke<AgentSessionMetadata>('agent_resume_session', {
-          sessionId,
-        });
-        await safeInvoke<AgentResponse>('agent_init_session_with_messages', {
-          sessionId,
-        });
-
-        await actions.loadMessages(sessionId);
+        setters.setMessages(response.messages.items.map(rustMessageToMessage));
+        setters.setHasOlderMessages(response.messages.hasMoreBefore);
+        setters.setOldestMessageCursor(response.messages.oldestCursor ?? null);
+        setters.setPendingApprovals(response.pendingApprovals ?? []);
         void actions.persistViewedAt().catch((err) => {
           logger.error(
             'Failed to mark session viewed during initialization',
@@ -343,7 +332,7 @@ export function useAgentSessionEvents(
       isMounted = false;
       if (unlisten) unlisten();
     };
-  }, [sessionId, actions.loadMessages, actions.persistViewedAt]);
+  }, [sessionId, actions.persistViewedAt]);
 
   useEffect(() => {
     const markViewedOnReturn = () => {

--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import type { AgentSession } from '@/models/agent';
 import type { Message, MessageError } from '@/models/chat';
 import type { AgentRuntimeError } from '@/models/agent-ipc';
+import type { MessageCursor } from '@/lib/backend/messages';
 import { applyViewedAtToSession } from '@/lib/session-utils';
 import type { WorkflowPhase, PendingApproval } from './types';
 import { buildMessageError } from './utils';
@@ -10,6 +11,10 @@ export function useAgentSessionState() {
   const [session, setSession] = useState<AgentSession | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [isSessionLoading, setIsSessionLoading] = useState(false);
+  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
+  const [hasOlderMessages, setHasOlderMessages] = useState(false);
+  const [oldestMessageCursor, setOldestMessageCursor] =
+    useState<MessageCursor | null>(null);
   const [error, setErrorState] = useState<MessageError | null>(null);
   const [llmError, setLlmError] = useState<MessageError | null>(null);
   const [workflowStatus, setWorkflowStatus] = useState<
@@ -56,11 +61,33 @@ export function useAgentSessionState() {
     });
   }, []);
 
+  const prependMessages = useCallback((olderMessages: Message[]) => {
+    if (olderMessages.length === 0) {
+      return;
+    }
+
+    setMessages((prev) => {
+      const existingIds = new Set(prev.map((message) => message.id));
+      const dedupedOlder = olderMessages.filter(
+        (message) => !existingIds.has(message.id),
+      );
+
+      if (dedupedOlder.length === 0) {
+        return prev;
+      }
+
+      return [...dedupedOlder, ...prev];
+    });
+  }, []);
+
   const setters = useMemo(
     () => ({
       setSession,
       setMessages,
       setIsSessionLoading,
+      setIsLoadingOlderMessages,
+      setHasOlderMessages,
+      setOldestMessageCursor,
       setError,
       setLlmError,
       setWorkflowStatus,
@@ -70,11 +97,15 @@ export function useAgentSessionState() {
       setYoloModeEnabled,
       applyLocalViewedAt,
       addMessage,
+      prependMessages,
     }),
     [
       setSession,
       setMessages,
       setIsSessionLoading,
+      setIsLoadingOlderMessages,
+      setHasOlderMessages,
+      setOldestMessageCursor,
       setError,
       setLlmError,
       setWorkflowStatus,
@@ -84,6 +115,7 @@ export function useAgentSessionState() {
       setYoloModeEnabled,
       applyLocalViewedAt,
       addMessage,
+      prependMessages,
     ],
   );
 
@@ -92,6 +124,9 @@ export function useAgentSessionState() {
       session,
       messages,
       isSessionLoading,
+      isLoadingOlderMessages,
+      hasOlderMessages,
+      oldestMessageCursor,
       error,
       llmError,
       workflowStatus,

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -103,8 +103,14 @@ export function AgentChatMessages() {
     retryMessage,
     workflowStatus,
   } = useAgentChat();
-  const { session, pendingApprovals, respondToToolApproval } =
-    useAgentSession();
+  const {
+    session,
+    pendingApprovals,
+    respondToToolApproval,
+    hasOlderMessages,
+    isLoadingOlderMessages,
+    loadOlderMessages,
+  } = useAgentSession();
   const { getCompactedRange } = useLLMService();
 
   // Compact range for divider rendering (null if no compaction has occurred)
@@ -113,10 +119,25 @@ export function AgentChatMessages() {
     : undefined;
   const { refetchSessionFiles } = useAgentResourceAttachment();
 
+  function handleReachTop() {
+    if (!hasOlderMessages || isLoadingOlderMessages) {
+      return;
+    }
+
+    prepareForPrepend();
+    void loadOlderMessages().catch((err) => {
+      logger.error('Failed to load older messages after scroll trigger', err);
+    });
+  }
+
   // Use custom hooks for side effects
-  const { messagesEndRef, scrollContainerRef, contentRef } = useChatScroll({
-    messages,
-  });
+  const { messagesEndRef, scrollContainerRef, contentRef, prepareForPrepend } =
+    useChatScroll({
+      messages,
+      onReachTop: handleReachTop,
+      canLoadOlder: hasOlderMessages,
+      isLoadingOlder: isLoadingOlderMessages,
+    });
   useFileRefetcher({ messages, refetchSessionFiles });
 
   // Group messages for display
@@ -201,6 +222,15 @@ export function AgentChatMessages() {
           ref={contentRef}
           className="p-4 pb-32 flex flex-col gap-6 min-h-full"
         >
+          {(hasOlderMessages || isLoadingOlderMessages) && (
+            <div className="flex justify-center">
+              <div className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs text-muted-foreground shadow-sm">
+                {isLoadingOlderMessages
+                  ? 'Loading older messages...'
+                  : 'Scroll up to load older messages'}
+              </div>
+            </div>
+          )}
           {groupedMessages.map((groupedMessage) => {
             const isCompactBoundary = groupedMessageContainsBoundary(
               groupedMessage,

--- a/src/features/agent/hooks/__tests__/useChatScroll.test.tsx
+++ b/src/features/agent/hooks/__tests__/useChatScroll.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChatScroll } from '../useChatScroll';
+import type { Message } from '@/models/chat';
+
+interface HookHarnessProps {
+  messages: Message[];
+  onReachTop?: () => void;
+  canLoadOlder?: boolean;
+  isLoadingOlder?: boolean;
+}
+
+function HookHarness({
+  messages,
+  onReachTop,
+  canLoadOlder = false,
+  isLoadingOlder = false,
+}: HookHarnessProps) {
+  const { scrollContainerRef, contentRef, messagesEndRef } = useChatScroll({
+    messages,
+    onReachTop,
+    canLoadOlder,
+    isLoadingOlder,
+  });
+
+  return (
+    <div ref={scrollContainerRef} data-testid="scroll-container">
+      <div ref={contentRef}>
+        {messages.map((message) => (
+          <div key={message.id}>{message.id}</div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+    </div>
+  );
+}
+
+const messages: Message[] = [
+  {
+    id: 'message-1',
+    sessionId: 'session-1',
+    threadId: 'session-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'hello' }],
+    createdAt: new Date('2026-04-24T00:00:00Z'),
+    updatedAt: new Date('2026-04-24T00:00:00Z'),
+  },
+];
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+describe('useChatScroll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 0));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('triggers older-message loading when scrolling upward into the top threshold', () => {
+    const onReachTop = vi.fn();
+    const { getByTestId } = render(
+      <HookHarness
+        messages={messages}
+        onReachTop={onReachTop}
+        canLoadOlder
+      />,
+    );
+    const scrollContainer = getByTestId('scroll-container');
+
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      configurable: true,
+      value: 400,
+    });
+
+    act(() => {
+      scrollContainer.scrollTop = 300;
+      fireEvent.scroll(scrollContainer);
+    });
+
+    expect(onReachTop).not.toHaveBeenCalled();
+
+    act(() => {
+      scrollContainer.scrollTop = 120;
+      fireEvent.scroll(scrollContainer);
+      vi.advanceTimersByTime(80);
+    });
+
+    expect(onReachTop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/agent/hooks/useChatScroll.ts
+++ b/src/features/agent/hooks/useChatScroll.ts
@@ -131,6 +131,17 @@ export function useChatScroll({
 
     lastScrollTopRef.current = currentScrollTop;
 
+    if (
+      onReachTop &&
+      canLoadOlder &&
+      !isLoadingOlder &&
+      currentScrollTop <= TOP_LOAD_THRESHOLD_PX &&
+      !topLoadTriggeredRef.current
+    ) {
+      topLoadTriggeredRef.current = true;
+      onReachTop();
+    }
+
     if (isScrollingUp && !atBottom) {
       setAutoScroll(false);
       return;
@@ -142,17 +153,6 @@ export function useChatScroll({
 
     if (currentScrollTop > TOP_LOAD_THRESHOLD_PX) {
       topLoadTriggeredRef.current = false;
-    }
-
-    if (
-      onReachTop &&
-      canLoadOlder &&
-      !isLoadingOlder &&
-      currentScrollTop <= TOP_LOAD_THRESHOLD_PX &&
-      !topLoadTriggeredRef.current
-    ) {
-      topLoadTriggeredRef.current = true;
-      onReachTop();
     }
   }, 80);
 

--- a/src/features/agent/hooks/useChatScroll.ts
+++ b/src/features/agent/hooks/useChatScroll.ts
@@ -10,11 +10,20 @@ import type { Message } from '@/models/chat';
 
 interface UseChatScrollProps {
   messages: Message[];
+  onReachTop?: () => void;
+  canLoadOlder?: boolean;
+  isLoadingOlder?: boolean;
 }
 
 const BOTTOM_THRESHOLD_PX = 80;
+const TOP_LOAD_THRESHOLD_PX = 160;
 
-export function useChatScroll({ messages }: UseChatScrollProps) {
+export function useChatScroll({
+  messages,
+  onReachTop,
+  canLoadOlder = false,
+  isLoadingOlder = false,
+}: UseChatScrollProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -23,9 +32,14 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
   const isProgrammaticScrollRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const animationFrameRef = useRef<number | null>(null);
+  const pendingPrependAdjustmentRef = useRef<{
+    scrollHeight: number;
+    scrollTop: number;
+  } | null>(null);
   const programmaticScrollTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null);
+  const topLoadTriggeredRef = useRef(false);
 
   const setAutoScroll = useCallback((enabled: boolean) => {
     autoScrollEnabledRef.current = enabled;
@@ -88,6 +102,18 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
     [scrollToBottom],
   );
 
+  const prepareForPrepend = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    pendingPrependAdjustmentRef.current = {
+      scrollHeight: container.scrollHeight,
+      scrollTop: container.scrollTop,
+    };
+  }, []);
+
   const handleScroll = useThrottle(() => {
     const container = scrollContainerRef.current;
     if (!container) {
@@ -113,6 +139,21 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
     if (atBottom) {
       setAutoScroll(true);
     }
+
+    if (currentScrollTop > TOP_LOAD_THRESHOLD_PX) {
+      topLoadTriggeredRef.current = false;
+    }
+
+    if (
+      onReachTop &&
+      canLoadOlder &&
+      !isLoadingOlder &&
+      currentScrollTop <= TOP_LOAD_THRESHOLD_PX &&
+      !topLoadTriggeredRef.current
+    ) {
+      topLoadTriggeredRef.current = true;
+      onReachTop();
+    }
   }, 80);
 
   useEffect(() => {
@@ -128,6 +169,23 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
       container.removeEventListener('scroll', handleScroll);
     };
   }, [handleScroll]);
+
+  useLayoutEffect(() => {
+    const pendingPrependAdjustment = pendingPrependAdjustmentRef.current;
+    const container = scrollContainerRef.current;
+    if (!pendingPrependAdjustment || !container) {
+      return;
+    }
+
+    const nextScrollTop =
+      container.scrollHeight -
+      pendingPrependAdjustment.scrollHeight +
+      pendingPrependAdjustment.scrollTop;
+    container.scrollTop = nextScrollTop;
+    lastScrollTopRef.current = nextScrollTop;
+    pendingPrependAdjustmentRef.current = null;
+    topLoadTriggeredRef.current = false;
+  }, [messages]);
 
   useLayoutEffect(() => {
     if (autoScrollEnabledRef.current) {
@@ -162,6 +220,12 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
   }, [isNearBottom, setAutoScroll]);
 
   useEffect(() => {
+    if (!isLoadingOlder) {
+      topLoadTriggeredRef.current = false;
+    }
+  }, [isLoadingOlder]);
+
+  useEffect(() => {
     return () => {
       clearProgrammaticScrollTimeout();
 
@@ -178,5 +242,6 @@ export function useChatScroll({ messages }: UseChatScrollProps) {
     contentRef,
     autoScrollEnabled,
     scrollToBottom,
+    prepareForPrepend,
   };
 }

--- a/src/lib/backend/agent-commands.ts
+++ b/src/lib/backend/agent-commands.ts
@@ -4,6 +4,7 @@ import type {
   AgentRuntimeError,
   HandleLLMResponseData,
   ExecuteUiTauriActionRequest,
+  AgentOpenSessionResponse,
 } from '../../models/agent-ipc';
 import type { RustMessage } from '../../models/chat';
 import type { MCPResult } from '../mcp/protocol/response';
@@ -118,6 +119,16 @@ export async function getAgentAvailableTools(
   sessionId: string,
 ): Promise<MCPTool[]> {
   return safeInvoke<MCPTool[]>('agent_get_available_tools', { sessionId });
+}
+
+export async function openAgentSession(
+  sessionId: string,
+  initialMessageLimit = 40,
+): Promise<AgentOpenSessionResponse> {
+  return safeInvoke<AgentOpenSessionResponse>('agent_open_session', {
+    sessionId,
+    initialMessageLimit,
+  });
 }
 
 /**

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -71,6 +71,8 @@ export {
 // Message management
 export {
   getMessagesPageForSession,
+  getMessagesBeforeCursor,
+  getRecentMessagesSlice,
   upsertMessages,
   upsertMessage,
   deleteMessage,
@@ -85,6 +87,7 @@ export {
   executeUiTauriAction,
   getAgentAvailableTools,
   agentCallBuiltinTool,
+  openAgentSession,
 } from './agent-commands';
 
 // Session management

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -72,7 +72,6 @@ export {
 export {
   getMessagesPageForSession,
   getMessagesBeforeCursor,
-  getRecentMessagesSlice,
   upsertMessages,
   upsertMessage,
   deleteMessage,

--- a/src/lib/backend/messages.ts
+++ b/src/lib/backend/messages.ts
@@ -2,6 +2,7 @@ import { safeInvoke } from './core';
 import { isMessageSource, type Message, type RustMessage } from '@/models/chat';
 import type { Page } from '@/lib/db/types';
 import type { MessageSearchResult } from './types';
+import type { MessageSlice as RustMessageSlice } from '@/models/agent-ipc';
 
 export interface RustSearchResult {
   messageId: string;
@@ -9,6 +10,11 @@ export interface RustSearchResult {
   score: number;
   snippet: string | null;
   createdAt: number;
+}
+
+export interface MessageCursor {
+  createdAt: number;
+  rowId: number;
 }
 
 // ========================================
@@ -76,6 +82,45 @@ export async function getMessagesPageForSession(
   });
 
   // Deserialize messages from Rust format
+  return {
+    ...result,
+    items: result.items.map(deserializeMessage),
+  };
+}
+
+export async function getRecentMessagesSlice(
+  sessionId: string,
+  limit: number,
+): Promise<RustMessageSlice<Message>> {
+  const result = await safeInvoke<RustMessageSlice<RustMessage>>(
+    'messages_get_recent_slice',
+    {
+      sessionId,
+      limit,
+    },
+  );
+
+  return {
+    ...result,
+    items: result.items.map(deserializeMessage),
+  };
+}
+
+export async function getMessagesBeforeCursor(
+  sessionId: string,
+  cursor: MessageCursor,
+  limit: number,
+): Promise<RustMessageSlice<Message>> {
+  const result = await safeInvoke<RustMessageSlice<RustMessage>>(
+    'messages_get_messages_before',
+    {
+      sessionId,
+      beforeCreatedAt: cursor.createdAt,
+      beforeRowId: cursor.rowId,
+      limit,
+    },
+  );
+
   return {
     ...result,
     items: result.items.map(deserializeMessage),

--- a/src/lib/backend/messages.ts
+++ b/src/lib/backend/messages.ts
@@ -88,24 +88,6 @@ export async function getMessagesPageForSession(
   };
 }
 
-export async function getRecentMessagesSlice(
-  sessionId: string,
-  limit: number,
-): Promise<RustMessageSlice<Message>> {
-  const result = await safeInvoke<RustMessageSlice<RustMessage>>(
-    'messages_get_recent_slice',
-    {
-      sessionId,
-      limit,
-    },
-  );
-
-  return {
-    ...result,
-    items: result.items.map(deserializeMessage),
-  };
-}
-
 export async function getMessagesBeforeCursor(
   sessionId: string,
   cursor: MessageCursor,

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/models/agent-ipc.ts
+++ b/src/models/agent-ipc.ts
@@ -178,3 +178,26 @@ export interface AgentSessionMetadata {
   isBookmarked?: boolean;
   yoloMode: boolean;
 }
+
+export interface MessageCursor {
+  createdAt: number;
+  rowId: number;
+}
+
+export interface MessageSlice<TMessage = RustMessage> {
+  items: TMessage[];
+  hasMoreBefore: boolean;
+  oldestCursor?: MessageCursor | null;
+}
+
+export interface PendingApprovalSnapshot {
+  toolCallId: string;
+  toolName: string;
+  arguments: string;
+}
+
+export interface AgentOpenSessionResponse {
+  session: AgentSessionMetadata;
+  messages: MessageSlice<RustMessage>;
+  pendingApprovals: PendingApprovalSnapshot[];
+}


### PR DESCRIPTION
## Summary
- load sessions with lightweight snapshots instead of eager runtime resume on open
- use stable rowid-based cursors for lazy older-message pagination
- auto-activate cold sessions only when send/resume/inject actually needs runtime state

## Validation
- pnpm refactor:validate