### PR TITLE
Fix MCP preset install state and chat scroll UX

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3842,7 +3842,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -69,6 +69,12 @@ export function shouldShowAnalysisLoader(
 
 export type AutoScrollEvent = 'none' | 'stream-start' | 'message-complete';
 
+function isStreamingAssistantMessage(
+  message: Message | undefined,
+): message is Message {
+  return message?.role === 'assistant' && message.isStreaming === true;
+}
+
 export function getAutoScrollEvent(args: {
   previousLatestMessage: Message | undefined;
   latestMessage: Message | undefined;
@@ -102,6 +108,40 @@ export function getAutoScrollEvent(args: {
   }
 
   return 'none';
+}
+
+export function getStreamingScrollLockMessageId(args: {
+  currentLockMessageId: string | null;
+  autoScrollEvent: AutoScrollEvent;
+  latestMessage: Message | undefined;
+  shouldStickToBottom: boolean;
+}): string | null {
+  const {
+    currentLockMessageId,
+    autoScrollEvent,
+    latestMessage,
+    shouldStickToBottom,
+  } = args;
+
+  if (autoScrollEvent === 'message-complete') {
+    return null;
+  }
+
+  if (autoScrollEvent === 'stream-start') {
+    return shouldStickToBottom && isStreamingAssistantMessage(latestMessage)
+      ? latestMessage.id
+      : null;
+  }
+
+  if (
+    currentLockMessageId &&
+    isStreamingAssistantMessage(latestMessage) &&
+    latestMessage.id === currentLockMessageId
+  ) {
+    return currentLockMessageId;
+  }
+
+  return null;
 }
 
 function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
@@ -380,6 +420,7 @@ export function AgentChatMessages() {
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
   const wasAtBottomRef = useRef(true);
   const previousLatestMessageRef = useRef<Message | undefined>(undefined);
+  const streamingScrollLockMessageIdRef = useRef<string | null>(null);
   const autoScrollFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
@@ -487,6 +528,7 @@ export function AgentChatMessages() {
   useEffect(() => {
     wasAtBottomRef.current = true;
     previousLatestMessageRef.current = undefined;
+    streamingScrollLockMessageIdRef.current = null;
     if (autoScrollFrameRef.current !== null) {
       cancelAnimationFrame(autoScrollFrameRef.current);
       autoScrollFrameRef.current = null;
@@ -535,15 +577,57 @@ export function AgentChatMessages() {
   }, [bottomThreshold, session?.id]);
 
   useEffect(() => {
+    const scroller = scrollerElementRef.current;
+
+    if (!scroller) {
+      return;
+    }
+
+    const handleScroll = () => {
+      const distanceFromBottom =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      const isNearBottom = distanceFromBottom <= bottomThreshold;
+
+      wasAtBottomRef.current = isNearBottom;
+
+      if (!isNearBottom && streamingScrollLockMessageIdRef.current !== null) {
+        streamingScrollLockMessageIdRef.current = null;
+      }
+    };
+
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll);
+    };
+  }, [bottomThreshold, session?.id]);
+
+  useEffect(() => {
     const previousLatestMessage = previousLatestMessageRef.current;
     const autoScrollEvent = getAutoScrollEvent({
       previousLatestMessage,
       latestMessage,
     });
+    const hadStreamingScrollLock =
+      streamingScrollLockMessageIdRef.current !== null;
+    const shouldStickToBottom =
+      wasAtBottomRef.current || hadStreamingScrollLock;
+    const nextStreamingScrollLockMessageId = getStreamingScrollLockMessageId({
+      currentLockMessageId: streamingScrollLockMessageIdRef.current,
+      autoScrollEvent,
+      latestMessage,
+      shouldStickToBottom,
+    });
+
+    streamingScrollLockMessageIdRef.current = nextStreamingScrollLockMessageId;
 
     previousLatestMessageRef.current = latestMessage;
 
-    if (autoScrollEvent === 'none' || !wasAtBottomRef.current) {
+    const shouldAutoScroll =
+      nextStreamingScrollLockMessageId !== null ||
+      (autoScrollEvent !== 'none' && shouldStickToBottom);
+
+    if (!shouldAutoScroll) {
       return;
     }
 

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -5,7 +5,6 @@ import {
   forwardRef,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -54,28 +53,6 @@ export function getVisualBottomThreshold(): number {
   return DEFAULT_BOTTOM_THRESHOLD;
 }
 
-export function shouldAutoFollowOutput(
-  latestMessage: Message | undefined,
-  workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'],
-): boolean {
-  if (!latestMessage) {
-    return false;
-  }
-
-  const assistantHasNoVisibleOutput =
-    latestMessage.role === 'assistant' &&
-    !latestMessage.content?.length &&
-    !latestMessage.thinking &&
-    !latestMessage.tool_calls?.length;
-
-  return (
-    workflowStatus === 'busy' &&
-    (latestMessage.role !== 'assistant' ||
-      latestMessage.isStreaming === true ||
-      assistantHasNoVisibleOutput)
-  );
-}
-
 export function shouldShowAnalysisLoader(
   latestMessage: Message | undefined,
   workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'],
@@ -90,83 +67,41 @@ export function shouldShowAnalysisLoader(
   );
 }
 
-export function getMessageOutputSignature(
-  message: Message | undefined,
-): string {
-  if (!message) {
+export type AutoScrollEvent = 'none' | 'stream-start' | 'message-complete';
+
+export function getAutoScrollEvent(args: {
+  previousLatestMessage: Message | undefined;
+  latestMessage: Message | undefined;
+}): AutoScrollEvent {
+  const { previousLatestMessage, latestMessage } = args;
+
+  if (!previousLatestMessage || !latestMessage) {
     return 'none';
   }
 
-  const contentSignature = (message.content ?? [])
-    .map((item) => {
-      switch (item.type) {
-        case 'text':
-          return `text:${item.text.length}`;
-        case 'thinking':
-          return `thinking:${item.thinking.length}`;
-        case 'tool_call':
-          return `tool:${item.name}`;
-        default:
-          return item.type;
-      }
-    })
-    .join('|');
+  const previousWasStreamingAssistant =
+    previousLatestMessage.role === 'assistant' &&
+    previousLatestMessage.isStreaming === true;
+  const currentIsStreamingAssistant =
+    latestMessage.role === 'assistant' && latestMessage.isStreaming === true;
 
-  const toolCallSignature = (message.tool_calls ?? [])
-    .map((toolCall) => toolCall.function.name)
-    .join('|');
+  if (
+    currentIsStreamingAssistant &&
+    (!previousWasStreamingAssistant ||
+      previousLatestMessage.id !== latestMessage.id)
+  ) {
+    return 'stream-start';
+  }
 
-  return [
-    message.id,
-    message.role,
-    message.isStreaming ? 'streaming' : 'static',
-    message.thinking?.length ?? 0,
-    contentSignature,
-    toolCallSignature,
-  ].join('::');
-}
+  if (
+    previousWasStreamingAssistant &&
+    (!currentIsStreamingAssistant ||
+      previousLatestMessage.id !== latestMessage.id)
+  ) {
+    return 'message-complete';
+  }
 
-export function getTailAnchorKey(args: {
-  latestMessage: Message | undefined;
-  workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'];
-  pendingApprovalsCount: number;
-  hasAgentError: boolean;
-  hasAgentLlmError: boolean;
-}): string {
-  return [
-    getMessageOutputSignature(args.latestMessage),
-    args.workflowStatus,
-    args.pendingApprovalsCount,
-    args.hasAgentError ? 'agent-error' : 'no-agent-error',
-    args.hasAgentLlmError ? 'llm-error' : 'no-llm-error',
-    shouldShowAnalysisLoader(args.latestMessage, args.workflowStatus)
-      ? 'analysis-loader'
-      : 'no-analysis-loader',
-  ].join('||');
-}
-
-export function shouldPreserveBottomAnchorOnTailChange(args: {
-  tailChanged: boolean;
-  wasAtBottomBeforeChange: boolean;
-  autoFollowOutput: boolean;
-  wasFollowingOutputBeforeChange: boolean;
-}): boolean {
-  return (
-    args.tailChanged &&
-    args.wasAtBottomBeforeChange &&
-    !args.autoFollowOutput &&
-    args.wasFollowingOutputBeforeChange
-  );
-}
-
-export function shouldSoftFollowOutputOnTailChange(args: {
-  tailChanged: boolean;
-  wasAtBottomBeforeChange: boolean;
-  autoFollowOutput: boolean;
-}): boolean {
-  return (
-    args.tailChanged && args.wasAtBottomBeforeChange && args.autoFollowOutput
-  );
+  return 'none';
 }
 
 function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
@@ -444,17 +379,12 @@ export function AgentChatMessages() {
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
   const wasAtBottomRef = useRef(true);
-  const settleLockRef = useRef(false);
-  const settleFrameRefs = useRef<number[]>([]);
-  const streamFollowFrameRef = useRef<number | null>(null);
+  const previousLatestMessageRef = useRef<Message | undefined>(undefined);
+  const autoScrollFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
   );
   const bottomThreshold = getVisualBottomThreshold();
-  const autoFollowOutput = useMemo(
-    () => shouldAutoFollowOutput(latestMessage, workflowStatus),
-    [latestMessage, workflowStatus],
-  );
   const previousListStateRef = useRef<{
     firstId: string | undefined;
     lastId: string | undefined;
@@ -501,26 +431,6 @@ export function AgentChatMessages() {
   // Memoize references so ErrorBubble memo stays effective during streaming re-renders
   const agentError = useMemo(() => error, [error]);
   const agentLlmError = useMemo(() => llmError, [llmError]);
-  const tailAnchorKey = useMemo(
-    () =>
-      getTailAnchorKey({
-        latestMessage,
-        workflowStatus,
-        pendingApprovalsCount: pendingApprovals?.length ?? 0,
-        hasAgentError: !!agentError,
-        hasAgentLlmError: !!agentLlmError,
-      }),
-    [
-      latestMessage,
-      workflowStatus,
-      pendingApprovals,
-      agentError,
-      agentLlmError,
-    ],
-  );
-  const previousTailAnchorKeyRef = useRef<string | undefined>(undefined);
-  const previousWasAtBottomRef = useRef(true);
-  const previousAutoFollowOutputRef = useRef(false);
 
   const streamingToolMessageIds = useMemo(
     () =>
@@ -576,26 +486,18 @@ export function AgentChatMessages() {
 
   useEffect(() => {
     wasAtBottomRef.current = true;
-    previousWasAtBottomRef.current = true;
-    previousAutoFollowOutputRef.current = false;
-    previousTailAnchorKeyRef.current = undefined;
-    settleLockRef.current = false;
-    settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-    settleFrameRefs.current = [];
-    if (streamFollowFrameRef.current !== null) {
-      cancelAnimationFrame(streamFollowFrameRef.current);
-      streamFollowFrameRef.current = null;
+    previousLatestMessageRef.current = undefined;
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
     }
   }, [session?.id]);
 
   useEffect(() => {
     return () => {
-      settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-      settleFrameRefs.current = [];
-      settleLockRef.current = false;
-      if (streamFollowFrameRef.current !== null) {
-        cancelAnimationFrame(streamFollowFrameRef.current);
-        streamFollowFrameRef.current = null;
+      if (autoScrollFrameRef.current !== null) {
+        cancelAnimationFrame(autoScrollFrameRef.current);
+        autoScrollFrameRef.current = null;
       }
     };
   }, []);
@@ -616,13 +518,7 @@ export function AgentChatMessages() {
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        const atBottom = entry?.isIntersecting ?? false;
-
-        if (settleLockRef.current && !atBottom) {
-          return;
-        }
-
-        wasAtBottomRef.current = atBottom;
+        wasAtBottomRef.current = entry?.isIntersecting ?? false;
       },
       {
         root: scroller,
@@ -638,73 +534,28 @@ export function AgentChatMessages() {
     };
   }, [bottomThreshold, session?.id]);
 
-  useLayoutEffect(() => {
-    const previousTailAnchorKey = previousTailAnchorKeyRef.current;
-    const wasAtBottomBeforeChange = previousWasAtBottomRef.current;
-    const wasFollowingOutputBeforeChange = previousAutoFollowOutputRef.current;
+  useEffect(() => {
+    const previousLatestMessage = previousLatestMessageRef.current;
+    const autoScrollEvent = getAutoScrollEvent({
+      previousLatestMessage,
+      latestMessage,
+    });
 
-    previousTailAnchorKeyRef.current = tailAnchorKey;
-    previousWasAtBottomRef.current = wasAtBottomRef.current;
-    previousAutoFollowOutputRef.current = autoFollowOutput;
+    previousLatestMessageRef.current = latestMessage;
 
-    if (previousTailAnchorKey === undefined) {
+    if (autoScrollEvent === 'none' || !wasAtBottomRef.current) {
       return;
     }
 
-    const tailChanged = previousTailAnchorKey !== tailAnchorKey;
-
-    if (
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged,
-        wasAtBottomBeforeChange,
-        autoFollowOutput,
-      })
-    ) {
-      if (streamFollowFrameRef.current === null) {
-        streamFollowFrameRef.current = requestAnimationFrame(() => {
-          streamFollowFrameRef.current = null;
-          scrollFooterSentinelIntoView(footerEndRef.current);
-        });
-      }
-      return;
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
     }
 
-    if (
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged,
-        wasAtBottomBeforeChange,
-        autoFollowOutput,
-        wasFollowingOutputBeforeChange,
-      })
-    ) {
-      settleLockRef.current = true;
-      if (streamFollowFrameRef.current !== null) {
-        cancelAnimationFrame(streamFollowFrameRef.current);
-        streamFollowFrameRef.current = null;
-      }
-      settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-      settleFrameRefs.current = [];
-
+    autoScrollFrameRef.current = requestAnimationFrame(() => {
+      autoScrollFrameRef.current = null;
       scrollFooterSentinelIntoView(footerEndRef.current);
-
-      const firstFrame = requestAnimationFrame(() => {
-        scrollFooterSentinelIntoView(footerEndRef.current);
-
-        const secondFrame = requestAnimationFrame(() => {
-          scrollFooterSentinelIntoView(footerEndRef.current);
-          settleLockRef.current = false;
-          wasAtBottomRef.current = true;
-        });
-
-        settleFrameRefs.current = settleFrameRefs.current.filter(
-          (frame) => frame !== firstFrame,
-        );
-        settleFrameRefs.current.push(secondFrame);
-      });
-
-      settleFrameRefs.current.push(firstFrame);
-    }
-  }, [autoFollowOutput, tailAnchorKey]);
+    });
+  }, [latestMessage]);
 
   const virtuosoContext = useMemo<AgentChatVirtuosoContext>(
     () => ({

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -4,15 +4,11 @@ import { forwardRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentChatMessages,
-  getMessageOutputSignature,
-  getTailAnchorKey,
+  getAutoScrollEvent,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
   getVisualBottomThreshold,
-  shouldPreserveBottomAnchorOnTailChange,
-  shouldSoftFollowOutputOnTailChange,
   shouldShowAnalysisLoader,
-  shouldAutoFollowOutput,
 } from '../AgentChatMessages';
 import type { Message } from '@/models/chat';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
@@ -212,87 +208,6 @@ describe('AgentChatMessages compaction rendering', () => {
     expect(getVisualBottomThreshold()).toBe(32);
   });
 
-  it('only auto-follows while the workflow is actively producing output', () => {
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          isStreaming: true,
-        },
-        'busy',
-      ),
-    ).toBe(true);
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          isStreaming: false,
-        },
-        'idle',
-      ),
-    ).toBe(false);
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          content: [],
-          isStreaming: false,
-        },
-        'busy',
-      ),
-    ).toBe(true);
-  });
-
-  it('derives a stable tail signature from the latest message output', () => {
-    expect(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abc' }],
-        isStreaming: true,
-      }),
-    ).toContain('streaming');
-    expect(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abcd' }],
-      }),
-    ).not.toBe(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abc' }],
-      }),
-    );
-  });
-
-  it('includes footer-affecting state in the tail anchor key', () => {
-    const baseKey = getTailAnchorKey({
-      latestMessage: baseMessage,
-      workflowStatus: 'idle',
-      pendingApprovalsCount: 0,
-      hasAgentError: false,
-      hasAgentLlmError: false,
-    });
-
-    expect(
-      getTailAnchorKey({
-        latestMessage: baseMessage,
-        workflowStatus: 'idle',
-        pendingApprovalsCount: 1,
-        hasAgentError: false,
-        hasAgentLlmError: false,
-      }),
-    ).not.toBe(baseKey);
-    expect(
-      getTailAnchorKey({
-        latestMessage: { ...baseMessage, content: [] },
-        workflowStatus: 'busy',
-        pendingApprovalsCount: 0,
-        hasAgentError: false,
-        hasAgentLlmError: false,
-      }),
-    ).not.toBe(baseKey);
-  });
-
   it('shows the analysis loader only for busy empty assistant output states', () => {
     expect(shouldShowAnalysisLoader(undefined, 'idle')).toBe(false);
     expect(
@@ -309,78 +224,77 @@ describe('AgentChatMessages compaction rendering', () => {
     ).toBe(false);
   });
 
-  it('preserves bottom anchoring through completion settle transitions', () => {
+  it('auto-scrolls only on streaming lifecycle boundaries', () => {
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: undefined,
+        latestMessage: { ...baseMessage, isStreaming: true },
       }),
-    ).toBe(true);
+    ).toBe('none');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: false,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: { ...baseMessage, isStreaming: false },
+        latestMessage: { ...baseMessage, isStreaming: true },
       }),
