### PR TITLE
Fix session init readiness and compact summary display

### DIFF
--- a/src-tauri/src/mcp/service_proxy_manager/creation.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/creation.rs
@@ -9,8 +9,10 @@ use crate::services::mcp_server_service::summarize_tool_names;
 use crate::session::SessionManager;
 use sea_orm::DatabaseConnection;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::AppHandle;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinSet;
@@ -53,6 +55,33 @@ pub fn decide_existing_proxy_disposition(
         ExistingProxyDisposition::Reuse
     } else {
         ExistingProxyDisposition::Recreate
+    }
+}
+
+async fn await_tool_discovery<T, E, F>(
+    future: F,
+    timeout: Duration,
+    transport: &str,
+    server_name: &str,
+    session_id: &str,
+) -> Result<T, String>
+where
+    F: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(format!(
+            "{} server '{}' tool discovery failed for session '{}': {}",
+            transport, server_name, session_id, error
+        )),
+        Err(_) => Err(format!(
+            "{} server '{}' tool discovery timed out after {}s for session '{}'",
+            transport,
+            server_name,
+            timeout.as_secs(),
+            session_id
+        )),
     }
 }
 
@@ -166,16 +195,9 @@ impl MCPServiceProxyManager {
         };
         let _session_lock = session_guard.lock().await;
 
-        emit_status(
-            "Initializing session environment",
-            InitializationStatus::Running,
-        );
-
         // Fetch configs directly from DB to support Session Isolation (independent of global connections)
         use crate::repositories::mcp_server_repository::MCPServerRepository;
         use crate::state::get_mcp_server_repository;
-
-        emit_status("Loading tool configurations", InitializationStatus::Running);
 
         let mut stdio_configs = HashMap::new();
         let mut http_configs = HashMap::new();
@@ -350,6 +372,12 @@ impl MCPServiceProxyManager {
             ));
         }
 
+        emit_status(
+            "Initializing session environment",
+            InitializationStatus::Running,
+        );
+        emit_status("Loading tool configurations", InitializationStatus::Running);
+
         // Clean up any leftover per-session managers/readiness state before rebuilding.
         // This preserves the old "stale manager" cleanup behavior for sessions that
         // somehow lost their proxy entry but still have session-scoped manager state.
