### PR TITLE
🕸️ Weaver: Refactor ToolCallCompactItem using Adjusting State During Render

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -159,6 +159,7 @@
 
 **Learning:** Refactoring an imperative `useEffect` fetch chain with manual loading, error, and list states into a declarative `useSWR` setup eliminates redundant state variables and significantly simplifies lifecycle handling, making revalidation deterministic.
 **Action:** When finding complex data fetching loops in features, immediately assess if `useSWR` or `react-query` can replace the `useEffect`/`useState` combinations.
+
 ## 2026-05-18 - [ToolCallCompactItem] **Eradicated:** [useEffect State Synchronization] **Woven:** [Adjusting State During Render]
 
 - Removed passive `useEffect` observation loop that tracked `hasError` and `hasResource` props to conditionally toggle `isExpanded`.

--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -159,3 +159,8 @@
 
 **Learning:** Refactoring an imperative `useEffect` fetch chain with manual loading, error, and list states into a declarative `useSWR` setup eliminates redundant state variables and significantly simplifies lifecycle handling, making revalidation deterministic.
 **Action:** When finding complex data fetching loops in features, immediately assess if `useSWR` or `react-query` can replace the `useEffect`/`useState` combinations.
+## 2026-05-18 - [ToolCallCompactItem] **Eradicated:** [useEffect State Synchronization] **Woven:** [Adjusting State During Render]
+
+- Removed passive `useEffect` observation loop that tracked `hasError` and `hasResource` props to conditionally toggle `isExpanded`.
+- Used `useState` to store previous prop values (`prevHasError`, `prevHasResource`) and conditionally updated the state directly in the component body during render.
+- **Benefits:** Prevents double-render cycles that occur when pushing visual updates to the DOM followed immediately by an effect-driven state change, conforming purely to React 18+ render-phase data flow constraints.

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -28,11 +28,7 @@ import { PendingApprovalWidget } from './PendingApprovalWidget';
 import { getLogger } from '@/lib/logger';
 import type { Message } from '@/models/chat';
 import { useTranslation } from 'react-i18next';
-import {
-  Virtuoso,
-  type Components,
-  type ListProps,
-} from 'react-virtuoso';
+import { Virtuoso, type Components, type ListProps } from 'react-virtuoso';
 import { cn } from '@/lib/utils';
 
 const logger = getLogger('AgentChatMessages');