-    ).toBe(false);
+    ).toBe('stream-start');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: false,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'a' }],
+        },
+        latestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'abcdef' }],
+        },
       }),
-    ).toBe(false);
+    ).toBe('none');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: { ...baseMessage, isStreaming: true },
+        latestMessage: { ...baseMessage, isStreaming: false },
       }),
-    ).toBe(false);
+    ).toBe('message-complete');
   });
 
-  it('allows completion settle even after auto follow has just turned off', () => {
+  it('treats a new static assistant message after streaming as completion', () => {
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          id: 'assistant-1',
+          isStreaming: true,
+        },
+        latestMessage: {
+          ...baseMessage,
+          id: 'assistant-2',
+          isStreaming: false,
+          content: [{ type: 'text', text: 'Done' }],
+        },
       }),
-    ).toBe(true);
+    ).toBe('message-complete');
   });
 
-  it('uses lightweight follow while output is still streaming', () => {
+  it('ignores non-assistant updates for auto-scroll lifecycle events', () => {
     expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          role: 'user',
+          isStreaming: false,
+        },
+        latestMessage: {
+          ...baseMessage,
+          role: 'user',
+          isStreaming: false,
+          content: [{ type: 'text', text: 'Still user content' }],
+        },
       }),
-    ).toBe(true);
-
-    expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-      }),
-    ).toBe(false);
-
-    expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: false,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-      }),
-    ).toBe(false);
+    ).toBe('none');
   });
 });

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -7,6 +7,7 @@ import {
   getAutoScrollEvent,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
+  getStreamingScrollLockMessageId,
   getVisualBottomThreshold,
   shouldShowAnalysisLoader,
 } from '../AgentChatMessages';
