### PR TITLE
⚗️ Distill: Optimize MCP response for scratchpad list

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -2,3 +2,7 @@
 
 **Learning:** Returning nested Markdown tables directly to LLM without explicitly declaring backticks for data constraints (such as `agent.id` and `sessionId`) reduces parsing stability and drops vital constraints.
 **Action:** When refactoring MCP Tools for tabular data, always explicitly quote ID fields and maintain strict structure without repeating conditional checks (`if !results.is_empty()`) for block-level additions.
+
+## 2024-05-25 - [Sanitize arbitrary text when generating Markdown tables]
+**Learning:** When directly converting arbitrary content (like user notes or logs) into Markdown tables, newline characters (`\n`) and pipe characters (`|`) will prematurely break rows or cell boundaries, causing the table syntax to fail for the LLM.
+**Action:** Always safely sanitize dynamic cell values by applying `.replace('|', "\\|").replace('\n', " ")` before inserting them into a generated Markdown table.

--- a/src-tauri/src/mcp/builtin/scratchpad/handlers.rs
+++ b/src-tauri/src/mcp/builtin/scratchpad/handlers.rs
@@ -295,23 +295,27 @@ pub async fn list(
         }
     } else {
         text_output.push_str(&format!(
-            "Scratchpad Notes (Page {}/{}):\n",
+            "Scratchpad Notes (Page {}/{}):\n\n",
             page,
             (total_items as f64 / page_size as f64).ceil() as u64
         ));
+        text_output.push_str("| ID | Title | Preview | Tags |\n");
+        text_output.push_str("|---|---|---|---|\n");
         for item in &paged_items {
             let id = item.id;
-            let title = item.title.clone().unwrap_or_else(|| "Untitled".to_string());
+            let title = item.title.clone().unwrap_or_else(|| "Untitled".to_string())
+                .replace('|', "\\|").replace('\n', " ");
             let preview = if item.content.chars().count() > 200 {
                 let truncated: String = item.content.chars().take(200).collect();
-                format!("{}...", truncated.replace('\n', " "))
+                format!("{}...", truncated)
             } else {
-                item.content.replace('\n', " ")
-            };
+                item.content.clone()
+            }.replace('|', "\\|").replace('\n', " ");
+
             let tags_str = if let Some(t) = &item.tags {
                 if let Ok(parsed) = serde_json::from_str::<Vec<String>>(t) {
                     if !parsed.is_empty() {
-                        format!(" [{}]", parsed.join(", "))
+                        parsed.join(", ").replace('|', "\\|")
                     } else {
                         String::new()
                     }
@@ -322,7 +326,7 @@ pub async fn list(
                 String::new()
             };
             text_output.push_str(&format!(
-                "- **ID: {}** | {} | {}{}\n",
+                "| `{}` | {} | {} | {} |\n",
                 id, title, preview, tags_str
             ));
         }


### PR DESCRIPTION
💡 What: Converted the scratchpad list handler output to a dense Markdown table, replacing the previous bulleted list formatting, and added explicit backticks around scratchpad IDs.

🎯 Why: To preserve the agent's context window by optimizing the display of list data, and to improve LLM parsing stability for ID fields during subsequent tool calls, adhering to the Distill Protocol.

📉 Token Impact: Reduces token overhead by utilizing concise Markdown tables instead of verbose structural characters per item.

🛠️ Error Recovery: Actionable hints remain untouched but the data representation ensures IDs are strongly identifiable and less likely to be hallucinated by the agent.

---
*PR created automatically by Jules for task [2402340829094141185](https://jules.google.com/task/2402340829094141185) started by @fritzprix*