### PR TITLE
🕸️ Weaver: Refactor Knowledge Hooks using useSWR and Adjusting State During Render

### DIFF
--- a/src/features/knowledge/hooks/useKnowledgeBrowser.ts
+++ b/src/features/knowledge/hooks/useKnowledgeBrowser.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useKnowledgeDelete } from './useKnowledgeDelete';
 import { useKnowledgeDetail } from './useKnowledgeDetail';
 import { useKnowledgeList } from './useKnowledgeList';
@@ -31,11 +31,13 @@ export function useKnowledgeBrowser() {
     setListRefreshToken((current) => current + 1);
   }, []);
 
-  useEffect(() => {
+  const [prevItems, setPrevItems] = useState(items);
+  if (items !== prevItems) {
+    setPrevItems(items);
     if (selectedId !== null && !items.some((item) => item.id === selectedId)) {
       setSelectedId(null);
     }
-  }, [items, selectedId]);
+  }
 
   const handleDeleted = useCallback(() => {
     setSelectedId(null);

--- a/src/features/knowledge/hooks/useKnowledgeDelete.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDelete.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
@@ -21,12 +21,14 @@ export function useKnowledgeDelete({
   const { t } = useTranslation('common');
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [prevSelectedItem, setPrevSelectedItem] = useState<KnowledgeChunkListItem | null>(selectedItem);
 
-  useEffect(() => {
+  if (selectedItem !== prevSelectedItem) {
+    setPrevSelectedItem(selectedItem);
     if (!selectedItem) {
       setIsDeleteDialogOpen(false);
     }
-  }, [selectedItem]);
+  }
 
   const requestDelete = useCallback(() => {
     if (!selectedItem || isDeleting) {

--- a/src/features/knowledge/hooks/useKnowledgeDetail.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDetail.ts
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import useSWR from 'swr';
 import {
   getGlobalKnowledgeDetail,
-  type KnowledgeChunkDetail,
 } from '@/lib/backend/knowledge';
 import { getLogger } from '@/lib/logger';
 
@@ -11,49 +10,28 @@ const logger = getLogger('useKnowledgeDetail');
 
 export function useKnowledgeDetail(selectedId: number | null) {
   const { t } = useTranslation('common');
-  const [detail, setDetail] = useState<KnowledgeChunkDetail | null>(null);
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
 
-  useEffect(() => {
-    if (selectedId === null) {
-      setDetail(null);
-      setIsDetailLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadDetail = async () => {
-      setIsDetailLoading(true);
+  const { data: detail = null, isValidating: isDetailLoading } = useSWR(
+    selectedId !== null ? ['knowledge-detail', selectedId] : null,
+    async ([, id]) => {
       try {
-        const response = await getGlobalKnowledgeDetail(selectedId);
-        if (!cancelled) {
-          setDetail(response);
-        }
+        return await getGlobalKnowledgeDetail(id as number);
       } catch (error) {
-        logger.error('Failed to load knowledge detail', { error, selectedId });
-        if (!cancelled) {
-          toast.error(
-            t(
-              'knowledge.loadDetailFailed',
-              'Failed to load knowledge details.',
-            ),
-          );
-          setDetail(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsDetailLoading(false);
-        }
+        logger.error('Failed to load knowledge detail', { error, selectedId: id });
+        toast.error(
+          t(
+            'knowledge.loadDetailFailed',
+            'Failed to load knowledge details.',
+          ),
+        );
+        throw error;
       }
-    };
-
-    void loadDetail();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedId, t]);
+    },
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    }
+  );
 
   return {
     detail,


### PR DESCRIPTION
### 🚫 Eradicated
- Imperative data fetching with `useState` and `useEffect` in `useKnowledgeDetail`.
- Derived state syncing (Action-Effect Chains) with `useEffect` in `useKnowledgeDelete` and `useKnowledgeBrowser`.

### ✨ Woven
- Implemented declarative data fetching with `useSWR` in `useKnowledgeDetail`.
- Refactored state synchronization using the 'Adjusting State During Render' pattern in `useKnowledgeDelete` and `useKnowledgeBrowser`.

### 📉 Impact
- Prevents unnecessary re-render cycles caused by `useEffect` state syncing and imperative fetching, enforcing declarative architecture and reducing code complexity.

---
*PR created automatically by Jules for task [14466616855946903680](https://jules.google.com/task/14466616855946903680) started by @fritzprix*