### PR TITLE
Unify compaction recovery path and trim log noise

### DIFF
--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -306,7 +306,7 @@ async fn load_merged_compaction_messages(
 
     Ok((
         session_name,
-        super::request::merge_consecutive_user_messages(messages),
+        super::request::normalize_request_messages(messages),
     ))
 }
 
@@ -537,11 +537,20 @@ pub(crate) async fn try_trigger_preflight_compaction(
     resume_completion_after_compact: bool,
 ) -> Result<bool, String> {
     if messages.len() <= 1 {
+        log::debug!(
+            "⏭️ Preflight compaction skipped (insufficient messages): session={}, count={}",
+            session_id,
+            messages.len()
+        );
         return Ok(false);
     }
 
     let split_idx = find_preflight_compaction_split_index(messages);
     if split_idx == 0 {
+        log::debug!(
+            "⏭️ Preflight compaction skipped (split_idx=0): session={}",
+            session_id
+        );
         return Ok(false);
     }
     let (
@@ -595,6 +604,12 @@ pub(crate) async fn try_trigger_preflight_compaction(
         && should_skip_same_tail_compaction(messages, split_idx)
     {
         compact_in_flight_arc.store(false, Ordering::SeqCst);
+        log::debug!(
+            "⏭️ Preflight compaction skipped (same tail): session={}, tail={}, split_idx={}",
+            session_id,
+            current_tail_id.as_deref().unwrap_or("?"),
+            split_idx
+        );
         return Ok(false);
     }
 
@@ -610,6 +625,12 @@ pub(crate) async fn try_trigger_preflight_compaction(
         )
     else {
         compact_in_flight_arc.store(false, Ordering::SeqCst);
+        log::debug!(
+            "⏭️ Preflight compaction skipped (no new delta beyond previous summary): session={}, tail={}, split_idx={}",
+            session_id,
+            current_tail_id.as_deref().unwrap_or("?"),
+            split_idx
+        );
         return Ok(false);
     };
 

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod compaction;
 pub(crate) mod context;
+pub(crate) mod orchestration;
 pub(crate) mod request;
 
 pub use compaction::{
@@ -11,9 +12,11 @@ pub use compaction::{
 pub use context::{
     resolve_context_management_settings, uses_compaction_strategy, ContextManagementSettings,
 };
+pub use orchestration::request_llm_completion_with_recovery;
 pub use request::{
     build_compact_context_selection_options, build_compact_summary_text,
-    merge_consecutive_user_messages, request_llm_completion, resolve_preserved_calibration_ratio,
+    merge_consecutive_user_messages, normalize_request_messages, request_llm_completion,
+    resolve_preserved_calibration_ratio,
 };
 
 // Crate-internal re-exports for intra-module visibility

--- a/src-tauri/src/agent/llm/completion/orchestration.rs
+++ b/src-tauri/src/agent/llm/completion/orchestration.rs
@@ -24,14 +24,15 @@ pub async fn request_llm_completion_with_recovery(
     {
         Ok(()) => Ok(()),
         Err(error) => {
-            crate::agent::llm::handle_llm_error(
+            let outcome = crate::agent::llm::handle_llm_error_with_outcome(
                 session_repo,
                 active_sessions,
                 app_handle,
                 session_id,
-                error,
+                error.clone(),
             )
-            .await
+            .await?;
+            crate::agent::llm::completion_result_from_error_handling_outcome(outcome, error)
         }
     }
 }

--- a/src-tauri/src/agent/llm/completion/orchestration.rs
+++ b/src-tauri/src/agent/llm/completion/orchestration.rs
@@ -1,0 +1,37 @@
+use crate::agent::state::AgentSession;
+use crate::mcp::MCPServiceProxyManager;
+use crate::repositories::session_repository::SessionRepository;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::AppHandle;
+use tokio::sync::RwLock;
+
+pub async fn request_llm_completion_with_recovery(
+    session_repo: &Arc<dyn SessionRepository>,
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    proxy_manager: &Arc<MCPServiceProxyManager>,
+    app_handle: &AppHandle,
+    session_id: String,
+) -> Result<(), String> {
+    match super::request::request_llm_completion(
+        session_repo,
+        active_sessions,
+        proxy_manager,
+        app_handle,
+        session_id.clone(),
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            crate::agent::llm::handle_llm_error(
+                session_repo,
+                active_sessions,
+                app_handle,
+                session_id,
+                error,
+            )
+            .await
+        }
+    }
+}

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -18,15 +18,22 @@ use crate::agent::llm::types::{
     AgentRuntimeError, AgentRuntimeErrorType, CompactionParentRequest, CompletionRequest,
 };
 
-async fn trigger_preflight_compaction_or_error(
+async fn trigger_preflight_compaction_for_messages_or_error(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     app_handle: &AppHandle,
     session_id: &str,
+    session_name: &str,
+    messages: &[Message],
+    parent_request: Option<CompactionParentRequest>,
 ) -> Result<bool, AgentRuntimeError> {
-    super::compaction::trigger_preflight_compaction_for_session(
+    super::compaction::try_trigger_preflight_compaction(
         active_sessions,
         app_handle,
         session_id,
+        session_name,
+        messages,
+        parent_request,
+        true,
     )
     .await
     .map_err(|error| {
@@ -115,6 +122,11 @@ struct CompactToolSnapshot {
     argument_preview: String,
     status: &'static str,
     result_preview: String,
+}
+
+pub fn normalize_request_messages(messages: Vec<Message>) -> Vec<Message> {
+    let merged_messages = merge_consecutive_user_messages(messages);
+    crate::agent::llm::context_selector::remove_incomplete_tool_chains(merged_messages)
 }
 
 pub fn build_compact_summary_text(summary: &str, compacted_messages: &[Message]) -> String {
@@ -450,6 +462,11 @@ pub async fn request_llm_completion(
 
     let model = session.metadata.model.clone();
     let provider = session.metadata.provider.clone();
+    let session_name = session
+        .metadata
+        .name
+        .clone()
+        .unwrap_or_else(|| session_id.chars().take(8).collect::<String>());
 
     let temperature = agent_config.temperature;
     let max_tokens = agent_config.max_tokens;
@@ -533,6 +550,7 @@ pub async fn request_llm_completion(
         session.compact_context.clone()
     };
 
+    let normalized_messages = messages.clone();
     let (messages, compact_summary_injected) = {
         let compact_record = compact_context_arc.read().await.clone();
         if let Some(record) = compact_record {
@@ -649,8 +667,15 @@ pub async fn request_llm_completion(
 
     if final_messages.is_empty() {
         if uses_compaction_strategy(&context_strategy)
-            && trigger_preflight_compaction_or_error(active_sessions, app_handle, &session_id)
-                .await?
+            && trigger_preflight_compaction_for_messages_or_error(
+                active_sessions,
+                app_handle,
+                &session_id,
+                &session_name,
+                &normalized_messages,
+                compaction_parent_request.clone(),
+            )
+            .await?
         {
             return Ok(());
         }
@@ -694,8 +719,15 @@ pub async fn request_llm_completion(
                 selected_message_breakdown
             );
 
-            if trigger_preflight_compaction_or_error(active_sessions, app_handle, &session_id)
-                .await?
+            if trigger_preflight_compaction_for_messages_or_error(
+                active_sessions,
+                app_handle,
+                &session_id,
+                &session_name,
+                &normalized_messages,
+                compaction_parent_request.clone(),
+            )
+            .await?
             {
                 return Ok(());
             }

--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -21,6 +21,22 @@ use crate::agent::llm::types::{
 use crate::agent::state::DeferredWorkflowStep;
 use crate::agent::tauri_events::TauriEventDispatcher;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmErrorHandlingOutcome {
+    RecoveredByCompaction,
+    FinalizedWorkflowError,
+}
+
+pub fn completion_result_from_error_handling_outcome(
+    outcome: LlmErrorHandlingOutcome,
+    error: AgentRuntimeError,
+) -> Result<(), String> {
+    match outcome {
+        LlmErrorHandlingOutcome::RecoveredByCompaction => Ok(()),
+        LlmErrorHandlingOutcome::FinalizedWorkflowError => Err(error.into()),
+    }
+}
+
 async fn calculate_post_response_compaction_pressure(
     assistant_message: &Message,
 ) -> Option<PostResponseCompactionPressure> {
@@ -819,13 +835,13 @@ The 'ui' builtin server is disabled for this session, so interactive circuit-bre
 }
 
 /// Handle LLM error from frontend
-pub async fn handle_llm_error(
+pub async fn handle_llm_error_with_outcome(
     session_repo: &Arc<dyn SessionRepository>,
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     app_handle: &AppHandle,
     session_id: String,
     error: AgentRuntimeError,
-) -> Result<(), String> {
+) -> Result<LlmErrorHandlingOutcome, String> {
     log::error!(
         "LLM error for session {}: {}",
         session_id,
@@ -852,7 +868,7 @@ pub async fn handle_llm_error(
                     "Recovered context-limit error by arming compaction recovery for session {}",
                     session_id
                 );
-                return Ok(());
+                return Ok(LlmErrorHandlingOutcome::RecoveredByCompaction);
             }
             Ok(false) => {
                 log::warn!(
@@ -887,7 +903,21 @@ pub async fn handle_llm_error(
         session_id,
         error,
     )
-    .await
+    .await?;
+
+    Ok(LlmErrorHandlingOutcome::FinalizedWorkflowError)
+}
+
+pub async fn handle_llm_error(
+    session_repo: &Arc<dyn SessionRepository>,
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    app_handle: &AppHandle,
+    session_id: String,
+    error: AgentRuntimeError,
+) -> Result<(), String> {
+    handle_llm_error_with_outcome(session_repo, active_sessions, app_handle, session_id, error)
+        .await
+        .map(|_| ())
 }
 
 pub async fn finalize_workflow_error_with_dispatcher(

--- a/src-tauri/src/agent/llm/token_utils.rs
+++ b/src-tauri/src/agent/llm/token_utils.rs
@@ -1,25 +1,84 @@
-use std::sync::OnceLock;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, OnceLock};
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
 /// Singleton tiktoken encoder for cl100k_base.
 /// Creating/freeing the BPE encoder can be expensive. We keep one instance alive for the app lifetime.
 static SHARED_ENCODER: OnceLock<Option<CoreBPE>> = OnceLock::new();
+static TOKEN_ESTIMATE_CACHE: OnceLock<Mutex<TokenEstimateCache>> = OnceLock::new();
+
+const TOKEN_ESTIMATE_CACHE_MAX_ENTRIES: usize = 1024;
+const TOKEN_ESTIMATE_CACHE_MAX_TEXT_BYTES: usize = 65_536;
+
+#[derive(Default)]
+struct TokenEstimateCache {
+    entries: HashMap<String, usize>,
+    order: VecDeque<String>,
+}
+
+impl TokenEstimateCache {
+    fn get(&self, text: &str) -> Option<usize> {
+        self.entries.get(text).copied()
+    }
+
+    fn insert(&mut self, text: String, tokens: usize) {
+        if self.entries.contains_key(&text) {
+            return;
+        }
+
+        while self.entries.len() >= TOKEN_ESTIMATE_CACHE_MAX_ENTRIES {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+
+        self.order.push_back(text.clone());
+        self.entries.insert(text, tokens);
+    }
+}
 
 /// Gets a reference to the shared cl100k_base encoder, initializing it if necessary.
 pub fn get_shared_encoder() -> Option<&'static CoreBPE> {
     SHARED_ENCODER.get_or_init(|| cl100k_base().ok()).as_ref()
 }
 
-/// Estimates the token count for arbitrary text using the `cl100k_base`
-/// Byte-Pair Encoding (BPE), which is a common encoding for many modern LLMs.
-/// Falls back to character-based estimation if tiktoken fails.
-pub fn estimate_text_tokens(text: &str) -> usize {
+fn get_token_estimate_cache() -> &'static Mutex<TokenEstimateCache> {
+    TOKEN_ESTIMATE_CACHE.get_or_init(|| Mutex::new(TokenEstimateCache::default()))
+}
+
+fn estimate_text_tokens_uncached(text: &str) -> usize {
     if let Some(encoder) = get_shared_encoder() {
         encoder.encode_with_special_tokens(text).len()
     } else {
         // Fallback: Use character-based estimation (~4 chars per token, conservative OpenAI estimate)
         (text.len() as f64 / 4.0).ceil() as usize
     }
+}
+
+/// Estimates the token count for arbitrary text using the `cl100k_base`
+/// Byte-Pair Encoding (BPE), which is a common encoding for many modern LLMs.
+/// Falls back to character-based estimation if tiktoken fails.
+pub fn estimate_text_tokens(text: &str) -> usize {
+    if text.is_empty() {
+        return 0;
+    }
+
+    if text.len() > TOKEN_ESTIMATE_CACHE_MAX_TEXT_BYTES {
+        return estimate_text_tokens_uncached(text);
+    }
+
+    let cache = get_token_estimate_cache();
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(tokens) = cache.get(text) {
+        return tokens;
+    }
+
+    let tokens = estimate_text_tokens_uncached(text);
+    cache.insert(text.to_string(), tokens);
+    tokens
 }
 
 use crate::mcp::types::MCPContent;
@@ -46,6 +105,51 @@ const CONSERVATIVE_DELTA_SAFETY_MULTIPLIER: f64 = 1.05;
 pub const PROMPT_ANCHOR_RATIO_MIN: f64 = 0.50;
 pub const PROMPT_ANCHOR_RATIO_MAX: f64 = 1.50;
 const MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE: usize = 2_048;
+
+#[derive(Debug)]
+struct MessageTokenStats {
+    per_message: Vec<usize>,
+    prefix_sums: Vec<usize>,
+    total_message_tokens: usize,
+}
+
+impl MessageTokenStats {
+    fn from_messages(messages: &[Message]) -> Self {
+        let mut per_message = Vec::with_capacity(messages.len());
+        let mut prefix_sums = Vec::with_capacity(messages.len() + 1);
+        let mut running_total = 0usize;
+        prefix_sums.push(0);
+
+        for message in messages {
+            let tokens = estimate_tokens_bpe(message);
+            running_total += tokens;
+            per_message.push(tokens);
+            prefix_sums.push(running_total);
+        }
+
+        Self {
+            per_message,
+            prefix_sums,
+            total_message_tokens: running_total,
+        }
+    }
+
+    fn tokens_before(&self, index: usize) -> usize {
+        self.prefix_sums.get(index).copied().unwrap_or(0)
+    }
+
+    fn tokens_from(&self, index: usize) -> usize {
+        self.total_message_tokens
+            .saturating_sub(self.tokens_before(index))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PromptAnchorRatio {
+    anchor_index: usize,
+    prompt_tokens: usize,
+    ratio: f64,
+}
 
 fn usage_metric_as_usize(usage: &serde_json::Value, key: &str) -> Option<usize> {
     usage
@@ -80,9 +184,10 @@ fn find_latest_assistant_usage_anchor(messages: &[Message], key: &str) -> Option
 
 fn get_prompt_anchor_ratio(
     messages: &[Message],
+    token_stats: &MessageTokenStats,
     system_prompt_tokens: usize,
     tools_tokens: usize,
-) -> Option<(usize, usize, f64)> {
+) -> Option<PromptAnchorRatio> {
     for (anchor_index, anchor_message) in messages.iter().enumerate().rev() {
         if anchor_message.role != "assistant" {
             continue;
@@ -98,11 +203,7 @@ fn get_prompt_anchor_ratio(
             continue;
         }
 
-        let prefix_messages = &messages[..anchor_index];
-        let prefix_message_bpe = prefix_messages
-            .iter()
-            .map(estimate_tokens_bpe)
-            .sum::<usize>();
+        let prefix_message_bpe = token_stats.tokens_before(anchor_index);
         let bpe_input = prefix_message_bpe + system_prompt_tokens + tools_tokens;
         let ratio = if bpe_input > 0 {
             prompt_tokens as f64 / bpe_input as f64
@@ -117,7 +218,11 @@ fn get_prompt_anchor_ratio(
             continue;
         }
 
-        return Some((anchor_index, prompt_tokens, ratio));
+        return Some(PromptAnchorRatio {
+            anchor_index,
+            prompt_tokens,
+            ratio,
+        });
     }
 
     None
@@ -179,8 +284,7 @@ pub fn estimate_tokens_bpe(message: &Message) -> usize {
         parts.push(thinking.clone());
     }
 
-    let text = format!("{}: {}", message.role, parts.join(" "));
-    estimate_text_tokens(&text)
+    estimate_text_tokens(&format!("{}: {}", message.role, parts.join(" ")))
 }
 
 pub fn summarize_message_token_breakdown(messages: &[Message]) -> String {
@@ -188,14 +292,16 @@ pub fn summarize_message_token_breakdown(messages: &[Message]) -> String {
         return "none".to_string();
     }
 
+    let token_stats = MessageTokenStats::from_messages(messages);
     messages
         .iter()
-        .map(|message| {
+        .zip(token_stats.per_message.iter())
+        .map(|(message, tokens)| {
             format!(
                 "{}:{}:bpe={}",
                 message.role,
                 shorten_message_id(&message.id),
-                estimate_tokens_bpe(message)
+                tokens
             )
         })
         .collect::<Vec<_>>()
@@ -218,19 +324,16 @@ pub fn calculate_grounded_total_tokens(
     system_prompt_tokens: usize,
     tools_tokens: usize,
 ) -> usize {
+    let token_stats = MessageTokenStats::from_messages(messages);
     if let Some((anchor_index, base_tokens)) =
         find_latest_assistant_usage_anchor(messages, "totalTokens")
     {
-        let incremental_tokens: usize = messages[anchor_index + 1..]
-            .iter()
-            .map(estimate_tokens_bpe)
-            .sum();
+        let incremental_tokens = token_stats.tokens_from(anchor_index + 1);
         return base_tokens + incremental_tokens;
     }
 
     // Fallback: Full BPE estimation
-    let message_tokens: usize = messages.iter().map(estimate_tokens_bpe).sum();
-    message_tokens + system_prompt_tokens + tools_tokens
+    token_stats.total_message_tokens + system_prompt_tokens + tools_tokens
 }
 
 /// Derives the BPE-to-provider tokenizer calibration ratio from the most recent
@@ -254,9 +357,11 @@ pub fn try_derive_bpe_calibration_ratio(
     system_prompt_tokens: usize,
     tools_tokens: usize,
 ) -> Option<f64> {
-    if let Some((_anchor_index, _prompt_tokens, ratio)) =
-        get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
+    let token_stats = MessageTokenStats::from_messages(messages);
+    if let Some(anchor) =
+        get_prompt_anchor_ratio(messages, &token_stats, system_prompt_tokens, tools_tokens)
     {
+        let ratio = anchor.ratio;
         return normalize_calibration_ratio(ratio);
     }
     None
@@ -296,22 +401,19 @@ pub fn calculate_prompt_anchored_total_tokens(
     system_prompt_tokens: usize,
     tools_tokens: usize,
 ) -> usize {
-    if let Some((anchor_index, prompt_tokens, ratio)) =
-        get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
+    let token_stats = MessageTokenStats::from_messages(messages);
+    if let Some(anchor) =
+        get_prompt_anchor_ratio(messages, &token_stats, system_prompt_tokens, tools_tokens)
     {
         // BPE of anchor's own output + all subsequent messages — everything added
         // after the model processed the anchor turn's input.
-        let bpe_output: usize = messages[anchor_index..]
-            .iter()
-            .map(estimate_tokens_bpe)
-            .sum();
-        let calibrated_output = (bpe_output as f64 * ratio).ceil() as usize;
-        return prompt_tokens + calibrated_output;
+        let bpe_output = token_stats.tokens_from(anchor.anchor_index);
+        let calibrated_output = (bpe_output as f64 * anchor.ratio).ceil() as usize;
+        return anchor.prompt_tokens + calibrated_output;
     }
 
     // Fallback: full BPE — no API anchor available yet (e.g. first turn).
-    let message_tokens: usize = messages.iter().map(estimate_tokens_bpe).sum();
-    message_tokens + system_prompt_tokens + tools_tokens
+    token_stats.total_message_tokens + system_prompt_tokens + tools_tokens
 }
 
 /// Estimates the next request input size conservatively enough for a Rust-owned
@@ -327,21 +429,18 @@ pub fn calculate_conservative_preflight_prompt_tokens(
     tools_tokens: usize,
     fallback_calibration_ratio: Option<f64>,
 ) -> usize {
-    if let Some((anchor_index, prompt_tokens, ratio)) =
-        get_prompt_anchor_ratio(messages, system_prompt_tokens, tools_tokens)
+    let token_stats = MessageTokenStats::from_messages(messages);
+    if let Some(anchor) =
+        get_prompt_anchor_ratio(messages, &token_stats, system_prompt_tokens, tools_tokens)
     {
-        let delta_bpe: usize = messages[anchor_index..]
-            .iter()
-            .map(estimate_tokens_bpe)
-            .sum();
-        let conservative_delta =
-            ((delta_bpe as f64 * ratio) * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
-        return prompt_tokens + conservative_delta;
+        let delta_bpe = token_stats.tokens_from(anchor.anchor_index);
+        let conservative_delta = ((delta_bpe as f64 * anchor.ratio)
+            * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER)
+            .ceil() as usize;
+        return anchor.prompt_tokens + conservative_delta;
     }
 
-    let full_estimate = messages.iter().map(estimate_tokens_bpe).sum::<usize>()
-        + system_prompt_tokens
-        + tools_tokens;
+    let full_estimate = token_stats.total_message_tokens + system_prompt_tokens + tools_tokens;
     if let Some(ratio) = fallback_calibration_ratio.and_then(normalize_calibration_ratio) {
         let calibrated_estimate = (full_estimate as f64 * ratio).ceil() as usize;
         let conservative_total =

--- a/src-tauri/src/agent/llm/token_utils.rs
+++ b/src-tauri/src/agent/llm/token_utils.rs
@@ -18,7 +18,6 @@ pub fn estimate_text_tokens(text: &str) -> usize {
         encoder.encode_with_special_tokens(text).len()
     } else {
         // Fallback: Use character-based estimation (~4 chars per token, conservative OpenAI estimate)
-        log::debug!("tiktoken encoding failed, using character-based fallback");
         (text.len() as f64 / 4.0).ceil() as usize
     }
 }
@@ -110,51 +109,11 @@ fn get_prompt_anchor_ratio(
         } else {
             1.0
         };
-        let message_breakdown = summarize_message_token_breakdown(prefix_messages);
-        log::debug!(
-            "promptTokens anchor ratio: anchor_index={}, anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
-            anchor_index,
-            anchor_message.id,
-            anchor_message.role,
-            prompt_tokens,
-            prefix_message_bpe,
-            system_prompt_tokens,
-            tools_tokens,
-            bpe_input,
-            ratio,
-            message_breakdown
-        );
-
         if prefix_message_bpe < MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE {
-            log::warn!(
-                "Rejecting promptTokens anchor with insufficient message prefix: anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, minimum_prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
-                anchor_message.id,
-                anchor_message.role,
-                prompt_tokens,
-                prefix_message_bpe,
-                MIN_PROMPT_ANCHOR_PREFIX_MESSAGE_BPE,
-                system_prompt_tokens,
-                tools_tokens,
-                bpe_input,
-                ratio,
-                message_breakdown
-            );
             continue;
         }
 
         if !(PROMPT_ANCHOR_RATIO_MIN..=PROMPT_ANCHOR_RATIO_MAX).contains(&ratio) {
-            log::warn!(
-                "Suspicious promptTokens calibration ratio: anchor_id={}, anchor_role={}, prompt_tokens={}, prefix_message_bpe={}, system_prompt_tokens={}, tools_tokens={}, denominator_bpe={}, ratio={:.4}, prefix_breakdown=[{}]",
-                anchor_message.id,
-                anchor_message.role,
-                prompt_tokens,
-                prefix_message_bpe,
-                system_prompt_tokens,
-                tools_tokens,
-                bpe_input,
-                ratio,
-                message_breakdown
-            );
             continue;
         }
 
@@ -266,28 +225,12 @@ pub fn calculate_grounded_total_tokens(
             .iter()
             .map(estimate_tokens_bpe)
             .sum();
-        log::debug!(
-            "Using grounded token estimation. base={}, inc={}, final={}",
-            base_tokens,
-            incremental_tokens,
-            base_tokens + incremental_tokens
-        );
         return base_tokens + incremental_tokens;
     }
 
     // Fallback: Full BPE estimation
     let message_tokens: usize = messages.iter().map(estimate_tokens_bpe).sum();
-    let full_estimate = message_tokens + system_prompt_tokens + tools_tokens;
-
-    log::debug!(
-        "Using full BPE token estimation. msg={}, sys={}, tools={}, final={}",
-        message_tokens,
-        system_prompt_tokens,
-        tools_tokens,
-        full_estimate
-    );
-
-    full_estimate
+    message_tokens + system_prompt_tokens + tools_tokens
 }
 
 /// Derives the BPE-to-provider tokenizer calibration ratio from the most recent
@@ -363,28 +306,12 @@ pub fn calculate_prompt_anchored_total_tokens(
             .map(estimate_tokens_bpe)
             .sum();
         let calibrated_output = (bpe_output as f64 * ratio).ceil() as usize;
-        log::debug!(
-            "prompt-anchored estimate: prompt_tokens={}, ratio={:.4}, bpe_output={}, calibrated_output={}, total={}",
-            prompt_tokens,
-            ratio,
-            bpe_output,
-            calibrated_output,
-            prompt_tokens + calibrated_output
-        );
         return prompt_tokens + calibrated_output;
     }
 
     // Fallback: full BPE — no API anchor available yet (e.g. first turn).
     let message_tokens: usize = messages.iter().map(estimate_tokens_bpe).sum();
-    let full_estimate = message_tokens + system_prompt_tokens + tools_tokens;
-    log::debug!(
-        "full-BPE fallback (no promptTokens anchor): msg={}, sys={}, tools={}, total={}",
-        message_tokens,
-        system_prompt_tokens,
-        tools_tokens,
-        full_estimate
-    );
-    full_estimate
+    message_tokens + system_prompt_tokens + tools_tokens
 }
 
 /// Estimates the next request input size conservatively enough for a Rust-owned
@@ -409,14 +336,6 @@ pub fn calculate_conservative_preflight_prompt_tokens(
             .sum();
         let conservative_delta =
             ((delta_bpe as f64 * ratio) * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
-        log::debug!(
-            "conservative preflight estimate: prompt_tokens={}, ratio={:.4}, delta_bpe={}, conservative_delta={}, total={}",
-            prompt_tokens,
-            ratio,
-            delta_bpe,
-            conservative_delta,
-            prompt_tokens + conservative_delta
-        );
         return prompt_tokens + conservative_delta;
     }
 
@@ -427,30 +346,10 @@ pub fn calculate_conservative_preflight_prompt_tokens(
         let calibrated_estimate = (full_estimate as f64 * ratio).ceil() as usize;
         let conservative_total =
             (calibrated_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
-        log::debug!(
-            "conservative preflight fallback (preserved calibration): message_bpe={}, system_prompt_tokens={}, tools_tokens={}, base={}, ratio={:.4}, calibrated={}, total={}, breakdown=[{}]",
-            full_estimate
-                .saturating_sub(system_prompt_tokens)
-                .saturating_sub(tools_tokens),
-            system_prompt_tokens,
-            tools_tokens,
-            full_estimate,
-            ratio,
-            calibrated_estimate,
-            conservative_total,
-            summarize_message_token_breakdown(messages)
-        );
         return conservative_total;
     }
 
-    let conservative_total =
-        (full_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize;
-    log::debug!(
-        "conservative preflight fallback (no promptTokens anchor): base={}, total={}",
-        full_estimate,
-        conservative_total
-    );
-    conservative_total
+    (full_estimate as f64 * CONSERVATIVE_DELTA_SAFETY_MULTIPLIER).ceil() as usize
 }
 
 /// Computes the post-response compaction trigger total from the provider-reported

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -435,7 +435,7 @@ impl AgentSessionManager {
             )
             .await?;
 
-            crate::agent::llm::request_llm_completion(
+            crate::agent::llm::request_llm_completion_with_recovery(
                 &self.session_repo,
                 &self.active_sessions,
                 &self.proxy_manager,

--- a/src-tauri/src/agent/session_manager/compact.rs
+++ b/src-tauri/src/agent/session_manager/compact.rs
@@ -24,7 +24,7 @@ fn spawn_resume_completion(
     let resume_session_id = session_id.to_string();
 
     tokio::spawn(async move {
-        if let Err(error) = crate::agent::llm::request_llm_completion(
+        if let Err(error) = crate::agent::llm::request_llm_completion_with_recovery(
             &session_repo,
             &active_sessions,
             &proxy_manager,
@@ -39,23 +39,6 @@ fn spawn_resume_completion(
                 resume_session_id,
                 error
             );
-
-            if let Err(handle_error) = crate::agent::llm::handle_llm_error(
-                &session_repo,
-                &active_sessions,
-                &app_handle,
-                resume_session_id.clone(),
-                error,
-            )
-            .await
-            {
-                log::error!(
-                    "Failed to surface {} resume error for session {}: {}",
-                    log_label,
-                    resume_session_id,
-                    handle_error
-                );
-            }
         }
     });
 }

--- a/src-tauri/src/agent/workflow/pause_resume.rs
+++ b/src-tauri/src/agent/workflow/pause_resume.rs
@@ -59,7 +59,7 @@ pub async fn resume_workflow(
         .await?;
 
     // Trigger LLM to pick up where it left off
-    crate::agent::llm::request_llm_completion(
+    crate::agent::llm::request_llm_completion_with_recovery(
         session_repo,
         active_sessions,
         proxy_manager,

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -154,7 +154,7 @@ pub async fn start_workflow(
     ensure_proxy_ready(proxy_manager, app_handle, &session_id, 60).await?;
 
     // Request LLM completion with cached messages (no DB query)
-    crate::agent::llm::request_llm_completion(
+    crate::agent::llm::request_llm_completion_with_recovery(
         session_repo,
         active_sessions,
         proxy_manager,

--- a/src-tauri/src/agent/workflow/tool.rs
+++ b/src-tauri/src/agent/workflow/tool.rs
@@ -187,7 +187,7 @@ pub async fn continue_workflow_after_tool(
                 }
 
                 // Request next LLM completion
-                if let Err(e) = crate::agent::llm::request_llm_completion(
+                if let Err(e) = crate::agent::llm::request_llm_completion_with_recovery(
                     session_repo,
                     active_sessions,
                     proxy_manager,

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_text,
     find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
-    merge_consecutive_user_messages, resolve_context_management_settings,
-    resolve_preserved_calibration_ratio, should_skip_same_tail_compaction,
-    should_trigger_background_compaction, should_trigger_post_response_compaction,
-    uses_compaction_strategy,
+    merge_consecutive_user_messages, normalize_request_messages,
+    resolve_context_management_settings, resolve_preserved_calibration_ratio,
+    should_skip_same_tail_compaction, should_trigger_background_compaction,
+    should_trigger_post_response_compaction, uses_compaction_strategy,
 };
 use tauri_mcp_agent_lib::agent::llm::context_selector::*;
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
@@ -213,6 +213,52 @@ fn test_preflight_compaction_split_after_removing_incomplete_tool_chains() {
 
     let idx = find_preflight_compaction_split_index(&cleaned);
     assert_eq!(idx, cleaned.len());
+}
+
+#[test]
+fn test_normalize_request_messages_removes_stale_incomplete_tool_chains_before_compaction() {
+    let intro = make_message("m0", "user", "Need analysis");
+
+    let mut stale_assistant = make_message("m1", "assistant", "Old stale tool call");
+    stale_assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "stale_call".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "toolA".to_string(),
+            arguments: "{}".to_string(),
+        },
+    }]);
+
+    let mut current_assistant = make_message("m2", "assistant", "Current resolved tool call");
+    current_assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "current_call".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "toolB".to_string(),
+            arguments: "{}".to_string(),
+        },
+    }]);
+
+    let mut current_tool = make_message("m3", "tool", &"very large tool result ".repeat(200));
+    current_tool.tool_call_id = Some("current_call".to_string());
+
+    let normalized = normalize_request_messages(vec![
+        intro,
+        stale_assistant,
+        current_assistant,
+        current_tool,
+    ]);
+
+    assert_eq!(normalized.len(), 4);
+    assert_eq!(normalized[0].id, "m0");
+    assert_eq!(normalized[1].id, "m1");
+    assert!(normalized[1].tool_calls.is_none());
+    assert_eq!(normalized[2].id, "m2");
+    assert_eq!(normalized[3].id, "m3");
+    assert_eq!(
+        find_preflight_compaction_split_index(&normalized),
+        normalized.len()
+    );
 }
 
 #[test]

--- a/src-tauri/tests/llm_error_outcome_tests.rs
+++ b/src-tauri/tests/llm_error_outcome_tests.rs
@@ -1,0 +1,34 @@
+use tauri_mcp_agent_lib::agent::llm::{
+    completion_result_from_error_handling_outcome, AgentRuntimeError, AgentRuntimeErrorType,
+    LlmErrorHandlingOutcome,
+};
+
+#[test]
+fn recovered_compaction_outcome_keeps_request_flow_successful() {
+    let error = AgentRuntimeError::new(
+        AgentRuntimeErrorType::ContextLimitError,
+        "Context limit reached",
+    );
+
+    let result = completion_result_from_error_handling_outcome(
+        LlmErrorHandlingOutcome::RecoveredByCompaction,
+        error,
+    );
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn finalized_workflow_error_outcome_propagates_original_failure() {
+    let error = AgentRuntimeError::new(
+        AgentRuntimeErrorType::AiServiceError,
+        "Provider request failed",
+    );
+
+    let result = completion_result_from_error_handling_outcome(
+        LlmErrorHandlingOutcome::FinalizedWorkflowError,
+        error,
+    );
+
+    assert_eq!(result, Err("Provider request failed".to_string()));
+}

--- a/src/context/AgentPlanningContext.tsx
+++ b/src/context/AgentPlanningContext.tsx
@@ -21,8 +21,6 @@ export function AgentPlanningProvider({
 }: AgentPlanningProviderProps) {
   const [showPlanningPanel, setShowPlanningPanel] = useState(false);
 
-  logger.debug('Provider render', { showPlanningPanel });
-
   const togglePlanningPanel = useCallback(() => {
     const newValue = !showPlanningPanel;
     logger.info('Planning panel toggled', {

--- a/src/context/AgentWorkspaceContext.tsx
+++ b/src/context/AgentWorkspaceContext.tsx
@@ -21,8 +21,6 @@ export function AgentWorkspaceProvider({
 }: AgentWorkspaceProviderProps) {
   const [showWorkspacePanel, setShowWorkspacePanel] = useState(false);
 
-  logger.debug('Provider render', { showWorkspacePanel });
-
   const toggleWorkspacePanel = useCallback(() => {
     const newValue = !showWorkspacePanel;
     logger.info('Workspace panel toggled', {

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -48,11 +48,6 @@ export function useAgentSessionEvents(
             return;
           }
 
-          logger.debug('Agent session event received', {
-            type: payload.type,
-            sessionId,
-          });
-
           switch (payload.type) {
             case 'initializationStep': {
               const rawStatus = payload.status;

--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -19,7 +19,6 @@ import {
   AgentPlanningProvider,
   useAgentPlanning,
 } from '@/context/AgentPlanningContext';
-import { AgentResourceAttachmentProvider } from './context/AgentResourceAttachmentContext';
 import { AgentChatHeader } from './components/AgentChatHeader';
 import { AgentChatStatusBar } from './components/AgentChatStatusBar';
 import { AgentChatMessages } from './components/AgentChatMessages';
@@ -30,6 +29,7 @@ import { AgentPlanningPanel } from './components/AgentPlanningPanel';
 import { AgentPlanningUpdates } from './components/AgentPlanningUpdates';
 import { getLogger } from '@/lib/logger';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
+import { AgentResourceAttachmentProvider } from './hooks/useAgentResourceAttachment';
 
 const logger = getLogger('AgentChatView');
 

--- a/src/features/agent/hooks/useAgentResourceAttachment.ts
+++ b/src/features/agent/hooks/useAgentResourceAttachment.ts
@@ -1,1 +1,4 @@
-export { useAgentResourceAttachment } from '../context/AgentResourceAttachmentContext';
+export {
+  AgentResourceAttachmentProvider,
+  useAgentResourceAttachment,
+} from '../context/AgentResourceAttachmentContext';

--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -59,16 +59,28 @@ function GeneralTabComponent({
               }
             >
               <option value="Pretendard">
-                {t('settings.display.fontFamilyOptions.pretendard', 'Pretendard (Standard Sans)')}
+                {t(
+                  'settings.display.fontFamilyOptions.pretendard',
+                  'Pretendard (Standard Sans)',
+                )}
               </option>
               <option value="Inter">
-                {t('settings.display.fontFamilyOptions.inter', 'Inter (Clean UI Sans)')}
+                {t(
+                  'settings.display.fontFamilyOptions.inter',
+                  'Inter (Clean UI Sans)',
+                )}
               </option>
               <option value="NanumSquare Neo">
-                {t('settings.display.fontFamilyOptions.nanumSquareNeo', 'NanumSquare Neo (Modern Geometric)')}
+                {t(
+                  'settings.display.fontFamilyOptions.nanumSquareNeo',
+                  'NanumSquare Neo (Modern Geometric)',
+                )}
               </option>
               <option value="D2Coding">
-                {t('settings.display.fontFamilyOptions.d2coding', 'D2Coding (Developer Mono)')}
+                {t(
+                  'settings.display.fontFamilyOptions.d2coding',
+                  'D2Coding (Developer Mono)',
+                )}
               </option>
             </select>
             <p className="text-xs text-muted-foreground mt-1">


### PR DESCRIPTION
## Summary
- unify backend LLM re-entry through a recovery-aware compaction orchestration path
- make preflight compaction use the same normalized message stack as request assembly
- remove high-frequency UI render/event logs and expensive token calibration spam
- fix the attachment provider regression by routing provider and hook through the same module entrypoint

## Validation
- pnpm refactor:validate