### PR TITLE
Improve process output inspection and preserve home env

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/execute_pending.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/execute_pending.rs
@@ -543,9 +543,7 @@ impl WorkspaceServer {
                         "Use waitForProcess(\"{}\", 0) to check status, or waitForProcess(\"{}\") to block until done",
                         process_id, process_id
                     ),
-                    "If status is 'failed', use readProcessOutput with 'stderr' to view errors"
-                        .to_string(),
-                    "If status is 'finished', use readProcessOutput with 'stdout' to view output"
+                    "Use readProcessOutput with 'both' to inspect stdout and stderr"
                         .to_string(),
                     "Use listProcesses to see all running processes".to_string(),
                 ],

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
@@ -298,10 +298,7 @@ impl WorkspaceServer {
                     "Use waitForProcess(\"{}\", 0) to check status and completion",
                     process_id
                 ),
-                "If status is 'failed', use readProcessOutput with 'stderr' to view errors"
-                    .to_string(),
-                "If status is 'finished', use readProcessOutput with 'stdout' to view output"
-                    .to_string(),
+                "Use readProcessOutput with 'both' to inspect stdout and stderr".to_string(),
                 "Use listProcesses to see all running processes".to_string(),
             ],
         );

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
@@ -135,19 +135,19 @@ impl WorkspaceServer {
             match first_status {
                 "failed" => {
                     actions.push(format!(
-                        "Use readProcessOutput('{}', 'stderr') to view error details",
+                        "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
                 }
                 "finished" => {
                     actions.push(format!(
-                        "Use readProcessOutput('{}', 'stdout') to view output",
+                        "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
                 }
                 "running" => {
                     actions.push(format!(
-                        "Use readProcessOutput('{}', 'stdout') to view output",
+                        "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
                     actions.push(format!(
@@ -157,7 +157,7 @@ impl WorkspaceServer {
                 }
                 _ => {
                     actions.push(format!(
-                        "Use readProcessOutput('{}', 'stdout') to view output",
+                        "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
                 }

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
@@ -4,7 +4,142 @@ use crate::mcp::builtin::error_guidance::{
 use crate::mcp::builtin::workspace::terminal_manager;
 use crate::mcp::builtin::workspace::WorkspaceServer;
 use crate::mcp::types::MCPResult;
+use serde_json::json;
 use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Clone, Copy)]
+enum OutputSelection {
+    Stdout,
+    Stderr,
+    Both,
+}
+
+impl OutputSelection {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "stdout" => Some(Self::Stdout),
+            "stderr" => Some(Self::Stderr),
+            "both" => Some(Self::Both),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+            Self::Both => "both",
+        }
+    }
+
+    fn stream_names(self) -> &'static [&'static str] {
+        match self {
+            Self::Stdout => &["stdout"],
+            Self::Stderr => &["stderr"],
+            Self::Both => &["stdout", "stderr"],
+        }
+    }
+}
+
+fn status_label(status: &terminal_manager::ProcessStatus) -> String {
+    format!("{status:?}").to_lowercase()
+}
+
+fn stream_file_path(entry: &terminal_manager::ProcessEntry, stream: &str) -> PathBuf {
+    match stream {
+        "stdout" => PathBuf::from(&entry.stdout_path),
+        "stderr" => PathBuf::from(&entry.stderr_path),
+        _ => unreachable!("validated stream name"),
+    }
+}
+
+async fn read_stream_output(
+    file_path: &PathBuf,
+    mode: &str,
+    lines: usize,
+) -> Result<Vec<String>, String> {
+    match mode {
+        "head" => terminal_manager::head_lines(file_path, lines).await,
+        "tail" => terminal_manager::tail_lines(file_path, lines).await,
+        _ => Err(format!("Unsupported mode '{mode}'")),
+    }
+}
+
+fn format_stream_section(stream: &str, lines: &[String]) -> String {
+    let body = if lines.is_empty() {
+        "(no output)".to_string()
+    } else {
+        lines.join("\n")
+    };
+
+    format!("[{}]\n{}", stream.to_uppercase(), body)
+}
+
+fn build_read_error(process_id: &str, stream_label: &str, error: &str) -> MCPResult {
+    let error_lower = error.to_lowercase();
+
+    let (error_title, guidance) =
+        if error_lower.contains("not found") || error_lower.contains("no such file") {
+            (
+                format!("No {stream_label} output file found"),
+                vec![
+                    "The process may not have started yet".to_string(),
+                    format!("Use waitForProcess(\"{process_id}\", 0) to verify process status"),
+                    "Wait a moment and try again - the process may not have generated output"
+                        .to_string(),
+                    "Check if the process ran with output redirected elsewhere".to_string(),
+                ],
+            )
+        } else if error_lower.contains("permission") || error_lower.contains("denied") {
+            (
+                "Permission denied reading output".to_string(),
+                vec![
+                    format!("Cannot read {stream_label} stream for process \"{process_id}\""),
+                    "Check process permissions and ownership".to_string(),
+                    "Try running as elevated user if needed".to_string(),
+                    "Use listProcesses to view process details".to_string(),
+                ],
+            )
+        } else if error_lower.contains("too large") || error_lower.contains("too big") {
+            (
+                "Output file too large".to_string(),
+                vec![
+                    "Maximum 100 lines per request".to_string(),
+                    "Reduce 'lines' parameter to read less data".to_string(),
+                    "Use mode=\"head\" for beginning or mode=\"tail\" for end".to_string(),
+                    "Use output_paths with readFile/search for deeper inspection".to_string(),
+                ],
+            )
+        } else if error_lower.contains("invalid") || error_lower.contains("utf") {
+            (
+                "Output contains non-UTF-8 data".to_string(),
+                vec![
+                    "The process output contains binary or invalid UTF-8 data".to_string(),
+                    "Try reading the other stream if it contains text diagnostics".to_string(),
+                    "Check if the process generated text output or binary data".to_string(),
+                ],
+            )
+        } else {
+            (
+                "Failed to read process output".to_string(),
+                vec![
+                    format!("Verify process {process_id} exists: use listProcesses()"),
+                    format!("Check stream=\"{stream_label}\" is correct (stdout, stderr, or both)"),
+                    "Ensure the process has generated output".to_string(),
+                    "Check file permissions and disk space".to_string(),
+                ],
+            )
+        };
+
+    guided_error(
+        ErrorCategory::OperationFailed,
+        error_title,
+        ToolGroup::Workspace,
+    )
+    .guidance(guidance)
+    .to_mcp_result()
+}
 
 impl WorkspaceServer {
     pub async fn handle_read_process_output(
@@ -26,19 +161,36 @@ impl WorkspaceServer {
                 return Ok(missing_param_error("stream", ToolGroup::Workspace));
             }
         };
+        let selection = match OutputSelection::parse(stream) {
+            Some(selection) => selection,
+            None => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Invalid stream '{stream}'"),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Use stream=\"stdout\", stream=\"stderr\", or stream=\"both\"".to_string(),
+                    "Use stream=\"both\" when you need both streams in one response".to_string(),
+                ])
+                .to_mcp_result());
+            }
+        };
 
         let mode = args.get("mode").and_then(|v| v.as_str()).unwrap_or("tail");
-
         let lines = args.get("lines").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
-
-        let start_line = args
-            .get("start_line")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize);
-        let end_line = args
-            .get("end_line")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize);
+        if !matches!(mode, "tail" | "head") {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!("Invalid mode '{mode}'"),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Use mode=\"tail\" to read the latest lines".to_string(),
+                "Use mode=\"head\" to read the earliest lines".to_string(),
+            ])
+            .to_mcp_result());
+        }
 
         // Get process entry
         let registry = self.process_registry.read().await;
@@ -91,125 +243,73 @@ impl WorkspaceServer {
         }
         drop(registry);
 
-        // Get file path
-        let file_path = if stream == "stdout" {
-            std::path::PathBuf::from(&entry.stdout_path)
-        } else {
-            std::path::PathBuf::from(&entry.stderr_path)
-        };
+        let status = status_label(&entry.status);
+        let is_process_running = matches!(
+            entry.status,
+            terminal_manager::ProcessStatus::Starting | terminal_manager::ProcessStatus::Running
+        );
 
-        // Read lines based on mode or range
-        let content = if let (Some(start), Some(end)) = (start_line, end_line) {
-            terminal_manager::read_lines_range(&file_path, start, end).await
-        } else {
-            match mode {
-                "head" => terminal_manager::head_lines(&file_path, lines).await,
-                _ => terminal_manager::tail_lines(&file_path, lines).await,
-            }
-        };
+        let mut stream_sections = Vec::new();
+        let mut outputs = serde_json::Map::new();
+        let mut output_paths = serde_json::Map::new();
+        let mut output_path_lines = Vec::new();
 
-        match content {
-            Ok(lines_vec) => {
-                let content_display = lines_vec.join("\n");
-                let response = serde_json::json!({
-                    "process_id": process_id,
-                    "stream": stream,
-                    "mode": mode,
-                    "lines_requested": lines.min(100),
-                    "lines_returned": lines_vec.len(),
-                    "content": lines_vec,
-                    "total_size": terminal_manager::get_file_size(&file_path).await,
-                    "note": "Text output only. Max 100 lines per request.",
-                });
+        for stream_name in selection.stream_names() {
+            let file_path = stream_file_path(&entry, stream_name);
+            let content = match read_stream_output(&file_path, mode, lines).await {
+                Ok(content) => content,
+                Err(error) => {
+                    return Ok(build_read_error(process_id, stream_name, &error));
+                }
+            };
+            let lines_returned = content.len();
+            let file_path_string = file_path.to_string_lossy().to_string();
 
-                let hint = SuccessHint::new(
-                    format!(
-                        "Read {} lines from process {} ({} {}):\n\n{}",
-                        lines_vec.len(),
-                        process_id,
-                        stream,
-                        mode,
-                        content_display
-                    ),
-                    SuccessHint::for_tool("readProcessOutput", ToolGroup::Workspace),
-                );
-
-                Ok(hint.to_mcp_result_with_data(Some(response)))
-            }
-            Err(e) => {
-                // ✅ ENHANCED: Context-specific error guidance based on error type
-                let error_lower = e.to_lowercase();
-
-                let (error_title, guidance) = if error_lower.contains("not found")
-                    || error_lower.contains("no such file")
-                {
-                    // Process hasn't generated output yet
-                    (
-                        format!("No {} output file found", stream),
-                        vec![
-                            "The process may not have started yet".to_string(),
-                            format!("Use waitForProcess(\"{}\", 0) to verify process status", process_id),
-                            "Wait a moment and try again - the process may not have generated output".to_string(),
-                            "Check if the process ran with output redirected elsewhere".to_string(),
-                        ],
-                    )
-                } else if error_lower.contains("permission") || error_lower.contains("denied") {
-                    // Permission denied accessing output file
-                    (
-                        "Permission denied reading output".to_string(),
-                        vec![
-                            format!(
-                                "Cannot read {} stream for process \"{}\"",
-                                stream, process_id
-                            ),
-                            "Check process permissions and ownership".to_string(),
-                            "Try running as elevated user if needed".to_string(),
-                            "Use listProcesses to view process details".to_string(),
-                        ],
-                    )
-                } else if error_lower.contains("too large") || error_lower.contains("too big") {
-                    // File is too large to read entirely
-                    (
-                        "Output file too large".to_string(),
-                        vec![
-                            "Maximum 100 lines per request".to_string(),
-                            "Reduce 'lines' parameter to read less data".to_string(),
-                            "Use mode=\"head\" for beginning or mode=\"tail\" for end".to_string(),
-                            "Consider grep or other text processing tools for filtering"
-                                .to_string(),
-                        ],
-                    )
-                } else if error_lower.contains("invalid") || error_lower.contains("utf") {
-                    // Output contains invalid UTF-8
-                    (
-                        "Output contains non-UTF-8 data".to_string(),
-                        vec![
-                            "The process output contains binary or invalid UTF-8 data".to_string(),
-                            "Try reading stderr instead if it contains error messages".to_string(),
-                            "Check if the process generated text output or binary data".to_string(),
-                        ],
-                    )
-                } else {
-                    // Generic error
-                    (
-                        "Failed to read process output".to_string(),
-                        vec![
-                            format!("Verify process {} exists: use listProcesses()", process_id),
-                            format!("Check stream=\"{}\" is correct (stdout or stderr)", stream),
-                            "Ensure the process has generated output".to_string(),
-                            "Check file permissions and disk space".to_string(),
-                        ],
-                    )
-                };
-
-                Ok(guided_error(
-                    ErrorCategory::OperationFailed,
-                    error_title,
-                    ToolGroup::Workspace,
-                )
-                .guidance(guidance)
-                .to_mcp_result())
-            }
+            stream_sections.push(format_stream_section(stream_name, &content));
+            output_paths.insert((*stream_name).to_string(), json!(file_path_string));
+            output_path_lines.push(format!("- {}: {}", stream_name, file_path_string));
+            outputs.insert(
+                (*stream_name).to_string(),
+                json!({
+                    "content": content,
+                    "lines_returned": lines_returned,
+                    "total_size_bytes": terminal_manager::get_file_size(&file_path).await,
+                }),
+            );
         }
+
+        let text = format!(
+            "Read output from process {} (stream: {}, mode: {}, status: {})\n\nOutput paths:\n{}\n\n{}",
+            process_id,
+            selection.as_str(),
+            mode,
+            status,
+            output_path_lines.join("\n"),
+            stream_sections.join("\n\n")
+        );
+
+        let response = serde_json::Map::from_iter([
+            ("process_id".to_string(), json!(process_id)),
+            ("stream".to_string(), json!(selection.as_str())),
+            ("mode".to_string(), json!(mode)),
+            ("status".to_string(), json!(status)),
+            ("is_process_running".to_string(), json!(is_process_running)),
+            ("output_paths".to_string(), Value::Object(output_paths)),
+            ("outputs".to_string(), Value::Object(outputs)),
+            ("lines_requested".to_string(), json!(lines.min(100))),
+            (
+                "note".to_string(),
+                json!(
+                    "Text output only. Max 100 lines per request. Use output_paths with file tools for deeper inspection."
+                ),
+            ),
+        ]);
+
+        let hint = SuccessHint::new(
+            text,
+            SuccessHint::for_tool("readProcessOutput", ToolGroup::Workspace),
+        );
+
+        Ok(hint.to_mcp_result_with_data(Some(Value::Object(response))))
     }
 }