@@ -389,6 +417,8 @@ impl MCPServiceProxyManager {
         let workspace_dir = self
             .session_manager
             .get_session_workspace_dir_by_id(&session_id);
+        let tool_discovery_timeout = Duration::from_secs(config.process_startup_timeout_seconds);
+
         let stdio_manager = SessionMCPManager::new(
             session_id.clone(),
             stdio_configs.clone(),
@@ -476,6 +506,7 @@ impl MCPServiceProxyManager {
             let server_name_to_id_bg = server_name_to_id;
             let stdio_configs_bg = stdio_configs;
             let http_configs_bg = http_configs;
+            let tool_discovery_timeout_bg = tool_discovery_timeout;
 
             tokio::spawn(async move {
                 let emit_bg = |step: &str, status: InitializationStatus| {
@@ -515,6 +546,7 @@ impl MCPServiceProxyManager {
                     let session_id = session_id_bg.clone();
                     let app = app_handle_bg.clone();
                     let server_name = server_name.clone();
+                    let tool_discovery_timeout = tool_discovery_timeout_bg;
                     stdio_tasks.spawn(async move {
                         let emit = |step: &str, status: InitializationStatus| {
                             if let Some(app_h) = &app {
@@ -539,7 +571,15 @@ impl MCPServiceProxyManager {
                             server_name,
                             session_id
                         );
-                        match mgr.list_tools(&server_name).await {
+                        match await_tool_discovery(
+                            mgr.list_tools(&server_name),
+                            tool_discovery_timeout,
+                            "stdio",
+                            &server_name,
+                            &session_id,
+                        )
+                        .await
+                        {
                             Ok(tools) => {
                                 log::info!(
                                     "[bg] ✅ Fetched {} tools from stdio server '{}' for session '{}': raw=[{}]",
@@ -576,9 +616,7 @@ impl MCPServiceProxyManager {
                             }
                             Err(e) => {
                                 log::error!(
-                                    "[bg] ❌ Failed to fetch tools from stdio server '{}' for session '{}': {:?}",
-                                    server_name,
-                                    session_id,
+                                    "[bg] ❌ {}",
                                     e
                                 );
                             }
@@ -612,6 +650,7 @@ impl MCPServiceProxyManager {
                     let id_map = server_name_to_id_arc.clone();
                     let session_id = session_id_bg.clone();
                     let server_name = server_name.clone();
+                    let tool_discovery_timeout = tool_discovery_timeout_bg;
                     http_tasks.spawn(async move {
                         let has_cache = proxy.has_http_tools_cached(&server_name).await;
                         if has_cache {
@@ -626,7 +665,15 @@ impl MCPServiceProxyManager {
                             server_name,
                             session_id
                         );
-                        match mgr.list_tools(&server_name).await {
+                        match await_tool_discovery(
+                            mgr.list_tools(&server_name),
+                            tool_discovery_timeout,
+                            "http",
+                            &server_name,
+                            &session_id,
+                        )
+                        .await
+                        {
                             Ok(tools) => {
                                 log::info!(
                                     "[bg] ✅ Fetched {} tools from HTTP server '{}' for session '{}': raw=[{}]",
@@ -663,9 +710,7 @@ impl MCPServiceProxyManager {
                             }
                             Err(e) => {
                                 log::error!(
-                                    "[bg] ❌ Failed to fetch tools from HTTP server '{}' for session '{}': {:?}",
-                                    server_name,
-                                    session_id,
+                                    "[bg] ❌ {}",
                                     e
                                 );
                             }

--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -1,8 +1,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import type { AgentSession } from '@/models/agent';
 import type { Message, MessageError } from '@/models/chat';
-import type { AgentRuntimeError } from '@/models/agent-ipc';
-import type { MessageCursor } from '@/lib/backend/messages';
+import type { AgentRuntimeError, MessageCursor } from '@/models/agent-ipc';
 import { applyViewedAtToSession } from '@/lib/session-utils';
 import type { WorkflowPhase, PendingApproval } from './types';
 import { buildMessageError } from './utils';

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -18,6 +18,7 @@ import { PendingApprovalWidget } from './PendingApprovalWidget';
 import { ScrollArea } from '@/components/ui';
 import { getLogger } from '@/lib/logger';
 import type { Message } from '@/models/chat';
+import { useTranslation } from 'react-i18next';
 
 const logger = getLogger('AgentChatMessages');
 
@@ -95,6 +96,7 @@ function groupedMessageContainsBoundary(
 }
 
 export function AgentChatMessages() {
+  const { t } = useTranslation();
   const {
     messages,
     pendingMessages,
@@ -167,14 +169,21 @@ export function AgentChatMessages() {
       (message) => message.id === compactedRange.toId,
     );
 
-    if (fromIndex === -1 || toIndex === -1 || fromIndex > toIndex) {
+    if (toIndex === -1) {
+      return undefined;
+    }
+
+    if (fromIndex > toIndex) {
       return undefined;
     }
 
     return {
-      earlierPreview: extractMessagePreview(messages[fromIndex]),
+      earlierPreview:
+        fromIndex === -1
+          ? undefined
+          : extractMessagePreview(messages[fromIndex]),
       latestIncludedPreview: extractMessagePreview(messages[toIndex]),
-      condensedCount: toIndex - fromIndex + 1,
+      condensedCount: fromIndex === -1 ? undefined : toIndex - fromIndex + 1,
       summary: compactedRange.summary,
     };
   }, [compactedRange, messages]);
@@ -226,8 +235,14 @@ export function AgentChatMessages() {
             <div className="flex justify-center">
               <div className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs text-muted-foreground shadow-sm">
                 {isLoadingOlderMessages
-                  ? 'Loading older messages...'
-                  : 'Scroll up to load older messages'}
+                  ? t(
+                      'agent.messages.loadingOlder',
+                      'Loading older messages...',
+                    )
+                  : t(
+                      'agent.messages.scrollToLoadOlder',
+                      'Scroll up to load older messages',
+                    )}
               </div>
             </div>
           )}

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -16,6 +16,13 @@ const baseMessage: Message = {
 };
 
 const groupedToolMessages: Message[] = [
+  {
+    id: 'earlier-user',
+    sessionId: 'session-1',
+    threadId: 'session-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'Earlier user message' }],
+  },
   baseMessage,
   {
     id: 'tool-1',
@@ -51,7 +58,7 @@ const groupedMessagesMock: GroupedMessage[] = [
 
 vi.mock('@/context/AgentChatContext', () => ({
   useAgentChat: () => ({
-    messages: groupedToolMessages,
+    messages: groupedToolMessages.slice(1),
     pendingMessages: [],
     error: undefined,
     llmError: undefined,
@@ -71,7 +78,7 @@ vi.mock('@/context/AgentSessionContext', () => ({
 vi.mock('@/context/LLMServiceContext', () => ({
   useLLMService: () => ({
     getCompactedRange: () => ({
-      fromId: 'assistant-1',
+      fromId: 'earlier-user',
       toId: 'tool-1',
       summary: 'Compacted summary',
     }),
@@ -110,7 +117,9 @@ vi.mock('../shared', () => ({
 }));
 
 vi.mock('../shared/CompactEventDivider', () => ({
-  CompactEventDivider: () => <div>compact divider</div>,
+  CompactEventDivider: ({ summary }: { summary?: string }) => (
+    <div>{summary ?? 'compact divider'}</div>
+  ),
 }));
 
 vi.mock('../PendingApprovalWidget', () => ({
@@ -129,6 +138,6 @@ describe('AgentChatMessages compaction rendering', () => {
   it('renders the compact event when the boundary falls inside a tool group', () => {
     render(<AgentChatMessages />);
 
-    expect(screen.getByText('compact divider')).toBeInTheDocument();
+    expect(screen.getByText('Compacted summary')).toBeInTheDocument();
   });
 });

--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -59,16 +59,28 @@ function GeneralTabComponent({
               }
             >
               <option value="Pretendard">
-                {t('settings.display.fontFamilyOptions.pretendard', 'Pretendard (Standard Sans)')}
+                {t(
+                  'settings.display.fontFamilyOptions.pretendard',
+                  'Pretendard (Standard Sans)',
+                )}
               </option>
               <option value="Inter">
-                {t('settings.display.fontFamilyOptions.inter', 'Inter (Clean UI Sans)')}
+                {t(
+                  'settings.display.fontFamilyOptions.inter',
+                  'Inter (Clean UI Sans)',
+                )}
               </option>
               <option value="NanumSquare Neo">
-                {t('settings.display.fontFamilyOptions.nanumSquareNeo', 'NanumSquare Neo (Modern Geometric)')}
+                {t(
+                  'settings.display.fontFamilyOptions.nanumSquareNeo',
+                  'NanumSquare Neo (Modern Geometric)',
+                )}
               </option>
               <option value="D2Coding">
-                {t('settings.display.fontFamilyOptions.d2coding', 'D2Coding (Developer Mono)')}
+                {t(
+                  'settings.display.fontFamilyOptions.d2coding',
+                  'D2Coding (Developer Mono)',
+                )}
               </option>
             </select>
             <p className="text-xs text-muted-foreground mt-1">

--- a/src/lib/backend/messages.ts
+++ b/src/lib/backend/messages.ts
@@ -2,7 +2,10 @@ import { safeInvoke } from './core';
 import { isMessageSource, type Message, type RustMessage } from '@/models/chat';
 import type { Page } from '@/lib/db/types';
 import type { MessageSearchResult } from './types';
-import type { MessageSlice as RustMessageSlice } from '@/models/agent-ipc';
+import type {
+  MessageCursor,
+  MessageSlice as RustMessageSlice,
+} from '@/models/agent-ipc';
 
 export interface RustSearchResult {
   messageId: string;
@@ -10,11 +13,6 @@ export interface RustSearchResult {
   score: number;
   snippet: string | null;
   createdAt: number;
-}
-
-export interface MessageCursor {
-  createdAt: number;
-  rowId: number;
 }
 
 // ========================================

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -80,6 +80,10 @@
       "description": "Description",
       "expand": "Expand configuration",
       "collapse": "Collapse configuration"
+    },
+    "messages": {
+      "loadingOlder": "Loading older messages...",
+      "scrollToLoadOlder": "Scroll up to load older messages"
     }
   },
   "status": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -80,10 +80,6 @@
       "description": "Description",
       "expand": "Expand configuration",
       "collapse": "Collapse configuration"
-    },
-    "messages": {
-      "loadingOlder": "Loading older messages...",
-      "scrollToLoadOlder": "Scroll up to load older messages"
     }
   },
   "status": {
@@ -671,6 +667,10 @@
     }
   },
   "agent": {
+    "messages": {
+      "loadingOlder": "Loading older messages...",
+      "scrollToLoadOlder": "Scroll up to load older messages"
+    },
     "draft": {
       "send": "Send message",
       "attachFiles": "Attach files",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -80,10 +80,6 @@
       "description": "설명",
       "expand": "설정 펼치기",
       "collapse": "설정 접기"
-    },
-    "messages": {
-      "loadingOlder": "이전 메시지를 불러오는 중...",
-      "scrollToLoadOlder": "위로 스크롤하여 이전 메시지 불러오기"
     }
   },
   "status": {
@@ -641,6 +637,10 @@
     }
   },
   "agent": {
+    "messages": {
+      "loadingOlder": "이전 메시지를 불러오는 중...",
+      "scrollToLoadOlder": "위로 스크롤하여 이전 메시지 불러오기"
+    },
     "draft": {
       "send": "메시지 보내기",
       "attachFiles": "파일 첨부",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -80,6 +80,10 @@
       "description": "설명",
       "expand": "설정 펼치기",
       "collapse": "설정 접기"
+    },
+    "messages": {
+      "loadingOlder": "이전 메시지를 불러오는 중...",
+      "scrollToLoadOlder": "위로 스크롤하여 이전 메시지 불러오기"
     }
   },
   "status": {


### PR DESCRIPTION
## Summary
- add tool discovery timeouts and avoid stale running init events when reusing session proxies
- keep compact summary content visible even when the compacted range starts outside the loaded message slice
- align message cursor imports and add localized older-message status strings
- include a separate formatter-only commit for GeneralTab

## Notes
- intentionally excludes the preflight token optimization commit already on the other branch
- intentionally excludes package.json validation changes and the knowledge repository optimization