@@ -296,5 +297,49 @@ describe('AgentChatMessages compaction rendering', () => {
         },
       }),
     ).toBe('none');
+  });
+
+  it('keeps a stream scroll lock alive for chunk updates after starting near the bottom', () => {
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: null,
+        autoScrollEvent: 'stream-start',
+        latestMessage: { ...baseMessage, isStreaming: true },
+        shouldStickToBottom: true,
+      }),
+    ).toBe('assistant-1');
+
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: 'assistant-1',
+        autoScrollEvent: 'none',
+        latestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'abcdef' }],
+        },
+        shouldStickToBottom: false,
+      }),
+    ).toBe('assistant-1');
+  });
+
+  it('drops the stream scroll lock when the user was not near the bottom or the stream completes', () => {
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: null,
+        autoScrollEvent: 'stream-start',
+        latestMessage: { ...baseMessage, isStreaming: true },
+        shouldStickToBottom: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: 'assistant-1',
+        autoScrollEvent: 'message-complete',
+        latestMessage: { ...baseMessage, isStreaming: false },
+        shouldStickToBottom: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { LoadingIndicator } from './LoadingIndicator';
 
 interface ThinkingBubbleProps {
@@ -22,7 +22,6 @@ interface ThinkingBubbleProps {
  * - Shows loading animation when streaming
  * - Scrollable content area with max height
  * - Consistent styling across components
- * - Auto-scrolls to bottom during streaming
  */
 export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   thinking,
@@ -30,15 +29,6 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   isStreaming = false,
   className = '',
 }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Auto-scroll to bottom while streaming
-  useEffect(() => {
-    if (isStreaming && scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [thinking, isStreaming]);
-
   // Format time as (XXs)
   const formattedTime = thinkingTime ? `(${thinkingTime.toFixed(1)}s)` : '';
 
@@ -50,10 +40,7 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
         {isStreaming && <LoadingIndicator size="sm" />}
         <span>Thinking Process {formattedTime}</span>
       </div>
-      <div
-        ref={scrollRef}
-        className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
-      >
+      <div className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto">
         {thinking != null && thinking.length > 0 ? thinking : 'Thinking...'}
       </div>
     </div>

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { LoadingIndicator } from './LoadingIndicator';
 
 interface ThinkingBubbleProps {
@@ -29,6 +29,16 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   isStreaming = false,
   className = '',
 }) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isStreaming || !scrollRef.current) {
+      return;
+    }
+
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [thinking, isStreaming]);
+
   // Format time as (XXs)
   const formattedTime = thinkingTime ? `(${thinkingTime.toFixed(1)}s)` : '';
 
@@ -40,7 +50,10 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
         {isStreaming && <LoadingIndicator size="sm" />}
         <span>Thinking Process {formattedTime}</span>
       </div>
-      <div className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto">
+      <div
+        ref={scrollRef}
+        className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
+      >
         {thinking != null && thinking.length > 0 ? thinking : 'Thinking...'}
       </div>
     </div>

--- a/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
+++ b/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThinkingBubble } from '../ThinkingBubble';
+
+describe('ThinkingBubble', () => {
+  it('keeps its internal scroll pinned to the bottom while streaming', () => {
+    const { container, rerender } = render(
+      <ThinkingBubble thinking="first line" isStreaming={true} />,
+    );
+
+    const scrollContainer = container.querySelector(
+      '.overflow-y-auto',
+    ) as HTMLDivElement | null;
+
+    expect(scrollContainer).not.toBeNull();
+
+    if (!scrollContainer) {
+      throw new Error('Expected thinking scroll container');
+    }
+
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      value: 240,
+    });
+    scrollContainer.scrollTop = 0;
+
+    rerender(
+      <ThinkingBubble
+        thinking={'first line\nsecond line\nthird line'}
+        isStreaming={true}
+      />,
+    );
+
+    expect(scrollContainer.scrollTop).toBe(240);
+  });
+});

