### PR TITLE
agent: harden teamwork workspace contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ test_results_*.txt
 /.libragent/tmp/
 /.libragent/exports/
 /.libragent/tool-results/
+/.libragent/teamwork.json
 /tmp/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3842,7 +3842,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/bundled_skills/delegate/SKILL.md
+++ b/src-tauri/bundled_skills/delegate/SKILL.md
@@ -53,8 +53,9 @@ Assume these rules:
 
 If the parent is running inside a task-force workspace, check `.libragent/teamwork.json` before delegating:
 
-- If `executionSubstrate.mode` is `"org"`, prefer `startSession(..., includeCurrentOrg=true)` and `workspaceOverride` so the child joins the org and shares the workspace. Switch to `org` for org-specific operating rules.
+- If `executionSubstrate.mode` is `"org"`, prefer `startSession(..., includeCurrentOrg=true)` and the shared teamwork workspace so the child joins the org and sees the same constitution files. Switch to `org` for org-specific operating rules.
 - If `executionSubstrate.mode` is `"scheduled"`, the delegation is likely a scheduled wake-up. Follow `schedule` for group management instead of ad-hoc delegation.
+- Treat the dedicated teamwork workspace as the orchestration/constitution workspace. If the child also needs to edit code in a repo, be explicit about whether it should stay in the teamwork workspace or target a separate implementation workspace.
 
 Important limitations:
 
@@ -62,7 +63,7 @@ Important limitations:
 - Persona / tone instructions are loaded separately from the first non-empty file among `.github/SOUL.md`, `SOUL.md`, `.github/soul.md`, and `soul.md`.
 - Both persona and workspace instruction content are cached for the session lifetime until the stable prompt cache is invalidated.
 - `startSession` can override the child workspace with `workspaceOverride`; files and prompt state still follow the child session.
-- Default to each session's own workspace. Use `workspaceOverride` when the child should work in the same workspace as the parent or another already-existing workspace.
+- Default to each session's own workspace. Use `workspaceOverride` when the child should work in the same teamwork workspace as the parent or another already-existing workspace.
 
 ## 3. Prepare the Handoff
 

--- a/src-tauri/bundled_skills/org/SKILL.md
+++ b/src-tauri/bundled_skills/org/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: org
-description: Run explicit org-based teamwork in LibrAgent. Use when collaboration needs durable org identity, org-visible child sessions, org-root resume behavior, or clear parent/sibling org context under one coordinator workspace.
+description: Run explicit org-based teamwork in LibrAgent. Use when collaboration needs durable org identity, org-visible child sessions, org-root resume behavior, or clear parent/sibling org context under one dedicated teamwork workspace.
 ---
 
 # Org
@@ -14,18 +14,19 @@ Use `teamwork` first when the workspace constitution is not ready.
 1. Confirm org is the right substrate.
    - Use org when the user wants org visibility, durable org identity, coordinator/specialist lineage, or root-session resume behavior.
    - If the real need is recurring or cron-like automation, stop and use `schedule`.
+   - If the governing root session has not adopted the dedicated teamwork workspace yet, stop and use `teamwork` to call `prepareTeamworkWorkspace()` first.
 2. Read `.libragent/teamwork.json` before acting.
    - Confirm `executionSubstrate.mode` is `"org"` and `orgLineage.intended` is `true`.
    - If the manifest says a different substrate, reconcile before proceeding.
 3. Keep one shared workspace.
-   - Treat the coordinator's current workspace as the SSOT.
-   - Org-visible children should normally work in that same workspace.
+   - Treat the dedicated teamwork workspace as the SSOT for orchestration files.
+   - The governing root session and org-visible children should normally share that same teamwork workspace.
 4. Create the org once from the root session.
    - Use `createOrg(orgName, description)` from the governing root session.
    - Record the returned `orgId` and `orgName` in `.libragent/teamwork.json` and `coordination/DECISIONS.md`.
    - The session that calls `createOrg` becomes the org root. Do not call `createOrg` again.
 5. Spawn org-visible members explicitly.
-   - Use `startSession(agentId, task, workspaceOverride=<coordinator-workspace>)` for org-visible children. If the current session already belongs to the org, inheritance is automatic.
+   - Use `startSession(agentId, task, workspaceOverride=<teamwork-workspace>)` for org-visible children when you need to be explicit. If the current session already belongs to the org, inheritance is automatic.
    - One-off delegated children that should stay out of Org view must set `includeCurrentOrg=false`.
 6. Resume through the org root.
    - The org root session is the canonical entry point. Org view should resume the root, not whichever child was last active.
@@ -36,7 +37,7 @@ Use `teamwork` first when the workspace constitution is not ready.
 
 ## Guardrails
 
-- Do not split org members into separate workspaces unless the task truly needs it.
+- Do not split org members away from the dedicated teamwork workspace unless the task truly needs a separate implementation target.
 - Do not use org identity for scheduled task groups or recurring automation.
 - Do not treat arbitrary child-session resume as org resume. The org root is the entry point.
 - Do not infer org membership from parent/child lineage alone — membership requires explicit org inheritance at session creation. Under an explicit org root that inheritance is automatic unless `includeCurrentOrg=false`.

--- a/src-tauri/bundled_skills/org/references/org-patterns.md
+++ b/src-tauri/bundled_skills/org/references/org-patterns.md
@@ -16,22 +16,32 @@ Use this file for concrete tool call patterns, manifest update rules, and troubl
 ## Pattern: Create Org and First Member
 
 ```
+// Step 0 — from the governing root session
+prepareTeamworkWorkspace()
+// -> returns "/absolute/path/to/teamwork-workspace"
+
 // Step 1 — from the root session
 createOrg(
   orgName: "Research Strike Team",
   description: "Coordinator + specialist org for the current research objective"
 )
-// → returns { orgId: "abc-123", ... }
+// -> returns {
+//      orgId: "abc-123",
+//      orgName: "Research Strike Team",
+//      orgRootSessionId: "<current-session-id>",
+//      teamworkScaffold: { ... }
+//    }
 
-// Step 2 — update .libragent/teamwork.json with orgId and rootSessionId
+// Step 2 — update .libragent/teamwork.json with orgId, orgName, and rootSessionId
 // executionSubstrate.orgLineage.orgId = "abc-123"
-// executionSubstrate.orgLineage.rootSessionId = <current session id>
+// executionSubstrate.orgLineage.orgName = "Research Strike Team"
+// executionSubstrate.orgLineage.rootSessionId = <returned orgRootSessionId>
 
 // Step 3 — spawn an org-visible researcher
 startSession(
   agentId: "<researcher-assistant-id>",
   task: "...",
-  workspaceOverride: "<coordinator-workspace-path>"
+  workspaceOverride: "<teamwork-workspace-path>"
 )
 ```
 
@@ -51,37 +61,67 @@ Do not resume a child session directly and treat it as the org coordinator. Chil
 
 ## Pattern: Keep Workspace Shared
 
-Org-visible children should work in the coordinator's workspace unless there is a concrete reason to diverge.
+Org-visible children should work in the dedicated teamwork workspace unless there is a concrete reason to diverge.
 
 ```
 startSession(
   agentId: "...",
   task: "...",
-  workspaceOverride: "/absolute/path/to/coordinator/workspace"
+  workspaceOverride: "/absolute/path/to/teamwork-workspace"
 )
 ```
 
-If a child starts without `workspaceOverride`, it gets its own workspace and will not automatically see `agents.md`, `MISSION.md`, or role skills.
+If a child starts without `workspaceOverride`, it gets its own workspace and will not automatically see the shared teamwork constitution unless org inheritance already points it at the root teamwork workspace.
 
 ## Manifest Update After Org Creation
 
