### PR TITLE
🎨 Palette: Add aria-labels to ChatInterfaceTab buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -62,3 +62,6 @@
 
 **Learning:** When using `opacity-X group-hover:opacity-100` to show controls inside a container on mouse hover, the controls remain invisible to keyboard users when the parent container receives focus, unless explicitly handled.
 **Action:** Always pair `group-hover:opacity-100` with `group-focus-visible:opacity-100` (or `group-focus-within:opacity-100` if the interactive element is inside the group) to ensure the UI elements become visible when accessed via keyboard navigation.
+## 2026-04-27 - [Accessible Symbol Controls]
+**Learning:** When using generic symbol controls like "+" or "-" inside components like ChatInterfaceTab, they remain ambiguous for screen readers without explicit ARIA labels, creating accessibility barriers for users.
+**Action:** Always provide explicit, translated `aria-label` attributes on icon-only or symbol-only interactive elements (like increment/decrement buttons) using `useTranslation`.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -62,6 +62,8 @@
 
 **Learning:** When using `opacity-X group-hover:opacity-100` to show controls inside a container on mouse hover, the controls remain invisible to keyboard users when the parent container receives focus, unless explicitly handled.
 **Action:** Always pair `group-hover:opacity-100` with `group-focus-visible:opacity-100` (or `group-focus-within:opacity-100` if the interactive element is inside the group) to ensure the UI elements become visible when accessed via keyboard navigation.
+
 ## 2026-04-27 - [Accessible Symbol Controls]
+
 **Learning:** When using generic symbol controls like "+" or "-" inside components like ChatInterfaceTab, they remain ambiguous for screen readers without explicit ARIA labels, creating accessibility barriers for users.
 **Action:** Always provide explicit, translated `aria-label` attributes on icon-only or symbol-only interactive elements (like increment/decrement buttons) using `useTranslation`.

--- a/src/features/settings/tabs/ChatInterfaceTab.tsx
+++ b/src/features/settings/tabs/ChatInterfaceTab.tsx
@@ -165,6 +165,7 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateToolCallCount(-1)}
               disabled={localToolCallGroupVisibleCount <= 1}
+              aria-label={t('settings.decreaseToolCallCount', 'Decrease tool call count')}
             >
               -
             </Button>
@@ -177,6 +178,7 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateToolCallCount(1)}
               disabled={localToolCallGroupVisibleCount >= 20}
+              aria-label={t('settings.increaseToolCallCount', 'Increase tool call count')}
             >
               +
             </Button>
@@ -200,6 +202,7 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateDiffContextLines(-1)}
               disabled={(localAdvancedSettings.diffContextLines ?? 3) <= 1}
+              aria-label={t('settings.chatInterface.decreaseDiffLines', 'Decrease diff context lines')}
             >
               -
             </Button>
@@ -212,6 +215,7 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateDiffContextLines(1)}
               disabled={(localAdvancedSettings.diffContextLines ?? 3) >= 10}
+              aria-label={t('settings.chatInterface.increaseDiffLines', 'Increase diff context lines')}
             >
               +
             </Button>

--- a/src/features/settings/tabs/ChatInterfaceTab.tsx
+++ b/src/features/settings/tabs/ChatInterfaceTab.tsx
@@ -165,7 +165,10 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateToolCallCount(-1)}
               disabled={localToolCallGroupVisibleCount <= 1}
-              aria-label={t('settings.decreaseToolCallCount', 'Decrease tool call count')}
+              aria-label={t(
+                'settings.decreaseToolCallCount',
+                'Decrease tool call count',
+              )}
             >
               -
             </Button>
@@ -178,7 +181,10 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateToolCallCount(1)}
               disabled={localToolCallGroupVisibleCount >= 20}
-              aria-label={t('settings.increaseToolCallCount', 'Increase tool call count')}
+              aria-label={t(
+                'settings.increaseToolCallCount',
+                'Increase tool call count',
+              )}
             >
               +
             </Button>
@@ -202,7 +208,10 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateDiffContextLines(-1)}
               disabled={(localAdvancedSettings.diffContextLines ?? 3) <= 1}
-              aria-label={t('settings.chatInterface.decreaseDiffLines', 'Decrease diff context lines')}
+              aria-label={t(
+                'settings.chatInterface.decreaseDiffLines',
+                'Decrease diff context lines',
+              )}
             >
               -
             </Button>
@@ -215,7 +224,10 @@ function ChatInterfaceTabComponent({
               className="h-9 w-9 px-0"
               onClick={() => updateDiffContextLines(1)}
               disabled={(localAdvancedSettings.diffContextLines ?? 3) >= 10}
-              aria-label={t('settings.chatInterface.increaseDiffLines', 'Increase diff context lines')}
+              aria-label={t(
+                'settings.chatInterface.increaseDiffLines',
+                'Increase diff context lines',
+              )}
             >
               +
             </Button>

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -306,6 +306,8 @@
     "toolCallGroupVisibleCount": "Tool Calls Visible Count",
     "toolCallGroupVisibleCountDescription": "Number of tool calls to show in collapsed group view",
     "toolCallGroupVisibleCountPlaceholder": "e.g., 4",
+    "decreaseToolCallCount": "Decrease tool call count",
+    "increaseToolCallCount": "Increase tool call count",
     "general": {
       "skillsDirectory": "Skills Directory",
       "skillsDirectorySelectTitle": "Select Skills Directory",
@@ -344,7 +346,9 @@
     "chatInterface": {
       "diffContextLines": "Diff Context Lines",
       "diffContextLinesPlaceholder": "e.g., 3",
-      "diffContextLinesDescription": "Number of context lines to show in file edit diffs (1-10)."
+      "diffContextLinesDescription": "Number of context lines to show in file edit diffs (1-10).",
+      "decreaseDiffLines": "Decrease diff context lines",
+      "increaseDiffLines": "Increase diff context lines"
     },
     "display": {
       "fontFamilyOptions": {


### PR DESCRIPTION
💡 What: Added aria-labels to increment/decrement buttons.
🎯 Why: Improves screen reader accessibility for settings controls.
📸 Before/After: N/A
♿ Accessibility: Added descriptive aria-labels to icon-only plus/minus buttons.

---
*PR created automatically by Jules for task [5813298278552367091](https://jules.google.com/task/5813298278552367091) started by @fritzprix*