--- a/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
+++ b/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
@@ -141,7 +141,8 @@ mod tests {
                 println!("Poll Result text: {}", text);
                 assert!(text.contains("Tail line 1"));
                 assert!(text.contains("Tail line 2"));
-                assert!(text.contains("Output (last 2 lines)"));
+                assert!(text.contains("Output paths:"));
+                assert!(text.contains("[STDOUT]"));
             }
             _ => panic!("Expected text content"),
         }

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -9,7 +9,10 @@ pub fn create_read_process_output_tool() -> MCPTool {
 
     props.insert(
         "stream".to_string(),
-        enum_prop_required(vec!["stdout", "stderr"], "Stream to read from"),
+        enum_prop_required(
+            vec!["stdout", "stderr", "both"],
+            "Stream to read: stdout, stderr, or both in one call",
+        ),
     );
 
     props.insert(
@@ -17,7 +20,7 @@ pub fn create_read_process_output_tool() -> MCPTool {
         enum_prop(
             vec!["tail", "head"],
             "tail",
-            Some("Read mode: 'tail' reads last N lines, 'head' reads first N lines"),
+            Some("Read mode: 'tail' reads the latest lines, 'head' reads the earliest lines"),
         ),
     );
 
@@ -26,23 +29,12 @@ pub fn create_read_process_output_tool() -> MCPTool {
         integer_prop_with_default(Some(1), Some(100), 20, Some("Number of lines to read")),
     );
 
-    props.insert(
-        "start_line".to_string(),
-        integer_prop(
-            Some(1),
-            None,
-            Some("Start line number (1-based, inclusive)"),
-        ),
-    );
-    props.insert(
-        "end_line".to_string(),
-        integer_prop(Some(1), None, Some("End line number (1-based, inclusive)")),
-    );
-
     MCPTool {
         name: "readProcessOutput".to_string(),
         title: Some("Read Process Output".to_string()),
-        description: "Read captured stdout or stderr from a background process.".to_string(),
+        description:
+            "Read captured stdout, stderr, or both streams from a background process using head/tail line windows. Returns output_paths so file tools can inspect the full captured files."
+                .to_string(),
         input_schema: object_schema(props, vec!["processId".to_string(), "stream".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/src/session_isolation/platforms/linux.rs
+++ b/src-tauri/src/session_isolation/platforms/linux.rs
@@ -55,7 +55,6 @@ pub async fn create_high_isolated_command(
     // Always ensure PATH is present so GUI-launched sessions can still find user-installed tools.
     cmd.env("PATH", crate::utils::env::get_effective_path_os());
 
-    cmd.env("HOME", &config.workspace_path);
     cmd.env("PWD", &config.workspace_path);
 
     for (key, value) in &config.env_vars {

--- a/src-tauri/src/session_isolation/platforms/macos.rs
+++ b/src-tauri/src/session_isolation/platforms/macos.rs
@@ -42,7 +42,6 @@ pub async fn create_high_isolated_command(
         cmd.env(k, v);
     }
 
-    cmd.env("HOME", &config.workspace_path);
     cmd.env("PWD", &config.workspace_path);
 
     for (key, value) in &config.env_vars {

--- a/src-tauri/src/session_isolation/platforms/unix.rs
+++ b/src-tauri/src/session_isolation/platforms/unix.rs
@@ -28,8 +28,7 @@ pub async fn create_basic_isolated_command(
     // whitelist of system variables required for basic shell and terminal behavior.
     cmd.env_clear();
 
-    // Whitelist essential variables from parent environment
-    // Note: HOME is deliberately excluded here as it's overridden below for isolation
+    // Whitelist essential variables from parent environment.
     // DISPLAY and XAUTHORITY are intentionally excluded to prevent GUI/X11 access
     // from within the isolated shell (screen capture, input injection, etc.)
     let preserved_vars = [
@@ -37,6 +36,7 @@ pub async fn create_basic_isolated_command(
         "USER",
         "LOGNAME",
         "SHELL",
+        "HOME",
         "http_proxy",
         "https_proxy",
         "no_proxy",
@@ -67,9 +67,7 @@ pub async fn create_basic_isolated_command(
         }
     }
 
-    // Set isolated environment variables
-    // Override HOME to workspace path for isolation
-    cmd.env("HOME", &config.workspace_path);
+    // Keep the host home directory for tool config discovery, but pin shell state to the workspace.
     cmd.env("PWD", &config.workspace_path);
     cmd.env("TMPDIR", config.workspace_path.join("tmp"));
     // Force English output for consistent AI reasoning

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -44,9 +44,7 @@ pub async fn create_basic_isolated_command(
         cmd.env(k, v);
     }
 
-    // Configure base environment overrides
-    cmd.env("USERPROFILE", &config.workspace_path);
-    cmd.env("HOME", &config.workspace_path);
+    // Keep host home directories so CLI tools can discover their config, but isolate temp files.
     cmd.env("TEMP", config.workspace_path.join("tmp"));
     cmd.env("TMP", config.workspace_path.join("tmp"));
 

--- a/src-tauri/tests/env_leakage_test.rs
+++ b/src-tauri/tests/env_leakage_test.rs
@@ -7,12 +7,15 @@ async fn test_env_leakage_in_unix_isolation() {
         IsolatedProcessConfig, IsolationLevel, ShellType,
     };
 
+    let workspace = tempfile::tempdir().expect("Failed to create workspace");
+    let host_home = std::env::var("HOME").expect("HOME should be available in test env");
+
     // Set a secret in the parent process
     std::env::set_var("SECRET_API_KEY", "super_secret_value");
 
     let config = IsolatedProcessConfig {
         session_id: "test-session".to_string(),
-        workspace_path: std::env::temp_dir(),
+        workspace_path: workspace.path().to_path_buf(),
         command: "env".to_string(), // Execute 'env' to list variables
         args: vec![],
         env_vars: HashMap::new(),
@@ -37,6 +40,16 @@ async fn test_env_leakage_in_unix_isolation() {
     assert!(
         stdout.contains("PATH="),
         "Expected PATH to be present in isolated environment, but it was missing."
+    );
+
+    assert!(
+        stdout.contains(&format!("HOME={host_home}")),
+        "Expected HOME to preserve the host home directory for config discovery."
+    );
+
+    assert!(
+        stdout.contains(&format!("PWD={}", workspace.path().display())),
+        "Expected PWD to remain pinned to the workspace directory."
     );
 
     // If TERM is set in the parent, it should also be present in the isolated environment
@@ -79,6 +92,9 @@ async fn test_env_leakage_in_linux_high_isolation() {
         return;
     }
 
+    let workspace = tempfile::tempdir().expect("Failed to create workspace");
+    let host_home = std::env::var("HOME").expect("HOME should be available in test env");
+
     // Set secrets in the parent process
     std::env::set_var("SECRET_API_KEY", "super_secret_value");
     std::env::set_var("XDG_RUNTIME_DIR", "/run/user/9999");
@@ -89,7 +105,7 @@ async fn test_env_leakage_in_linux_high_isolation() {
 
     let config = IsolatedProcessConfig {
         session_id: "test-high-session".to_string(),
-        workspace_path: std::env::temp_dir(),
+        workspace_path: workspace.path().to_path_buf(),
         command: "env".to_string(),
         args: vec![],
         env_vars: HashMap::new(),
@@ -120,6 +136,16 @@ async fn test_env_leakage_in_linux_high_isolation() {
     assert!(
         stdout.contains("PATH="),
         "PATH is missing from high isolation environment"
+    );
+
+    assert!(
+        stdout.contains(&format!("HOME={host_home}")),
+        "Expected HOME to preserve the host home directory in high isolation."
+    );
+
+    assert!(
+        stdout.contains(&format!("PWD={}", workspace.path().display())),
+        "Expected PWD to remain pinned to the workspace directory in high isolation."
     );
 
     // Clean up

--- a/src-tauri/tests/read_process_output_tests.rs
+++ b/src-tauri/tests/read_process_output_tests.rs
@@ -1,0 +1,259 @@
+mod common;
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::agent::concurrency::{
+    ConcurrencyGate, DEFAULT_MAX_ACTIVE_AGENTS, DEFAULT_MAX_ACTIVE_PROCESSES,
+    DEFAULT_MAX_SUSPENDED_AGENTS, DEFAULT_MAX_SUSPENDED_PROCESSES,
+};
+use tauri_mcp_agent_lib::agent::session_bus::SessionBus;
+use tauri_mcp_agent_lib::lifecycle::repositories::init_repositories;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::builtin::BuiltinMCPServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tauri_mcp_agent_lib::{init_concurrency_gate, init_session_bus};
+use tempfile::tempdir;
+use tokio::sync::OnceCell;
+use tokio::time::{sleep, Duration};
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+async fn ensure_settings_repository() {
+    static REPOSITORIES: OnceCell<()> = OnceCell::const_new();
+
+    REPOSITORIES
+        .get_or_init(|| async {
+            let db = common::setup_test_db_with_migrations().await;
+            init_repositories(&db).await;
+            init_session_bus(SessionBus::new());
+            init_concurrency_gate(ConcurrencyGate::new(
+                DEFAULT_MAX_ACTIVE_AGENTS,
+                DEFAULT_MAX_SUSPENDED_AGENTS,
+                DEFAULT_MAX_ACTIVE_PROCESSES,
+                DEFAULT_MAX_SUSPENDED_PROCESSES,
+            ));
+        })
+        .await;
+}
+
+#[cfg(unix)]
+fn dual_stream_command() -> &'static str {
+    "printf 'stdout line 1\\nstdout line 2\\n'; printf 'stderr line 1\\nstderr line 2\\n' >&2"
+}
+
+#[cfg(windows)]
+fn dual_stream_command() -> &'static str {
+    "Write-Output 'stdout line 1'; Write-Output 'stdout line 2'; [Console]::Error.WriteLine('stderr line 1'); [Console]::Error.WriteLine('stderr line 2')"
+}
+
+async fn wait_for_terminal_state(server: &WorkspaceServer, process_id: &str, session_id: &str) {
+    for _ in 0..30 {
+        let wait_result = server
+            .call_tool(
+                "waitForProcess",
+                json!({ "processId": process_id, "timeout": 0 }),
+                Some(session_id.to_string()),
+            )
+            .await
+            .expect("waitForProcess should succeed");
+
+        let structured = wait_result
+            .structured_content
+            .as_ref()
+            .expect("waitForProcess structured content expected");
+        let status = structured["status"]
+            .as_str()
+            .expect("waitForProcess should return status");
+
+        if matches!(status, "finished" | "failed" | "killed") {
+            return;
+        }
+
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    panic!("process did not reach a terminal state in time");
+}
+
+#[tokio::test]
+async fn read_process_output_both_returns_both_sections_and_structured_outputs() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-process-output-both";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(json!({ "command": dual_stream_command() }), session_id)
+        .await
+        .expect("spawnProcess should succeed");
+    let process_id = spawn_result
+        .structured_content
+        .as_ref()
+        .and_then(|data| data.get("process_id"))
+        .and_then(|value| value.as_str())
+        .expect("spawnProcess should return process_id")
+        .to_string();
+
+    wait_for_terminal_state(&server, &process_id, session_id).await;
+
+    let read_result = server
+        .call_tool(
+            "readProcessOutput",
+            json!({
+                "processId": process_id,
+                "stream": "both",
+                "mode": "tail",
+                "lines": 10
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readProcessOutput should succeed");
+
+    assert_eq!(read_result.is_error, Some(false));
+
+    let text = extract_text_content(&read_result);
+    assert!(text.contains("[STDOUT]"), "stdout section missing: {text}");
+    assert!(text.contains("[STDERR]"), "stderr section missing: {text}");
+    assert!(
+        text.contains("stdout line 1"),
+        "stdout content missing: {text}"
+    );
+    assert!(
+        text.contains("stderr line 1"),
+        "stderr content missing: {text}"
+    );
+    assert!(
+        text.contains("Output paths:"),
+        "output paths section missing: {text}"
+    );
+
+    let structured = read_result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert_eq!(structured["stream"], json!("both"));
+    assert_eq!(structured["mode"], json!("tail"));
+    assert_eq!(structured["status"], json!("finished"));
+    assert_eq!(structured["is_process_running"], json!(false));
+    assert_eq!(structured["lines_requested"], json!(10));
+
+    let stdout = &structured["outputs"]["stdout"];
+    let stderr = &structured["outputs"]["stderr"];
+    let stdout_path = structured["output_paths"]["stdout"]
+        .as_str()
+        .expect("stdout output path should be present");
+    let stderr_path = structured["output_paths"]["stderr"]
+        .as_str()
+        .expect("stderr output path should be present");
+    assert!(
+        stdout["content"].to_string().contains("stdout line 1"),
+        "stdout structured content missing expected line: {}",
+        stdout["content"]
+    );
+    assert!(
+        stderr["content"].to_string().contains("stderr line 1"),
+        "stderr structured content missing expected line: {}",
+        stderr["content"]
+    );
+    assert_eq!(stdout["lines_returned"], json!(2));
+    assert_eq!(stderr["lines_returned"], json!(2));
+    assert!(
+        stdout["total_size_bytes"].as_u64().unwrap_or(0) > 0,
+        "stdout total_size_bytes should be populated"
+    );
+    assert!(
+        stderr["total_size_bytes"].as_u64().unwrap_or(0) > 0,
+        "stderr total_size_bytes should be populated"
+    );
+    assert!(
+        text.contains(stdout_path),
+        "stdout output path missing from text: {text}"
+    );
+    assert!(
+        text.contains(stderr_path),
+        "stderr output path missing from text: {text}"
+    );
+    assert!(
+        std::path::Path::new(stdout_path).exists(),
+        "stdout output path should exist: {stdout_path}"
+    );
+    assert!(
+        std::path::Path::new(stderr_path).exists(),
+        "stderr output path should exist: {stderr_path}"
+    );
+}
+
+#[tokio::test]
+async fn read_process_output_stdout_returns_single_output_path() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-process-output-stdout-only";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(json!({ "command": dual_stream_command() }), session_id)
+        .await
+        .expect("spawnProcess should succeed");
+    let process_id = spawn_result
+        .structured_content
+        .as_ref()
+        .and_then(|data| data.get("process_id"))
+        .and_then(|value| value.as_str())
+        .expect("spawnProcess should return process_id")
+        .to_string();
+
+    wait_for_terminal_state(&server, &process_id, session_id).await;
+
+    let result = server
+        .call_tool(
+            "readProcessOutput",
+            json!({
+                "processId": process_id,
+                "stream": "stdout",
+                "mode": "tail",
+                "lines": 10
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readProcessOutput should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(text.contains("[STDOUT]"), "stdout section missing: {text}");
+    assert!(
+        !text.contains("[STDERR]"),
+        "stderr section should be absent: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert!(structured["output_paths"]["stdout"].is_string());
+    assert!(structured["output_paths"].get("stderr").is_none());
+    assert!(structured["outputs"]["stdout"].is_object());
+    assert!(structured["outputs"].get("stderr").is_none());
+}


### PR DESCRIPTION
## Summary
- simplify `readProcessOutput` to head/tail windows with `stream="both"` and exposed `output_paths`
- update workspace tool guidance to use the simplified process-output flow
- preserve host HOME/USERPROFILE in isolated shell launchers while keeping workspace cwd/temp isolation
- add regression coverage for both process output reading and env isolation behavior

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml --test read_process_output_tests
- cargo test --manifest-path src-tauri/Cargo.toml --test env_leakage_test
- pnpm refactor:validate