### PR TITLE
⚡ Bolt: Remove redundant array reductions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -107,3 +107,8 @@
 
 **Learning:** Found instances where `Array.prototype.reduce` was used directly in the render body for derived metrics (like calculating completed todos). In components that re-render frequently (like `AgentPlanningUpdates` and `AgentPlanningPanel`), this causes unnecessary O(N) recalculations on every render.
 **Action:** Use `useMemo` to cache derived values (especially array reductions and filter loops) where the underlying dependencies change infrequently.
+
+## 2026-05-15 - Redundant O(N) Array Reductions After Grouping
+
+**Learning:** `selectOrgSummaries` and `buildScheduledTaskGroups` were doing `Array.prototype.reduce` on grouped subsets *after* finishing an O(N) map building loop, re-traversing elements to compute simple metrics (`busyCount` and `enabledCount`).
+**Action:** When aggregating derived state across subsets (like counting status types), maintain variables tracking the metrics inline within the initial, primary `for` loop that iterates over the base array and performs grouping. This prevents subsequent redundant traversals.

--- a/src/features/history/org-sessions.ts
+++ b/src/features/history/org-sessions.ts
@@ -28,45 +28,61 @@ function hasExplicitOrgIdentity(
   );
 }
 
+// ⚡ Bolt: Using a structured tracking object to avoid multiple O(N) reduce passes later
+interface OrgTrackingData {
+  members: AgentSession[];
+  busyCount: number;
+  latestUpdate: Date;
+}
+
 export function selectOrgSummaries(sessions: AgentSession[]): OrgSummary[] {
-  const grouped = new Map<string, AgentSession[]>();
+  const grouped = new Map<string, OrgTrackingData>();
 
   for (const session of sessions) {
     if (!hasExplicitOrgIdentity(session)) {
       continue;
     }
 
-    const members = grouped.get(session.orgId) ?? [];
-    members.push(session);
-    grouped.set(session.orgId, members);
+    const isBusy = session.status === 'busy';
+    const candidateDate = session.updatedAt ?? session.createdAt;
+
+    const data = grouped.get(session.orgId);
+    if (data) {
+      data.members.push(session);
+      if (isBusy) data.busyCount++;
+      if (candidateDate.getTime() > data.latestUpdate.getTime()) {
+        data.latestUpdate = candidateDate;
+      }
+    } else {
+      grouped.set(session.orgId, {
+        members: [session],
+        busyCount: isBusy ? 1 : 0,
+        latestUpdate: candidateDate,
+      });
+    }
   }
 
   const summaries: OrgSummary[] = [];
 
-  for (const [orgId, members] of grouped.entries()) {
-    const orgRootSessionId = members[0]?.orgRootSessionId;
+  for (const [orgId, data] of grouped.entries()) {
+    const orgRootSessionId = data.members[0]?.orgRootSessionId;
     if (!orgRootSessionId) {
       continue;
     }
 
-    const rootSession = members.find(
+    const rootSession = data.members.find(
       (session) => session.id === orgRootSessionId,
     );
     if (!rootSession || !hasExplicitOrgIdentity(rootSession)) {
       continue;
     }
 
-    const updatedAt = members.reduce((latest, session) => {
-      const candidate = session.updatedAt ?? session.createdAt;
-      return candidate.getTime() > latest.getTime() ? candidate : latest;
-    }, rootSession.updatedAt ?? rootSession.createdAt);
-
     summaries.push({
       orgId,
       orgName: rootSession.orgName,
       orgRootSessionId: rootSession.orgRootSessionId,
       rootSession,
-      members: [...members].sort((left, right) => {
+      members: [...data.members].sort((left, right) => {
         const leftDepth = left.depth ?? 0;
         const rightDepth = right.depth ?? 0;
         if (leftDepth !== rightDepth) {
@@ -74,12 +90,9 @@ export function selectOrgSummaries(sessions: AgentSession[]): OrgSummary[] {
         }
         return left.createdAt.getTime() - right.createdAt.getTime();
       }),
-      memberCount: members.length,
-      busyCount: members.reduce(
-        (acc, session) => (session.status === 'busy' ? acc + 1 : acc),
-        0,
-      ),
-      updatedAt,
+      memberCount: data.members.length,
+      busyCount: data.busyCount,
+      updatedAt: data.latestUpdate,
     });
   }
 

--- a/src/features/scheduled-tasks/scheduled-task-utils.ts
+++ b/src/features/scheduled-tasks/scheduled-task-utils.ts
@@ -43,6 +43,9 @@ export function buildScheduledTaskGroups(
     const existing = groups.get(key);
     if (existing) {
       existing.tasks.push(task);
+      if (task.enabled) {
+        existing.enabledCount++;
+      }
       continue;
     }
 
@@ -51,20 +54,17 @@ export function buildScheduledTaskGroups(
       groupId: task.groupId,
       groupName: task.groupName,
       tasks: [task],
-      enabledCount: 0,
+      enabledCount: task.enabled ? 1 : 0,
     });
   }
 
   return Array.from(groups.values())
     .map((group) => {
+      // ⚡ Bolt: Removed O(N) enabledCount reduce, already calculated during build loop
       const sortedTasks = [...group.tasks].sort(compareScheduledTasks);
       return {
         ...group,
         tasks: sortedTasks,
-        enabledCount: sortedTasks.reduce(
-          (count, task) => (task.enabled ? count + 1 : count),
-          0,
-        ),
       };
     })
     .sort((left, right) => left.groupName.localeCompare(right.groupName));


### PR DESCRIPTION
💡 What: Removed inline `.reduce()` calls used to compute counts on arrays when mapping/grouping. Calculated counts in the initial iteration step instead.

🎯 Why: Running `.reduce()` within derived array processing steps repeats work O(N) where N is the length of arrays for grouping operations. 

📊 Impact: Reduces unnecessary iterations over arrays inside `ScheduledTasksPage` mapping loops and `OrgSessions` selection.

🔬 Measurement: Reviewing the loops shows `reduce` operations replaced with inline O(1) accumulation.

---
*PR created automatically by Jules for task [10551792059506752407](https://jules.google.com/task/10551792059506752407) started by @fritzprix*