### PR TITLE
⚗️ Distill: Optimize MCP response for read_message

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -2,3 +2,8 @@
 
 **Learning:** Returning nested Markdown tables directly to LLM without explicitly declaring backticks for data constraints (such as `agent.id` and `sessionId`) reduces parsing stability and drops vital constraints.
 **Action:** When refactoring MCP Tools for tabular data, always explicitly quote ID fields and maintain strict structure without repeating conditional checks (`if !results.is_empty()`) for block-level additions.
+
+## 2024-05-25 - [Removed rawMessage bloat from read_message]
+
+**Learning:** Dropping fields from an existing MCP tool response can introduce a regression risk if any downstream agents or prompts secretly rely on extracting IDs or metadata from the raw JSON object. Always ask for permission before dropping existing fields if the field might be relied upon.
+**Action:** When asked to remove fields that look like context bloat, double check with the user or codebase references to ensure it is safe to remove, and only proceed after explicit verification.

--- a/src-tauri/src/mcp/builtin/history/handlers.rs
+++ b/src-tauri/src/mcp/builtin/history/handlers.rs
@@ -224,8 +224,7 @@ pub async fn read_message(_server: &HistoryServer, args: Value) -> Result<MCPRes
             .unwrap_or_default(),
     )
     .to_mcp_result_with_data(Some(json!({
-        "message": response,
-        "rawMessage": message
+        "message": response
     }))))
 }
 


### PR DESCRIPTION
💡 What: Removed rawMessage from the JSON output of read_message.

🎯 Why: To prevent context window bloat. The rawMessage contained the full unpaginated message content, defeating the purpose of the offset/limit pagination parameters.

📉 Token Impact: Reduces token output proportionally to message size by omitting the full raw message body, ensuring response sizes remain bounded by the chunk max length.

🛠️ Error Recovery: No error recovery changes were made, as this is purely a response payload optimization to match the pagination structure.

---
*PR created automatically by Jules for task [13505448287059750273](https://jules.google.com/task/13505448287059750273) started by @fritzprix*