### PR TITLE
🎨 Palette: Improve PlaybookGroup keyboard accessibility

### DIFF
--- a/src/features/playbook/PlaybookGroup.tsx
+++ b/src/features/playbook/PlaybookGroup.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { PlaybookCard } from './Card';
@@ -25,32 +25,37 @@ export function PlaybookGroup({
 }: PlaybookGroupProps) {
   const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const panelId = useId();
 
   return (
     <div className="space-y-4">
-      <button
-        type="button"
-        aria-expanded={!isCollapsed}
-        className="flex w-full items-center gap-2 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
-        onClick={() => setIsCollapsed(!isCollapsed)}
-      >
-        <div className="flex h-6 w-6 items-center justify-center rounded-md hover:bg-muted/50 text-muted-foreground group-hover:text-foreground transition-colors">
-          {isCollapsed ? (
-            <ChevronRight className="h-4 w-4" />
-          ) : (
-            <ChevronDown className="h-4 w-4" />
-          )}
-        </div>
-        <h3 className="font-semibold text-lg tracking-tight group-hover:text-primary transition-colors select-none">
-          {title}
-        </h3>
-        <Badge variant="secondary" className="ml-2 font-mono text-xs">
-          {playbooks.length}
-        </Badge>
-        <div className="flex-1 h-px bg-border group-hover:bg-primary/20 transition-colors ml-2" />
-      </button>
+      <h3 className="w-full">
+        <button
+          type="button"
+          aria-expanded={!isCollapsed}
+          aria-controls={panelId}
+          className="flex w-full items-center gap-2 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+        >
+          <span className="flex h-6 w-6 items-center justify-center rounded-md hover:bg-muted/50 text-muted-foreground group-hover:text-foreground transition-colors">
+            {isCollapsed ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </span>
+          <span className="font-semibold text-lg tracking-tight group-hover:text-primary transition-colors select-none">
+            {title}
+          </span>
+          <Badge variant="secondary" className="ml-2 font-mono text-xs">
+            {playbooks.length}
+          </Badge>
+          <span className="flex-1 h-px bg-border group-hover:bg-primary/20 transition-colors ml-2" />
+        </button>
+      </h3>
 
       <div
+        id={panelId}
         className={cn(
           'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4',
           isCollapsed && 'hidden',

--- a/src/features/playbook/PlaybookGroup.tsx
+++ b/src/features/playbook/PlaybookGroup.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { PlaybookCard } from './Card';
 import type { PlaybookWithMeta } from './types';
@@ -29,21 +28,19 @@ export function PlaybookGroup({
 
   return (
     <div className="space-y-4">
-      <div
-        className="flex items-center gap-2 cursor-pointer group"
+      <button
+        type="button"
+        aria-expanded={!isCollapsed}
+        className="flex w-full items-center gap-2 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
         onClick={() => setIsCollapsed(!isCollapsed)}
       >
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 w-6 p-0 hover:bg-muted/50"
-        >
+        <div className="flex h-6 w-6 items-center justify-center rounded-md hover:bg-muted/50 text-muted-foreground group-hover:text-foreground transition-colors">
           {isCollapsed ? (
             <ChevronRight className="h-4 w-4" />
           ) : (
             <ChevronDown className="h-4 w-4" />
           )}
-        </Button>
+        </div>
         <h3 className="font-semibold text-lg tracking-tight group-hover:text-primary transition-colors select-none">
           {title}
         </h3>
@@ -51,7 +48,7 @@ export function PlaybookGroup({
           {playbooks.length}
         </Badge>
         <div className="flex-1 h-px bg-border group-hover:bg-primary/20 transition-colors ml-2" />
-      </div>
+      </button>
 
       <div
         className={cn(


### PR DESCRIPTION
💡 **What**: Converted the clickable `div` header in `PlaybookGroup` into a semantic `<button>` and removed the nested `<Button>`.
🎯 **Why**: To fix keyboard accessibility issues (missing keyboard interaction on the group header) and prevent invalid nested interactive elements, making it screen reader and keyboard friendly.
📸 **Before/After**: Visually looks the same, but now shows a focus ring when navigated to via keyboard.
♿ **Accessibility**: Added `aria-expanded` state, enabled keyboard focus (`focus-visible`), and removed nested buttons.

---
*PR created automatically by Jules for task [3345614481384747408](https://jules.google.com/task/3345614481384747408) started by @fritzprix*