### PR TITLE
🎨 Palette: Add DialogDescription to SessionFilesPopover for accessibility

### DIFF
--- a/src/components/shared/SessionFilesPopover.tsx
+++ b/src/components/shared/SessionFilesPopover.tsx
@@ -228,7 +228,22 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
               {selectedFile?.filename}
             </DialogTitle>
             <DialogDescription className="sr-only">
-              {t('sessionFiles.fileDetails', 'Details and content of the selected file')}
+              {[
+                selectedFile?.mimeType
+                  ? `${t('sessionFiles.type', 'Type:')} ${selectedFile.mimeType}`
+                  : null,
+                selectedFile?.size
+                  ? `${t('sessionFiles.size', 'Size:')} ${formatFileSize(selectedFile.size)}`
+                  : null,
+                selectedFile?.uploadedAt
+                  ? `${t('sessionFiles.created', 'Created:')} ${formatDate(selectedFile.uploadedAt)}`
+                  : null,
+                selectedFile?.workspacePath
+                  ? `${t('sessionFiles.workspace', 'Workspace:')} ${selectedFile.workspacePath}`
+                  : null,
+              ]
+                .filter((value): value is string => Boolean(value))
+                .join(' • ')}
             </DialogDescription>
             <div className="text-xs text-muted-foreground">
               {selectedFile?.mimeType && (

--- a/src/components/shared/SessionFilesPopover.tsx
+++ b/src/components/shared/SessionFilesPopover.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui';
@@ -226,6 +227,9 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
             <DialogTitle className="text-sm">
               {selectedFile?.filename}
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              {t('sessionFiles.fileDetails', 'Details and content of the selected file')}
+            </DialogDescription>
             <div className="text-xs text-muted-foreground">
               {selectedFile?.mimeType && (
                 <span className="mr-4">


### PR DESCRIPTION
### 💡 What
Added a visually hidden `DialogDescription` to the Radix UI Dialog in `SessionFilesPopover`.

### 🎯 Why
Radix UI requires a description for its Dialog components to satisfy accessibility guidelines. Without it, it causes warnings and degrades screen reader experience.

### 📸 Before/After
No visual changes.

### ♿ Accessibility
Screen readers will now properly announce the dialog's purpose to users when they view a session file.

---
*PR created automatically by Jules for task [10074643410581307668](https://jules.google.com/task/10074643410581307668) started by @fritzprix*