### PR TITLE
🎨 Palette: Add focus-visible styling to DraftPendingFilesBar remove file button

### DIFF
--- a/src/features/agent/components/DraftPendingFilesBar.tsx
+++ b/src/features/agent/components/DraftPendingFilesBar.tsx
@@ -30,7 +30,7 @@ export function DraftPendingFilesBar({
             <button
               type="button"
               onClick={() => onRemoveFile(index)}
-              className="text-muted-foreground hover:text-destructive transition-colors focus:outline-none"
+              className="text-muted-foreground hover:text-destructive transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label={t('fileAttachment.removeFile', {
                 name: file.name,
                 defaultValue: `Remove ${file.name}`,


### PR DESCRIPTION
💡 What: Replaced 'focus:outline-none' with 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' on the remove file button in DraftPendingFilesBar.
🎯 Why: To improve keyboard accessibility by providing a clear focus indicator for users navigating via keyboard, while avoiding focus outlines for mouse clicks.
📸 Before/After: Before: no visible focus indicator when using Tab. After: standard ring focus indicator appears when navigating with keyboard.
♿ Accessibility: Improved keyboard navigation feedback.

---
*PR created automatically by Jules for task [2635886046243917942](https://jules.google.com/task/2635886046243917942) started by @fritzprix*