-After calling `createOrg`, update `.libragent/teamwork.json`:
+After calling `createOrg`, update the scaffolded `.libragent/teamwork.json` instead of replacing it with a smaller hand-written object. Preserve the existing scaffold fields such as `workspacePolicy`, `specialistSkills`, `refreshSemantics`, and `constitutionAdoption`, then fill in the org identity fields returned by `createOrg`.
 
 ```json
 {
+  "schemaVersion": 2,
+  "teamName": "<team-name>",
+  "objective": "<objective>",
+  "originalUserRequest": "<original-user-request>",
+  "framework": "<framework>",
   "executionSubstrate": {
     "mode": "org",
     "specialistSkill": "org",
+    "workspacePolicy": {
+      "plainChildSessions": "isolated-by-default",
+      "explicitOrgLineage": "share-governing-teamwork-workspace-by-default",
+      "scheduledTaskGroups": "workspace-defined-per-group"
+    },
+    "specialistSkills": {
+      "plainChildSessions": "delegate",
+      "explicitOrgLineage": "org",
+      "scheduledTaskGroups": "schedule"
+    },
     "orgLineage": {
       "intended": true,
       "orgId": "<returned-org-id>",
       "orgName": "<org-name>",
-      "rootSessionId": "<current-session-id>",
+      "rootSessionId": "<returned-orgRootSessionId>",
       "rootAction": "createOrg",
       "childAction": "startSession",
-      "childArgs": {},
-      "workspaceSharing": "inherit-root-workspace-by-default"
+      "childArgs": {
+        "includeCurrentOrg": true
+      },
+      "compatibilityAlias": "spawnOrgAgent",
+      "workspaceSharing": "inherit-root-teamwork-workspace-by-default"
+    },
+    "scheduledTaskGroups": {
+      "intended": false,
+      "notes": "Use scheduled task groups for recurring or cron-like collaboration, not org lineage."
     }
+  },
+  "refreshSemantics": {
+    "workspaceInstructions": "Changes to agents.md and related workspace constitution files apply in a later execution step, not in the current turn.",
+    "workspaceSkills": "New workspace skills apply in a later execution step, not retroactively in the same turn."
+  },
+  "constitutionAdoption": {
+    "coordinatorMustShareScaffoldRoot": true,
+    "rule": "Continue coordination in the dedicated teamwork workspace where the constitution was created."
   }
 }
 ```
@@ -102,7 +142,7 @@ Also record the org creation decision in `coordination/DECISIONS.md`:
 
 Likely cause: child started without `workspaceOverride`.
 
-Fix: restart child with `workspaceOverride` pointing to the coordinator workspace, or copy critical rules into the task text.
+Fix: restart child with `workspaceOverride` pointing to the dedicated teamwork workspace, or copy critical rules into the task text.
 
 ### Org view shows unexpected sessions
 

--- a/src-tauri/bundled_skills/schedule/SKILL.md
+++ b/src-tauri/bundled_skills/schedule/SKILL.md
@@ -14,6 +14,7 @@ Use `teamwork` first when the workspace constitution is not ready.
 1. Confirm scheduled collaboration is the right substrate.
    - Use it for periodic wake-ups, background recurrence, heartbeat loops, or resumable async automation.
    - If the user wants org-visible lineage or org-root resume behavior, stop and use `org`.
+   - If the governing root session has not adopted the dedicated teamwork workspace yet, stop and use `teamwork` to call `prepareTeamworkWorkspace()` first.
 2. Read `.libragent/teamwork.json` before acting.
    - Confirm `executionSubstrate.mode` is `"scheduled"` and `scheduledTaskGroups.intended` is `true`.
    - If no manifest exists yet, run `teamwork` first to scaffold the workspace constitution.
@@ -21,8 +22,8 @@ Use `teamwork` first when the workspace constitution is not ready.
    - If `agents.md`, `MISSION.md`, or `coordination/KANBAN.md` are missing, repair the scaffold before creating scheduled tasks.
    - A master agent woken by a scheduled task must verify the scaffold is present and current before issuing directives.
 4. Reuse the existing workspace constitution.
-   - Treat the current workspace scaffold as the SSOT.
-   - Scheduled runs should operate against that shared scaffold.
+   - Treat the dedicated teamwork workspace scaffold as the SSOT.
+   - Scheduled runs should operate against that shared teamwork workspace unless a task explicitly targets a different implementation workspace.
 5. Create the task group explicitly.
    - Use `createScheduledTask(message, cronExpression, groupName, agentId)` for the first loop in a new group.
    - The `groupName` must be stable, readable, and unique within the team. Record it in `coordination/DECISIONS.md`.
@@ -43,7 +44,7 @@ Use `teamwork` first when the workspace constitution is not ready.
 
 ## Guardrails
 
-- Default to the current workspace scaffold; do not invent a separate workspace just because work is asynchronous.
+- Default to the dedicated teamwork workspace scaffold; do not fall back to a repo root just because work is asynchronous.
 - Use `workspaceOverride` only when the scheduled run must target a specific existing shared workspace.
 - Keep group names stable and readable. Changing a `groupName` mid-run makes group tracking unreliable.
 - Always record `groupId` in `.libragent/teamwork.json` after the first task in a group is created.

--- a/src-tauri/bundled_skills/teamwork/SKILL.md
+++ b/src-tauri/bundled_skills/teamwork/SKILL.md
@@ -9,9 +9,9 @@ Build a task force only when the work is genuinely multi-track. If one capable a
 
 ## Non-Negotiable Rules
 
-1. **One team, one workspace.** The coordinator and shared files stay in the same workspace.
-2. **Scaffold in the current workspace.** Create `./agents.md`, `./MISSION.md`, `./ROLES.md`, and `./coordination/` there.
-3. **Keep coordination in that same workspace.**
+1. **One team, one workspace.** The governing coordinator and shared files stay in the same dedicated teamwork workspace.
+2. **Provision the teamwork workspace first.** From the governing root session, call `prepareTeamworkWorkspace()` before scaffolding any teamwork files.
+3. **Scaffold only in that teamwork workspace.** Do not write `agents.md`, `MISSION.md`, `ROLES.md`, `coordination/`, or role `skills/` into a repo root unless you intentionally want repo pollution.
 4. **Use deterministic scaffolding first.** `scripts/init_task_force.py` is the default path.
 5. **Refresh happens later.** Changes to `agents.md` or workspace skills do not take effect in the current turn.
 6. **Route execution explicitly.** Keep framework-specific operating rules in the specialist skill that matches the chosen substrate.
@@ -56,13 +56,13 @@ Coordination model and execution substrate are not the same thing.
 Pick the execution substrate that matches the job:
 
 - **Plain child sessions** - use `startSession(...)` for one-off delegation that does not need org visibility.
-- **Explicit org lineage** - use `createOrg(...)` once from the root session, then use `startSession(...)` for org-visible children. Under the explicit org root, org inheritance is automatic unless you set `includeCurrentOrg=false`. Org-visible children should normally share the coordinator's workspace.
+- **Explicit org lineage** - call `prepareTeamworkWorkspace()` first, then use `createOrg(...)` once from the root session, then use `startSession(...)` for org-visible children. Under the explicit org root, org inheritance is automatic unless you set `includeCurrentOrg=false`. Org-visible children should normally share the dedicated teamwork workspace.
 - **Scheduled task groups** - use `createScheduledTask(...)` and the other `scheduled_task` tools for recurring, heartbeat, cron-like, or resumable automation loops.
 
 Keep these separate:
 
 - **Org** is for explicit lineage-based teamwork and org UX.
-- **Org** should normally share the coordinator's workspace so every member sees the same SSOT files.
+- **Org** should normally share the dedicated teamwork workspace so every member sees the same SSOT files.
 - **Scheduled task groups** are for recurring automation and policy-governed background collaboration.
 - A recurring task group may wake a coordinator session, but that does not make the scheduled group an org.
 
@@ -78,7 +78,7 @@ After choosing the execution substrate, route to the matching specialist skill:
 
 ### 3. Create the workspace contract
 
