### PR TITLE
Fix MCP preset install state and agent chat scroll UX

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3842,7 +3842,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/context/MCPServerRegistryContext.tsx
+++ b/src/context/MCPServerRegistryContext.tsx
@@ -25,6 +25,8 @@ export interface MCPServerRegistryContextType {
   allServers: MCPServerEntity[];
   // Filtered active servers
   activeServers: MCPServerEntity[];
+  // Whether the initial registry load has completed at least once
+  loaded: boolean;
   // Loading state
   loading: boolean;
   // Error state
@@ -58,6 +60,7 @@ export const MCPServerRegistryProvider = ({
   children: React.ReactNode;
 }) => {
   const [allServers, setAllServers] = useState<MCPServerEntity[]>([]);
+  const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -93,6 +96,7 @@ export const MCPServerRegistryProvider = ({
         const servers = await mcpServerService.getAll();
         setAllServers(servers);
         hasLoadedRef.current = true;
+        setLoaded(true);
         setError(undefined);
         logger.debug(`Loaded ${servers.length} MCP servers from service`);
       } catch (err) {
@@ -210,6 +214,7 @@ export const MCPServerRegistryProvider = ({
     () => ({
       allServers,
       activeServers,
+      loaded,
       loading,
       error,
       saveServer,
@@ -221,6 +226,7 @@ export const MCPServerRegistryProvider = ({
     [
       allServers,
       activeServers,
+      loaded,
       loading,
       error,
       saveServer,

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -69,6 +69,12 @@ export function shouldShowAnalysisLoader(
 
 export type AutoScrollEvent = 'none' | 'stream-start' | 'message-complete';
 
+function isStreamingAssistantMessage(
+  message: Message | undefined,
+): message is Message {
+  return message?.role === 'assistant' && message.isStreaming === true;
+}
+
 export function getAutoScrollEvent(args: {
   previousLatestMessage: Message | undefined;
   latestMessage: Message | undefined;
@@ -102,6 +108,40 @@ export function getAutoScrollEvent(args: {
   }
 
   return 'none';
+}
+
+export function getStreamingScrollLockMessageId(args: {
+  currentLockMessageId: string | null;
+  autoScrollEvent: AutoScrollEvent;
+  latestMessage: Message | undefined;
+  shouldStickToBottom: boolean;
+}): string | null {
+  const {
+    currentLockMessageId,
+    autoScrollEvent,
+    latestMessage,
+    shouldStickToBottom,
+  } = args;
+
+  if (autoScrollEvent === 'message-complete') {
+    return null;
+  }
+
+  if (autoScrollEvent === 'stream-start') {
+    return shouldStickToBottom && isStreamingAssistantMessage(latestMessage)
+      ? latestMessage.id
+      : null;
+  }
+
+  if (
+    currentLockMessageId &&
+    isStreamingAssistantMessage(latestMessage) &&
+    latestMessage.id === currentLockMessageId
+  ) {
+    return currentLockMessageId;
+  }
+
+  return null;
 }
 
 function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
@@ -380,6 +420,7 @@ export function AgentChatMessages() {
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
   const wasAtBottomRef = useRef(true);
   const previousLatestMessageRef = useRef<Message | undefined>(undefined);
+  const streamingScrollLockMessageIdRef = useRef<string | null>(null);
   const autoScrollFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
@@ -487,6 +528,7 @@ export function AgentChatMessages() {
   useEffect(() => {
     wasAtBottomRef.current = true;
     previousLatestMessageRef.current = undefined;
+    streamingScrollLockMessageIdRef.current = null;
     if (autoScrollFrameRef.current !== null) {
       cancelAnimationFrame(autoScrollFrameRef.current);
       autoScrollFrameRef.current = null;
@@ -535,15 +577,57 @@ export function AgentChatMessages() {
   }, [bottomThreshold, session?.id]);
 
   useEffect(() => {
+    const scroller = scrollerElementRef.current;
+
+    if (!scroller) {
+      return;
+    }
+
+    const handleScroll = () => {
+      const distanceFromBottom =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      const isNearBottom = distanceFromBottom <= bottomThreshold;
+
+      wasAtBottomRef.current = isNearBottom;
+
+      if (!isNearBottom && streamingScrollLockMessageIdRef.current !== null) {
+        streamingScrollLockMessageIdRef.current = null;
+      }
+    };
+
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll);
+    };
+  }, [bottomThreshold, session?.id]);
+
+  useEffect(() => {
     const previousLatestMessage = previousLatestMessageRef.current;
     const autoScrollEvent = getAutoScrollEvent({
       previousLatestMessage,
       latestMessage,
     });
+    const hadStreamingScrollLock =
+      streamingScrollLockMessageIdRef.current !== null;
+    const shouldStickToBottom =
+      wasAtBottomRef.current || hadStreamingScrollLock;
+    const nextStreamingScrollLockMessageId = getStreamingScrollLockMessageId({
+      currentLockMessageId: streamingScrollLockMessageIdRef.current,
+      autoScrollEvent,
+      latestMessage,
+      shouldStickToBottom,
+    });
+
+    streamingScrollLockMessageIdRef.current = nextStreamingScrollLockMessageId;
 
     previousLatestMessageRef.current = latestMessage;
 
-    if (autoScrollEvent === 'none' || !wasAtBottomRef.current) {
+    const shouldAutoScroll =
+      nextStreamingScrollLockMessageId !== null ||
+      (autoScrollEvent !== 'none' && shouldStickToBottom);
+
+    if (!shouldAutoScroll) {
       return;
     }
 

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -94,6 +94,13 @@ function scrollFooterSentinelIntoView(sentinel: HTMLDivElement | null) {
   });
 }
 
+function getScrollContentElement(
+  scroller: HTMLDivElement | null,
+): HTMLElement | null {
+  const firstChild = scroller?.firstElementChild;
+  return firstChild instanceof HTMLElement ? firstChild : null;
+}
+
 interface AgentChatVirtuosoContext {
   agentError: ReturnType<typeof useAgentChat>['error'];
   agentLlmError: ReturnType<typeof useAgentChat>['llmError'];
@@ -351,6 +358,7 @@ export function AgentChatMessages() {
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
   const isPinnedToBottomRef = useRef(true);
   const autoScrollFrameRef = useRef<number | null>(null);
+  const streamFollowFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
   );
@@ -402,6 +410,7 @@ export function AgentChatMessages() {
   // Memoize references so ErrorBubble memo stays effective during streaming re-renders
   const agentError = useMemo(() => error, [error]);
   const agentLlmError = useMemo(() => llmError, [llmError]);
+  const shouldContinuouslyFollowOutput = isPinned && workflowStatus === 'busy';
 
   const streamingToolMessageIds = useMemo(
     () =>
@@ -455,6 +464,17 @@ export function AgentChatMessages() {
     };
   }, [groupedMessages, session?.id]);
 
+  const scheduleScrollToBottom = useCallback(() => {
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+    }
+
+    autoScrollFrameRef.current = requestAnimationFrame(() => {
+      autoScrollFrameRef.current = null;
+      scrollFooterSentinelIntoView(footerEndRef.current);
+    });
+  }, []);
+
   useEffect(() => {
     isPinnedToBottomRef.current = true;
     setIsPinned(true);
@@ -462,13 +482,22 @@ export function AgentChatMessages() {
       cancelAnimationFrame(autoScrollFrameRef.current);
       autoScrollFrameRef.current = null;
     }
-  }, [session?.id]);
+    if (streamFollowFrameRef.current !== null) {
+      cancelAnimationFrame(streamFollowFrameRef.current);
+      streamFollowFrameRef.current = null;
+    }
+    scheduleScrollToBottom();
+  }, [scheduleScrollToBottom, session?.id]);
 
   useEffect(() => {
     return () => {
       if (autoScrollFrameRef.current !== null) {
         cancelAnimationFrame(autoScrollFrameRef.current);
         autoScrollFrameRef.current = null;
+      }
+      if (streamFollowFrameRef.current !== null) {
+        cancelAnimationFrame(streamFollowFrameRef.current);
+        streamFollowFrameRef.current = null;
       }
     };
   }, []);
@@ -502,30 +531,76 @@ export function AgentChatMessages() {
   const scrollToBottom = useCallback(() => {
     isPinnedToBottomRef.current = true;
     setIsPinned(true);
+    scheduleScrollToBottom();
+  }, [scheduleScrollToBottom]);
 
-    if (autoScrollFrameRef.current !== null) {
-      cancelAnimationFrame(autoScrollFrameRef.current);
+  useEffect(() => {
+    const scroller = scrollerElementRef.current;
+    const content = getScrollContentElement(scroller);
+
+    if (!content || typeof ResizeObserver === 'undefined') {
+      return;
     }
 
-    autoScrollFrameRef.current = requestAnimationFrame(() => {
-      autoScrollFrameRef.current = null;
-      scrollFooterSentinelIntoView(footerEndRef.current);
+    const observer = new ResizeObserver(() => {
+      if (!isPinnedToBottomRef.current) {
+        return;
+      }
+
+      scheduleScrollToBottom();
     });
-  }, []);
+
+    observer.observe(content);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [scheduleScrollToBottom, session?.id]);
+
+  useEffect(() => {
+    if (!shouldContinuouslyFollowOutput) {
+      if (streamFollowFrameRef.current !== null) {
+        cancelAnimationFrame(streamFollowFrameRef.current);
+        streamFollowFrameRef.current = null;
+      }
+      return;
+    }
+
+    const followStreamingOutput = () => {
+      if (!isPinnedToBottomRef.current) {
+        streamFollowFrameRef.current = null;
+        return;
+      }
+
+      scrollFooterSentinelIntoView(footerEndRef.current);
+      streamFollowFrameRef.current = requestAnimationFrame(
+        followStreamingOutput,
+      );
+    };
+
+    streamFollowFrameRef.current = requestAnimationFrame(followStreamingOutput);
+
+    return () => {
+      if (streamFollowFrameRef.current !== null) {
+        cancelAnimationFrame(streamFollowFrameRef.current);
+        streamFollowFrameRef.current = null;
+      }
+    };
+  }, [shouldContinuouslyFollowOutput]);
 
   useEffect(() => {
     if (!isPinnedToBottomRef.current) {
       return;
     }
 
-    scrollToBottom();
+    scheduleScrollToBottom();
   }, [
     latestMessage,
     workflowStatus,
     pendingApprovals?.length,
     agentError,
     agentLlmError,
-    scrollToBottom,
+    scheduleScrollToBottom,
   ]);
 
   const virtuosoContext = useMemo<AgentChatVirtuosoContext>(
@@ -572,7 +647,7 @@ export function AgentChatMessages() {
     const AgentChatMessagesScroller = forwardRef<
       HTMLDivElement,
       ComponentPropsWithoutRef<'div'>
-    >(function AgentChatMessagesScroller({ className, ...props }, ref) {
+    >(function AgentChatMessagesScroller({ className, style, ...props }, ref) {
       return (
         <div
           {...props}
@@ -581,6 +656,10 @@ export function AgentChatMessages() {
             setForwardedRef(ref, node);
           }}
           className={cn('agent-chat-scrollbar', className)}
+          style={{
+            ...style,
+            overflowAnchor: 'none',
+          }}
         />
       );
     });

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -5,7 +5,6 @@ import {
   forwardRef,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -54,28 +53,6 @@ export function getVisualBottomThreshold(): number {
   return DEFAULT_BOTTOM_THRESHOLD;
 }
 
-export function shouldAutoFollowOutput(
-  latestMessage: Message | undefined,
-  workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'],
-): boolean {
-  if (!latestMessage) {
-    return false;
-  }
-
-  const assistantHasNoVisibleOutput =
-    latestMessage.role === 'assistant' &&
-    !latestMessage.content?.length &&
-    !latestMessage.thinking &&
-    !latestMessage.tool_calls?.length;
-
-  return (
-    workflowStatus === 'busy' &&
-    (latestMessage.role !== 'assistant' ||
-      latestMessage.isStreaming === true ||
-      assistantHasNoVisibleOutput)
-  );
-}
-
 export function shouldShowAnalysisLoader(
   latestMessage: Message | undefined,
   workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'],
@@ -90,83 +67,41 @@ export function shouldShowAnalysisLoader(
   );
 }
 
-export function getMessageOutputSignature(
-  message: Message | undefined,
-): string {
-  if (!message) {
+export type AutoScrollEvent = 'none' | 'stream-start' | 'message-complete';
+
+export function getAutoScrollEvent(args: {
+  previousLatestMessage: Message | undefined;
+  latestMessage: Message | undefined;
+}): AutoScrollEvent {
+  const { previousLatestMessage, latestMessage } = args;
+
+  if (!previousLatestMessage || !latestMessage) {
     return 'none';
   }
 
-  const contentSignature = (message.content ?? [])
-    .map((item) => {
-      switch (item.type) {
-        case 'text':
-          return `text:${item.text.length}`;
-        case 'thinking':
-          return `thinking:${item.thinking.length}`;
-        case 'tool_call':
-          return `tool:${item.name}`;
-        default:
-          return item.type;
-      }
-    })
-    .join('|');
+  const previousWasStreamingAssistant =
+    previousLatestMessage.role === 'assistant' &&
+    previousLatestMessage.isStreaming === true;
+  const currentIsStreamingAssistant =
+    latestMessage.role === 'assistant' && latestMessage.isStreaming === true;
 
-  const toolCallSignature = (message.tool_calls ?? [])
-    .map((toolCall) => toolCall.function.name)
-    .join('|');
+  if (
+    currentIsStreamingAssistant &&
+    (!previousWasStreamingAssistant ||
+      previousLatestMessage.id !== latestMessage.id)
+  ) {
+    return 'stream-start';
+  }
 
-  return [
-    message.id,
-    message.role,
-    message.isStreaming ? 'streaming' : 'static',
-    message.thinking?.length ?? 0,
-    contentSignature,
-    toolCallSignature,
-  ].join('::');
-}
+  if (
+    previousWasStreamingAssistant &&
+    (!currentIsStreamingAssistant ||
+      previousLatestMessage.id !== latestMessage.id)
+  ) {
+    return 'message-complete';
+  }
 
-export function getTailAnchorKey(args: {
-  latestMessage: Message | undefined;
-  workflowStatus: ReturnType<typeof useAgentChat>['workflowStatus'];
-  pendingApprovalsCount: number;
-  hasAgentError: boolean;
-  hasAgentLlmError: boolean;
-}): string {
-  return [
-    getMessageOutputSignature(args.latestMessage),
-    args.workflowStatus,
-    args.pendingApprovalsCount,
-    args.hasAgentError ? 'agent-error' : 'no-agent-error',
-    args.hasAgentLlmError ? 'llm-error' : 'no-llm-error',
-    shouldShowAnalysisLoader(args.latestMessage, args.workflowStatus)
-      ? 'analysis-loader'
-      : 'no-analysis-loader',
-  ].join('||');
-}
-
-export function shouldPreserveBottomAnchorOnTailChange(args: {
-  tailChanged: boolean;
-  wasAtBottomBeforeChange: boolean;
-  autoFollowOutput: boolean;
-  wasFollowingOutputBeforeChange: boolean;
-}): boolean {
-  return (
-    args.tailChanged &&
-    args.wasAtBottomBeforeChange &&
-    !args.autoFollowOutput &&
-    args.wasFollowingOutputBeforeChange
-  );
-}
-
-export function shouldSoftFollowOutputOnTailChange(args: {
-  tailChanged: boolean;
-  wasAtBottomBeforeChange: boolean;
-  autoFollowOutput: boolean;
-}): boolean {
-  return (
-    args.tailChanged && args.wasAtBottomBeforeChange && args.autoFollowOutput
-  );
+  return 'none';
 }
 
 function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
@@ -444,17 +379,12 @@ export function AgentChatMessages() {
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
   const wasAtBottomRef = useRef(true);
-  const settleLockRef = useRef(false);
-  const settleFrameRefs = useRef<number[]>([]);
-  const streamFollowFrameRef = useRef<number | null>(null);
+  const previousLatestMessageRef = useRef<Message | undefined>(undefined);
+  const autoScrollFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
   );
   const bottomThreshold = getVisualBottomThreshold();
-  const autoFollowOutput = useMemo(
-    () => shouldAutoFollowOutput(latestMessage, workflowStatus),
-    [latestMessage, workflowStatus],
-  );
   const previousListStateRef = useRef<{
     firstId: string | undefined;
     lastId: string | undefined;
@@ -501,26 +431,6 @@ export function AgentChatMessages() {
   // Memoize references so ErrorBubble memo stays effective during streaming re-renders
   const agentError = useMemo(() => error, [error]);
   const agentLlmError = useMemo(() => llmError, [llmError]);
-  const tailAnchorKey = useMemo(
-    () =>
-      getTailAnchorKey({
-        latestMessage,
-        workflowStatus,
-        pendingApprovalsCount: pendingApprovals?.length ?? 0,
-        hasAgentError: !!agentError,
-        hasAgentLlmError: !!agentLlmError,
-      }),
-    [
-      latestMessage,
-      workflowStatus,
-      pendingApprovals,
-      agentError,
-      agentLlmError,
-    ],
-  );
-  const previousTailAnchorKeyRef = useRef<string | undefined>(undefined);
-  const previousWasAtBottomRef = useRef(true);
-  const previousAutoFollowOutputRef = useRef(false);
 
   const streamingToolMessageIds = useMemo(
     () =>
@@ -576,26 +486,18 @@ export function AgentChatMessages() {
 
   useEffect(() => {
     wasAtBottomRef.current = true;
-    previousWasAtBottomRef.current = true;
-    previousAutoFollowOutputRef.current = false;
-    previousTailAnchorKeyRef.current = undefined;
-    settleLockRef.current = false;
-    settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-    settleFrameRefs.current = [];
-    if (streamFollowFrameRef.current !== null) {
-      cancelAnimationFrame(streamFollowFrameRef.current);
-      streamFollowFrameRef.current = null;
+    previousLatestMessageRef.current = undefined;
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
     }
   }, [session?.id]);
 
   useEffect(() => {
     return () => {
-      settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-      settleFrameRefs.current = [];
-      settleLockRef.current = false;
-      if (streamFollowFrameRef.current !== null) {
-        cancelAnimationFrame(streamFollowFrameRef.current);
-        streamFollowFrameRef.current = null;
+      if (autoScrollFrameRef.current !== null) {
+        cancelAnimationFrame(autoScrollFrameRef.current);
+        autoScrollFrameRef.current = null;
       }
     };
   }, []);
@@ -616,13 +518,7 @@ export function AgentChatMessages() {
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        const atBottom = entry?.isIntersecting ?? false;
-
-        if (settleLockRef.current && !atBottom) {
-          return;
-        }
-
-        wasAtBottomRef.current = atBottom;
+        wasAtBottomRef.current = entry?.isIntersecting ?? false;
       },
       {
         root: scroller,
@@ -638,73 +534,28 @@ export function AgentChatMessages() {
     };
   }, [bottomThreshold, session?.id]);
 
-  useLayoutEffect(() => {
-    const previousTailAnchorKey = previousTailAnchorKeyRef.current;
-    const wasAtBottomBeforeChange = previousWasAtBottomRef.current;
-    const wasFollowingOutputBeforeChange = previousAutoFollowOutputRef.current;
+  useEffect(() => {
+    const previousLatestMessage = previousLatestMessageRef.current;
+    const autoScrollEvent = getAutoScrollEvent({
+      previousLatestMessage,
+      latestMessage,
+    });
 
-    previousTailAnchorKeyRef.current = tailAnchorKey;
-    previousWasAtBottomRef.current = wasAtBottomRef.current;
-    previousAutoFollowOutputRef.current = autoFollowOutput;
+    previousLatestMessageRef.current = latestMessage;
 
-    if (previousTailAnchorKey === undefined) {
+    if (autoScrollEvent === 'none' || !wasAtBottomRef.current) {
       return;
     }
 
-    const tailChanged = previousTailAnchorKey !== tailAnchorKey;
-
-    if (
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged,
-        wasAtBottomBeforeChange,
-        autoFollowOutput,
-      })
-    ) {
-      if (streamFollowFrameRef.current === null) {
-        streamFollowFrameRef.current = requestAnimationFrame(() => {
-          streamFollowFrameRef.current = null;
-          scrollFooterSentinelIntoView(footerEndRef.current);
-        });
-      }
-      return;
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
     }
 
-    if (
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged,
-        wasAtBottomBeforeChange,
-        autoFollowOutput,
-        wasFollowingOutputBeforeChange,
-      })
-    ) {
-      settleLockRef.current = true;
-      if (streamFollowFrameRef.current !== null) {
-        cancelAnimationFrame(streamFollowFrameRef.current);
-        streamFollowFrameRef.current = null;
-      }
-      settleFrameRefs.current.forEach((frame) => cancelAnimationFrame(frame));
-      settleFrameRefs.current = [];
-
+    autoScrollFrameRef.current = requestAnimationFrame(() => {
+      autoScrollFrameRef.current = null;
       scrollFooterSentinelIntoView(footerEndRef.current);
-
-      const firstFrame = requestAnimationFrame(() => {
-        scrollFooterSentinelIntoView(footerEndRef.current);
-
-        const secondFrame = requestAnimationFrame(() => {
-          scrollFooterSentinelIntoView(footerEndRef.current);
-          settleLockRef.current = false;
-          wasAtBottomRef.current = true;
-        });
-
-        settleFrameRefs.current = settleFrameRefs.current.filter(
-          (frame) => frame !== firstFrame,
-        );
-        settleFrameRefs.current.push(secondFrame);
-      });
-
-      settleFrameRefs.current.push(firstFrame);
-    }
-  }, [autoFollowOutput, tailAnchorKey]);
+    });
+  }, [latestMessage]);
 
   const virtuosoContext = useMemo<AgentChatVirtuosoContext>(
     () => ({

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -22,17 +22,18 @@ import { AgentMessageBubble } from './AgentMessageBubble';
 import { ErrorBubble } from '@/components/shared/ErrorBubble';
 import { AnalysisLoader } from './shared';
 import { CompactEventDivider } from './shared/CompactEventDivider';
-import { Bot } from 'lucide-react';
+import { Bot, ChevronDown } from 'lucide-react';
 import { PendingApprovalWidget } from './PendingApprovalWidget';
 import { getLogger } from '@/lib/logger';
 import type { Message } from '@/models/chat';
 import { useTranslation } from 'react-i18next';
 import { Virtuoso, type Components, type ListProps } from 'react-virtuoso';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 const logger = getLogger('AgentChatMessages');
 const INITIAL_FIRST_ITEM_INDEX = 10_000;
-const DEFAULT_BOTTOM_THRESHOLD = 32;
+const DEFAULT_BOTTOM_THRESHOLD = 4;
 const CHAT_COMPOSER_CLEARANCE = 24;
 
 export function getPrependedFirstItemIndex(
@@ -67,81 +68,11 @@ export function shouldShowAnalysisLoader(
   );
 }
 
-export type AutoScrollEvent = 'none' | 'stream-start' | 'message-complete';
-
-function isStreamingAssistantMessage(
-  message: Message | undefined,
-): message is Message {
-  return message?.role === 'assistant' && message.isStreaming === true;
-}
-
-export function getAutoScrollEvent(args: {
-  previousLatestMessage: Message | undefined;
-  latestMessage: Message | undefined;
-}): AutoScrollEvent {
-  const { previousLatestMessage, latestMessage } = args;
-
-  if (!previousLatestMessage || !latestMessage) {
-    return 'none';
-  }
-
-  const previousWasStreamingAssistant =
-    previousLatestMessage.role === 'assistant' &&
-    previousLatestMessage.isStreaming === true;
-  const currentIsStreamingAssistant =
-    latestMessage.role === 'assistant' && latestMessage.isStreaming === true;
-
-  if (
-    currentIsStreamingAssistant &&
-    (!previousWasStreamingAssistant ||
-      previousLatestMessage.id !== latestMessage.id)
-  ) {
-    return 'stream-start';
-  }
-
-  if (
-    previousWasStreamingAssistant &&
-    (!currentIsStreamingAssistant ||
-      previousLatestMessage.id !== latestMessage.id)
-  ) {
-    return 'message-complete';
-  }
-
-  return 'none';
-}
-
-export function getStreamingScrollLockMessageId(args: {
-  currentLockMessageId: string | null;
-  autoScrollEvent: AutoScrollEvent;
-  latestMessage: Message | undefined;
-  shouldStickToBottom: boolean;
-}): string | null {
-  const {
-    currentLockMessageId,
-    autoScrollEvent,
-    latestMessage,
-    shouldStickToBottom,
-  } = args;
-
-  if (autoScrollEvent === 'message-complete') {
-    return null;
-  }
-
-  if (autoScrollEvent === 'stream-start') {
-    return shouldStickToBottom && isStreamingAssistantMessage(latestMessage)
-      ? latestMessage.id
-      : null;
-  }
-
-  if (
-    currentLockMessageId &&
-    isStreamingAssistantMessage(latestMessage) &&
-    latestMessage.id === currentLockMessageId
-  ) {
-    return currentLockMessageId;
-  }
-
-  return null;
+export function isPinnedToBottom(
+  distanceFromBottom: number,
+  threshold = DEFAULT_BOTTOM_THRESHOLD,
+): boolean {
+  return distanceFromBottom <= threshold;
 }
 
 function setForwardedRef<T>(ref: ForwardedRef<T>, value: T) {
@@ -418,13 +349,12 @@ export function AgentChatMessages() {
   const assistantName = session?.assistant?.name || 'Agent';
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
-  const wasAtBottomRef = useRef(true);
-  const previousLatestMessageRef = useRef<Message | undefined>(undefined);
-  const streamingScrollLockMessageIdRef = useRef<string | null>(null);
+  const isPinnedToBottomRef = useRef(true);
   const autoScrollFrameRef = useRef<number | null>(null);
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
   );
+  const [isPinned, setIsPinned] = useState(true);
   const bottomThreshold = getVisualBottomThreshold();
   const previousListStateRef = useRef<{
     firstId: string | undefined;
@@ -526,9 +456,8 @@ export function AgentChatMessages() {
   }, [groupedMessages, session?.id]);
 
   useEffect(() => {
-    wasAtBottomRef.current = true;
-    previousLatestMessageRef.current = undefined;
-    streamingScrollLockMessageIdRef.current = null;
+    isPinnedToBottomRef.current = true;
+    setIsPinned(true);
     if (autoScrollFrameRef.current !== null) {
       cancelAnimationFrame(autoScrollFrameRef.current);
       autoScrollFrameRef.current = null;
@@ -545,91 +474,34 @@ export function AgentChatMessages() {
   }, []);
 
   useEffect(() => {
-    const sentinel = footerEndRef.current;
-    const scroller = scrollerElementRef.current;
-
-    if (!sentinel || !scroller) {
-      return;
-    }
-
-    if (typeof IntersectionObserver === 'undefined') {
-      wasAtBottomRef.current = true;
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        wasAtBottomRef.current = entry?.isIntersecting ?? false;
-      },
-      {
-        root: scroller,
-        threshold: 0,
-        rootMargin: `0px 0px ${bottomThreshold}px 0px`,
-      },
-    );
-
-    observer.observe(sentinel);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [bottomThreshold, session?.id]);
-
-  useEffect(() => {
     const scroller = scrollerElementRef.current;
 
     if (!scroller) {
       return;
     }
 
-    const handleScroll = () => {
+    const updatePinnedState = () => {
       const distanceFromBottom =
         scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
-      const isNearBottom = distanceFromBottom <= bottomThreshold;
-
-      wasAtBottomRef.current = isNearBottom;
-
-      if (!isNearBottom && streamingScrollLockMessageIdRef.current !== null) {
-        streamingScrollLockMessageIdRef.current = null;
-      }
+      const nextPinned = isPinnedToBottom(distanceFromBottom, bottomThreshold);
+      isPinnedToBottomRef.current = nextPinned;
+      setIsPinned((current) => (current === nextPinned ? current : nextPinned));
+    };
+    const handleScroll = () => {
+      updatePinnedState();
     };
 
     scroller.addEventListener('scroll', handleScroll, { passive: true });
+    updatePinnedState();
 
     return () => {
       scroller.removeEventListener('scroll', handleScroll);
     };
   }, [bottomThreshold, session?.id]);
 
-  useEffect(() => {
-    const previousLatestMessage = previousLatestMessageRef.current;
-    const autoScrollEvent = getAutoScrollEvent({
-      previousLatestMessage,
-      latestMessage,
-    });
-    const hadStreamingScrollLock =
-      streamingScrollLockMessageIdRef.current !== null;
-    const shouldStickToBottom =
-      wasAtBottomRef.current || hadStreamingScrollLock;
-    const nextStreamingScrollLockMessageId = getStreamingScrollLockMessageId({
-      currentLockMessageId: streamingScrollLockMessageIdRef.current,
-      autoScrollEvent,
-      latestMessage,
-      shouldStickToBottom,
-    });
-
-    streamingScrollLockMessageIdRef.current = nextStreamingScrollLockMessageId;
-
-    previousLatestMessageRef.current = latestMessage;
-
-    const shouldAutoScroll =
-      nextStreamingScrollLockMessageId !== null ||
-      (autoScrollEvent !== 'none' && shouldStickToBottom);
-
-    if (!shouldAutoScroll) {
-      return;
-    }
+  const scrollToBottom = useCallback(() => {
+    isPinnedToBottomRef.current = true;
+    setIsPinned(true);
 
     if (autoScrollFrameRef.current !== null) {
       cancelAnimationFrame(autoScrollFrameRef.current);
@@ -639,7 +511,22 @@ export function AgentChatMessages() {
       autoScrollFrameRef.current = null;
       scrollFooterSentinelIntoView(footerEndRef.current);
     });
-  }, [latestMessage]);
+  }, []);
+
+  useEffect(() => {
+    if (!isPinnedToBottomRef.current) {
+      return;
+    }
+
+    scrollToBottom();
+  }, [
+    latestMessage,
+    workflowStatus,
+    pendingApprovals?.length,
+    agentError,
+    agentLlmError,
+    scrollToBottom,
+  ]);
 
   const virtuosoContext = useMemo<AgentChatVirtuosoContext>(
     () => ({
@@ -809,7 +696,7 @@ export function AgentChatMessages() {
   );
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
+    <div className="relative flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
       <Virtuoso
         key={session?.id ?? 'agent-chat'}
         className="flex-1"
@@ -829,6 +716,24 @@ export function AgentChatMessages() {
         startReached={handleReachTop}
         itemContent={renderMessageGroup}
       />
+      {!isPinned && (
+        <div
+          className="pointer-events-none absolute right-6 z-10"
+          style={{
+            bottom: `calc(var(--agent-chat-composer-overlap, 64px) + ${CHAT_COMPOSER_CLEARANCE + 16}px)`,
+          }}
+        >
+          <Button
+            type="button"
+            size="icon"
+            className="pointer-events-auto size-10 rounded-full shadow-lg"
+            aria-label={t('agent.messages.scrollToLatest', 'Scroll to latest')}
+            onClick={scrollToBottom}
+          >
+            <ChevronDown className="size-4" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/agent/components/AgentToolCallGroup.tsx
+++ b/src/features/agent/components/AgentToolCallGroup.tsx
@@ -263,7 +263,7 @@ const AgentToolCallGroupImpl: React.FC<AgentToolCallGroupProps> = ({
   );
 
   return (
-    <div className={containerClass}>
+    <div className={containerClass} style={{ overflowAnchor: 'none' }}>
       <GroupHeader
         totalCalls={toolGroup.calls.length}
         statusSummary={statusSummary}

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -121,7 +121,10 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   // they are never hidden from the user.
   if (isSimpleMode) {
     return (
-      <div className="rounded px-3 py-2 text-sm bg-background">
+      <div
+        className="rounded px-3 py-2 text-sm bg-background"
+        style={{ overflowAnchor: 'none' }}
+      >
         <div className="flex items-center gap-2">
           <ToolStatusIcon hasResult={!!toolResult} hasError={hasError} />
           <span className="font-medium flex-shrink-0">{displayToolName}</span>
@@ -158,6 +161,7 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
           ? 'bg-destructive/10 hover:bg-destructive/20'
           : 'bg-background hover:bg-muted/50',
       )}
+      style={{ overflowAnchor: 'none' }}
     >
       {/* Collapsed header line */}
       <button

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -4,10 +4,9 @@ import { forwardRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentChatMessages,
-  getAutoScrollEvent,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
-  getStreamingScrollLockMessageId,
+  isPinnedToBottom,
   getVisualBottomThreshold,
   shouldShowAnalysisLoader,
 } from '../AgentChatMessages';
@@ -198,7 +197,7 @@ describe('AgentChatMessages compaction rendering', () => {
     expect(getPrependedFirstItemIndex(2, 3)).toBe(0);
   });
 
-  it('uses a fixed bottom threshold after moving input into layout flow', () => {
+  it('uses a tiny bottom threshold as scroll noise tolerance', () => {
     render(<AgentChatMessages />);
 
     const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
@@ -206,7 +205,7 @@ describe('AgentChatMessages compaction rendering', () => {
     };
 
     expect(virtuosoProps.atBottomThreshold).toBe(getVisualBottomThreshold());
-    expect(getVisualBottomThreshold()).toBe(32);
+    expect(getVisualBottomThreshold()).toBe(4);
   });
 
   it('shows the analysis loader only for busy empty assistant output states', () => {
@@ -225,121 +224,9 @@ describe('AgentChatMessages compaction rendering', () => {
     ).toBe(false);
   });
 
-  it('auto-scrolls only on streaming lifecycle boundaries', () => {
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: undefined,
-        latestMessage: { ...baseMessage, isStreaming: true },
-      }),
-    ).toBe('none');
-
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: { ...baseMessage, isStreaming: false },
-        latestMessage: { ...baseMessage, isStreaming: true },
-      }),
-    ).toBe('stream-start');
-
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: {
-          ...baseMessage,
-          isStreaming: true,
-          content: [{ type: 'text', text: 'a' }],
-        },
-        latestMessage: {
-          ...baseMessage,
-          isStreaming: true,
-          content: [{ type: 'text', text: 'abcdef' }],
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: { ...baseMessage, isStreaming: true },
-        latestMessage: { ...baseMessage, isStreaming: false },
-      }),
-    ).toBe('message-complete');
-  });
-
-  it('treats a new static assistant message after streaming as completion', () => {
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: {
-          ...baseMessage,
-          id: 'assistant-1',
-          isStreaming: true,
-        },
-        latestMessage: {
-          ...baseMessage,
-          id: 'assistant-2',
-          isStreaming: false,
-          content: [{ type: 'text', text: 'Done' }],
-        },
-      }),
-    ).toBe('message-complete');
-  });
-
-  it('ignores non-assistant updates for auto-scroll lifecycle events', () => {
-    expect(
-      getAutoScrollEvent({
-        previousLatestMessage: {
-          ...baseMessage,
-          role: 'user',
-          isStreaming: false,
-        },
-        latestMessage: {
-          ...baseMessage,
-          role: 'user',
-          isStreaming: false,
-          content: [{ type: 'text', text: 'Still user content' }],
-        },
-      }),
-    ).toBe('none');
-  });
-
-  it('keeps a stream scroll lock alive for chunk updates after starting near the bottom', () => {
-    expect(
-      getStreamingScrollLockMessageId({
-        currentLockMessageId: null,
-        autoScrollEvent: 'stream-start',
-        latestMessage: { ...baseMessage, isStreaming: true },
-        shouldStickToBottom: true,
-      }),
-    ).toBe('assistant-1');
-
-    expect(
-      getStreamingScrollLockMessageId({
-        currentLockMessageId: 'assistant-1',
-        autoScrollEvent: 'none',
-        latestMessage: {
-          ...baseMessage,
-          isStreaming: true,
-          content: [{ type: 'text', text: 'abcdef' }],
-        },
-        shouldStickToBottom: false,
-      }),
-    ).toBe('assistant-1');
-  });
-
-  it('drops the stream scroll lock when the user was not near the bottom or the stream completes', () => {
-    expect(
-      getStreamingScrollLockMessageId({
-        currentLockMessageId: null,
-        autoScrollEvent: 'stream-start',
-        latestMessage: { ...baseMessage, isStreaming: true },
-        shouldStickToBottom: false,
-      }),
-    ).toBeNull();
-
-    expect(
-      getStreamingScrollLockMessageId({
-        currentLockMessageId: 'assistant-1',
-        autoScrollEvent: 'message-complete',
-        latestMessage: { ...baseMessage, isStreaming: false },
-        shouldStickToBottom: true,
-      }),
-    ).toBeNull();
+  it('treats only tiny distances as pinned to the bottom', () => {
+    expect(isPinnedToBottom(0)).toBe(true);
+    expect(isPinnedToBottom(4)).toBe(true);
+    expect(isPinnedToBottom(5)).toBe(false);
   });
 });

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -4,15 +4,11 @@ import { forwardRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentChatMessages,
-  getMessageOutputSignature,
-  getTailAnchorKey,
+  getAutoScrollEvent,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
   getVisualBottomThreshold,
-  shouldPreserveBottomAnchorOnTailChange,
-  shouldSoftFollowOutputOnTailChange,
   shouldShowAnalysisLoader,
-  shouldAutoFollowOutput,
 } from '../AgentChatMessages';
 import type { Message } from '@/models/chat';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
@@ -212,87 +208,6 @@ describe('AgentChatMessages compaction rendering', () => {
     expect(getVisualBottomThreshold()).toBe(32);
   });
 
-  it('only auto-follows while the workflow is actively producing output', () => {
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          isStreaming: true,
-        },
-        'busy',
-      ),
-    ).toBe(true);
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          isStreaming: false,
-        },
-        'idle',
-      ),
-    ).toBe(false);
-    expect(
-      shouldAutoFollowOutput(
-        {
-          ...baseMessage,
-          content: [],
-          isStreaming: false,
-        },
-        'busy',
-      ),
-    ).toBe(true);
-  });
-
-  it('derives a stable tail signature from the latest message output', () => {
-    expect(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abc' }],
-        isStreaming: true,
-      }),
-    ).toContain('streaming');
-    expect(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abcd' }],
-      }),
-    ).not.toBe(
-      getMessageOutputSignature({
-        ...baseMessage,
-        content: [{ type: 'text', text: 'abc' }],
-      }),
-    );
-  });
-
-  it('includes footer-affecting state in the tail anchor key', () => {
-    const baseKey = getTailAnchorKey({
-      latestMessage: baseMessage,
-      workflowStatus: 'idle',
-      pendingApprovalsCount: 0,
-      hasAgentError: false,
-      hasAgentLlmError: false,
-    });
-
-    expect(
-      getTailAnchorKey({
-        latestMessage: baseMessage,
-        workflowStatus: 'idle',
-        pendingApprovalsCount: 1,
-        hasAgentError: false,
-        hasAgentLlmError: false,
-      }),
-    ).not.toBe(baseKey);
-    expect(
-      getTailAnchorKey({
-        latestMessage: { ...baseMessage, content: [] },
-        workflowStatus: 'busy',
-        pendingApprovalsCount: 0,
-        hasAgentError: false,
-        hasAgentLlmError: false,
-      }),
-    ).not.toBe(baseKey);
-  });
-
   it('shows the analysis loader only for busy empty assistant output states', () => {
     expect(shouldShowAnalysisLoader(undefined, 'idle')).toBe(false);
     expect(
@@ -309,78 +224,77 @@ describe('AgentChatMessages compaction rendering', () => {
     ).toBe(false);
   });
 
-  it('preserves bottom anchoring through completion settle transitions', () => {
+  it('auto-scrolls only on streaming lifecycle boundaries', () => {
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: undefined,
+        latestMessage: { ...baseMessage, isStreaming: true },
       }),
-    ).toBe(true);
+    ).toBe('none');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: false,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: { ...baseMessage, isStreaming: false },
+        latestMessage: { ...baseMessage, isStreaming: true },
       }),
-    ).toBe(false);
+    ).toBe('stream-start');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: false,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'a' }],
+        },
+        latestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'abcdef' }],
+        },
       }),
-    ).toBe(false);
+    ).toBe('none');
 
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: { ...baseMessage, isStreaming: true },
+        latestMessage: { ...baseMessage, isStreaming: false },
       }),
-    ).toBe(false);
+    ).toBe('message-complete');
   });
 
-  it('allows completion settle even after auto follow has just turned off', () => {
+  it('treats a new static assistant message after streaming as completion', () => {
     expect(
-      shouldPreserveBottomAnchorOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-        wasFollowingOutputBeforeChange: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          id: 'assistant-1',
+          isStreaming: true,
+        },
+        latestMessage: {
+          ...baseMessage,
+          id: 'assistant-2',
+          isStreaming: false,
+          content: [{ type: 'text', text: 'Done' }],
+        },
       }),
-    ).toBe(true);
+    ).toBe('message-complete');
   });
 
-  it('uses lightweight follow while output is still streaming', () => {
+  it('ignores non-assistant updates for auto-scroll lifecycle events', () => {
     expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
+      getAutoScrollEvent({
+        previousLatestMessage: {
+          ...baseMessage,
+          role: 'user',
+          isStreaming: false,
+        },
+        latestMessage: {
+          ...baseMessage,
+          role: 'user',
+          isStreaming: false,
+          content: [{ type: 'text', text: 'Still user content' }],
+        },
       }),
-    ).toBe(true);
-
-    expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: true,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: false,
-      }),
-    ).toBe(false);
-
-    expect(
-      shouldSoftFollowOutputOnTailChange({
-        tailChanged: false,
-        wasAtBottomBeforeChange: true,
-        autoFollowOutput: true,
-      }),
-    ).toBe(false);
+    ).toBe('none');
   });
 });

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -7,6 +7,7 @@ import {
   getAutoScrollEvent,
   getInitialTopMostItemIndex,
   getPrependedFirstItemIndex,
+  getStreamingScrollLockMessageId,
   getVisualBottomThreshold,
   shouldShowAnalysisLoader,
 } from '../AgentChatMessages';
