### PR TITLE
🎨 Palette: Add PasswordInput component to improve sensitive fields usability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -67,3 +67,6 @@
 
 **Learning:** When using generic symbol controls like "+" or "-" inside components like ChatInterfaceTab, they remain ambiguous for screen readers without explicit ARIA labels, creating accessibility barriers for users.
 **Action:** Always provide explicit, translated `aria-label` attributes on icon-only or symbol-only interactive elements (like increment/decrement buttons) using `useTranslation`.
+## 2024-05-02 - [Testing Mocks & ESLint]
+**Learning:** When adding new UI components and mocking them in Vitest, using `any` for props triggers `@typescript-eslint/no-explicit-any` errors, failing the build.
+**Action:** Always use `Record<string, unknown>` or explicit types instead of `any` when creating component mocks in tests.

--- a/src/components/ui/PasswordInput.tsx
+++ b/src/components/ui/PasswordInput.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Input } from './input';
+import { Button } from './button';
+import { Eye, EyeOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useTranslation } from 'react-i18next';
+
+export interface PasswordInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  wrapperClassName?: string;
+}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, wrapperClassName, ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+    const { t } = useTranslation('common');
+
+    return (
+      <div className={cn('relative', wrapperClassName)}>
+        <Input
+          type={showPassword ? 'text' : 'password'}
+          className={cn('pr-10', className)}
+          ref={ref}
+          {...props}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+          onClick={() => setShowPassword((prev) => !prev)}
+          aria-label={
+            showPassword
+              ? t('components.passwordInput.hide', 'Hide value')
+              : t('components.passwordInput.show', 'Show value')
+          }
+          aria-pressed={showPassword}
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Eye className="h-4 w-4 text-muted-foreground" />
+          )}
+        </Button>
+      </div>
+    );
+  },
+);
+PasswordInput.displayName = 'PasswordInput';
+
+export { PasswordInput };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -61,3 +61,4 @@ export { default as StatusIndicator } from './StatusIndicator';
 export { default as TextareaWithLabel } from './TextareaWithLabel';
 
 // NOTE: Do not re-export ModelPicker here to avoid cycles.
+export * from './PasswordInput';

--- a/src/features/mcp-servers/components/EnvVarsForm.tsx
+++ b/src/features/mcp-servers/components/EnvVarsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Input, Label } from '@/components/ui';
+import { Button, Input, PasswordInput, Label } from '@/components/ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { KeyValuePair, MCPServerMetadata } from '../hooks/useMCPServerForm';
 import { MCPServerEntity } from '@/models/chat';