--- a/src/features/mcp-servers/MCPServerManagement.tsx
+++ b/src/features/mcp-servers/MCPServerManagement.tsx
@@ -28,6 +28,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
 
   const {
     servers,
+    allServers,
     presets,
     isLoading,
     isValidating,
@@ -137,7 +138,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
       <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
         <RecommendedPresets
           presets={presets}
-          servers={servers}
+          allServers={allServers}
           onSetupPreset={handleSetupPreset}
         />
       </div>

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -13,13 +13,13 @@ import { cn } from '@/lib/utils';
 
 interface RecommendedPresetsProps {
   presets: MCPServerPreset[] | undefined;
-  servers: MCPServerEntity[];
+  allServers: MCPServerEntity[];
   onSetupPreset: (preset: MCPServerPreset) => void;
 }
 
 export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   presets,
-  servers,
+  allServers,
   onSetupPreset,
 }) => {
   const { t } = useTranslation('common');
@@ -39,7 +39,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {presets.map((preset) => {
-          const isInstalled = servers.some((s) => s.name === preset.name);
+          const isInstalled = allServers.some((s) => s.name === preset.name);
           return (
             <div
               key={preset.name}

--- a/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
+++ b/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RecommendedPresets } from '../RecommendedPresets';
+import type { MCPServerEntity } from '@/models/chat';
+import type { MCPServerPreset } from '@/lib/backend/mcp-server-config';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue: string | { defaultValue?: string }) => {
+      if (typeof defaultValue === 'string') {
+        return defaultValue;
+      }
+
+      return defaultValue?.defaultValue ?? _key;
+    },
+  }),
+}));
+
+const basePreset: MCPServerPreset = {
+  name: 'filesystem',
+  description: 'Filesystem tools',
+  transportType: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-filesystem'],
+};
+
+const installedServer: MCPServerEntity = {
+  id: 'server-1',
+  name: 'filesystem',
+  isActive: true,
+  transport: {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem'],
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('RecommendedPresets', () => {
+  it('marks a preset as installed when it exists in the full server list but not the paged grid', () => {
+    render(
+      <RecommendedPresets
+        presets={[basePreset]}
+        allServers={[installedServer]}
+        onSetupPreset={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Installed')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Install filesystem extension'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -20,7 +20,7 @@ const logger = getLogger('MCPServerManagement');
 
 export function useMCPServerManagement(service?: McpServerService) {
   const { t } = useTranslation('common');
-  const { saveServer, deleteServer, toggleActive, ensureLoaded } =
+  const { allServers, saveServer, deleteServer, toggleActive, ensureLoaded } =
     useMCPServerRegistry();
   const { value: settings } = useSettings();
 
@@ -220,6 +220,7 @@ export function useMCPServerManagement(service?: McpServerService) {
 
   return {
     servers,
+    allServers,
     presets,
     isLoading,
     isValidating,


### PR DESCRIPTION
## Summary
- use the full installed MCP server set when marking recommended presets as installed
- simplify agent chat auto-scroll to only react to coarse streaming lifecycle events near the bottom
- remove ThinkingBubble's forced internal auto-scroll and add regression coverage

## Validation
- pnpm refactor:validate