### PR TITLE
🕸️ Weaver: Refactor ScheduledTaskModal using Custom Hook Pattern

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -149,3 +149,8 @@
 
 **Learning:** The ESLint configuration in this project does not define the `react-hooks/exhaustive-deps` rule, leading to errors when attempting to suppress it.
 **Action:** Avoid using `// eslint-disable-next-line react-hooks/exhaustive-deps`, and generally favor fixing dependency arrays natively rather than suppressing the missing rule.
+
+## 2025-04-25 - [ScheduledTaskModal] **Eradicated:** [God useEffect block / Mixed drag-and-drop side effects with presentation] **Woven:** [Custom Hook Pattern (useWorkspaceDropZone)]
+
+- **ScheduledTaskModal:** Extracted the complex Tauri drag-and-drop subscription logic (`subscribe`, path processing, and state management) into a dedicated custom hook `useWorkspaceDropZone`.
+- **Benefits:** Strictly separates drag-and-drop side-effects from the component's main render logic, drastically reducing the component's footprint and adhering to the modernized React custom hook pattern for isolated logic sharing.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3786,7 +3786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
+++ b/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { open } from '@tauri-apps/plugin-dialog';
 import { toast } from 'sonner';
@@ -27,11 +27,7 @@ import { MentionTextarea } from './MentionTextarea';
 import { getDisplayCron, ScheduleBuilder } from './ScheduleBuilder';
 import type { Assistant } from '@/models/chat';
 import { getLogger } from '@/lib/logger';
-import { useDnDContext } from '@/context/DnDContext';
-import {
-  checkDroppedPathType,
-  registerDroppedFiles,
-} from '@/lib/backend/file-operations';
+import { useWorkspaceDropZone } from '../hooks/useWorkspaceDropZone';
 
 const logger = getLogger('ScheduledTaskModal');
 
