### PR TITLE
🎨 Palette: Add tooltip to Delete User Skill icon button

### DIFF
--- a/src/features/settings/components/SkillsListModal.tsx
+++ b/src/features/settings/components/SkillsListModal.tsx
@@ -163,19 +163,19 @@ export function SkillsListModal({
                             size="sm"
                             disabled={deletingSkillName === skill.name}
                             onClick={() => onDeleteUserSkill(skill.name)}
-                            aria-label={t(
-                              'settings.skills.deleteUserSkill',
-                              'Delete user skill',
-                            )}
+                            aria-label={t('settings.skills.deleteUserSkill', {
+                              name: skill.name,
+                              defaultValue: 'Delete {{name}}',
+                            })}
                           >
                             <Trash2 className="w-4 h-4 text-destructive" />
                           </Button>
                         </TooltipTrigger>
                         <TooltipContent>
-                          {t(
-                            'settings.skills.deleteUserSkill',
-                            'Delete user skill',
-                          )}
+                          {t('settings.skills.deleteUserSkill', {
+                            name: skill.name,
+                            defaultValue: 'Delete {{name}}',
+                          })}
                         </TooltipContent>
                       </Tooltip>
                     }

--- a/src/features/settings/components/SkillsListModal.tsx
+++ b/src/features/settings/components/SkillsListModal.tsx
@@ -6,6 +6,9 @@ import {
   DialogDescription,
   Button,
   Badge,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@/components/ui';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -152,19 +155,29 @@ export function SkillsListModal({
                     key={skill.path}
                     skill={skill}
                     action={
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        disabled={deletingSkillName === skill.name}
-                        onClick={() => onDeleteUserSkill(skill.name)}
-                        aria-label={t(
-                          'settings.skills.deleteUserSkill',
-                          'Delete user skill',
-                        )}
-                      >
-                        <Trash2 className="w-4 h-4 text-destructive" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={deletingSkillName === skill.name}
+                            onClick={() => onDeleteUserSkill(skill.name)}
+                            aria-label={t(
+                              'settings.skills.deleteUserSkill',
+                              'Delete user skill',
+                            )}
+                          >
+                            <Trash2 className="w-4 h-4 text-destructive" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t(
+                            'settings.skills.deleteUserSkill',
+                            'Delete user skill',
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
                     }
                   />
                 ))

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -520,6 +520,7 @@
       "revertFailed": "Failed to revert skill",
       "resetSuccess": "Assistant skills reset successfully",
       "resetFailed": "Failed to reset skills",
+      "deleteUserSkill": "Delete {{name}}",
       "userSkillDeleted": "User skill deleted.",
       "userSkillsReset": "User skills reset.",
       "dragDropDesc": "Drag and drop a .skill, .zip, or skill folder to override skills.",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -496,6 +496,7 @@
       "revertFailed": "스킬 되돌리기 실패",
       "resetSuccess": "어시스턴트 스킬 초기화 성공",
       "resetFailed": "스킬 초기화 실패",
+      "deleteUserSkill": "{{name}} 삭제",
       "dragDropDesc": "스킬을 재정의하려면 zip 파일이나 폴더를 드래그 앤 드롭하세요.",
       "resetTooltip": "모든 어시스턴트 전용 스킬 제거",
       "reset": "재정의 초기화",


### PR DESCRIPTION
## 💡 What
Added a tooltip to the icon-only 'Delete user skill' button in the SkillsListModal.

## 🎯 Why
The delete button for user skills only showed a trash can icon without visual text. While it had an aria-label, adding a tooltip provides immediate visual context for mouse users, clarifying that it deletes the specific user skill.

## 📸 Before/After
Before: Hovering over the trash icon showed nothing.
After: Hovering over the trash icon shows a 'Delete user skill' tooltip.

## ♿ Accessibility
Addresses the 'Tooltips on Action Buttons' pattern from the Palette journal, ensuring icon-only buttons offer both visual feedback and ARIA support.

---
*PR created automatically by Jules for task [11668495282007560575](https://jules.google.com/task/11668495282007560575) started by @fritzprix*