### PR TITLE
Refactor knowledge browser state and dialog

### DIFF
--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -29,7 +29,6 @@ export default function KnowledgePage() {
     closeDetail,
     deleteSelectedItem,
     detail,
-    entityNameById,
     hasMoreItems,
     isDeleteDialogOpen,
     isDeleting,
@@ -200,7 +199,6 @@ export default function KnowledgePage() {
       <KnowledgeDetailDialog
         open={isDetailOpen}
         detail={detail}
-        entityNameById={entityNameById}
         isDeleting={isDeleting}
         isDetailLoading={isDetailLoading}
         onClose={closeDetail}

--- a/src/features/knowledge/components/KnowledgeDetailDialog.tsx
+++ b/src/features/knowledge/components/KnowledgeDetailDialog.tsx
@@ -1,13 +1,8 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileText, Loader2, Network, Trash2 } from 'lucide-react';
 import {
-  Badge,
   Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -18,121 +13,17 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/components/ui';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import type {
   KnowledgeChunkDetail,
   KnowledgeChunkListItem,
 } from '@/lib/backend/knowledge';
-import { formatTimestamp, layoutGraphNodes } from '../knowledge-utils';
-
-function KnowledgeGraphPreview({ detail }: { detail: KnowledgeChunkDetail }) {
-  const { t } = useTranslation('common');
-  const positions = useMemo(
-    () => layoutGraphNodes(detail.entities),
-    [detail.entities],
-  );
-
-  if (!detail.entities.length) {
-    return (
-      <div className="rounded-xl border border-dashed border-border/60 p-8 text-center text-sm text-muted-foreground">
-        {t(
-          'knowledge.graph.empty',
-          'No graph data linked to this knowledge entry.',
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="rounded-xl border bg-muted/20 p-3">
-        <svg viewBox="0 0 360 280" className="h-[280px] w-full">
-          {detail.relationships.map((relationship) => {
-            const source = positions.get(relationship.sourceEntityId);
-            const target = positions.get(relationship.targetEntityId);
-            if (!source || !target) {
-              return null;
-            }
-
-            const midX = (source.x + target.x) / 2;
-            const midY = (source.y + target.y) / 2;
-
-            return (
-              <g key={relationship.id}>
-                <line
-                  x1={source.x}
-                  y1={source.y}
-                  x2={target.x}
-                  y2={target.y}
-                  stroke="currentColor"
-                  strokeOpacity="0.25"
-                  strokeWidth="1.5"
-                  className="text-muted-foreground"
-                />
-                <text
-                  x={midX}
-                  y={midY}
-                  textAnchor="middle"
-                  className="fill-muted-foreground text-[9px]"
-                >
-                  {relationship.relationType}
-                </text>
-              </g>
-            );
-          })}
-
-          {detail.entities.map((entity) => {
-            const position = positions.get(entity.id);
-            if (!position) {
-              return null;
-            }
-
-            return (
-              <g key={entity.id}>
-                <circle
-                  cx={position.x}
-                  cy={position.y}
-                  r={entity.isPrimary ? 20 : 16}
-                  className={
-                    entity.isPrimary
-                      ? 'fill-primary/80 stroke-primary'
-                      : 'fill-muted stroke-muted-foreground/40'
-                  }
-                  strokeWidth="1.5"
-                />
-                <text
-                  x={position.x}
-                  y={position.y + (entity.isPrimary ? 34 : 28)}
-                  textAnchor="middle"
-                  className="fill-foreground text-[10px] font-medium"
-                >
-                  {entity.name}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
-      </div>
-
-      <div className="flex flex-wrap gap-2 text-xs">
-        <Badge variant="secondary" className="gap-1">
-          <span className="inline-block h-2 w-2 rounded-full bg-primary" />
-          {t('knowledge.graph.primaryEntity', 'Primary entity')}
-        </Badge>
-        <Badge variant="outline" className="gap-1">
-          <span className="inline-block h-2 w-2 rounded-full bg-muted-foreground/60" />
-          {t('knowledge.graph.relatedEntity', 'Related entity')}
-        </Badge>
-      </div>
-    </div>
-  );
-}
+import { KnowledgeDetailGraphTab } from './knowledge-detail/KnowledgeDetailGraphTab';
+import { KnowledgeDetailOverviewTab } from './knowledge-detail/KnowledgeDetailOverviewTab';
 
 interface KnowledgeDetailDialogProps {
   open: boolean;
   detail: KnowledgeChunkDetail | null;
-  entityNameById: Map<number, string>;
   isDeleting: boolean;
   isDetailLoading: boolean;
   onClose: () => void;
@@ -143,7 +34,6 @@ interface KnowledgeDetailDialogProps {
 export const KnowledgeDetailDialog = memo(function KnowledgeDetailDialog({
   open,
   detail,
-  entityNameById,
   isDeleting,
   isDetailLoading,
   onClose,
@@ -222,167 +112,11 @@ export const KnowledgeDetailDialog = memo(function KnowledgeDetailDialog({
               </TabsList>
 
               <TabsContent value="overview" className="min-h-0 flex-1">
-                <div className="grid h-full gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
-                  <Card className="min-h-0 py-4">
-                    <CardHeader className="px-4">
-                      <div className="flex flex-wrap gap-2">
-                        <Badge variant="secondary">{detail.assistantId}</Badge>
-                        {detail.source ? (
-                          <Badge variant="outline">{detail.source}</Badge>
-                        ) : null}
-                        {detail.tags.map((tag) => (
-                          <Badge key={tag} variant="outline">
-                            #{tag}
-                          </Badge>
-                        ))}
-                      </div>
-                    </CardHeader>
-                    <CardContent className="min-h-0 px-4">
-                      <ScrollArea className="h-[420px] pr-4">
-                        <div className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
-                          {detail.content}
-                        </div>
-                      </ScrollArea>
-                    </CardContent>
-                  </Card>
-
-                  <div className="flex min-h-0 flex-col gap-4">
-                    <Card className="py-4">
-                      <CardHeader className="px-4">
-                        <CardTitle className="text-sm">
-                          {t('knowledge.metadataTitle', 'Metadata')}
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent className="space-y-2 px-4 text-sm">
-                        <div>
-                          <span className="text-muted-foreground">
-                            {t('knowledge.fields.createdAt', 'Created')}
-                          </span>
-                          <div>{formatTimestamp(detail.createdAt)}</div>
-                        </div>
-                        <div>
-                          <span className="text-muted-foreground">
-                            {t(
-                              'knowledge.fields.primaryEntities',
-                              'Primary entities',
-                            )}
-                          </span>
-                          <div>{detail.primaryEntityIds.length}</div>
-                        </div>
-                        <div>
-                          <span className="text-muted-foreground">
-                            {t(
-                              'knowledge.fields.relationships',
-                              'Relationships',
-                            )}
-                          </span>
-                          <div>{detail.relationships.length}</div>
-                        </div>
-                      </CardContent>
-                    </Card>
-
-                    <Card className="min-h-0 flex-1 py-4">
-                      <CardHeader className="px-4">
-                        <CardTitle className="text-sm">
-                          {t('knowledge.entitiesTitle', 'Entities')}
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent className="min-h-0 px-4">
-                        <ScrollArea className="h-[250px] pr-3">
-                          <div className="space-y-2">
-                            {detail.entities.length === 0 ? (
-                              <p className="text-sm text-muted-foreground">
-                                {t(
-                                  'knowledge.noEntities',
-                                  'No linked entities for this entry.',
-                                )}
-                              </p>
-                            ) : (
-                              detail.entities.map((entity) => (
-                                <div
-                                  key={entity.id}
-                                  className="rounded-lg border p-3 text-sm"
-                                >
-                                  <div className="flex items-center gap-2">
-                                    <span className="font-medium">
-                                      {entity.name}
-                                    </span>
-                                    {entity.isPrimary ? (
-                                      <Badge variant="secondary">
-                                        {t(
-                                          'knowledge.primaryEntity',
-                                          'Primary',
-                                        )}
-                                      </Badge>
-                                    ) : null}
-                                  </div>
-                                  {entity.entityType ? (
-                                    <div className="mt-1 text-xs text-muted-foreground">
-                                      {entity.entityType}
-                                    </div>
-                                  ) : null}
-                                  {entity.description ? (
-                                    <p className="mt-2 text-muted-foreground">
-                                      {entity.description}
-                                    </p>
-                                  ) : null}
-                                </div>
-                              ))
-                            )}
-                          </div>
-                        </ScrollArea>
-                      </CardContent>
-                    </Card>
-                  </div>
-                </div>
+                <KnowledgeDetailOverviewTab detail={detail} />
               </TabsContent>
 
               <TabsContent value="graph" className="min-h-0 flex-1">
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
-                  <KnowledgeGraphPreview detail={detail} />
-
-                  <Card className="py-4">
-                    <CardHeader className="px-4">
-                      <CardTitle className="text-sm">
-                        {t('knowledge.relationshipListTitle', 'Relationships')}
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="px-4">
-                      <ScrollArea className="h-[320px] pr-3">
-                        <div className="space-y-2 text-sm">
-                          {detail.relationships.length === 0 ? (
-                            <p className="text-muted-foreground">
-                              {t(
-                                'knowledge.noRelationships',
-                                'No relationships linked to this entry.',
-                              )}
-                            </p>
-                          ) : (
-                            detail.relationships.map((relationship) => (
-                              <div
-                                key={relationship.id}
-                                className="rounded-lg border p-3"
-                              >
-                                <div className="font-medium">
-                                  {relationship.relationType}
-                                </div>
-                                <div className="mt-1 text-xs text-muted-foreground">
-                                  {entityNameById.get(
-                                    relationship.sourceEntityId,
-                                  ) ?? relationship.sourceEntityId}{' '}
-                                  -&gt;{' '}
-                                  {entityNameById.get(
-                                    relationship.targetEntityId,
-                                  ) ?? relationship.targetEntityId}
-                                </div>
-                              </div>
-                            ))
-                          )}
-                        </div>
-                      </ScrollArea>
-                    </CardContent>
-                  </Card>
-                </div>
+                <KnowledgeDetailGraphTab detail={detail} />
               </TabsContent>
             </Tabs>
           )}

--- a/src/features/knowledge/components/knowledge-detail/KnowledgeDetailGraphTab.tsx
+++ b/src/features/knowledge/components/knowledge-detail/KnowledgeDetailGraphTab.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { KnowledgeChunkDetail } from '@/lib/backend/knowledge';
+import { KnowledgeGraphPreview } from './KnowledgeGraphPreview';
+
+interface KnowledgeDetailGraphTabProps {
+  detail: KnowledgeChunkDetail;
+}
+
+export function KnowledgeDetailGraphTab({
+  detail,
+}: KnowledgeDetailGraphTabProps) {
+  const { t } = useTranslation('common');
+  const entityNameById = useMemo(
+    () => new Map(detail.entities.map((entity) => [entity.id, entity.name])),
+    [detail.entities],
+  );
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <KnowledgeGraphPreview detail={detail} />
+
+      <Card className="py-4">
+        <CardHeader className="px-4">
+          <CardTitle className="text-sm">
+            {t('knowledge.relationshipListTitle', 'Relationships')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-4">
+          <ScrollArea className="h-[320px] pr-3">
+            <div className="space-y-2 text-sm">
+              {detail.relationships.length === 0 ? (
+                <p className="text-muted-foreground">
+                  {t(
+                    'knowledge.noRelationships',
+                    'No relationships linked to this entry.',
+                  )}
+                </p>
+              ) : (
+                detail.relationships.map((relationship) => (
+                  <div key={relationship.id} className="rounded-lg border p-3">
+                    <div className="font-medium">
+                      {relationship.relationType}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {entityNameById.get(relationship.sourceEntityId) ??
+                        relationship.sourceEntityId}{' '}
+                      -&gt;{' '}
+                      {entityNameById.get(relationship.targetEntityId) ??
+                        relationship.targetEntityId}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/features/knowledge/components/knowledge-detail/KnowledgeDetailOverviewTab.tsx
+++ b/src/features/knowledge/components/knowledge-detail/KnowledgeDetailOverviewTab.tsx
@@ -1,0 +1,126 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { KnowledgeChunkDetail } from '@/lib/backend/knowledge';
+import { formatTimestamp } from '../../knowledge-utils';
+
+interface KnowledgeDetailOverviewTabProps {
+  detail: KnowledgeChunkDetail;
+}
+
+export function KnowledgeDetailOverviewTab({
+  detail,
+}: KnowledgeDetailOverviewTabProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="grid h-full gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <Card className="min-h-0 py-4">
+        <CardHeader className="px-4">
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">{detail.assistantId}</Badge>
+            {detail.source ? (
+              <Badge variant="outline">{detail.source}</Badge>
+            ) : null}
+            {detail.tags.map((tag) => (
+              <Badge key={tag} variant="outline">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        </CardHeader>
+        <CardContent className="min-h-0 px-4">
+          <ScrollArea className="h-[420px] pr-4">
+            <div className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
+              {detail.content}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+
+      <div className="flex min-h-0 flex-col gap-4">
+        <Card className="py-4">
+          <CardHeader className="px-4">
+            <CardTitle className="text-sm">
+              {t('knowledge.metadataTitle', 'Metadata')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 px-4 text-sm">
+            <div>
+              <span className="text-muted-foreground">
+                {t('knowledge.fields.createdAt', 'Created')}
+              </span>
+              <div>{formatTimestamp(detail.createdAt)}</div>
+            </div>
+            <div>
+              <span className="text-muted-foreground">
+                {t('knowledge.fields.primaryEntities', 'Primary entities')}
+              </span>
+              <div>{detail.primaryEntityIds.length}</div>
+            </div>
+            <div>
+              <span className="text-muted-foreground">
+                {t('knowledge.fields.relationships', 'Relationships')}
+              </span>
+              <div>{detail.relationships.length}</div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="min-h-0 flex-1 py-4">
+          <CardHeader className="px-4">
+            <CardTitle className="text-sm">
+              {t('knowledge.entitiesTitle', 'Entities')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="min-h-0 px-4">
+            <ScrollArea className="h-[250px] pr-3">
+              <div className="space-y-2">
+                {detail.entities.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {t(
+                      'knowledge.noEntities',
+                      'No linked entities for this entry.',
+                    )}
+                  </p>
+                ) : (
+                  detail.entities.map((entity) => (
+                    <div
+                      key={entity.id}
+                      className="rounded-lg border p-3 text-sm"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{entity.name}</span>
+                        {entity.isPrimary ? (
+                          <Badge variant="secondary">
+                            {t('knowledge.primaryEntity', 'Primary')}
+                          </Badge>
+                        ) : null}
+                      </div>
+                      {entity.entityType ? (
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {entity.entityType}
+                        </div>
+                      ) : null}
+                      {entity.description ? (
+                        <p className="mt-2 text-muted-foreground">
+                          {entity.description}
+                        </p>
+                      ) : null}
+                    </div>
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/features/knowledge/components/knowledge-detail/KnowledgeGraphPreview.tsx
+++ b/src/features/knowledge/components/knowledge-detail/KnowledgeGraphPreview.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui';
+import type { KnowledgeChunkDetail } from '@/lib/backend/knowledge';
+import { layoutGraphNodes } from '../../knowledge-utils';
+
+interface KnowledgeGraphPreviewProps {
+  detail: KnowledgeChunkDetail;
+}
+
+export function KnowledgeGraphPreview({ detail }: KnowledgeGraphPreviewProps) {
+  const { t } = useTranslation('common');
+  const positions = useMemo(
+    () => layoutGraphNodes(detail.entities),
+    [detail.entities],
+  );
+
+  if (!detail.entities.length) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/60 p-8 text-center text-sm text-muted-foreground">
+        {t(
+          'knowledge.graph.empty',
+          'No graph data linked to this knowledge entry.',
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border bg-muted/20 p-3">
+        <svg viewBox="0 0 360 280" className="h-[280px] w-full">
+          {detail.relationships.map((relationship) => {
+            const source = positions.get(relationship.sourceEntityId);
+            const target = positions.get(relationship.targetEntityId);
+            if (!source || !target) {
+              return null;
+            }
+
+            const midX = (source.x + target.x) / 2;
+            const midY = (source.y + target.y) / 2;
+
+            return (
+              <g key={relationship.id}>
+                <line
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  stroke="currentColor"
+                  strokeOpacity="0.25"
+                  strokeWidth="1.5"
+                  className="text-muted-foreground"
+                />
+                <text
+                  x={midX}
+                  y={midY}
+                  textAnchor="middle"
+                  className="fill-muted-foreground text-[9px]"
+                >
+                  {relationship.relationType}
+                </text>
+              </g>
+            );
+          })}
+
+          {detail.entities.map((entity) => {
+            const position = positions.get(entity.id);
+            if (!position) {
+              return null;
+            }
+
+            return (
+              <g key={entity.id}>
+                <circle
+                  cx={position.x}
+                  cy={position.y}
+                  r={entity.isPrimary ? 20 : 16}
+                  className={
+                    entity.isPrimary
+                      ? 'fill-primary/80 stroke-primary'
+                      : 'fill-muted stroke-muted-foreground/40'
+                  }
+                  strokeWidth="1.5"
+                />
+                <text
+                  x={position.x}
+                  y={position.y + (entity.isPrimary ? 34 : 28)}
+                  textAnchor="middle"
+                  className="fill-foreground text-[10px] font-medium"
+                >
+                  {entity.name}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Badge variant="secondary" className="gap-1">
+          <span className="inline-block h-2 w-2 rounded-full bg-primary" />
+          {t('knowledge.graph.primaryEntity', 'Primary entity')}
+        </Badge>
+        <Badge variant="outline" className="gap-1">
+          <span className="inline-block h-2 w-2 rounded-full bg-muted-foreground/60" />
+          {t('knowledge.graph.relatedEntity', 'Related entity')}
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/src/features/knowledge/hooks/useDebouncedValue.ts
+++ b/src/features/knowledge/hooks/useDebouncedValue.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [delayMs, value]);
+
+  return debouncedValue;
+}

--- a/src/features/knowledge/hooks/useKnowledgeBrowser.ts
+++ b/src/features/knowledge/hooks/useKnowledgeBrowser.ts
@@ -1,254 +1,65 @@
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from 'react';
-import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
-import { getLogger } from '@/lib/logger';
-import {
-  deleteGlobalKnowledge,
-  getGlobalKnowledgeDetail,
-  listGlobalKnowledge,
-  type KnowledgeChunkDetail,
-  type KnowledgeChunkListItem,
-  type KnowledgeListCursor,
-} from '@/lib/backend/knowledge';
-
-const logger = getLogger('useKnowledgeBrowser');
-const KNOWLEDGE_PAGE_SIZE = 60;
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useKnowledgeDelete } from './useKnowledgeDelete';
+import { useKnowledgeDetail } from './useKnowledgeDetail';
+import { useKnowledgeList } from './useKnowledgeList';
 
 export function useKnowledgeBrowser() {
-  const { t } = useTranslation('common');
   const [query, setQuery] = useState('');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
   const [assistantFilter, setAssistantFilter] = useState('all');
-  const [items, setItems] = useState<KnowledgeChunkListItem[]>([]);
-  const [assistants, setAssistants] = useState<string[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
-  const [detail, setDetail] = useState<KnowledgeChunkDetail | null>(null);
-  const [isListLoading, setIsListLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [listRefreshToken, setListRefreshToken] = useState(0);
-  const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
-    null,
-  );
-  const deferredQuery = useDeferredValue(query);
-  const [, startSelectionTransition] = useTransition();
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      setDebouncedQuery(deferredQuery.trim());
-    }, 250);
-
-    return () => window.clearTimeout(timeout);
-  }, [deferredQuery]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      setIsListLoading(true);
-      try {
-        const response = await listGlobalKnowledge({
-          query: debouncedQuery || undefined,
-          assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
-          limit: KNOWLEDGE_PAGE_SIZE,
-        });
-
-        if (cancelled) {
-          return;
-        }
-
-        setItems(response.items);
-        setAssistants(response.assistants);
-        setNextCursor(response.nextCursor ?? null);
-        setSelectedId((current) => {
-          if (current && response.items.some((item) => item.id === current)) {
-            return current;
-          }
-          return null;
-        });
-      } catch (error) {
-        logger.error('Failed to load global knowledge list', error);
-        if (!cancelled) {
-          toast.error(
-            t(
-              'knowledge.loadListFailed',
-              'Failed to load global knowledge entries.',
-            ),
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setIsListLoading(false);
-        }
-      }
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [assistantFilter, debouncedQuery, listRefreshToken, t]);
-
-  useEffect(() => {
-    if (selectedId === null) {
-      setDetail(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadDetail = async () => {
-      setIsDetailLoading(true);
-      try {
-        const response = await getGlobalKnowledgeDetail(selectedId);
-        if (!cancelled) {
-          setDetail(response);
-        }
-      } catch (error) {
-        logger.error('Failed to load knowledge detail', { selectedId, error });
-        if (!cancelled) {
-          toast.error(
-            t(
-              'knowledge.loadDetailFailed',
-              'Failed to load knowledge details.',
-            ),
-          );
-          setDetail(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsDetailLoading(false);
-        }
-      }
-    };
-
-    void loadDetail();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedId, t]);
+  const {
+    assistants,
+    hasMoreItems,
+    isListLoading,
+    isLoadingMore,
+    items,
+    loadMore,
+  } = useKnowledgeList({
+    assistantFilter,
+    query,
+    refreshToken: listRefreshToken,
+  });
+  const { detail, isDetailLoading } = useKnowledgeDetail(selectedId);
 
   const selectedItem = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,
     [items, selectedId],
-  );
-  const isDetailOpen = selectedItem !== null;
-  const hasMoreItems = nextCursor !== null;
-  const entityNameById = useMemo(
-    () =>
-      new Map(detail?.entities.map((entity) => [entity.id, entity.name]) ?? []),
-    [detail?.entities],
   );
 
   const refresh = useCallback(() => {
     setListRefreshToken((current) => current + 1);
   }, []);
 
+  useEffect(() => {
+    if (selectedId !== null && !items.some((item) => item.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [items, selectedId]);
+
+  const handleDeleted = useCallback(() => {
+    setSelectedId(null);
+    setListRefreshToken((current) => current + 1);
+  }, []);
+  const {
+    deleteSelectedItem,
+    isDeleteDialogOpen,
+    isDeleting,
+    requestDelete,
+    setIsDeleteDialogOpen,
+  } = useKnowledgeDelete({
+    onDeleted: handleDeleted,
+    selectedItem,
+  });
+
   const closeDetail = useCallback(() => {
     setIsDeleteDialogOpen(false);
     setSelectedId(null);
+  }, [setIsDeleteDialogOpen]);
+
+  const selectItem = useCallback((id: number) => {
+    setSelectedId(id);
   }, []);
-
-  const selectItem = useCallback(
-    (id: number) => {
-      startSelectionTransition(() => {
-        setSelectedId(id);
-      });
-    },
-    [startSelectionTransition],
-  );
-
-  const loadMore = useCallback(async () => {
-    if (isListLoading || isLoadingMore || nextCursor === null) {
-      return;
-    }
-
-    setIsLoadingMore(true);
-    try {
-      const response = await listGlobalKnowledge({
-        query: debouncedQuery || undefined,
-        assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
-        cursor: nextCursor,
-        limit: KNOWLEDGE_PAGE_SIZE,
-      });
-
-      setItems((current) => {
-        const seenIds = new Set(current.map((item) => item.id));
-        const appendedItems = response.items.filter(
-          (item) => !seenIds.has(item.id),
-        );
-        return [...current, ...appendedItems];
-      });
-      setNextCursor(response.nextCursor ?? null);
-    } catch (error) {
-      logger.error('Failed to load more global knowledge entries', error);
-      toast.error(
-        t('knowledge.loadMoreFailed', 'Failed to load more knowledge entries.'),
-      );
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [
-    assistantFilter,
-    debouncedQuery,
-    isListLoading,
-    isLoadingMore,
-    nextCursor,
-    t,
-  ]);
-
-  const requestDelete = useCallback(() => {
-    if (!selectedItem || isDeleting) {
-      return;
-    }
-    setIsDeleteDialogOpen(true);
-  }, [isDeleting, selectedItem]);
-
-  const deleteSelectedItem = useCallback(async () => {
-    if (!selectedItem || isDeleting) {
-      return;
-    }
-
-    setIsDeleting(true);
-    try {
-      const response = await deleteGlobalKnowledge(selectedItem.id);
-      toast.success(t('knowledge.deleteSuccess', 'Knowledge entry deleted.'), {
-        description: t(
-          'knowledge.deleteSuccessDescription',
-          'Removed {{entities}} orphan entities and {{relationships}} orphan relationships.',
-          {
-            entities: response.orphanEntityCount,
-            relationships: response.orphanRelationshipCount,
-          },
-        ),
-      });
-      setDetail(null);
-      setSelectedId(null);
-      setIsDeleteDialogOpen(false);
-      setListRefreshToken((current) => current + 1);
-    } catch (error) {
-      logger.error('Failed to delete knowledge entry', {
-        id: selectedItem.id,
-        error,
-      });
-      toast.error(
-        t('knowledge.deleteFailed', 'Failed to delete knowledge entry.'),
-      );
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [isDeleting, selectedItem, t]);
 
   return {
     assistantFilter,
@@ -256,12 +67,11 @@ export function useKnowledgeBrowser() {
     closeDetail,
     deleteSelectedItem,
     detail,
-    entityNameById,
     hasMoreItems,
     isDeleteDialogOpen,
     isDeleting,
     isDetailLoading,
-    isDetailOpen,
+    isDetailOpen: selectedItem !== null,
     isListLoading,
     isLoadingMore,
     items,

--- a/src/features/knowledge/hooks/useKnowledgeDelete.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDelete.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+  deleteGlobalKnowledge,
+  type KnowledgeChunkListItem,
+} from '@/lib/backend/knowledge';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('useKnowledgeDelete');
+
+interface UseKnowledgeDeleteOptions {
+  onDeleted: () => void;
+  selectedItem: KnowledgeChunkListItem | null;
+}
+
+export function useKnowledgeDelete({
+  onDeleted,
+  selectedItem,
+}: UseKnowledgeDeleteOptions) {
+  const { t } = useTranslation('common');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (!selectedItem) {
+      setIsDeleteDialogOpen(false);
+    }
+  }, [selectedItem]);
+
+  const requestDelete = useCallback(() => {
+    if (!selectedItem || isDeleting) {
+      return;
+    }
+
+    setIsDeleteDialogOpen(true);
+  }, [isDeleting, selectedItem]);
+
+  const deleteSelectedItem = useCallback(async () => {
+    if (!selectedItem || isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const response = await deleteGlobalKnowledge(selectedItem.id);
+      toast.success(t('knowledge.deleteSuccess', 'Knowledge entry deleted.'), {
+        description: t(
+          'knowledge.deleteSuccessDescription',
+          'Removed {{entities}} orphan entities and {{relationships}} orphan relationships.',
+          {
+            entities: response.orphanEntityCount,
+            relationships: response.orphanRelationshipCount,
+          },
+        ),
+      });
+      setIsDeleteDialogOpen(false);
+      onDeleted();
+    } catch (error) {
+      logger.error('Failed to delete knowledge entry', {
+        error,
+        id: selectedItem.id,
+      });
+      toast.error(
+        t('knowledge.deleteFailed', 'Failed to delete knowledge entry.'),
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [isDeleting, onDeleted, selectedItem, t]);
+
+  return {
+    deleteSelectedItem,
+    isDeleteDialogOpen,
+    isDeleting,
+    requestDelete,
+    setIsDeleteDialogOpen,
+  };
+}

--- a/src/features/knowledge/hooks/useKnowledgeDetail.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDetail.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+  getGlobalKnowledgeDetail,
+  type KnowledgeChunkDetail,
+} from '@/lib/backend/knowledge';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('useKnowledgeDetail');
+
+export function useKnowledgeDetail(selectedId: number | null) {
+  const { t } = useTranslation('common');
+  const [detail, setDetail] = useState<KnowledgeChunkDetail | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+
+  useEffect(() => {
+    if (selectedId === null) {
+      setDetail(null);
+      setIsDetailLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadDetail = async () => {
+      setIsDetailLoading(true);
+      try {
+        const response = await getGlobalKnowledgeDetail(selectedId);
+        if (!cancelled) {
+          setDetail(response);
+        }
+      } catch (error) {
+        logger.error('Failed to load knowledge detail', { error, selectedId });
+        if (!cancelled) {
+          toast.error(
+            t(
+              'knowledge.loadDetailFailed',
+              'Failed to load knowledge details.',
+            ),
+          );
+          setDetail(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsDetailLoading(false);
+        }
+      }
+    };
+
+    void loadDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, t]);
+
+  return {
+    detail,
+    isDetailLoading,
+  };
+}

--- a/src/features/knowledge/hooks/useKnowledgeList.test.tsx
+++ b/src/features/knowledge/hooks/useKnowledgeList.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useKnowledgeList } from './useKnowledgeList';
+import { listGlobalKnowledge } from '@/lib/backend/knowledge';
+
+vi.mock('@/lib/backend/knowledge', () => ({
+  listGlobalKnowledge: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function createItem(id: number) {
+  return {
+    id,
+    assistantId: 'assistant-1',
+    preview: `item-${id}`,
+    tags: [],
+    source: null,
+    createdAt: id,
+  };
+}
+
+function createCursor(id: number) {
+  return {
+    createdAt: id,
+    id,
+  };
+}
+
+describe('useKnowledgeList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ignores stale loadMore responses after the filter changes', async () => {
+    let resolveStaleLoadMore: ((value: {
+      items: ReturnType<typeof createItem>[];
+      assistants: string[];
+      nextCursor: { createdAt: number; id: number } | null;
+    }) => void) | null = null;
+
+    vi.mocked(listGlobalKnowledge).mockImplementation(async (request = {}) => {
+      if (request.cursor) {
+        return new Promise((resolve) => {
+          resolveStaleLoadMore = resolve;
+        });
+      }
+
+      if (request.assistantId === 'assistant-2') {
+        return {
+          items: [createItem(2)],
+          assistants: ['assistant-2'],
+          nextCursor: null,
+        };
+      }
+
+      return {
+        items: [createItem(1)],
+        assistants: ['assistant-1'],
+        nextCursor: createCursor(1),
+      };
+    });
+
+    const { result, rerender } = renderHook(
+      ({ assistantFilter }) =>
+        useKnowledgeList({
+          assistantFilter,
+          query: '',
+          refreshToken: 0,
+        }),
+      {
+        initialProps: {
+          assistantFilter: 'all',
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(1)]);
+    });
+
+    act(() => {
+      void result.current.loadMore();
+    });
+
+    rerender({ assistantFilter: 'assistant-2' });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(2)]);
+      expect(result.current.hasMoreItems).toBe(false);
+    });
+
+    act(() => {
+      resolveStaleLoadMore?.({
+        items: [createItem(3)],
+        assistants: ['assistant-1'],
+        nextCursor: createCursor(3),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(2)]);
+      expect(result.current.hasMoreItems).toBe(false);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+  });
+});

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { getLogger } from '@/lib/logger';
+import {
+  listGlobalKnowledge,
+  type KnowledgeChunkListItem,
+  type KnowledgeListCursor,
+} from '@/lib/backend/knowledge';
+import { useDebouncedValue } from './useDebouncedValue';
+
+const logger = getLogger('useKnowledgeList');
+const KNOWLEDGE_PAGE_SIZE = 60;
+
+interface UseKnowledgeListOptions {
+  assistantFilter: string;
+  query: string;
+  refreshToken: number;
+}
+
+export function useKnowledgeList({
+  assistantFilter,
+  query,
+  refreshToken,
+}: UseKnowledgeListOptions) {
+  const { t } = useTranslation('common');
+  const [items, setItems] = useState<KnowledgeChunkListItem[]>([]);
+  const [assistants, setAssistants] = useState<string[]>([]);
+  const [isListLoading, setIsListLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
+    null,
+  );
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const normalizedQuery = debouncedQuery.trim();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsListLoading(true);
+      try {
+        const response = await listGlobalKnowledge({
+          query: normalizedQuery || undefined,
+          assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
+          limit: KNOWLEDGE_PAGE_SIZE,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        setItems(response.items);
+        setAssistants(response.assistants);
+        setNextCursor(response.nextCursor ?? null);
+      } catch (error) {
+        logger.error('Failed to load global knowledge list', error);
+        if (!cancelled) {
+          toast.error(
+            t(
+              'knowledge.loadListFailed',
+              'Failed to load global knowledge entries.',
+            ),
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsListLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantFilter, normalizedQuery, refreshToken, t]);
+
+  const loadMore = useCallback(async () => {
+    if (isListLoading || isLoadingMore || nextCursor === null) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    try {
+      const response = await listGlobalKnowledge({
+        query: normalizedQuery || undefined,
+        assistantId: assistantFilter === 'all' ? undefined : assistantFilter,
+        cursor: nextCursor,
+        limit: KNOWLEDGE_PAGE_SIZE,
+      });
+
+      setItems((current) => {
+        const seenIds = new Set(current.map((item) => item.id));
+        const appendedItems = response.items.filter(
+          (item) => !seenIds.has(item.id),
+        );
+        return [...current, ...appendedItems];
+      });
+      setNextCursor(response.nextCursor ?? null);
+    } catch (error) {
+      logger.error('Failed to load more global knowledge entries', error);
+      toast.error(
+        t('knowledge.loadMoreFailed', 'Failed to load more knowledge entries.'),
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    assistantFilter,
+    isListLoading,
+    isLoadingMore,
+    nextCursor,
+    normalizedQuery,
+    t,
+  ]);
+
+  return {
+    assistants,
+    hasMoreItems: nextCursor !== null,
+    isListLoading,
+    isLoadingMore,
+    items,
+    loadMore,
+  };
+}

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { getLogger } from '@/lib/logger';
@@ -11,6 +11,14 @@ import { useDebouncedValue } from './useDebouncedValue';
 
 const logger = getLogger('useKnowledgeList');
 const KNOWLEDGE_PAGE_SIZE = 60;
+
+function buildKnowledgeRequestKey(
+  assistantFilter: string,
+  normalizedQuery: string,
+  refreshToken: number,
+): string {
+  return `${assistantFilter}::${normalizedQuery}::${refreshToken}`;
+}
 
 interface UseKnowledgeListOptions {
   assistantFilter: string;
@@ -33,6 +41,13 @@ export function useKnowledgeList({
   );
   const debouncedQuery = useDebouncedValue(query, 250);
   const normalizedQuery = debouncedQuery.trim();
+  const requestKey = buildKnowledgeRequestKey(
+    assistantFilter,
+    normalizedQuery,
+    refreshToken,
+  );
+  const latestRequestKeyRef = useRef(requestKey);
+  latestRequestKeyRef.current = requestKey;
 
   useEffect(() => {
     let cancelled = false;
@@ -82,6 +97,7 @@ export function useKnowledgeList({
       return;
     }
 
+    const requestKeyAtInvocation = latestRequestKeyRef.current;
     setIsLoadingMore(true);
     try {
       const response = await listGlobalKnowledge({
@@ -90,6 +106,10 @@ export function useKnowledgeList({
         cursor: nextCursor,
         limit: KNOWLEDGE_PAGE_SIZE,
       });
+
+      if (latestRequestKeyRef.current !== requestKeyAtInvocation) {
+        return;
+      }
 
       setItems((current) => {
         const seenIds = new Set(current.map((item) => item.id));


### PR DESCRIPTION
## Summary
- split knowledge browser orchestration into focused list, detail, delete, and debounce hooks
- break the large knowledge detail dialog into overview and graph subcomponents
- simplify selection handling and keep entity-name mapping local to the graph tab

## Validation
- pnpm refactor:validate