-Create the shared files in the current workspace first. At minimum create:
+Create the shared files in the dedicated teamwork workspace first. At minimum create:
 
 ```text
 ./
@@ -105,7 +105,7 @@ The scaffold must preserve:
 - the chosen collaboration framework
 - the canonical file ownership and operating rules
 
-The coordinator continues in that same workspace after scaffolding.
+The governing coordinator continues in that same teamwork workspace after scaffolding.
 
 Use the file contracts in [coordination-contract.md](references/coordination-contract.md).
 
@@ -142,6 +142,7 @@ Refresh behavior:
 
 - `agents.md` changes do **not** instantly rewrite the current session prompt
 - new workspace skills apply in a later execution step, not retroactively in the same turn
+- `.libragent/teamwork.json` should keep `constitutionAdoption.coordinatorMustShareScaffoldRoot=true` so downstream agents know the governing/root session must rebind to the dedicated teamwork workspace before continuing orchestration there
 
 After scaffolding or constitution edits, state when the updated rules become effective.
 
@@ -149,7 +150,7 @@ After scaffolding or constitution edits, state when the updated rules become eff
 
 When you execute the scaffold:
 
-1. Bootstrap in the current workspace.
+1. Bootstrap in the dedicated teamwork workspace returned by `prepareTeamworkWorkspace()`.
 2. Use portable commands and the available tools.
 3. Match the editing primitive to the change size.
 4. Use `workspaceOverride` only when a child must work in a different workspace.
@@ -188,8 +189,11 @@ If the task force cannot surface blocked state, it is not robust.
 Prefer deterministic scaffolding:
 
 ```bash
+prepareTeamworkWorkspace()
+# -> returns workspacePath
+
 python scripts/init_task_force.py \
-  --output . \
+  --output "/absolute/path/from/prepareTeamworkWorkspace" \
   --team-name "Research Strike Team" \
   --objective "Build a reusable research and implementation team" \
   --request "Research the space, structure findings, and hand implementation-ready guidance to coding specialists." \
@@ -199,7 +203,7 @@ python scripts/init_task_force.py \
   --role "Implementer:Turn approved plans into code and tests"
 ```
 
-Use `.` for `--output` when you are scaffolding the current teamwork run.
+Use the dedicated teamwork workspace path returned by `prepareTeamworkWorkspace()` for `--output`. Do not default to `.` from a repo root.
 
 Then review and tighten:
 
@@ -222,7 +226,7 @@ Before announcing success, verify:
 6. the handoff path between roles is obvious
 7. the execution substrate and follow-up specialist skill are explicit: plain child sessions, `org`, or `schedule`
 8. refresh semantics are written down so agents know that updated rules apply only in a later execution step
-9. the governing session is still working in the workspace where it created the constitution
+9. the governing session is still working in the dedicated teamwork workspace where it created the constitution
 
 ## References
 

--- a/src-tauri/bundled_skills/teamwork/references/coordination-contract.md
+++ b/src-tauri/bundled_skills/teamwork/references/coordination-contract.md
@@ -6,7 +6,7 @@ These files are the minimum shared operating system for a durable task force.
 
 This file is the workspace constitution.
 
-It lives in the workspace where the governing session is working. Keep coordination in that same workspace.
+It lives in the dedicated teamwork workspace where the governing session is working. Keep coordination in that same workspace.
 
 It should state:
 
@@ -30,7 +30,7 @@ For execution substrate, make the contract explicit:
 
 Make that choice explicit.
 
-For explicit org lineage, default to the coordinator's workspace as the shared collaboration substrate.
+For explicit org lineage, default to the dedicated teamwork workspace as the shared collaboration substrate.
 
 Refresh rule: edits to `agents.md` apply in a later execution step, not in the current turn.
 
@@ -138,3 +138,8 @@ At minimum capture:
 - whether scheduled task groups are intended
 - refresh semantics notes for downstream sessions
 - whether the coordinator must rebind or resume in the workspace where the constitution now lives before continuing
+
+Use explicit field names so agents do not have to guess:
+
+- `constitutionAdoption.coordinatorMustShareScaffoldRoot = true`
+- `constitutionAdoption.rule = "Continue coordination in the dedicated teamwork workspace where the constitution was created."`

--- a/src-tauri/bundled_skills/teamwork/references/expert-skill-template.md
+++ b/src-tauri/bundled_skills/teamwork/references/expert-skill-template.md
@@ -51,7 +51,7 @@ You are a specialist inside the current task force. Work only within your role b
 - If blocked, update `coordination/KANBAN.md` and `coordination/RISKS.md`.
 - Stop when your owned artifact and handoff are complete.
 - If the teamwork contract says this role is part of explicit org lineage, use the org-aware child-session path instead of inventing a new delegation pattern.
-- If the teamwork contract says this role is part of explicit org lineage, assume the coordinator's workspace is the shared SSOT unless the contract explicitly says otherwise.
+- If the teamwork contract says this role is part of explicit org lineage, assume the dedicated teamwork workspace is the shared SSOT unless the contract explicitly says otherwise.
 ```
 
 ## Role design checklist

--- a/src-tauri/bundled_skills/teamwork/references/framework-selection.md
+++ b/src-tauri/bundled_skills/teamwork/references/framework-selection.md
@@ -58,7 +58,7 @@ After choosing the coordination model, choose the execution substrate explicitly
 | Execution need | Use this substrate | Then follow | Why |
 | --- | --- | --- | --- |
 | One-off specialist delegation | `startSession(...)` | `delegate` | Lightweight child session without org coupling |
-| Org-visible lineage under a governing teamwork session | `createOrg(...)` once, then `startSession(..., includeCurrentOrg=true)` | `org` | Preserves explicit org membership, Org view semantics, and shared coordinator workspace defaults |
+| Org-visible lineage under a governing teamwork session | `prepareTeamworkWorkspace()`, then `createOrg(...)`, then `startSession(..., includeCurrentOrg=true)` | `org` | Preserves explicit org membership, Org view semantics, and a shared dedicated teamwork workspace |
 | Recurring, cron, heartbeat, or resumable automation | Scheduled task groups via `createScheduledTask(...)` and related `scheduled_task` tools | `schedule` | Keeps recurring collaboration separate from org lineage and under policy control |
 
 ## Hard separation rules
@@ -66,7 +66,7 @@ After choosing the coordination model, choose the execution substrate explicitly
 - Do not use explicit org lineage just because work is recurring.
 - Do not use scheduled task groups just because there are multiple roles.
 - Do not add redundant org-specific spawn wrappers. `startSession(...)` is the primitive; explicit org inheritance is automatic under an org root unless `includeCurrentOrg=false`.
-- Do not split org members into separate workspaces unless the task has a concrete reason to break the shared SSOT.
+- Do not split org members away from the dedicated teamwork workspace unless the task has a concrete reason to break the shared SSOT.
 - Do not keep execution-specific org and scheduled-task operating rules mixed together once the substrate is chosen. Route to the specialist skill.
 - If the user wants an org chart, root-session resume, or explicit lineage visibility, choose explicit org lineage.
 - If the user wants periodic wake-ups, background recurrence, or governed automation cohorts, choose scheduled task groups.