@@ -296,5 +297,49 @@ describe('AgentChatMessages compaction rendering', () => {
         },
       }),
     ).toBe('none');
+  });
+
+  it('keeps a stream scroll lock alive for chunk updates after starting near the bottom', () => {
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: null,
+        autoScrollEvent: 'stream-start',
+        latestMessage: { ...baseMessage, isStreaming: true },
+        shouldStickToBottom: true,
+      }),
+    ).toBe('assistant-1');
+
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: 'assistant-1',
+        autoScrollEvent: 'none',
+        latestMessage: {
+          ...baseMessage,
+          isStreaming: true,
+          content: [{ type: 'text', text: 'abcdef' }],
+        },
+        shouldStickToBottom: false,
+      }),
+    ).toBe('assistant-1');
+  });
+
+  it('drops the stream scroll lock when the user was not near the bottom or the stream completes', () => {
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: null,
+        autoScrollEvent: 'stream-start',
+        latestMessage: { ...baseMessage, isStreaming: true },
+        shouldStickToBottom: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      getStreamingScrollLockMessageId({
+        currentLockMessageId: 'assistant-1',
+        autoScrollEvent: 'message-complete',
+        latestMessage: { ...baseMessage, isStreaming: false },
+        shouldStickToBottom: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
-import { forwardRef } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import React, { forwardRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentChatMessages,
@@ -62,24 +62,45 @@ const groupedMessagesMock: GroupedMessage[] = [
   },
 ];
 
-const { virtuosoMock } = vi.hoisted(() => ({
+const { virtuosoMock, sessionState, chatState } = vi.hoisted(() => ({
   virtuosoMock: vi.fn(),
+  sessionState: {
+    session: { id: 'session-1', assistant: { name: 'Agent' } },
+  },
+  chatState: {
+    messages: [] as Message[],
+    workflowStatus: 'idle' as 'idle' | 'busy',
+  },
 }));
+
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+class MockResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+global.ResizeObserver = MockResizeObserver;
 
 vi.mock('@/context/AgentChatContext', () => ({
   useAgentChat: () => ({
-    messages: groupedToolMessages.slice(1),
+    messages: chatState.messages,
     pendingMessages: [],
     error: undefined,
     llmError: undefined,
     retryMessage: vi.fn(),
-    workflowStatus: 'idle',
+    workflowStatus: chatState.workflowStatus,
   }),
 }));
 
 vi.mock('@/context/AgentSessionContext', () => ({
   useAgentSession: () => ({
-    session: { id: 'session-1', assistant: { name: 'Agent' } },
+    session: sessionState.session,
     pendingApprovals: [],
     respondToToolApproval: vi.fn(),
   }),
@@ -142,6 +163,10 @@ vi.mock('react-virtuoso', () => ({
 describe('AgentChatMessages compaction rendering', () => {
   beforeEach(() => {
     virtuosoMock.mockClear();
+    resizeObserverCallback = null;
+    sessionState.session = { id: 'session-1', assistant: { name: 'Agent' } };
+    chatState.messages = groupedToolMessages.slice(1);
+    chatState.workflowStatus = 'idle';
     virtuosoMock.mockImplementation(
       ({
         components,
@@ -152,6 +177,14 @@ describe('AgentChatMessages compaction rendering', () => {
         components?: {
           Footer?: ({ context }: { context: unknown }) => JSX.Element | null;
           Header?: ({ context }: { context: unknown }) => JSX.Element | null;
+          List?: (props: {
+            children: React.ReactNode;
+            context: unknown;
+            style?: React.CSSProperties;
+          }) => JSX.Element | null;
+          Scroller?: React.ComponentType<
+            React.ComponentPropsWithoutRef<'div'>
+          > | null;
         };
         context: unknown;
         data: GroupedMessage[];
@@ -159,15 +192,31 @@ describe('AgentChatMessages compaction rendering', () => {
           index: number,
           item: GroupedMessage,
         ) => JSX.Element | null;
-      }) => (
-        <div>
-          {components?.Header ? <components.Header context={context} /> : null}
-          {data.map((item, index) => (
-            <div key={item.message.id}>{itemContent(index, item)}</div>
-          ))}
-          {components?.Footer ? <components.Footer context={context} /> : null}
-        </div>
-      ),
+      }) => {
+        const Scroller = components?.Scroller ?? 'div';
+        const List = components?.List;
+        const content = (
+          <>
+            {components?.Header ? <components.Header context={context} /> : null}
+            {data.map((item, index) => (
+              <div key={item.message.id}>{itemContent(index, item)}</div>
+            ))}
+            {components?.Footer ? <components.Footer context={context} /> : null}
+          </>
+        );
+
+        return (
+          <Scroller>
+            {List ? (
+              <List context={context} style={{}}>
+                {content}
+              </List>
+            ) : (
+              content
+            )}
+          </Scroller>
+        );
+      },
     );
   });
 
@@ -175,6 +224,14 @@ describe('AgentChatMessages compaction rendering', () => {
     render(<AgentChatMessages />);
 
     expect(screen.getByText('Compacted summary')).toBeInTheDocument();
+  });
+
+  it('opts the chat scroller out of browser scroll anchoring', () => {
+    const { container } = render(<AgentChatMessages />);
+
+    expect(container.querySelector('.agent-chat-scrollbar')).toHaveStyle({
+      overflowAnchor: 'none',
+    });
   });
 
   it('uses the absolute firstItemIndex offset for the initial bottom position', () => {
@@ -228,5 +285,162 @@ describe('AgentChatMessages compaction rendering', () => {
     expect(isPinnedToBottom(0)).toBe(true);
     expect(isPinnedToBottom(4)).toBe(true);
     expect(isPinnedToBottom(5)).toBe(false);
+  });
+
+  it('keeps bottom alignment when the pinned content resizes after render', () => {
+    const scrollIntoView = vi.fn();
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      render(<AgentChatMessages />);
+
+      act(() => {
+        resizeObserverCallback?.([], {} as ResizeObserver);
+      });
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('scrolls to the bottom again when the resumed session changes', () => {
+    const scrollIntoView = vi.fn();
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      const { rerender } = render(<AgentChatMessages />);
+      scrollIntoView.mockClear();
+
+      sessionState.session = { id: 'session-2', assistant: { name: 'Agent' } };
+      rerender(<AgentChatMessages />);
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('keeps following bottom while assistant text content is actively streaming', () => {
+    const scrollIntoView = vi.fn();
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const frameQueue: FrameRequestCallback[] = [];
+
+    chatState.messages = [
+      {
+        ...baseMessage,
+        id: 'assistant-stream',
+        content: [{ type: 'text', text: 'streaming output' }],
+        isStreaming: true,
+      },
+    ];
+    chatState.workflowStatus = 'busy';
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frameQueue.push(callback);
+      return frameQueue.length;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      render(<AgentChatMessages />);
+      scrollIntoView.mockClear();
+
+      const nextFrame = frameQueue.shift();
+      expect(nextFrame).toBeDefined();
+
+      act(() => {
+        nextFrame?.(0);
+      });
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('keeps following bottom while busy tool results keep accumulating', () => {
+    const scrollIntoView = vi.fn();
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const frameQueue: FrameRequestCallback[] = [];
+
+    chatState.messages = [
+      {
+        ...baseMessage,
+        id: 'assistant-tool-call',
+        content: [],
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'agent__runTool',
+              arguments: '{}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-result-1',
+        sessionId: 'session-1',
+        threadId: 'session-1',
+        role: 'tool',
+        tool_call_id: 'call-1',
+        content: [{ type: 'text', text: 'First tool result chunk' }],
+      },
+    ];
+    chatState.workflowStatus = 'busy';
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frameQueue.push(callback);
+      return frameQueue.length;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      render(<AgentChatMessages />);
+      scrollIntoView.mockClear();
+
+      const nextFrame = frameQueue.shift();
+      expect(nextFrame).toBeDefined();
+
+      act(() => {
+        nextFrame?.(0);
+      });
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
   });
 });

--- a/src/features/agent/components/__tests__/AgentToolCallGroup.render.test.tsx
+++ b/src/features/agent/components/__tests__/AgentToolCallGroup.render.test.tsx
@@ -111,4 +111,20 @@ describe('AgentToolCallGroup Rendering', () => {
     expect(items[0]).toHaveTextContent('call-0');
     expect(items[0]).toHaveTextContent('result-0');
   });
+
+  it('opts the tool group container out of browser scroll anchoring', () => {
+    const calls = Array.from({ length: 2 }, (_, i) => makeToolCall(`call-${i}`));
+    const results = calls.map((c, i) => makeToolResult(`result-${i}`, c.id));
+
+    const { container } = render(
+      <AgentToolCallGroup
+        message={mockMessage}
+        toolGroup={{ calls }}
+        toolResults={results}
+        visibleCount={1}
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveStyle({ overflowAnchor: 'none' });
+  });
 });

--- a/src/features/agent/components/__tests__/ToolCallCompactItem.rendering.test.tsx
+++ b/src/features/agent/components/__tests__/ToolCallCompactItem.rendering.test.tsx
@@ -141,4 +141,12 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
 
     expect(getByText('agent.toolDetails.preparingTool')).toBeInTheDocument();
   });
+
+  it('opts the expandable item container out of browser scroll anchoring', () => {
+    mockDetailLevel = 'developer';
+    const toolCall = makeToolCall('call-6');
+    const { container } = render(<ToolCallCompactItem toolCall={toolCall} />);
+
+    expect(container.firstElementChild).toHaveStyle({ overflowAnchor: 'none' });
+  });
 });

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { LoadingIndicator } from './LoadingIndicator';
 
 interface ThinkingBubbleProps {
@@ -22,7 +22,6 @@ interface ThinkingBubbleProps {
  * - Shows loading animation when streaming
  * - Scrollable content area with max height
  * - Consistent styling across components
- * - Auto-scrolls to bottom during streaming
  */
 export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   thinking,
@@ -30,15 +29,6 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   isStreaming = false,
   className = '',
 }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Auto-scroll to bottom while streaming
-  useEffect(() => {
-    if (isStreaming && scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [thinking, isStreaming]);
-
   // Format time as (XXs)
   const formattedTime = thinkingTime ? `(${thinkingTime.toFixed(1)}s)` : '';
 
@@ -50,10 +40,7 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
         {isStreaming && <LoadingIndicator size="sm" />}
         <span>Thinking Process {formattedTime}</span>
       </div>
-      <div
-        ref={scrollRef}
-        className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
-      >
+      <div className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto">
         {thinking != null && thinking.length > 0 ? thinking : 'Thinking...'}
       </div>
     </div>

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -21,6 +21,7 @@ interface ThinkingBubbleProps {
  * - Displays "Thinking Process" label with timer
  * - Shows loading animation when streaming
  * - Scrollable content area with max height
+ * - Keeps the internal scroll pinned to the latest streamed reasoning output
  * - Consistent styling across components
  */
 export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { LoadingIndicator } from './LoadingIndicator';
 
 interface ThinkingBubbleProps {
@@ -29,6 +29,16 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   isStreaming = false,
   className = '',
 }) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isStreaming || !scrollRef.current) {
+      return;
+    }
+
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [thinking, isStreaming]);
+
   // Format time as (XXs)
   const formattedTime = thinkingTime ? `(${thinkingTime.toFixed(1)}s)` : '';
 
@@ -40,7 +50,10 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
         {isStreaming && <LoadingIndicator size="sm" />}
         <span>Thinking Process {formattedTime}</span>
       </div>
-      <div className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto">
+      <div
+        ref={scrollRef}
+        className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
+      >
         {thinking != null && thinking.length > 0 ? thinking : 'Thinking...'}
       </div>
     </div>

--- a/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
+++ b/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThinkingBubble } from '../ThinkingBubble';
+
+describe('ThinkingBubble', () => {
+  it('keeps its internal scroll pinned to the bottom while streaming', () => {
+    const { container, rerender } = render(
+      <ThinkingBubble thinking="first line" isStreaming={true} />,
+    );
+
+    const scrollContainer = container.querySelector(
+      '.overflow-y-auto',
+    ) as HTMLDivElement | null;
+
+    expect(scrollContainer).not.toBeNull();
+
+    if (!scrollContainer) {
+      throw new Error('Expected thinking scroll container');
+    }
+
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      value: 240,
+    });
+    scrollContainer.scrollTop = 0;
+
+    rerender(
+      <ThinkingBubble
+        thinking={'first line\nsecond line\nthird line'}
+        isStreaming={true}
+      />,
+    );
+
+    expect(scrollContainer.scrollTop).toBe(240);
+  });
+});

--- a/src/features/mcp-servers/MCPServerManagement.tsx
+++ b/src/features/mcp-servers/MCPServerManagement.tsx
@@ -29,6 +29,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
   const {
     servers,
     allServers,
+    registryLoaded,
     presets,
     isLoading,
     isValidating,
@@ -138,7 +139,9 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
       <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
         <RecommendedPresets
           presets={presets}
+          servers={servers}
           allServers={allServers}
+          registryLoaded={registryLoaded}
           onSetupPreset={handleSetupPreset}
         />
       </div>

--- a/src/features/mcp-servers/MCPServerManagement.tsx
+++ b/src/features/mcp-servers/MCPServerManagement.tsx
@@ -28,6 +28,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
 
   const {
     servers,
+    allServers,
     presets,
     isLoading,
     isValidating,
@@ -137,7 +138,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
       <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
         <RecommendedPresets
           presets={presets}
-          servers={servers}
+          allServers={allServers}
           onSetupPreset={handleSetupPreset}
         />
       </div>

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -13,13 +13,17 @@ import { cn } from '@/lib/utils';
 
 interface RecommendedPresetsProps {
   presets: MCPServerPreset[] | undefined;
+  servers: MCPServerEntity[];
   allServers: MCPServerEntity[];
+  registryLoaded: boolean;
   onSetupPreset: (preset: MCPServerPreset) => void;
 }
 
 export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   presets,
+  servers,
   allServers,
+  registryLoaded,
   onSetupPreset,
 }) => {
   const { t } = useTranslation('common');
@@ -39,7 +43,10 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {presets.map((preset) => {
-          const isInstalled = allServers.some((s) => s.name === preset.name);
+          const isInstalled = [...servers, ...allServers].some(
+            (server) => server.name === preset.name,
+          );
+          const canInstall = !isInstalled && registryLoaded;
           return (
             <div
               key={preset.name}
@@ -47,22 +54,24 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
                 'group relative flex flex-col justify-between rounded-[1.5rem] border bg-background/50 backdrop-blur-sm p-5 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-primary/20 outline-none',
                 isInstalled
                   ? 'opacity-60 cursor-default bg-muted/20 border-border/50'
-                  : 'hover:shadow-2xl hover:bg-background hover:-translate-y-1 cursor-pointer border-border/50 hover:border-primary/40',
+                  : canInstall
+                    ? 'hover:shadow-2xl hover:bg-background hover:-translate-y-1 cursor-pointer border-border/50 hover:border-primary/40'
+                    : 'opacity-60 cursor-wait border-border/50',
               )}
-              role={isInstalled ? undefined : 'button'}
-              tabIndex={isInstalled ? -1 : 0}
-              aria-disabled={isInstalled}
+              role={canInstall ? 'button' : undefined}
+              tabIndex={canInstall ? 0 : -1}
+              aria-disabled={!canInstall}
               aria-label={
-                !isInstalled
+                canInstall
                   ? t('mcpServer.installExtension', {
                       name: preset.name,
                       defaultValue: 'Install {{name}} extension',
                     })
                   : undefined
               }
-              onClick={() => !isInstalled && onSetupPreset(preset)}
+              onClick={() => canInstall && onSetupPreset(preset)}
               onKeyDown={(event) => {
-                if (isInstalled) return;
+                if (!canInstall) return;
                 if (event.key === 'Enter' || event.key === ' ') {
                   event.preventDefault();
                   onSetupPreset(preset);
@@ -103,9 +112,13 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
                     <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium flex items-center gap-1">
                       {t('mcpServer.installed', 'Installed')}
                     </span>
-                  ) : (
+                  ) : canInstall ? (
                     <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
                       {t('assistant.mcp.transport.stdio', 'stdio')}
+                    </span>
+                  ) : (
+                    <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
+                      {t('common.loading', 'Loading')}
                     </span>
                   )}
                 </div>
@@ -114,7 +127,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
                     t('mcpServer.noDescription', 'No description available')}
                 </p>
               </div>
-              {!isInstalled && (
+              {canInstall && (
                 <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 group-focus-visible:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <code className="text-[10px] bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">
                     {preset.command} {preset.args?.[0]}

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -13,13 +13,13 @@ import { cn } from '@/lib/utils';
 
 interface RecommendedPresetsProps {
   presets: MCPServerPreset[] | undefined;
-  servers: MCPServerEntity[];
+  allServers: MCPServerEntity[];
   onSetupPreset: (preset: MCPServerPreset) => void;
 }
 
 export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   presets,
-  servers,
+  allServers,
   onSetupPreset,
 }) => {
   const { t } = useTranslation('common');
@@ -39,7 +39,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {presets.map((preset) => {
-          const isInstalled = servers.some((s) => s.name === preset.name);
+          const isInstalled = allServers.some((s) => s.name === preset.name);
           return (
             <div
               key={preset.name}

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Download, Server } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { MCPServerPreset } from '@/lib/backend/mcp-server-config';
@@ -27,6 +27,19 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   onSetupPreset,
 }) => {
   const { t } = useTranslation('common');
+  const installedServerNames = useMemo(() => {
+    const names = new Set<string>();
+
+    for (const server of servers) {
+      names.add(server.name);
+    }
+
+    for (const server of allServers) {
+      names.add(server.name);
+    }
+
+    return names;
+  }, [allServers, servers]);
 
   if (!presets || presets.length === 0) {
     return null;
@@ -43,9 +56,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {presets.map((preset) => {
-          const isInstalled = [...servers, ...allServers].some(
-            (server) => server.name === preset.name,
-          );
+          const isInstalled = installedServerNames.has(preset.name);
           const canInstall = !isInstalled && registryLoaded;
           return (
             <div

--- a/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
+++ b/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RecommendedPresets } from '../RecommendedPresets';
+import type { MCPServerEntity } from '@/models/chat';
+import type { MCPServerPreset } from '@/lib/backend/mcp-server-config';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue: string | { defaultValue?: string }) => {
+      if (typeof defaultValue === 'string') {
+        return defaultValue;
+      }
+
+      return defaultValue?.defaultValue ?? _key;
+    },
+  }),
+}));
+
+const basePreset: MCPServerPreset = {
+  name: 'filesystem',
+  description: 'Filesystem tools',
+  transportType: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-filesystem'],
+};
+
+const installedServer: MCPServerEntity = {
+  id: 'server-1',
+  name: 'filesystem',
+  isActive: true,
+  transport: {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem'],
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('RecommendedPresets', () => {
+  it('marks a preset as installed when it exists in the full server list but not the paged grid', () => {
+    render(
+      <RecommendedPresets
+        presets={[basePreset]}
+        allServers={[installedServer]}
+        onSetupPreset={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Installed')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Install filesystem extension'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
+++ b/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { RecommendedPresets } from '../RecommendedPresets';
 import type { MCPServerEntity } from '@/models/chat';
@@ -43,7 +43,9 @@ describe('RecommendedPresets', () => {
     render(
       <RecommendedPresets
         presets={[basePreset]}
+        servers={[]}
         allServers={[installedServer]}
+        registryLoaded={true}
         onSetupPreset={vi.fn()}
       />,
     );
@@ -52,5 +54,44 @@ describe('RecommendedPresets', () => {
     expect(
       screen.queryByText('Install filesystem extension'),
     ).not.toBeInTheDocument();
+  });
+
+  it('uses the visible installed grid as a temporary installed source before the full registry finishes loading', () => {
+    render(
+      <RecommendedPresets
+        presets={[basePreset]}
+        servers={[installedServer]}
+        allServers={[]}
+        registryLoaded={false}
+        onSetupPreset={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Installed')).toBeInTheDocument();
+  });
+
+  it('blocks opening install flow until the full registry load completes', () => {
+    const onSetupPreset = vi.fn();
+
+    render(
+      <RecommendedPresets
+        presets={[basePreset]}
+        servers={[]}
+        allServers={[]}
+        registryLoaded={false}
+        onSetupPreset={onSetupPreset}
+      />,
+    );
+
+    const presetCard = screen.getByText('filesystem').closest('div[aria-disabled]');
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+    expect(presetCard).toHaveAttribute('aria-disabled', 'true');
+
+    if (!presetCard) {
+      throw new Error('Expected preset card');
+    }
+
+    fireEvent.click(presetCard);
+    expect(onSetupPreset).not.toHaveBeenCalled();
   });
 });

--- a/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
+++ b/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
@@ -7,12 +7,21 @@ import type { MCPServerPreset } from '@/lib/backend/mcp-server-config';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, defaultValue: string | { defaultValue?: string }) => {
-      if (typeof defaultValue === 'string') {
-        return defaultValue;
+    t: (
+      key: string,
+      defaultValueOrOptions:
+        | string
+        | { defaultValue?: string; name?: string }
+        | undefined,
+    ) => {
+      if (typeof defaultValueOrOptions === 'string') {
+        return defaultValueOrOptions;
       }
 
-      return defaultValue?.defaultValue ?? _key;
+      const template = defaultValueOrOptions?.defaultValue ?? key;
+      const name = defaultValueOrOptions?.name;
+
+      return name ? template.replace('{{name}}', name) : template;
     },
   }),
 }));
@@ -52,7 +61,7 @@ describe('RecommendedPresets', () => {
 
     expect(screen.getByText('Installed')).toBeInTheDocument();
     expect(
-      screen.queryByText('Install filesystem extension'),
+      screen.queryByRole('button', { name: 'Install filesystem extension' }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -20,7 +20,7 @@ const logger = getLogger('MCPServerManagement');
 
 export function useMCPServerManagement(service?: McpServerService) {
   const { t } = useTranslation('common');
-  const { saveServer, deleteServer, toggleActive, ensureLoaded } =
+  const { allServers, saveServer, deleteServer, toggleActive, ensureLoaded } =
     useMCPServerRegistry();
   const { value: settings } = useSettings();
 
@@ -220,6 +220,7 @@ export function useMCPServerManagement(service?: McpServerService) {
 
   return {
     servers,
+    allServers,
     presets,
     isLoading,
     isValidating,

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -20,8 +20,14 @@ const logger = getLogger('MCPServerManagement');
 
 export function useMCPServerManagement(service?: McpServerService) {
   const { t } = useTranslation('common');
-  const { allServers, saveServer, deleteServer, toggleActive, ensureLoaded } =
-    useMCPServerRegistry();
+  const {
+    allServers,
+    loaded: registryLoaded,
+    saveServer,
+    deleteServer,
+    toggleActive,
+    ensureLoaded,
+  } = useMCPServerRegistry();
   const { value: settings } = useSettings();
 
   useEffect(() => {
@@ -221,6 +227,7 @@ export function useMCPServerManagement(service?: McpServerService) {
   return {
     servers,
     allServers,
+    registryLoaded,
     presets,
     isLoading,
     isValidating,


### PR DESCRIPTION
## Summary
- fix recommended MCP preset install detection by checking the full installed server registry
- restore thinking bubble internal bottom follow while streaming
- simplify agent chat scroll behavior to a pinned-to-bottom model with a scroll-to-latest FAB

## Validation
- pnpm refactor:validate