### PR TITLE
🎨 Palette: [UX improvement] Add DialogDescription to SkillsListModal

### DIFF
--- a/src/features/settings/components/SkillsListModal.tsx
+++ b/src/features/settings/components/SkillsListModal.tsx
@@ -3,6 +3,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   Button,
   Badge,
 } from '@/components/ui';
@@ -89,6 +90,12 @@ export function SkillsListModal({
               defaultValue: 'Installed Skills ({{count}})',
             })}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {t(
+              'settings.skills.modalDescription',
+              'A list of installed system and user skills for your assistants.',
+            )}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto min-h-0 pr-4">


### PR DESCRIPTION
💡 What: Added DialogDescription to the SkillsListModal to fix an accessibility warning.
🎯 Why: Radix UI DialogContent requires a DialogDescription or aria-describedby={undefined} for screen reader support. Since this modal displays a list of skills, an explicit description is appropriate.
📸 Before/After: Accessibility improvement, no major visual change.
♿ Accessibility: Ensures the Skills List Modal is accessible to screen readers, fixing a test warning.

---
*PR created automatically by Jules for task [15975603726261743558](https://jules.google.com/task/15975603726261743558) started by @fritzprix*