@@ -111,7 +107,6 @@ function ScheduledTaskForm({
   onSave,
 }: ScheduledTaskFormProps) {
   const { t } = useTranslation();
-  const { subscribe } = useDnDContext();
   const [name, setName] = useState(task?.name ?? '');
   const initialCronExpression =
     task !== undefined && task !== null
@@ -145,72 +140,14 @@ function ScheduledTaskForm({
   const [workspaceOverride, setWorkspaceOverride] = useState<string | null>(
     task?.workspaceOverride ?? null,
   );
-  const [workspaceDragState, setWorkspaceDragState] = useState<
-    'none' | 'valid' | 'invalid'
-  >('none');
   const [browsingWorkspace, setBrowsingWorkspace] = useState(false);
   const [saving, setSaving] = useState(false);
   const workspaceDropRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const processDroppedPaths = (paths: string[]) => {
-      const run = async () => {
-        try {
-          await registerDroppedFiles(paths);
-        } catch (error: unknown) {
-          logger.error('Failed to register dropped workspace folder', error);
-          toast.error(t('scheduledTasks.modal.workspaceRegisterFailed'));
-          return;
-        }
-
-        for (const filePath of paths) {
-          try {
-            const pathType = await checkDroppedPathType(filePath);
-            if (pathType === 'directory') {
-              setWorkspaceOverride(filePath);
-              return;
-            }
-          } catch (error: unknown) {
-            logger.error('Failed to inspect dropped workspace path', {
-              filePath,
-              error,
-            });
-          }
-        }
-
-        toast.error(t('scheduledTasks.modal.workspaceDropFolderError'));
-      };
-
-      void run();
-    };
-
-    const unsubscribe = subscribe(
-      workspaceDropRef as RefObject<HTMLElement>,
-      (event, payload) => {
-        if (event === 'drag-over') {
-          setWorkspaceDragState(
-            payload.paths && payload.paths.length > 0 ? 'valid' : 'invalid',
-          );
-          return;
-        }
-
-        if (event === 'leave') {
-          setWorkspaceDragState('none');
-          return;
-        }
-
-        setWorkspaceDragState('none');
-        if (payload.paths && payload.paths.length > 0) {
-          processDroppedPaths(payload.paths);
-        }
-      },
-      { priority: 5 },
-    );
-
-    return () => {
-      unsubscribe();
-    };
-  }, [subscribe, t]);
+  const { workspaceDragState } = useWorkspaceDropZone(
+    workspaceDropRef,
+    setWorkspaceOverride,
+  );
 
   const handleBrowseWorkspace = async () => {
     if (browsingWorkspace) return;

--- a/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
+++ b/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState, type RefObject } from 'react';
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+import { useDnDContext } from '@/context/DnDContext';
+import {
+  checkDroppedPathType,
+  registerDroppedFiles,
+} from '@/lib/backend/file-operations';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('useWorkspaceDropZone');
+
+export function useWorkspaceDropZone(
+  dropZoneRef: RefObject<HTMLElement>,
+  onWorkspaceSelected: (path: string) => void,
+) {
+  const { t } = useTranslation();
+  const { subscribe } = useDnDContext();
+  const [workspaceDragState, setWorkspaceDragState] = useState<'none' | 'valid' | 'invalid'>(
+    'none',
+  );
+
+  useEffect(() => {
+    const processDroppedPaths = (paths: string[]) => {
+      const run = async () => {
+        try {
+          await registerDroppedFiles(paths);
+        } catch (error: unknown) {
+          logger.error('Failed to register dropped workspace folder', error);
+          toast.error(t('scheduledTasks.modal.workspaceRegisterFailed'));
+          return;
+        }
+
+        for (const filePath of paths) {
+          try {
+            const pathType = await checkDroppedPathType(filePath);
+            if (pathType === 'directory') {
+              onWorkspaceSelected(filePath);
+              return;
+            }
+          } catch (error: unknown) {
+            logger.error('Failed to inspect dropped workspace path', {
+              filePath,
+              error,
+            });
+          }
+        }
+
+        toast.error(t('scheduledTasks.modal.workspaceDropFolderError'));
+      };
+
+      void run();
+    };
+
+    const unsubscribe = subscribe(
+      dropZoneRef,
+      (event, payload) => {
+        if (event === 'drag-over') {
+          setWorkspaceDragState(
+            payload.paths && payload.paths.length > 0 ? 'valid' : 'invalid',
+          );
+          return;
+        }
+
+        if (event === 'leave') {
+          setWorkspaceDragState('none');
+          return;
+        }
+
+        setWorkspaceDragState('none');
+        if (payload.paths && payload.paths.length > 0) {
+          processDroppedPaths(payload.paths);
+        }
+      },
+      { priority: 5 },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [dropZoneRef, onWorkspaceSelected, subscribe, t]);
+
+  return { workspaceDragState };
+}

--- a/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
+++ b/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
@@ -16,9 +16,9 @@ export function useWorkspaceDropZone(
 ) {
   const { t } = useTranslation();
   const { subscribe } = useDnDContext();
-  const [workspaceDragState, setWorkspaceDragState] = useState<'none' | 'valid' | 'invalid'>(
-    'none',
-  );
+  const [workspaceDragState, setWorkspaceDragState] = useState<
+    'none' | 'valid' | 'invalid'
+  >('none');
 
   useEffect(() => {
     const processDroppedPaths = (paths: string[]) => {
@@ -39,7 +39,11 @@ export function useWorkspaceDropZone(
               return;
             }
           } catch (error: unknown) {
-            logger.error('Failed to inspect dropped workspace path', { filePath }, error);
+            logger.error(
+              'Failed to inspect dropped workspace path',
+              { filePath },
+              error,
+            );
           }
         }
 

--- a/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
+++ b/src/features/scheduled-tasks/hooks/useWorkspaceDropZone.ts
@@ -39,10 +39,7 @@ export function useWorkspaceDropZone(
               return;
             }
           } catch (error: unknown) {
-            logger.error('Failed to inspect dropped workspace path', {
-              filePath,
-              error,
-            });
+            logger.error('Failed to inspect dropped workspace path', { filePath }, error);
           }
         }
 

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
### 🚫 Eradicated
God useEffect blocks, mixed business logic and presentation, derived state related to workspace drag-and-drop in `ScheduledTaskModal`.

### ✨ Woven
Custom Hook Pattern (`useWorkspaceDropZone`) to strictly separate drag-and-drop side-effects from presentation.

### 📉 Impact
Decoupled event subscription from component rendering logic, significantly improving component readability and reusability.

---
*PR created automatically by Jules for task [10815882281224972427](https://jules.google.com/task/10815882281224972427) started by @fritzprix*