@@ -78,27 +78,50 @@ export function EnvVarsForm({
                   {def.label || key}
                   {def.required && <span className="text-destructive">*</span>}
                 </Label>
-                <Input
-                  id={`env-${key}`}
-                  type={def.type === 'password' ? 'password' : 'text'}
-                  value={val}
-                  placeholder={def.label}
-                  onChange={(e) => {
-                    if (envVar) {
-                      handleUpdateEnvVar(envVar.id, 'value', e.target.value);
-                    } else {
-                      // If it doesn't exist, add it
-                      setEnvVars((prev) => [
-                        ...prev,
-                        {
-                          id: createId(),
-                          key,
-                          value: e.target.value,
-                        },
-                      ]);
-                    }
-                  }}
-                />
+                {def.type === 'password' ? (
+                  <PasswordInput
+                    id={`env-${key}`}
+                    value={val}
+                    placeholder={def.label}
+                    onChange={(e) => {
+                      if (envVar) {
+                        handleUpdateEnvVar(envVar.id, 'value', e.target.value);
+                      } else {
+                        // If it doesn't exist, add it
+                        setEnvVars((prev) => [
+                          ...prev,
+                          {
+                            id: createId(),
+                            key,
+                            value: e.target.value,
+                          },
+                        ]);
+                      }
+                    }}
+                  />
+                ) : (
+                  <Input
+                    id={`env-${key}`}
+                    type="text"
+                    value={val}
+                    placeholder={def.label}
+                    onChange={(e) => {
+                      if (envVar) {
+                        handleUpdateEnvVar(envVar.id, 'value', e.target.value);
+                      } else {
+                        // If it doesn't exist, add it
+                        setEnvVars((prev) => [
+                          ...prev,
+                          {
+                            id: createId(),
+                            key,
+                            value: e.target.value,
+                          },
+                        ]);
+                      }
+                    }}
+                  />
+                )}
                 {def.description && (
                   <p className="text-xs text-muted-foreground">
                     {def.description}
@@ -174,7 +197,7 @@ export function EnvVarsForm({
                     />
                   </div>
                   <div className="flex-1">
-                    <Input
+                    <PasswordInput
                       placeholder={t(
                         'mcpServer.dialog.envVarValuePlaceholder',
                         'Value',
@@ -183,7 +206,6 @@ export function EnvVarsForm({
                       onChange={(e) =>
                         handleUpdateEnvVar(item.id, 'value', e.target.value)
                       }
-                      type="password" // Mask values for security
                       className="h-8 text-sm font-mono"
                       aria-label="Environment variable value"
                     />

--- a/src/features/mcp-servers/components/HttpForm.tsx
+++ b/src/features/mcp-servers/components/HttpForm.tsx
@@ -2,7 +2,7 @@ import React, { useId, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MCPServerEntity } from '@/models/chat';
 import type { TransportConfig } from '@/lib/mcp/config/transport';
-import { Button, Input, Label } from '@/components/ui';
+import { Button, Input, PasswordInput, Label } from '@/components/ui';
 import { Switch } from '@/components/ui/switch';
 import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { KeyValuePair, MCPServerMetadata } from '../hooks/useMCPServerForm';
@@ -125,40 +125,80 @@ export function HttpForm({
                   {def.label || key}
                   {def.required && <span className="text-destructive">*</span>}
                 </Label>
-                <Input
-                  id={`http-var-${key}`}
-                  type={def.type === 'password' ? 'password' : 'text'}
-                  value={currentValue}
-                  placeholder={def.label}
-                  onChange={(e) => {
-                    if (target === 'bearer-token') {
-                      setApiKey(e.target.value);
-                    } else if (target === 'header') {
-                      const existing = customHeaders.find((h) => h.key === key);
-                      if (existing) {
-                        handleUpdateHeader(
-                          existing.id,
-                          'value',
-                          e.target.value,
+                {def.type === 'password' ? (
+                  <PasswordInput
+                    id={`http-var-${key}`}
+                    value={currentValue}
+                    placeholder={def.label}
+                    onChange={(e) => {
+                      if (target === 'bearer-token') {
+                        setApiKey(e.target.value);
+                      } else if (target === 'header') {
+                        const existing = customHeaders.find(
+                          (h) => h.key === key,
                         );
-                      } else {
-                        setCustomHeaders((prev) => [
+                        if (existing) {
+                          handleUpdateHeader(
+                            existing.id,
+                            'value',
+                            e.target.value,
+                          );
+                        } else {
+                          setCustomHeaders((prev) => [
+                            ...prev,
+                            {
+                              id: createId(),
+                              key,
+                              value: e.target.value,
+                            },
+                          ]);
+                        }
+                      } else if (target === 'url-param') {
+                        setUrlParams((prev) => ({
                           ...prev,
-                          {
-                            id: createId(),
-                            key,
-                            value: e.target.value,
-                          },
-                        ]);
+                          [key]: e.target.value,
+                        }));
                       }
-                    } else if (target === 'url-param') {
-                      setUrlParams((prev) => ({
-                        ...prev,
-                        [key]: e.target.value,
-                      }));
-                    }
-                  }}
-                />
+                    }}
+                  />
+                ) : (
+                  <Input
+                    id={`http-var-${key}`}
+                    type="text"
+                    value={currentValue}
+                    placeholder={def.label}
+                    onChange={(e) => {
+                      if (target === 'bearer-token') {
+                        setApiKey(e.target.value);
+                      } else if (target === 'header') {
+                        const existing = customHeaders.find(
+                          (h) => h.key === key,
+                        );
+                        if (existing) {
+                          handleUpdateHeader(
+                            existing.id,
+                            'value',
+                            e.target.value,
+                          );
+                        } else {
+                          setCustomHeaders((prev) => [
+                            ...prev,
+                            {
+                              id: createId(),
+                              key,
+                              value: e.target.value,
+                            },
+                          ]);
+                        }
+                      } else if (target === 'url-param') {
+                        setUrlParams((prev) => ({
+                          ...prev,
+                          [key]: e.target.value,
+                        }));
+                      }
+                    }}
+                  />
+                )}
                 {def.description && (
                   <p className="text-xs text-muted-foreground">
                     {def.description}
@@ -181,9 +221,8 @@ export function HttpForm({
               {t('mcpServer.dialog.apiKeyOptional', '(Optional)')}
             </span>
           </Label>
-          <Input
+          <PasswordInput
             id="http-api-key"
-            type="password"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
             placeholder={t(

--- a/src/features/settings/components/ProviderCard.tsx
+++ b/src/features/settings/components/ProviderCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { AIServiceProvider } from '@/lib/ai-service';
 import { ServiceConfig } from '@/context/SettingsContext';
 import {
@@ -8,9 +8,8 @@ import {
   CardTitle,
   Input,
   Checkbox,
-  Button,
+  PasswordInput,
 } from '@/components/ui';
-import { Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 export interface ProviderCardProps {
@@ -38,7 +37,6 @@ function ProviderCardBase({
   customModelId,
   onPendingChange,
 }: ProviderCardProps) {
-  const [showApiKey, setShowApiKey] = useState(false);
   const { t } = useTranslation('common');
 
   return (
@@ -56,42 +54,20 @@ function ProviderCardBase({
           <label className="block text-muted-foreground mb-2 text-sm font-medium">
             {t('settings.provider.apiKey', 'API Key')}
           </label>
-          <div className="relative">
-            <Input
-              type={showApiKey ? 'text' : 'password'}
-              placeholder={t('settings.provider.apiKeyPlaceholder', {
-                name: providerName,
-                defaultValue: 'Enter your {{name}} API key',
-              })}
-              value={apiKey}
-              // Keep provider settings controlled by the form state.
-              // A debounced/local mirror caused saves and downstream model refreshes
-              // to read stale URLs/keys before the latest keystroke reached the form.
-              onChange={(e) => {
-                onPendingChange(provider, { apiKey: e.target.value });
-              }}
-              className="bg-background border text-foreground w-full pr-10"
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-              onClick={() => setShowApiKey((v) => !v)}
-              aria-label={
-                showApiKey
-                  ? t('settings.provider.hideApiKey', 'Hide API key')
-                  : t('settings.provider.showApiKey', 'Show API key')
-              }
-              aria-pressed={showApiKey}
-            >
-              {showApiKey ? (
-                <EyeOff className="h-4 w-4 text-muted-foreground" />
-              ) : (
-                <Eye className="h-4 w-4 text-muted-foreground" />
-              )}
-            </Button>
-          </div>
+          <PasswordInput
+            placeholder={t('settings.provider.apiKeyPlaceholder', {
+              name: providerName,
+              defaultValue: 'Enter your {{name}} API key',
+            })}
+            value={apiKey}
+            // Keep provider settings controlled by the form state.
+            // A debounced/local mirror caused saves and downstream model refreshes
+            // to read stale URLs/keys before the latest keystroke reached the form.
+            onChange={(e) => {
+              onPendingChange(provider, { apiKey: e.target.value });
+            }}
+            className="bg-background border text-foreground w-full"
+          />
         </div>
 
         {(provider === AIServiceProvider.Ollama ||

--- a/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
+++ b/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/components/ui', () => ({
     children: ReactNode;
     onClick?: () => void;
   }) => <button onClick={onClick}>{children}</button>,
+  PasswordInput: (props: Record<string, unknown>) => <input {...props} />,
   Input: ({
     value,
     onChange,

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
💡 What: Added a reusable `PasswordInput` component and replaced standard `type="password"` fields with it in ProviderCard, EnvVarsForm, and HttpForm.
🎯 Why: Provides a consistent, accessible show/hide toggle for sensitive fields, reducing user errors and improving usability without duplicating inline toggle logic.
📸 Before/After: Replaced multiple instances of custom toggle buttons and standard masked inputs with the unified `PasswordInput`.
♿ Accessibility: Ensures proper ARIA labels, aria-pressed attributes, and keyboard navigation for the show/hide toggles.

---
*PR created automatically by Jules for task [15259752692311155964](https://jules.google.com/task/15259752692311155964) started by @fritzprix*