### PR TITLE
🎨 Palette: Add accessible DialogDescription to modals

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3842,7 +3842,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/features/mcp-servers/MCPServerDialog.tsx
+++ b/src/features/mcp-servers/MCPServerDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
   Button,
   Input,
@@ -82,6 +83,11 @@ function MCPServerDialogComponent({
                   defaultValue: 'Edit Extension: {{name}}',
                 })}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {isNewServer
+              ? t('mcpServer.dialog.descriptionNew', 'Configure a new MCP server extension')
+              : t('mcpServer.dialog.descriptionEdit', 'Edit settings for the MCP server extension')}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">

--- a/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
+++ b/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -67,6 +68,11 @@ export function ScheduledTaskModal({
               ? t('scheduledTasks.modal.titleEdit')
               : t('scheduledTasks.modal.titleNew')}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {task
+              ? t('scheduledTasks.modal.descriptionEdit', 'Edit scheduled task details')
+              : t('scheduledTasks.modal.descriptionNew', 'Create a new scheduled task')}
+          </DialogDescription>
         </DialogHeader>
 
         {open && (

--- a/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
+++ b/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
@@ -77,6 +77,7 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 


### PR DESCRIPTION
## 💡 What
Added `DialogDescription` with `className="sr-only"` to `ScheduledTaskModal` and `MCPServerDialog` components.

## 🎯 Why
Radix UI triggers accessibility warnings if `DialogDescription` is missing. Even if the content is self-explanatory, a description is required for screen readers.

## 📸 Before/After
Before: Screen readers lack context and Radix UI throws accessibility warnings.
After: Screen readers receive proper context, and warnings are resolved.

## ♿ Accessibility
Adds explicit, screen-reader-only dialog descriptions to ensure WCAG compliance and improve the experience for assistive technology users.

---
*PR created automatically by Jules for task [16178986231646261516](https://jules.google.com/task/16178986231646261516) started by @fritzprix*