--- a/src-tauri/bundled_skills/teamwork/scripts/init_task_force.py
+++ b/src-tauri/bundled_skills/teamwork/scripts/init_task_force.py
@@ -21,7 +21,7 @@ SUBSTRATE_DISPLAY = {
     SUBSTRATE_ORG: (
         "Explicit org lineage via createOrg(...) once from the root session, "
         "then startSession(...) for org-visible children. "
-        "Org-visible children share the coordinator's workspace by default. "
+        "Org-visible children share the dedicated teamwork workspace by default. "
         "Follow org for org-specific operating rules."
     ),
     SUBSTRATE_SCHEDULED: (
@@ -61,6 +61,10 @@ def parse_role(raw: str) -> tuple[str, str]:
 def write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def is_inside_git_worktree(path: Path) -> bool:
+    return any(candidate.joinpath(".git").exists() for candidate in [path, *path.parents])
 
 
 def build_role_skill(
@@ -220,7 +224,7 @@ def build_teamwork_manifest(
             "specialistSkill": SUBSTRATE_SPECIALIST_SKILL[execution_substrate],
             "workspacePolicy": {
                 "plainChildSessions": "isolated-by-default",
-                "explicitOrgLineage": "share-coordinator-workspace-by-default",
+                "explicitOrgLineage": "share-governing-teamwork-workspace-by-default",
                 "scheduledTaskGroups": "workspace-defined-per-group",
             },
             "specialistSkills": {
@@ -234,7 +238,7 @@ def build_teamwork_manifest(
                 "childAction": "startSession",
                 "childArgs": {"includeCurrentOrg": True},
                 "compatibilityAlias": "spawnOrgAgent",
-                "workspaceSharing": "inherit-root-workspace-by-default",
+                "workspaceSharing": "inherit-root-teamwork-workspace-by-default",
             },
             "scheduledTaskGroups": {
                 "intended": is_scheduled,
@@ -247,7 +251,7 @@ def build_teamwork_manifest(
         },
         "constitutionAdoption": {
             "coordinatorMustShareScaffoldRoot": True,
-            "rule": "Continue coordination in the same workspace where the constitution was created.",
+            "rule": "Continue coordination in the dedicated teamwork workspace where the constitution was created.",
         },
         "roles": [
             {"name": role_name, "responsibility": responsibility}
@@ -263,7 +267,15 @@ def main() -> None:
         "--output",
         required=True,
         help=(
-            "Workspace to scaffold into. Use the current workspace for the current teamwork run."
+            "Dedicated teamwork workspace to scaffold into. Prefer the absolute path returned by prepareTeamworkWorkspace()."
+        ),
+    )
+    parser.add_argument(
+        "--allow-git-worktree",
+        action="store_true",
+        help=(
+            "Allow scaffolding inside a Git worktree. "
+            "Disabled by default to prevent polluting repo workspaces with orchestration files."
         ),
     )
     parser.add_argument("--objective", required=True, help="Overall task force objective")
@@ -304,6 +316,12 @@ def main() -> None:
 
     workspace = Path(args.output).expanduser().resolve()
     workspace.mkdir(parents=True, exist_ok=True)
+    if is_inside_git_worktree(workspace) and not args.allow_git_worktree:
+        raise SystemExit(
+            "Refusing to scaffold inside a Git worktree. "
+            "Use prepareTeamworkWorkspace() and pass its workspacePath to --output, "
+            "or add --allow-git-worktree if repo scaffolding is truly intentional."
+        )
     original_request = args.request.strip() if args.request else args.objective
     team_name = args.team_name.strip() if args.team_name else workspace.name
     role_definitions = args.role or [

--- a/src-tauri/bundled_skills/teamwork/scripts/init_task_force.py
+++ b/src-tauri/bundled_skills/teamwork/scripts/init_task_force.py
@@ -315,13 +315,13 @@ def main() -> None:
     args = parser.parse_args()
 
     workspace = Path(args.output).expanduser().resolve()
-    workspace.mkdir(parents=True, exist_ok=True)
     if is_inside_git_worktree(workspace) and not args.allow_git_worktree:
         raise SystemExit(
             "Refusing to scaffold inside a Git worktree. "
             "Use prepareTeamworkWorkspace() and pass its workspacePath to --output, "
             "or add --allow-git-worktree if repo scaffolding is truly intentional."
         )
+    workspace.mkdir(parents=True, exist_ok=True)
     original_request = args.request.strip() if args.request else args.objective
     team_name = args.team_name.strip() if args.team_name else workspace.name
     role_definitions = args.role or [

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -258,6 +258,73 @@ pub async fn load_accessible_delegated_session(
     .to_mcp_result())
 }
 
+pub async fn prepare_teamwork_workspace(
+    server: &super::AgentServer,
+    _args: Value,
+    caller_session_id: &str,
+) -> Result<MCPResult, String> {
+    let manager = server
+        .get_manager()
+        .ok_or("AgentSessionManager not available")?;
+    let session = match manager.get_session(caller_session_id).await? {
+        Some(session) => session,
+        None => return Ok(caller_session_not_found_result(caller_session_id)),
+    };
+
+    if session.parent_session_id.is_some() {
+        return Ok(guided_error(
+            ErrorCategory::InvalidInput,
+            "prepareTeamworkWorkspace must be called from a top-level governing/root session."
+                .to_string(),
+            ToolGroup::Agent,
+        )
+        .with_guidance(vec![
+            "Resume the governing/root session first.".to_string(),
+            "Then call prepareTeamworkWorkspace() before writing teamwork scaffold files."
+                .to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    let workspace_path =
+        crate::services::WorkspaceService::provision_teamwork_workspace(caller_session_id).await?;
+    let message = format!(
+        "Shared teamwork workspace is ready for session {}: {}",
+        caller_session_id, workspace_path
+    );
+    let hint = SuccessHint::new(
+        message.clone(),
+        vec![
+            "Scaffold orchestration files in this dedicated teamwork workspace, not the repo root."
+                .to_string(),
+            format!(
+                "Use startSession(..., workspaceOverride=\"{}\") for plain child sessions that must share the teamwork constitution.",
+                workspace_path
+            ),
+        ],
+    );
+
+    let mut response_data = build_agent_tool_data(
+        "prepareTeamworkWorkspace",
+        "workspace",
+        Some(caller_session_id),
+        &message,
+        "success",
+        vec![],
+    );
+    response_data.insert(
+        "sessionId".to_string(),
+        Value::String(caller_session_id.to_string()),
+    );
+    response_data.insert(
+        "workspacePath".to_string(),
+        Value::String(workspace_path.clone()),
+    );
+    response_data.insert("mode".to_string(), Value::String("teamwork".to_string()));
+
+    Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
+}
+
 fn recovery_action_for_session(session_id: &str, status: &str, reason: &str) -> Value {
     json!({
         "toolName": "messageToSession",
@@ -463,5 +530,8 @@ mod sessions;
 
 pub use check_session::check_session;
 pub use configs::{create_agent, list_agents_or_sessions, update_agent};
-pub use orgs::{create_org, get_org, inspect_teamwork_scaffold, TeamworkScaffoldStatus};
+pub use orgs::{
+    create_org, create_org_preflight, existing_explicit_org_identity, get_org,
+    inspect_teamwork_scaffold, CreateOrgPreflight, TeamworkScaffoldStatus,
+};
 pub use sessions::{compact_session_context, message_to_session, start_session, stop_session};

--- a/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
@@ -5,13 +5,27 @@ use std::path::{Path, PathBuf};
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::builtin::session_api::utils::{build_agent_tool_data, read_required_string};
 use crate::mcp::types::MCPResult;
-use crate::repositories::session_repository::SessionRepository;
+use crate::repositories::{session_repository::SessionRepository, SessionMetadata};
 
 use super::super::AgentServer;
 use super::{
     caller_session_not_found_result, invalid_explicit_org_result, missing_explicit_org_result,
     read_optional_string,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CreateOrgPreflight {
+    ExistingOrg {
+        org_id: String,
+        org_name: String,
+        root_session_id: String,
+    },
+    RequiresDedicatedWorkspace {
+        effective_workspace: PathBuf,
+        dedicated_workspace: PathBuf,
+    },
+    Proceed,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TeamworkScaffoldStatus {
@@ -191,6 +205,67 @@ fn create_org_hint_lines(scaffold: &TeamworkScaffoldStatus) -> Vec<String> {
     lines
 }
 
+fn existing_org_hint_lines(
+    scaffold: &TeamworkScaffoldStatus,
+    workspace_status: &crate::session::TeamworkWorkspaceStatus,
+) -> Vec<String> {
+    let mut lines = create_org_hint_lines(scaffold);
+
+    if !workspace_status.uses_dedicated_teamwork_workspace() {
+        lines.push(format!(
+            "Current effective workspace is still {}.",
+            workspace_status.effective_workspace.display()
+        ));
+        lines.push(format!(
+            "This org should be resumed from the dedicated teamwork workspace at {}.",
+            workspace_status.dedicated_workspace.display()
+        ));
+        lines.push(
+            "Call prepareTeamworkWorkspace() from the org root session to migrate the active workspace before continuing teamwork operations."
+                .to_string(),
+        );
+    }
+
+    lines
+}
+
+pub fn existing_explicit_org_identity(
+    session: &SessionMetadata,
+) -> Option<(String, String, String)> {
+    match (
+        session.org_id.clone(),
+        session.org_name.clone(),
+        session.org_root_session_id.clone(),
+    ) {
+        (Some(org_id), Some(org_name), Some(root_session_id)) => {
+            Some((org_id, org_name, root_session_id))
+        }
+        _ => None,
+    }
+}
+
+pub fn create_org_preflight(
+    session: &SessionMetadata,
+    workspace_status: &crate::session::TeamworkWorkspaceStatus,
+) -> CreateOrgPreflight {
+    if let Some((org_id, org_name, root_session_id)) = existing_explicit_org_identity(session) {
+        return CreateOrgPreflight::ExistingOrg {
+            org_id,
+            org_name,
+            root_session_id,
+        };
+    }
+
+    if !workspace_status.uses_dedicated_teamwork_workspace() {
+        return CreateOrgPreflight::RequiresDedicatedWorkspace {
+            effective_workspace: workspace_status.effective_workspace.clone(),
+            dedicated_workspace: workspace_status.dedicated_workspace.clone(),
+        };
+    }
+
+    CreateOrgPreflight::Proceed
+}
+
 pub async fn create_org(
     server: &AgentServer,
     args: Value,
@@ -218,39 +293,83 @@ pub async fn create_org(
         .to_mcp_result());
     }
 
-    let org_name = read_required_string(&args, "name")?;
-    if let (Some(existing_org_id), Some(existing_org_name), Some(existing_root_id)) = (
-        session.org_id.clone(),
-        session.org_name.clone(),
-        session.org_root_session_id.clone(),
-    ) {
-        let scaffold = teamwork_scaffold_status_for_session(caller_session_id)?;
-        let message = format!(
-            "Current session already owns explicit org '{}' (ID: {}, root session: {}).",
-            existing_org_name, existing_org_id, existing_root_id
-        );
-        let mut response_data = build_agent_tool_data(
-            "createOrg",
-            "org",
-            Some(&existing_org_id),
-            &message,
-            "success",
-            create_org_next_actions(&existing_org_id, !scaffold.is_ready_for_explicit_org()),
-        );
-        response_data.insert("orgId".to_string(), Value::String(existing_org_id));
-        response_data.insert("orgName".to_string(), Value::String(existing_org_name));
-        response_data.insert(
-            "orgRootSessionId".to_string(),
-            Value::String(existing_root_id),
-        );
-        response_data.insert(
-            "teamworkScaffold".to_string(),
-            serde_json::to_value(&scaffold).unwrap_or(Value::Null),
-        );
-        return Ok(SuccessHint::new(message, create_org_hint_lines(&scaffold))
+    let workspace_status = crate::session::teamwork_workspace_status(
+        crate::session::get_session_manager()?,
+        caller_session_id,
+    );
+    match create_org_preflight(&session, &workspace_status) {
+        CreateOrgPreflight::ExistingOrg {
+            org_id: existing_org_id,
+            org_name: existing_org_name,
+            root_session_id: existing_root_id,
+        } => {
+            let scaffold = teamwork_scaffold_status_for_session(caller_session_id)?;
+            let message = format!(
+                "Current session already owns explicit org '{}' (ID: {}, root session: {}).",
+                existing_org_name, existing_org_id, existing_root_id
+            );
+            let mut response_data = build_agent_tool_data(
+                "createOrg",
+                "org",
+                Some(&existing_org_id),
+                &message,
+                "success",
+                create_org_next_actions(&existing_org_id, !scaffold.is_ready_for_explicit_org()),
+            );
+            response_data.insert("orgId".to_string(), Value::String(existing_org_id));
+            response_data.insert("orgName".to_string(), Value::String(existing_org_name));
+            response_data.insert(
+                "orgRootSessionId".to_string(),
+                Value::String(existing_root_id),
+            );
+            response_data.insert(
+                "teamworkScaffold".to_string(),
+                serde_json::to_value(&scaffold).unwrap_or(Value::Null),
+            );
+            response_data.insert(
+                "workspaceMismatch".to_string(),
+                Value::Bool(!workspace_status.uses_dedicated_teamwork_workspace()),
+            );
+            response_data.insert(
+                "effectiveWorkspace".to_string(),
+                Value::String(workspace_status.effective_workspace.display().to_string()),
+            );
+            response_data.insert(
+                "dedicatedTeamworkWorkspace".to_string(),
+                Value::String(workspace_status.dedicated_workspace.display().to_string()),
+            );
+            return Ok(SuccessHint::new(
+                message,
+                existing_org_hint_lines(&scaffold, &workspace_status),
+            )
             .to_mcp_result_with_data(Some(Value::Object(response_data))));
+        }
+        CreateOrgPreflight::RequiresDedicatedWorkspace {
+            effective_workspace,
+            dedicated_workspace,
+        } => {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "createOrg requires the governing/root session to already be using its dedicated teamwork workspace."
+                    .to_string(),
+                ToolGroup::Agent,
+            )
+            .with_guidance(vec![
+                format!("Current effective workspace: {}", effective_workspace.display()),
+                format!(
+                    "Dedicated teamwork workspace required: {}",
+                    dedicated_workspace.display()
+                ),
+                "Call prepareTeamworkWorkspace() from this root session first.".to_string(),
+                "Then create or repair the teamwork scaffold in that workspace and retry createOrg(name=\"...\")."
+                    .to_string(),
+            ])
+            .to_mcp_result());
+        }
+        CreateOrgPreflight::Proceed => {}
     }
 
+    let org_name = read_required_string(&args, "name")?;
     let org_id = format!("org-{}", uuid::Uuid::new_v4().simple());
     let org_root_session_id = session.id.clone();
     let session_repo = crate::state::get_session_repository();

--- a/src-tauri/src/mcp/builtin/agent/mod.rs
+++ b/src-tauri/src/mcp/builtin/agent/mod.rs
@@ -97,6 +97,9 @@ impl BuiltinMCPServer for AgentServer {
             "create" => handlers::create_agent(self, args).await,
             "update" => handlers::update_agent(self, args, Some(session_id.clone())).await,
             "list" => handlers::list_agents_or_sessions(self, args, &session_id).await,
+            "prepareTeamworkWorkspace" => {
+                handlers::prepare_teamwork_workspace(self, args, &session_id).await
+            }
             "createOrg" => handlers::create_org(self, args, &session_id).await,
             "getOrg" => handlers::get_org(self, args, &session_id).await,
             "startSession" => handlers::start_session(self, args, &session_id).await,
@@ -172,6 +175,7 @@ impl BuiltinMCPServer for AgentServer {
     async fn get_service_context(&self, _options: Option<&Value>) -> ServiceContext {
         let mut context_prompt = concat!(
             "# Agent Delegation\n\n",
+            "- `agent__prepareTeamworkWorkspace` moves the current governing/root session into a dedicated shared teamwork workspace for orchestration files.\n",
             "- `agent__startSession` starts delegated work.\n",
             "- `agent__messageToSession` resumes or retries an existing delegated session.\n",
             "- `agent__compactSessionContext` refreshes another session's stored compact summary before more work.\n",

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -8,6 +8,7 @@ pub fn all_tools() -> Vec<MCPTool> {
         create_tool(),
         list_tool(),
         update_tool(),
+        prepare_teamwork_workspace_tool(),
         create_org_tool(),
         get_org_tool(),
         start_session_tool(),
@@ -121,6 +122,17 @@ fn update_tool() -> MCPTool {
     }
 }
 
+fn prepare_teamwork_workspace_tool() -> MCPTool {
+    MCPTool {
+        name: "prepareTeamworkWorkspace".to_string(),
+        title: Some("Prepare Shared Teamwork Workspace".to_string()),
+        description: "Create or reuse a dedicated teamwork workspace under app data for the current governing/root session, then switch the current session to that shared orchestration workspace. Use this before scaffolding teamwork files so repo roots stay clean. Org-visible child sessions can then share the same teamwork workspace by default.".to_string(),
+        input_schema: object_prop(vec![], vec![], None),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
 fn start_session_tool() -> MCPTool {
     MCPTool {
         name: "startSession".to_string(),
@@ -154,7 +166,7 @@ fn create_org_tool() -> MCPTool {
     MCPTool {
         name: "createOrg".to_string(),
         title: Some("Create Explicit Org".to_string()),
-        description: "Mark the current root session as an explicit org root. This is the only path that makes a lineage appear in Org view. Use this from a top-level/root session, not from arbitrary child sessions. If the teamwork scaffold is missing or inconsistent, the result will tell you to use teamwork next.".to_string(),
+        description: "Mark the current root session as an explicit org root. This is the only path that makes a lineage appear in Org view. Use this from a top-level/root session that has already adopted its dedicated teamwork workspace via prepareTeamworkWorkspace(). If the teamwork scaffold is missing or inconsistent, the result will tell you to use teamwork next.".to_string(),
         input_schema: object_prop(
             vec![(
                 "name".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/utils.rs
@@ -100,7 +100,20 @@ pub fn sanitize_command_for_logging(command: &str) -> String {
 }
 
 pub fn is_internal_workspace_artifact_path(workspace_root: &Path, path: &Path) -> bool {
-    let Ok(relative_path) = path.strip_prefix(workspace_root) else {
+    let relative_path = path
+        .strip_prefix(workspace_root)
+        .ok()
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            let canonical_workspace_root = workspace_root.canonicalize().ok()?;
+            let canonical_path = path.canonicalize().ok()?;
+            canonical_path
+                .strip_prefix(&canonical_workspace_root)
+                .ok()
+                .map(Path::to_path_buf)
+        });
+
+    let Some(relative_path) = relative_path else {
         return false;
     };
 
@@ -120,6 +133,7 @@ pub fn is_internal_workspace_artifact_path(workspace_root: &Path, path: &Path) -
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
     fn test_sanitize_sudo_s_flag() {
@@ -186,6 +200,28 @@ mod tests {
         assert!(!is_internal_workspace_artifact_path(
             &workspace_root,
             &workspace_root.join("tmp/process_123/stdout"),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn internal_workspace_artifact_detection_handles_canonical_workspace_paths() {
+        use std::fs;
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempdir().expect("temp dir");
+        let real_workspace_root = temp_dir.path().join("real-workspace");
+        fs::create_dir_all(real_workspace_root.join(".libragent/tmp/process_123"))
+            .expect("internal tmp dir");
+        let stdout_path = real_workspace_root.join(".libragent/tmp/process_123/stdout");
+        fs::write(&stdout_path, "test output").expect("stdout artifact");
+
+        let symlinked_workspace_root = temp_dir.path().join("workspace-link");
+        symlink(&real_workspace_root, &symlinked_workspace_root).expect("workspace symlink");
+
+        assert!(is_internal_workspace_artifact_path(
+            &symlinked_workspace_root,
+            &stdout_path,
         ));
     }
 }

--- a/src-tauri/src/services/session_directory_service.rs
+++ b/src-tauri/src/services/session_directory_service.rs
@@ -14,6 +14,9 @@ impl SessionDirectoryService {
         fs::create_dir_all(base_data_dir.join("workspaces"))
             .map_err(|e| format!("Failed to create workspaces directory: {e}"))?;
 
+        fs::create_dir_all(base_data_dir.join("teamwork-workspaces"))
+            .map_err(|e| format!("Failed to create teamwork workspaces directory: {e}"))?;
+
         fs::create_dir_all(base_data_dir.join("workspaces").join("templates"))
             .map_err(|e| format!("Failed to create templates directory: {e}"))?;
 
@@ -177,6 +180,30 @@ Write-Host "Available tools: python3, typescript/deno, shell commands"
     /// Get session workspace directory path without ensuring it exists or performing any I/O.
     pub fn get_workspace_dir_unverified(&self, session_id: &str) -> PathBuf {
         self.base_data_dir.join("workspaces").join(session_id)
+    }
+
+    /// Get the dedicated teamwork workspace directory for a governing/root session.
+    pub fn get_teamwork_workspace_dir_unverified(&self, root_session_id: &str) -> PathBuf {
+        self.base_data_dir
+            .join("teamwork-workspaces")
+            .join(root_session_id)
+    }
+
+    /// Ensure a dedicated teamwork workspace exists for the given governing/root session.
+    pub async fn create_teamwork_workspace(
+        &self,
+        root_session_id: &str,
+    ) -> Result<PathBuf, String> {
+        let workspace_dir = self.get_teamwork_workspace_dir_unverified(root_session_id);
+        tokio::fs::create_dir_all(&workspace_dir)
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to create teamwork workspace directory '{}': {e}",
+                    workspace_dir.display()
+                )
+            })?;
+        Ok(workspace_dir)
     }
 
     /// Remove workspace directory

--- a/src-tauri/src/services/workspace_service.rs
+++ b/src-tauri/src/services/workspace_service.rs
@@ -242,6 +242,42 @@ impl WorkspaceService {
         Ok(())
     }
 
+    /// Provision and adopt the dedicated teamwork workspace for a governing/root session.
+    pub async fn provision_teamwork_workspace(session_id: &str) -> Result<String, String> {
+        let session_manager = get_session_manager().map_err(|e| e.to_string())?;
+        crate::session::resolve_session_workspace_dir(session_manager, session_id).await?;
+
+        let teamwork_workspace = crate::session::provision_teamwork_workspace_for_session(
+            crate::state::get_session_repository(),
+            session_manager,
+            session_id,
+        )
+        .await?;
+
+        let teamwork_workspace_str = teamwork_workspace
+            .to_str()
+            .ok_or_else(|| {
+                format!(
+                    "Invalid teamwork workspace path encoding: {}",
+                    teamwork_workspace.display()
+                )
+            })?
+            .to_string();
+
+        Self::sync_active_session_workspace_override(
+            session_id,
+            Some(teamwork_workspace_str.clone()),
+        )
+        .await;
+        crate::agent::tauri_events::emit_resource_updated(
+            "session",
+            "update",
+            Some(session_id.to_string()),
+        );
+
+        Ok(teamwork_workspace_str)
+    }
+
     /// Cancels the workspace override for a session.
     pub async fn cancel_override(session_id: &str) -> Result<(), String> {
         let session_manager = get_session_manager().map_err(|e| e.to_string())?;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,8 +1,10 @@
 pub mod manager;
+pub mod teamwork_workspace;
 pub mod types;
 pub mod workspace_override;
 
 pub use manager::*;
+pub use teamwork_workspace::*;
 pub use types::*;
 pub use workspace_override::*;
 

--- a/src-tauri/src/session/teamwork_workspace.rs
+++ b/src-tauri/src/session/teamwork_workspace.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use crate::repositories::SessionRepository;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamworkWorkspaceStatus {
+    pub effective_workspace: PathBuf,
+    pub dedicated_workspace: PathBuf,
+}
+
+impl TeamworkWorkspaceStatus {
+    pub fn uses_dedicated_teamwork_workspace(&self) -> bool {
+        self.effective_workspace == self.dedicated_workspace
+    }
+}
+
+pub fn teamwork_workspace_status(
+    session_manager: &crate::session::SessionManager,
+    session_id: &str,
+) -> TeamworkWorkspaceStatus {
+    TeamworkWorkspaceStatus {
+        effective_workspace: session_manager.get_session_workspace_dir_by_id(session_id),
+        dedicated_workspace: session_manager
+            .get_directory_service()
+            .get_teamwork_workspace_dir_unverified(session_id),
+    }
+}
+
+/// Provision the dedicated teamwork workspace for a governing/root session and
+/// persist it as that session's effective workspace override.
+pub async fn provision_teamwork_workspace_for_session(
+    session_repo: &dyn SessionRepository,
+    session_manager: &crate::session::SessionManager,
+    session_id: &str,
+) -> Result<PathBuf, String> {
+    let teamwork_workspace = session_manager
+        .get_directory_service()
+        .create_teamwork_workspace(session_id)
+        .await?;
+
+    let teamwork_workspace_str = teamwork_workspace
+        .to_str()
+        .ok_or_else(|| {
+            format!(
+                "Invalid teamwork workspace path encoding: {}",
+                teamwork_workspace.display()
+            )
+        })?
+        .to_string();
+
+    session_repo
+        .update_workspace_override(session_id, Some(teamwork_workspace_str))
+        .await
+        .map_err(|e| format!("Failed to persist teamwork workspace override: {}", e))?;
+
+    session_manager
+        .register_session_override(session_id, teamwork_workspace.clone())
+        .await?;
+
+    Ok(teamwork_workspace)
+}

--- a/src-tauri/tests/org_create_teamwork_workspace_guard_tests.rs
+++ b/src-tauri/tests/org_create_teamwork_workspace_guard_tests.rs
@@ -1,0 +1,188 @@
+mod common;
+
+use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::{
+    create_org_preflight, existing_explicit_org_identity, CreateOrgPreflight,
+};
+use tauri_mcp_agent_lib::repositories::{
+    SessionMetadata, SessionRepository, SessionStatus, SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::session::{
+    provision_teamwork_workspace_for_session, teamwork_workspace_status, SessionManager,
+    TeamworkWorkspaceStatus,
+};
+
+fn make_session(session_id: &str) -> SessionMetadata {
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Org Root".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: Some(session_id.to_string()),
+        depth: Some(0),
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: 1,
+        updated_at: 1,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[test]
+fn existing_org_identity_bypasses_new_org_workspace_enforcement() {
+    let mut session = make_session("existing-org-root");
+    session.org_id = Some("org-alpha".to_string());
+    session.org_name = Some("Alpha Org".to_string());
+    session.org_root_session_id = Some("existing-org-root".to_string());
+
+    let existing = existing_explicit_org_identity(&session);
+    assert_eq!(
+        existing,
+        Some((
+            "org-alpha".to_string(),
+            "Alpha Org".to_string(),
+            "existing-org-root".to_string()
+        ))
+    );
+
+    let workspace_status = TeamworkWorkspaceStatus {
+        effective_workspace: std::path::PathBuf::from("/repo"),
+        dedicated_workspace: std::path::PathBuf::from("/app/teamwork"),
+    };
+    assert_eq!(
+        create_org_preflight(&session, &workspace_status),
+        CreateOrgPreflight::ExistingOrg {
+            org_id: "org-alpha".to_string(),
+            org_name: "Alpha Org".to_string(),
+            root_session_id: "existing-org-root".to_string(),
+        }
+    );
+}
+
+#[test]
+fn new_org_requires_dedicated_teamwork_workspace_before_creation() {
+    let session = make_session("new-org-root");
+    let workspace_status = TeamworkWorkspaceStatus {
+        effective_workspace: std::path::PathBuf::from("/repo"),
+        dedicated_workspace: std::path::PathBuf::from("/app/teamwork"),
+    };
+
+    assert_eq!(
+        create_org_preflight(&session, &workspace_status),
+        CreateOrgPreflight::RequiresDedicatedWorkspace {
+            effective_workspace: std::path::PathBuf::from("/repo"),
+            dedicated_workspace: std::path::PathBuf::from("/app/teamwork"),
+        }
+    );
+}
+
+#[test]
+fn new_org_can_proceed_once_dedicated_teamwork_workspace_is_active() {
+    let session = make_session("new-org-root");
+    let workspace_path = std::path::PathBuf::from("/app/teamwork");
+    let workspace_status = TeamworkWorkspaceStatus {
+        effective_workspace: workspace_path.clone(),
+        dedicated_workspace: workspace_path,
+    };
+
+    assert_eq!(
+        create_org_preflight(&session, &workspace_status),
+        CreateOrgPreflight::Proceed
+    );
+}
+
+#[test]
+fn existing_org_still_reports_existing_org_even_when_workspace_mismatch_exists() {
+    let mut session = make_session("existing-org-root");
+    session.org_id = Some("org-alpha".to_string());
+    session.org_name = Some("Alpha Org".to_string());
+    session.org_root_session_id = Some("existing-org-root".to_string());
+
+    let workspace_status = TeamworkWorkspaceStatus {
+        effective_workspace: std::path::PathBuf::from("/repo"),
+        dedicated_workspace: std::path::PathBuf::from("/app/teamwork"),
+    };
+
+    assert_eq!(
+        create_org_preflight(&session, &workspace_status),
+        CreateOrgPreflight::ExistingOrg {
+            org_id: "org-alpha".to_string(),
+            org_name: "Alpha Org".to_string(),
+            root_session_id: "existing-org-root".to_string(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn org_root_defaults_to_session_workspace_until_teamwork_workspace_is_provisioned() {
+    common::register_sqlite_vec();
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db);
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let session_manager =
+        SessionManager::new_with_base_dir(temp_dir.path().join("session-root")).unwrap();
+    let session_id = "org-root-session";
+
+    repo.upsert_session(&make_session(session_id))
+        .await
+        .expect("session should persist");
+
+    let status = teamwork_workspace_status(&session_manager, session_id);
+    assert!(
+        !status.uses_dedicated_teamwork_workspace(),
+        "root sessions should not look teamwork-ready before explicit preparation"
+    );
+    assert!(
+        status
+            .effective_workspace
+            .ends_with(std::path::Path::new("workspaces").join(session_id)),
+        "expected default session workspace before preparation: {}",
+        status.effective_workspace.display()
+    );
+    assert!(
+        status
+            .dedicated_workspace
+            .ends_with(std::path::Path::new("teamwork-workspaces").join(session_id)),
+        "expected dedicated teamwork workspace target: {}",
+        status.dedicated_workspace.display()
+    );
+}
+
+#[tokio::test]
+async fn org_root_uses_dedicated_teamwork_workspace_after_preparation() {
+    common::register_sqlite_vec();
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db);
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let session_manager =
+        SessionManager::new_with_base_dir(temp_dir.path().join("session-root")).unwrap();
+    let session_id = "org-root-session";
+
+    repo.upsert_session(&make_session(session_id))
+        .await
+        .expect("session should persist");
+
+    let teamwork_workspace =
+        provision_teamwork_workspace_for_session(&repo, &session_manager, session_id)
+            .await
+            .expect("teamwork workspace should provision");
+
+    let status = teamwork_workspace_status(&session_manager, session_id);
+    assert!(
+        status.uses_dedicated_teamwork_workspace(),
+        "root sessions should become teamwork-ready after explicit preparation"
+    );
+    assert_eq!(status.effective_workspace, teamwork_workspace);
+    assert_eq!(status.dedicated_workspace, teamwork_workspace);
+}

--- a/src-tauri/tests/teamwork_scaffold_script_tests.rs
+++ b/src-tauri/tests/teamwork_scaffold_script_tests.rs
@@ -56,7 +56,6 @@ fn scaffold_script_refuses_nested_git_worktree_path_without_opt_in() {
     let temp_dir = tempfile::tempdir().expect("temp dir should be created");
     std::fs::create_dir_all(temp_dir.path().join(".git")).expect(".git dir should be created");
     let nested = temp_dir.path().join("teamwork");
-    std::fs::create_dir_all(&nested).expect("nested dir should be created");
 
     let output = base_command(&nested).output().expect("script should run");
 
@@ -68,6 +67,10 @@ fn scaffold_script_refuses_nested_git_worktree_path_without_opt_in() {
     assert!(
         stderr.contains("Refusing to scaffold inside a Git worktree"),
         "expected git-worktree refusal message, got: {stderr}"
+    );
+    assert!(
+        !nested.exists(),
+        "script should not create nested output paths before refusing"
     );
 }
 

--- a/src-tauri/tests/teamwork_scaffold_script_tests.rs
+++ b/src-tauri/tests/teamwork_scaffold_script_tests.rs
@@ -1,0 +1,138 @@
+#![cfg(not(windows))]
+
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("bundled_skills")
+        .join("teamwork")
+        .join("scripts")
+        .join("init_task_force.py")
+}
+
+fn base_command(output_dir: &std::path::Path) -> Command {
+    let mut command = Command::new("python3");
+    command
+        .arg(script_path())
+        .arg("--output")
+        .arg(output_dir)
+        .arg("--team-name")
+        .arg("Research Strike Team")
+        .arg("--objective")
+        .arg("Build a reusable research and implementation team")
+        .arg("--request")
+        .arg("Research the space, structure findings, and hand implementation-ready guidance to coding specialists.")
+        .arg("--framework")
+        .arg("hub-and-spoke")
+        .arg("--role")
+        .arg("Coordinator:Own planning, prioritization, and integration");
+    command
+}
+
+#[test]
+fn scaffold_script_refuses_git_worktree_without_opt_in() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    std::fs::create_dir_all(temp_dir.path().join(".git")).expect(".git dir should be created");
+
+    let output = base_command(temp_dir.path())
+        .output()
+        .expect("script should run");
+
+    assert!(
+        !output.status.success(),
+        "script should reject git worktrees by default"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Refusing to scaffold inside a Git worktree"),
+        "expected git-worktree refusal message, got: {stderr}"
+    );
+}
+
+#[test]
+fn scaffold_script_refuses_nested_git_worktree_path_without_opt_in() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    std::fs::create_dir_all(temp_dir.path().join(".git")).expect(".git dir should be created");
+    let nested = temp_dir.path().join("teamwork");
+    std::fs::create_dir_all(&nested).expect("nested dir should be created");
+
+    let output = base_command(&nested).output().expect("script should run");
+
+    assert!(
+        !output.status.success(),
+        "script should reject nested paths inside a git worktree by default"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Refusing to scaffold inside a Git worktree"),
+        "expected git-worktree refusal message, got: {stderr}"
+    );
+}
+
+#[test]
+fn scaffold_script_allows_git_worktree_with_explicit_opt_in() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    std::fs::create_dir_all(temp_dir.path().join(".git")).expect(".git dir should be created");
+
+    let output = base_command(temp_dir.path())
+        .arg("--allow-git-worktree")
+        .output()
+        .expect("script should run");
+
+    assert!(
+        output.status.success(),
+        "script should allow git repo root when explicitly opted in: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        temp_dir.path().join("MISSION.md").exists(),
+        "expected scaffold file to be created when opt-in is set"
+    );
+}
+
+#[test]
+fn scaffold_script_writes_expected_teamwork_manifest_contract() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let output_dir = temp_dir.path().join("teamwork-workspace");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+
+    let output = base_command(&output_dir)
+        .arg("--execution-substrate")
+        .arg("org")
+        .output()
+        .expect("script should run");
+
+    assert!(
+        output.status.success(),
+        "script should scaffold successfully outside a git worktree: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let manifest_path = output_dir.join(".libragent").join("teamwork.json");
+    let manifest_raw =
+        std::fs::read_to_string(&manifest_path).expect("teamwork manifest should exist");
+    let manifest: Value =
+        serde_json::from_str(&manifest_raw).expect("teamwork manifest should be valid JSON");
+
+    assert_eq!(manifest["schemaVersion"], 2);
+    assert_eq!(manifest["executionSubstrate"]["mode"], "org");
+    assert_eq!(manifest["executionSubstrate"]["specialistSkill"], "org");
+    assert_eq!(
+        manifest["executionSubstrate"]["workspacePolicy"]["explicitOrgLineage"],
+        "share-governing-teamwork-workspace-by-default"
+    );
+    assert_eq!(
+        manifest["executionSubstrate"]["orgLineage"]["childArgs"]["includeCurrentOrg"],
+        true
+    );
+    assert_eq!(
+        manifest["constitutionAdoption"]["coordinatorMustShareScaffoldRoot"],
+        true
+    );
+    assert_eq!(
+        manifest["constitutionAdoption"]["rule"],
+        "Continue coordination in the dedicated teamwork workspace where the constitution was created."
+    );
+}

--- a/src-tauri/tests/teamwork_workspace_provision_tests.rs
+++ b/src-tauri/tests/teamwork_workspace_provision_tests.rs
@@ -1,0 +1,120 @@
+mod common;
+
+use tauri_mcp_agent_lib::repositories::{
+    SessionMetadata, SessionRepository, SessionStatus, SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::session::{provision_teamwork_workspace_for_session, SessionManager};
+
+fn make_session(session_id: &str) -> SessionMetadata {
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Team Root".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: Some(session_id.to_string()),
+        depth: Some(0),
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: 1,
+        updated_at: 1,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[tokio::test]
+async fn provision_teamwork_workspace_uses_dedicated_directory_and_persists_override() {
+    common::register_sqlite_vec();
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db);
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let session_manager =
+        SessionManager::new_with_base_dir(temp_dir.path().join("session-root")).unwrap();
+    let session_id = "team-root-session";
+
+    repo.upsert_session(&make_session(session_id))
+        .await
+        .expect("session should persist");
+
+    let teamwork_workspace =
+        provision_teamwork_workspace_for_session(&repo, &session_manager, session_id)
+            .await
+            .expect("teamwork workspace should provision");
+
+    assert!(
+        teamwork_workspace.exists(),
+        "workspace should exist on disk"
+    );
+    assert!(
+        teamwork_workspace.ends_with(std::path::Path::new("teamwork-workspaces").join(session_id)),
+        "teamwork workspace should live under the dedicated teamwork-workspaces root: {}",
+        teamwork_workspace.display()
+    );
+
+    let persisted = repo
+        .get_session(session_id)
+        .await
+        .expect("session lookup should succeed")
+        .expect("session should still exist");
+    assert_eq!(
+        persisted.workspace_override.as_deref(),
+        teamwork_workspace.to_str(),
+        "workspace override should persist to the repository"
+    );
+
+    let effective_workspace = session_manager.get_session_workspace_dir_by_id(session_id);
+    assert_eq!(
+        effective_workspace, teamwork_workspace,
+        "session manager should resolve the teamwork workspace as the effective workspace"
+    );
+}
+
+#[tokio::test]
+async fn provision_teamwork_workspace_is_idempotent_for_repeated_calls() {
+    common::register_sqlite_vec();
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db);
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let session_manager =
+        SessionManager::new_with_base_dir(temp_dir.path().join("session-root")).unwrap();
+    let session_id = "team-root-session-repeat";
+
+    repo.upsert_session(&make_session(session_id))
+        .await
+        .expect("session should persist");
+
+    let first = provision_teamwork_workspace_for_session(&repo, &session_manager, session_id)
+        .await
+        .expect("first teamwork workspace provisioning should succeed");
+    let second = provision_teamwork_workspace_for_session(&repo, &session_manager, session_id)
+        .await
+        .expect("second teamwork workspace provisioning should also succeed");
+
+    assert_eq!(
+        first, second,
+        "repeated provisioning should reuse the same path"
+    );
+
+    let persisted = repo
+        .get_session(session_id)
+        .await
+        .expect("session lookup should succeed")
+        .expect("session should exist");
+    assert_eq!(persisted.workspace_override.as_deref(), second.to_str());
+    assert_eq!(
+        session_manager.get_session_workspace_dir_by_id(session_id),
+        second,
+        "session manager should still resolve the same teamwork workspace after repeated provisioning"
+    );
+}

--- a/src-tauri/tests/workspace_internal_artifacts_tests.rs
+++ b/src-tauri/tests/workspace_internal_artifacts_tests.rs
@@ -72,6 +72,56 @@ async fn list_directory_hides_internal_tmp_and_exports_inside_libragent() {
     assert!(!names.contains(&"exports"));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn list_directory_hides_internal_artifacts_when_workspace_root_is_symlinked() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let real_base_dir = temp_dir.path().join("real-base");
+    std::fs::create_dir_all(&real_base_dir).expect("real base dir");
+
+    let symlink_base_dir = temp_dir.path().join("symlink-base");
+    symlink(&real_base_dir, &symlink_base_dir).expect("base dir symlink");
+
+    let session_id = "workspace-internal-listing-symlinked";
+    let server = build_workspace_server(&symlink_base_dir, session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join(".libragent/tmp/process_123")).expect("tmp dir");
+    std::fs::create_dir_all(workspace_dir.join(".libragent/exports/files")).expect("exports dir");
+    std::fs::write(
+        workspace_dir.join(".libragent/tmp/process_123/stdout"),
+        "process output",
+    )
+    .expect("tmp artifact");
+
+    let result = server
+        .handle_list_directory(
+            json!({
+                "path": ".libragent"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("listDirectory should succeed");
+
+    let items = result
+        .structured_content
+        .as_ref()
+        .and_then(|value| value.get("items"))
+        .and_then(|value| value.as_array())
+        .expect("items array expected");
+
+    let names = items
+        .iter()
+        .filter_map(|item| item.get("name").and_then(|value| value.as_str()))
+        .collect::<Vec<_>>();
+
+    assert!(!names.contains(&"tmp"));
+    assert!(!names.contains(&"exports"));
+}
+
 #[tokio::test]
 async fn export_response_uses_libragent_download_path() {
     let temp_dir = tempdir().expect("temp dir");

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
- add dedicated teamwork workspace provisioning and createOrg preflight enforcement
- harden teamwork/org/schedule skill contracts and scaffold manifest wording
- add regression coverage for teamwork workspace provisioning, scaffold contract, and createOrg guardrails