### PR TITLE
Improve editFiles guidance and error clarity

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
@@ -149,6 +149,37 @@ fn canonicalize_edit_file_args(args: &Value) -> Value {
     Value::Object(canonical)
 }
 
+pub(super) fn format_edit_label(edit_obj: &Map<String, Value>, idx: usize) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(path) = edit_obj
+        .get("path")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        parts.push(format!("path='{}'", path));
+    }
+
+    if let Some(op) = edit_obj.get("op").and_then(|value| value.as_str()) {
+        parts.push(format!("op='{}'", op));
+    }
+
+    if let Some(start_line) = edit_obj.get("startLine").and_then(|value| value.as_u64()) {
+        parts.push(format!("startLine={}", start_line));
+    }
+
+    if let Some(end_line) = edit_obj.get("endLine").and_then(|value| value.as_u64()) {
+        parts.push(format!("endLine={}", end_line));
+    }
+
+    if parts.is_empty() {
+        format!("Edit at index {}", idx)
+    } else {
+        format!("Edit at index {} [{}]", idx, parts.join(", "))
+    }
+}
+
 pub(super) fn canonicalize_edit_files_args(args: &Value) -> Value {
     let Some(args_obj) = args.as_object() else {
         return args.clone();
@@ -227,20 +258,19 @@ pub(super) fn parse_line_edit(
     edit_obj: &Map<String, Value>,
     idx: usize,
 ) -> Result<LineEdit, MCPResult> {
+    let edit_label = format_edit_label(edit_obj, idx);
     let start_line = match edit_obj.get("startLine").and_then(|value| value.as_u64()) {
         Some(line) => line as usize,
         _ => {
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
-                format!(
-                    "Edit at index {}: 'startLine' field is required and must be an integer",
-                    idx
-                ),
+                format!("{edit_label}: 'startLine' field is required and must be an integer"),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
                 "Provide startLine as an integer (e.g., \"startLine\": 10)".to_string(),
-                "Use startLine: 0 to insert at the beginning of the file".to_string(),
+                "Existing lines are 1-based: use startLine: 1 for the first line".to_string(),
+                "Use startLine: 0 only to prepend at the beginning of the file".to_string(),
             ])
             .to_mcp_result());
         }
@@ -261,7 +291,7 @@ pub(super) fn parse_line_edit(
         Some(other) => {
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
-                format!("Edit at index {}: invalid op '{}'", idx, other),
+                format!("{edit_label}: invalid op '{}'", other),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
@@ -287,8 +317,8 @@ pub(super) fn parse_line_edit(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "Edit at index {}: 'endLine' ({}) must be ≥ 'startLine' ({})",
-                    idx, line, start_line
+                    "{edit_label}: 'endLine' ({}) must be ≥ 'startLine' ({})",
+                    line, start_line
                 ),
                 ToolGroup::Workspace,
             )
@@ -307,10 +337,7 @@ pub(super) fn parse_line_edit(
     if action == EditAction::InsertAfter && has_end_line {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!(
-                "Edit at index {}: 'endLine' cannot be used with op 'insert_after'",
-                idx
-            ),
+            format!("{edit_label}: 'endLine' cannot be used with op 'insert_after'"),
             ToolGroup::Workspace,
         )
         .guidance(vec![
@@ -326,8 +353,7 @@ pub(super) fn parse_line_edit(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "Edit at index {}: delete edits must omit 'content' (or set op='replace' if you meant to replace)",
-                    idx
+                    "{edit_label}: delete edits must omit 'content' (or set op='replace' if you meant to replace)"
                 ),
                 ToolGroup::Workspace,
             )
@@ -342,10 +368,7 @@ pub(super) fn parse_line_edit(
         (_, Some(_)) => {
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
-                format!(
-                    "Edit at index {}: 'content' must be a string when provided",
-                    idx
-                ),
+                format!("{edit_label}: 'content' must be a string when provided"),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
@@ -356,10 +379,7 @@ pub(super) fn parse_line_edit(
         (_, None) => {
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
-                format!(
-                    "Edit at index {}: 'content' is required for replace and insert_after",
-                    idx
-                ),
+                format!("{edit_label}: 'content' is required for replace and insert_after"),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
@@ -382,10 +402,7 @@ pub(super) fn parse_line_edit(
     if requires_anchor && start_anchor.is_none() {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!(
-                "Edit at index {} targets existing content and requires 'startAnchor'",
-                idx
-            ),
+            format!("{edit_label} targets existing content and requires 'startAnchor'"),
             ToolGroup::Workspace,
         )
         .guidance(vec![
@@ -405,10 +422,7 @@ pub(super) fn parse_line_edit(
     {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!(
-                "Edit at index {} uses 'endLine' and requires 'endAnchor' for the exact end line",
-                idx
-            ),
+            format!("{edit_label} uses 'endLine' and requires 'endAnchor' for the exact end line"),
             ToolGroup::Workspace,
         )
         .guidance(vec![

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -256,10 +256,7 @@ impl WorkspaceServer {
             let edit_obj = match edit_value.as_object() {
                 Some(obj) => obj,
                 None => {
-                    let context = edit_value
-                        .as_object()
-                        .map(|obj| format_edit_label(obj, idx))
-                        .unwrap_or_else(|| format!("Edit at index {}", idx));
+                    let context = format!("Edit at index {}", idx);
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
                         format!("{context} must be an object"),

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -12,7 +12,7 @@ mod types;
 use apply::prepare_file_edit_batch;
 use args::{
     canonicalize_edit_files_args, canonicalize_legacy_edit_file_args_as_edit_files,
-    parse_line_edit, validate_edit_files_arguments,
+    format_edit_label, parse_line_edit, validate_edit_files_arguments,
 };
 use response::build_edit_files_success;
 use types::{LineEdit, ParsedEdit, PreparedFileEdit};
@@ -212,6 +212,7 @@ impl WorkspaceServer {
                 "Insert top: [{\"path\": \"src/a.ts\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
                 "Insert below a line: [{\"path\": \"src/a.ts\", \"op\": \"insert_after\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
                 "Delete range: [{\"path\": \"src/b.ts\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                "Existing lines are 1-based; use startLine=0 only to prepend at the top".to_string(),
                 "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
             ])
             .to_mcp_result());
@@ -233,6 +234,7 @@ impl WorkspaceServer {
                     "Insert-top: [{\"path\": \"src/a.ts\", \"startLine\": 0, \"content\": \"header\"}]".to_string(),
                     "Insert below a line: [{\"path\": \"src/a.ts\", \"op\": \"insert_after\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]".to_string(),
                     "Delete range: [{\"path\": \"src/b.ts\", \"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]".to_string(),
+                    "Existing lines are 1-based; use startLine=0 only to prepend at the top".to_string(),
                     "Use readFile(showLineAnchors=true) to get anchor values first".to_string(),
                 ])
                 .to_mcp_result());
@@ -254,9 +256,13 @@ impl WorkspaceServer {
             let edit_obj = match edit_value.as_object() {
                 Some(obj) => obj,
                 None => {
+                    let context = edit_value
+                        .as_object()
+                        .map(|obj| format_edit_label(obj, idx))
+                        .unwrap_or_else(|| format!("Edit at index {}", idx));
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
-                        format!("Edit at index {} must be an object", idx),
+                        format!("{context} must be an object"),
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
@@ -270,11 +276,11 @@ impl WorkspaceServer {
             let path = match edit_obj.get("path").and_then(|value| value.as_str()) {
                 Some(path) if !path.trim().is_empty() => path.trim().to_string(),
                 _ => {
+                    let edit_label = format_edit_label(edit_obj, idx);
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
                         format!(
-                            "Edit at index {}: 'path' field is required and must be a non-empty string",
-                            idx
+                            "{edit_label}: 'path' field is required and must be a non-empty string"
                         ),
                         ToolGroup::Workspace,
                     )

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
@@ -54,8 +54,8 @@ pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) ->
             file_sections.join("\n\n")
         ),
         vec![
-            "Anchors above are current — reuse them with editFiles per file".to_string(),
-            "Use readFile only if you need broader context beyond the edited ranges".to_string(),
+            "Anchors above are current for the edited ranges — reuse them directly with editFiles for follow-up edits in those same ranges".to_string(),
+            "Use readFile only when you need broader context, untouched lines, or fresh anchors outside the ranges shown above".to_string(),
         ],
     );
 

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -548,7 +548,7 @@ Use flat params (line/anchor) for a single deletion, or the `edits` array for mu
 
 fn create_edit_item_schema(path_required: bool) -> JSONSchema {
     let path_desc = "Relative path to the file to edit (from workspace root).";
-    let start_line_desc = "Target start line number (1-based). Use 0 to prepend at the file top.";
+    let start_line_desc = "Target start line number. Existing lines are 1-based. Use 0 only to prepend at the file top; to insert below an existing line, keep that line's 1-based number and set op='insert_after'.";
     let end_line_desc =
         "Inclusive end line for a multi-line replace/delete range. Omit for a single-line edit.";
     let start_anchor_desc =
@@ -556,7 +556,7 @@ fn create_edit_item_schema(path_required: bool) -> JSONSchema {
     let end_anchor_desc =
         "6-character opaque anchor for the end line. Required when endLine is set for a multi-line replace/delete range.";
     let content_desc =
-        "Replacement or inserted content. Omit it to delete. Keep op='insert_after' when inserting below an existing line; use startLine=0 to prepend at the top.";
+        "Replacement or inserted content. Omit it to delete. Existing lines stay 1-based; use startLine=0 only for prepend, or keep a 1-based existing line number with op='insert_after' to insert below it.";
 
     let mut props = HashMap::new();
     if path_required {
@@ -604,7 +604,7 @@ fn create_edit_item_schema(path_required: bool) -> JSONSchema {
         },
     );
     schema.description = Some(
-        "A single edit operation. Provide path + startLine, plus anchors for existing-line edits. op is optional for common replace/delete flows but still useful for insert_after.".to_string(),
+        "A single edit operation. Provide path + startLine, plus anchors for existing-line edits. Existing content uses 1-based line numbers; only startLine=0 prepends at the file top. op is optional for common replace/delete flows but still useful for insert_after.".to_string(),
     );
     schema
 }
@@ -652,6 +652,8 @@ pub fn create_edit_files_tool() -> MCPTool {
         description: "Apply multiple line edits across one or more files atomically in a single operation.
 
 PREREQUISITE: Call readFile(showLineAnchors=true) first to obtain anchor values. For anchors, pass only the 6 hex characters between ':' and '|'.
+
+Line numbering is 1-based for existing content. The only valid 0 value is startLine=0, which prepends at the file top.
 
 Each edit item carries its own path. Keep the payload simple and let the server infer the common cases:
 - replace single line: path + startLine + startAnchor + content

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -79,6 +79,18 @@ fn edit_files_schema_uses_single_object_item_contract() {
     assert!(required
         .iter()
         .any(|value| value.as_str() == Some("startLine")));
+
+    let start_line_description = edits_items
+        .get("properties")
+        .and_then(|properties| properties.get("startLine"))
+        .and_then(|value| value.get("description"))
+        .and_then(|value| value.as_str())
+        .expect("startLine description");
+    assert!(
+        start_line_description.contains("Existing lines are 1-based")
+            && start_line_description.contains("Use 0 only to prepend"),
+        "startLine description should make the 1-based/0-based exception explicit: {start_line_description}"
+    );
 }
 
 #[tokio::test]
@@ -233,8 +245,57 @@ async fn edit_files_allows_replace_without_explicit_op() {
         .expect("edit batch should succeed");
 
     assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Anchors above are current for the edited ranges")
+            && text.contains("reuse them directly with editFiles"),
+        "success response should explain anchor reuse without rereading: {text}"
+    );
     let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
     assert_eq!(updated, "ALPHA\nbeta\n");
+}
+
+#[tokio::test]
+async fn edit_files_error_messages_include_edit_context() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-error-context";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let anchors = format_as_hashlines("alpha\nbeta\n");
+    let start_anchor = anchors
+        .lines()
+        .next()
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("start anchor");
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "sample.txt",
+                        "op": "insert_after",
+                        "startLine": 1,
+                        "startAnchor": start_anchor
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit batch should return MCPResult");
+
+    assert_eq!(result.is_error, Some(true));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Edit at index 0 [path='sample.txt', op='insert_after', startLine=1]")
+            && text.contains("'content' is required"),
+        "error should include offending edit context: {text}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add edit context to editFiles validation errors
- clarify 1-based line numbering with startLine=0 as prepend-only
- explain when returned anchors can be reused without rereading

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml --test workspace_hash_anchor_tests
- pnpm refactor:validate