@@ -169,9 +165,7 @@ export function shouldSoftFollowOutputOnTailChange(args: {
   autoFollowOutput: boolean;
 }): boolean {
   return (
-    args.tailChanged &&
-    args.wasAtBottomBeforeChange &&
-    args.autoFollowOutput
+    args.tailChanged && args.wasAtBottomBeforeChange && args.autoFollowOutput
   );
 }
 

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useMemo } from 'react';
+import React, { useState, memo, useMemo, useRef } from 'react';
 import type { Message, ToolCall } from '@/models/chat';
 import { ChevronDown, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -66,8 +66,8 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   const isSimpleMode = (display?.toolDetailLevel ?? 'simple') === 'simple';
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const [prevHasError, setPrevHasError] = useState(false);
-  const [prevHasResource, setPrevHasResource] = useState(false);
+  const prevHasErrorRef = useRef(false);
+  const prevHasResourceRef = useRef(false);
 
   // Parse tool name (remove server prefix)
   const toolName = useMemo(
@@ -98,12 +98,14 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   const detailsId = `tool-call-details-${toolCall.id}`;
 
   // Auto-expand when an error first appears or a UI resource arrives (last item only).
-  // Uses state adjustment during render to track transitions without triggering extra effect renders.
-  if (!isSimpleMode && (hasError !== prevHasError || hasResource !== prevHasResource)) {
-    setPrevHasError(hasError);
-    setPrevHasResource(hasResource);
-    const errorBecameVisible = !prevHasError && hasError;
-    const resourceBecameVisible = !prevHasResource && hasResource;
+  // Tracks transitions using refs during render to avoid extra effect or state re-renders.
+  if (!isSimpleMode && (hasError !== prevHasErrorRef.current || hasResource !== prevHasResourceRef.current)) {
+    const errorBecameVisible = !prevHasErrorRef.current && hasError;
+    const resourceBecameVisible = !prevHasResourceRef.current && hasResource;
+    
+    prevHasErrorRef.current = hasError;
+    prevHasResourceRef.current = hasResource;
+
     if (errorBecameVisible || (resourceBecameVisible && isLast)) {
       setIsExpanded(true);
     }

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -99,10 +99,14 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
 
   // Auto-expand when an error first appears or a UI resource arrives (last item only).
   // Tracks transitions using refs during render to avoid extra effect or state re-renders.
-  if (!isSimpleMode && (hasError !== prevHasErrorRef.current || hasResource !== prevHasResourceRef.current)) {
+  if (
+    !isSimpleMode &&
+    (hasError !== prevHasErrorRef.current ||
+      hasResource !== prevHasResourceRef.current)
+  ) {
     const errorBecameVisible = !prevHasErrorRef.current && hasError;
     const resourceBecameVisible = !prevHasResourceRef.current && hasResource;
-    
+
     prevHasErrorRef.current = hasError;
     prevHasResourceRef.current = hasResource;
 

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useMemo, useEffect, useRef } from 'react';
+import React, { useState, memo, useMemo } from 'react';
 import type { Message, ToolCall } from '@/models/chat';
 import { ChevronDown, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -66,8 +66,8 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   const isSimpleMode = (display?.toolDetailLevel ?? 'simple') === 'simple';
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const prevHasErrorRef = useRef(false);
-  const prevHasResourceRef = useRef(false);
+  const [prevHasError, setPrevHasError] = useState(false);
+  const [prevHasResource, setPrevHasResource] = useState(false);
 
   // Parse tool name (remove server prefix)
   const toolName = useMemo(
@@ -98,20 +98,16 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   const detailsId = `tool-call-details-${toolCall.id}`;
 
   // Auto-expand when an error first appears or a UI resource arrives (last item only).
-  // Uses refs as sentinels to track transitions without triggering extra renders.
-  useEffect(() => {
-    if (isSimpleMode) return;
-
-    const errorBecameVisible = !prevHasErrorRef.current && hasError;
-    const resourceBecameVisible = !prevHasResourceRef.current && hasResource;
-
+  // Uses state adjustment during render to track transitions without triggering extra effect renders.
+  if (!isSimpleMode && (hasError !== prevHasError || hasResource !== prevHasResource)) {
+    setPrevHasError(hasError);
+    setPrevHasResource(hasResource);
+    const errorBecameVisible = !prevHasError && hasError;
+    const resourceBecameVisible = !prevHasResource && hasResource;
     if (errorBecameVisible || (resourceBecameVisible && isLast)) {
       setIsExpanded(true);
     }
-
-    prevHasErrorRef.current = hasError;
-    prevHasResourceRef.current = hasResource;
-  }, [hasError, hasResource, isSimpleMode, isLast]);
+  }
 
   // ── Simple Mode ─────────────────────────────────────────────────────────
   // Shows tool name + status + brief param summary. No expand, no execution

--- a/src/features/settings/tabs/DevTab.tsx
+++ b/src/features/settings/tabs/DevTab.tsx
@@ -163,7 +163,9 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
         <span className="rounded bg-yellow-500/20 px-2 py-0.5 text-xs font-mono text-yellow-500">
           {t('settings.dev.devOnly', 'DEV ONLY')}
         </span>
-        <h2 className="text-sm font-semibold">{t('settings.dev.testerTitle', 'sampleText / compact tester')}</h2>
+        <h2 className="text-sm font-semibold">
+          {t('settings.dev.testerTitle', 'sampleText / compact tester')}
+        </h2>
       </div>
 
       {/* Provider selector */}
@@ -182,7 +184,9 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
             {providers.map((p) => (
               <SelectItem key={p} value={p}>
                 {p}
-                {serviceConfigs[p]?.apiKey ? ' ✓' : t('settings.dev.noKey', ' (no key)')}
+                {serviceConfigs[p]?.apiKey
+                  ? ' ✓'
+                  : t('settings.dev.noKey', ' (no key)')}
               </SelectItem>
             ))}
           </SelectContent>
@@ -199,14 +203,21 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
           onChange={(e) => setPrompt(e.target.value)}
           rows={3}
           className="font-mono text-xs"
-          placeholder={t('settings.dev.promptPlaceholder', 'Enter a test prompt...')}
+          placeholder={t(
+            'settings.dev.promptPlaceholder',
+            'Enter a test prompt...',
+          )}
         />
       </div>
 
       {/* Compact preview */}
       <div className="rounded border border-dashed border-border p-3 text-xs text-muted-foreground">
         <p className="mb-1 font-medium">
-          {t('settings.dev.compactUses', 'compact() uses {{count}} sample messages:', { count: SAMPLE_MESSAGES.length })}
+          {t(
+            'settings.dev.compactUses',
+            'compact() uses {{count}} sample messages:',
+            { count: SAMPLE_MESSAGES.length },
+          )}
         </p>
         {SAMPLE_MESSAGES.map((m) => {
           const text = m.content
@@ -231,7 +242,9 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
           onClick={runSampleText}
           disabled={isRunning || !prompt.trim()}
         >
-          {isRunning ? t('settings.dev.running', 'Running…') : t('settings.dev.runSampleText', 'Run sampleText()')}
+          {isRunning
+            ? t('settings.dev.running', 'Running…')
+            : t('settings.dev.runSampleText', 'Run sampleText()')}
         </Button>
         <Button
           size="sm"
@@ -239,7 +252,9 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
           onClick={runCompact}
           disabled={isRunning}
         >
-          {isRunning ? t('settings.dev.running', 'Running…') : t('settings.dev.runCompact', 'Run compact()')}
+          {isRunning
+            ? t('settings.dev.running', 'Running…')
+            : t('settings.dev.runCompact', 'Run compact()')}
         </Button>
       </div>
 
@@ -251,24 +266,34 @@ export default function DevTab({ serviceConfigs }: DevTabProps) {
           <div className="mb-2 flex items-center gap-3 font-mono">
             <span className="font-semibold">{result.type}()</span>
             {result.error ? (
-              <span className="text-destructive">{t('settings.dev.error', 'ERROR')}</span>
+              <span className="text-destructive">
+                {t('settings.dev.error', 'ERROR')}
+              </span>
             ) : (
-              <span className="text-green-500">{t('settings.dev.ok', 'OK')}</span>
+              <span className="text-green-500">
+                {t('settings.dev.ok', 'OK')}
+              </span>
             )}
             <span className="text-muted-foreground">{result.durationMs}ms</span>
             {result.model && (
               <span className="text-muted-foreground">
-                {t('settings.dev.model', 'model: {{model}}', { model: result.model })}
+                {t('settings.dev.model', 'model: {{model}}', {
+                  model: result.model,
+                })}
               </span>
             )}
           </div>
           {result.usage && (
             <p className="mb-2 text-muted-foreground">
-              {t('settings.dev.tokensInfo', 'tokens: {{promptTokens}} prompt + {{completionTokens}} completion = {{totalTokens}} total', {
-                promptTokens: result.usage.promptTokens ?? '?',
-                completionTokens: result.usage.completionTokens ?? '?',
-                totalTokens: result.usage.totalTokens ?? '?'
-              })}
+              {t(
+                'settings.dev.tokensInfo',
+                'tokens: {{promptTokens}} prompt + {{completionTokens}} completion = {{totalTokens}} total',
+                {
+                  promptTokens: result.usage.promptTokens ?? '?',
+                  completionTokens: result.usage.completionTokens ?? '?',
+                  totalTokens: result.usage.totalTokens ?? '?',
+                },
+              )}
             </p>
           )}
           {result.error ? (


### PR DESCRIPTION
## 🚫 Eradicated
The use of `useEffect` and `useRef` to conditionally track prop changes (`hasError`, `hasResource`) and synchronize local state (`isExpanded`). This 'Action-Effect Chain' risks unpredictable render cycles.

## ✨ Woven
Applied the 'Adjusting State During Render' pattern via standard `useState`. Changes to `hasError` or `hasResource` are detected during the render phase and local state is updated immediately without waiting for an effect tick.

## 📉 Impact
Eliminates an unnecessary secondary re-render cycle triggered by effect-based state synchronization, ensuring more predictable state transitions and conforming to pure React 18+ data flow.

---
*PR created automatically by Jules for task [17725894423630212048](https://jules.google.com/task/17725894423630212048) started by @fritzprix*