### PR TITLE
⚗️ Distill: Optimize MCP response for explore_context

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -2,3 +2,6 @@
 
 **Learning:** Returning nested Markdown tables directly to LLM without explicitly declaring backticks for data constraints (such as `agent.id` and `sessionId`) reduces parsing stability and drops vital constraints.
 **Action:** When refactoring MCP Tools for tabular data, always explicitly quote ID fields and maintain strict structure without repeating conditional checks (`if !results.is_empty()`) for block-level additions.
+## 2024-05-24 - [Format Explore Context output as dense Markdown tables]
+**Learning:** Returning large, verbose lists (e.g., node graphs and linked chunks) without structured Markdown tables inflates token count and reduces LLM readability. Also, failing to quote IDs (e.g. `` `123` ``) inside tables can reduce the LLM's ability to chain them reliably.
+**Action:** When extracting nested entities and hierarchical data, immediately map the unrolled context arrays into Markdown tables, explicitly quoting ID fields to preserve token limits and semantic stability.

--- a/src-tauri/src/mcp/builtin/knowledge/queries.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/queries.rs
@@ -185,47 +185,50 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
         nodes.len()
     );
 
-    for node in &nodes {
-        let id = node
-            .get("id")
-            .and_then(|value| value.as_i64())
-            .unwrap_or_default();
-        let name = node
-            .get("name")
-            .and_then(|value| value.as_str())
-            .unwrap_or("unknown");
-        let entity_type = node
-            .get("type")
-            .and_then(|value| value.as_str())
-            .unwrap_or("unknown");
-        let node_depth = node
-            .get("depth")
-            .and_then(|value| value.as_i64())
-            .unwrap_or_default();
-        let description = node
-            .get("description")
-            .and_then(|value| value.as_str())
-            .unwrap_or("");
+    if nodes.is_empty() {
+        output.push_str("- none\n");
+    } else {
+        output.push_str("| ID | Name | Type | Depth | Description |\n|---|---|---|---|---|\n");
+        for node in &nodes {
+            let id = node
+                .get("id")
+                .and_then(|value| value.as_i64())
+                .unwrap_or_default();
+            let name = node
+                .get("name")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown");
+            let entity_type = node
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown");
+            let node_depth = node
+                .get("depth")
+                .and_then(|value| value.as_i64())
+                .unwrap_or_default();
+            let description = node
+                .get("description")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .replace('\n', " ");
 
-        node_names.insert(id, name.to_string());
-        output.push_str(&format!(
-            "- [{}] {} | type: {} | depth: {}{}\n",
-            id,
-            name,
-            entity_type,
-            node_depth,
-            if description.is_empty() {
-                String::new()
-            } else {
-                format!(" | {}", description)
-            }
-        ));
+            node_names.insert(id, name.to_string());
+            output.push_str(&format!(
+                "| `{}` | {} | {} | {} | {} |\n",
+                id,
+                name,
+                entity_type,
+                node_depth,
+                description
+            ));
+        }
     }
 
     output.push_str(&format!("\nEdges ({}):\n", edges.len()));
     if edges.is_empty() {
         output.push_str("- none\n");
     } else {
+        output.push_str("| Source | Relation | Target |\n|---|---|---|\n");
         for edge in &edges {
             let source_id = edge
                 .get("source_id")
@@ -249,8 +252,8 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
                 .unwrap_or("unknown");
 
             output.push_str(&format!(
-                "- {} ({}) -[{}]-> {} ({})\n",
-                source_name, source_id, relation_type, target_name, target_id
+                "| `{}` ({}) | {} | `{}` ({}) |\n",
+                source_id, source_name, relation_type, target_id, target_name
             ));
         }
     }
@@ -262,6 +265,7 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
     if linked_chunks.is_empty() {
         output.push_str("- none\n");
     } else {
+        output.push_str("| Chunk ID | Source | Content |\n|---|---|---|\n");
         for chunk in &linked_chunks {
             let chunk_id = chunk
                 .get("id")
@@ -274,9 +278,10 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
             let content = chunk
                 .get("content")
                 .and_then(|value| value.as_str())
-                .unwrap_or("");
+                .unwrap_or("")
+                .replace('\n', "<br>");
             output.push_str(&format!(
-                "- Chunk {} | source: {} | {}\n",
+                "| `{}` | {} | {} |\n",
                 chunk_id, source, content
             ));
         }

--- a/src-tauri/src/mcp/builtin/knowledge/queries.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/queries.rs
@@ -215,11 +215,7 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
             node_names.insert(id, name.to_string());
             output.push_str(&format!(
                 "| `{}` | {} | {} | {} | {} |\n",
-                id,
-                name,
-                entity_type,
-                node_depth,
-                description
+                id, name, entity_type, node_depth, description
             ));
         }
     }
@@ -280,10 +276,7 @@ fn format_graph_context(entity_name: &str, depth: u32, context: &Value) -> Strin
                 .and_then(|value| value.as_str())
                 .unwrap_or("")
                 .replace('\n', "<br>");
-            output.push_str(&format!(
-                "| `{}` | {} | {} |\n",
-                chunk_id, source, content
-            ));
+            output.push_str(&format!("| `{}` | {} | {} |\n", chunk_id, source, content));
         }
     }
 


### PR DESCRIPTION
💡 What: Refactored explore_context response to use dense Markdown tables.
🎯 Why: Condenses multi-line raw list output into tables to preserve context window and improve LLM readability.
📉 Token Impact: Reduces repetitive formatting tokens by converting verbose list syntax into structured tables.
🛠️ Error Recovery: Actionable errors already present via SuccessHint; updated output enforces strict ID quoting for chaining.

---
*PR created automatically by Jules for task [12080881232608545728](https://jules.google.com/task/12080881232608545728) started by @fritzprix*