### PR TITLE
Fix agent chat bottom threshold

### DIFF
--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -194,7 +194,7 @@ function AgentChatInner() {
         >
           <AgentChatHeader />
           <AgentChatStatusBar />
-          <AgentChatMessages />
+          <AgentChatMessages inputOverlayHeight={inputOverlayHeight} />
 
           {/* Floating Input Container */}
           <div className="absolute bottom-0 left-0 right-0 z-10 pointer-events-none">

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -28,6 +28,8 @@ import { Virtuoso, type Components, type ListProps } from 'react-virtuoso';
 
 const logger = getLogger('AgentChatMessages');
 const INITIAL_FIRST_ITEM_INDEX = 10_000;
+const DEFAULT_BOTTOM_THRESHOLD = 80;
+const CHAT_INPUT_SPACER_GAP = 24;
 
 export function getPrependedFirstItemIndex(
   current: number,
@@ -41,6 +43,13 @@ export function getInitialTopMostItemIndex(
   itemCount: number,
 ): number {
   return itemCount > 0 ? firstItemIndex + itemCount - 1 : firstItemIndex;
+}
+
+export function getVisualBottomThreshold(inputOverlayHeight: number): number {
+  return Math.max(
+    DEFAULT_BOTTOM_THRESHOLD,
+    inputOverlayHeight + CHAT_INPUT_SPACER_GAP,
+  );
 }
 
 interface AgentChatVirtuosoContext {
@@ -239,7 +248,13 @@ function groupedMessageContainsBoundary(
   return groupedMessage.messages.some((message) => message.id === boundaryId);
 }
 
-export function AgentChatMessages() {
+interface AgentChatMessagesProps {
+  inputOverlayHeight?: number;
+}
+
+export function AgentChatMessages({
+  inputOverlayHeight = 88,
+}: AgentChatMessagesProps = {}) {
   const { t } = useTranslation();
   const {
     messages,
@@ -293,6 +308,10 @@ export function AgentChatMessages() {
   const assistantName = session?.assistant?.name || 'Agent';
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
+  );
+  const bottomThreshold = useMemo(
+    () => getVisualBottomThreshold(inputOverlayHeight),
+    [inputOverlayHeight],
   );
   const previousListStateRef = useRef<{
     firstId: string | undefined;
@@ -558,7 +577,7 @@ export function AgentChatMessages() {
           groupedMessages.length,
         )}
         alignToBottom={true}
-        atBottomThreshold={80}
+        atBottomThreshold={bottomThreshold}
         followOutput={(isAtBottom) => (isAtBottom ? 'auto' : false)}
         increaseViewportBy={{ top: 640, bottom: 960 }}
         startReached={handleReachTop}

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -5,6 +5,7 @@ import {
   AgentChatMessages,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
+  getVisualBottomThreshold,
 } from '../AgentChatMessages';
 import type { Message } from '@/models/chat';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
@@ -188,5 +189,19 @@ describe('AgentChatMessages compaction rendering', () => {
   it('keeps prepend index adjustments monotonic at zero instead of rebounding to list length', () => {
     expect(getPrependedFirstItemIndex(10_000, 3)).toBe(9_997);
     expect(getPrependedFirstItemIndex(2, 3)).toBe(0);
+  });
+
+  it('uses the input overlay height to define the visual bottom threshold', () => {
+    render(<AgentChatMessages inputOverlayHeight={144} />);
+
+    const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
+      atBottomThreshold: number;
+    };
+
+    expect(virtuosoProps.atBottomThreshold).toBe(
+      getVisualBottomThreshold(144),
+    );
+    expect(getVisualBottomThreshold(20)).toBe(80);
+    expect(getVisualBottomThreshold(144)).toBe(168);
   });
 });


### PR DESCRIPTION
## Summary
- pass the measured input overlay height into AgentChatMessages
- compute a visual bottom threshold from the overlay height instead of a fixed 80px only
- add coverage for the threshold calculation in AgentChatMessages tests

## Notes
- targeted AgentChatMessages vitest passed
- lint and build:nosync passed
- repo-wide refactor:validate is currently blocked by a pre-existing formatting issue in src/lib/generated/builtin-services.ts