### PR TITLE
Fix session switch flicker

### DIFF
--- a/src/context/AgentChatContext.tsx
+++ b/src/context/AgentChatContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -123,6 +124,21 @@ export function AgentChatProvider({ children }: AgentChatProviderProps) {
 
   // Pending messages queue for busy state
   const [pendingMessages, setPendingMessages] = useState<Message[]>([]);
+  const previousSessionIdRef = useRef<string | null>(session?.id ?? null);
+  const activeSessionIdRef = useRef<string | null>(session?.id ?? null);
+
+  useEffect(() => {
+    const nextSessionId = session?.id ?? null;
+    activeSessionIdRef.current = nextSessionId;
+
+    if (previousSessionIdRef.current === nextSessionId) {
+      return;
+    }
+
+    previousSessionIdRef.current = nextSessionId;
+    setPendingMessages([]);
+    setServiceContexts({});
+  }, [session?.id]);
 
   const enqueuePendingMessage = useCallback((message: Message) => {
     setPendingMessages((prev) => {
@@ -149,6 +165,9 @@ export function AgentChatProvider({ children }: AgentChatProviderProps) {
         'agent_get_service_contexts',
         { sessionId },
       );
+      if (activeSessionIdRef.current !== sessionId) {
+        return;
+      }
       setServiceContexts(contexts);
       logger.info('Service contexts updated', {
         contexts,

--- a/src/context/__tests__/AgentChatContext.test.tsx
+++ b/src/context/__tests__/AgentChatContext.test.tsx
@@ -533,6 +533,67 @@ describe('AgentChatContext', () => {
       });
     });
 
+    it('clears pending messages when the active session changes', async () => {
+      const deferred = createDeferred<{ success: boolean }>();
+      let sessionState = {
+        session: { id: 'test-session', name: 'Test Session' },
+        messages: mockMessages,
+        isSessionLoading: false,
+        error: null,
+        llmError: null,
+        workflowStatus: 'idle' as const,
+      };
+
+      (useAgentSessionState as ReturnType<typeof vi.fn>).mockImplementation(
+        () => sessionState,
+      );
+      (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation(
+        (command: string) => {
+          if (command === 'agent_inject_messages') {
+            return deferred.promise;
+          }
+          return Promise.resolve({ success: true });
+        },
+      );
+
+      const pendingMessage: Message = {
+        id: 'msg-pending-switch',
+        sessionId: 'test-session',
+        threadId: 'test-session',
+        role: 'user',
+        content: [{ type: 'text', text: 'Carry me only in this session' }],
+        createdAt: new Date(),
+      };
+
+      const { result, rerender } = renderHook(() => useAgentChat(), {
+        wrapper: TestWrapper,
+      });
+
+      await act(async () => {
+        void result.current.submit(pendingMessage);
+      });
+
+      await waitFor(() => {
+        expect(result.current.pendingMessages).toEqual([pendingMessage]);
+      });
+
+      sessionState = {
+        ...sessionState,
+        session: { id: 'next-session', name: 'Next Session' },
+        messages: [],
+      };
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.pendingMessages).toEqual([]);
+      });
+
+      deferred.resolve({ success: true });
+      await act(async () => {
+        await deferred.promise;
+      });
+    });
+
     it('should reject submit while session is loading', async () => {
       (useAgentSessionState as ReturnType<typeof vi.fn>).mockReturnValue({
         session: { id: 'test-session', name: 'Test Session' },

--- a/src/context/__tests__/AgentSessionContext.test.tsx
+++ b/src/context/__tests__/AgentSessionContext.test.tsx
@@ -254,6 +254,98 @@ describe('AgentSessionContext (Local)', () => {
         );
     });
 
+    it('keeps the previous session state visible while the next session hydrates', async () => {
+        let resolveNextSession:
+            | ((
+                  value: Awaited<
+                      ReturnType<typeof agentCommandsBackend.openAgentSession>
+                  >,
+              ) => void)
+            | undefined;
+
+        (agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>).mockImplementation(
+            (sessionId: string) => {
+                if (sessionId === 'session-2') {
+                    return new Promise((resolve) => {
+                        resolveNextSession = resolve;
+                    });
+                }
+
+                return Promise.resolve({
+                    session: {
+                        id: sessionId,
+                        name: `Session ${sessionId}`,
+                        status: 'idle',
+                        model: 'test-model',
+                        provider: 'test-provider',
+                        createdAt: Date.now(),
+                        updatedAt: Date.now(),
+                        yoloMode: false,
+                    },
+                    messages: {
+                        items: [],
+                        hasMoreBefore: false,
+                        oldestCursor: null,
+                    },
+                    pendingApprovals: [],
+                    runtimeState: READY_RUNTIME_STATE,
+                });
+            }
+        );
+
+        let activeSessionId = 'session-1';
+        const Wrapper = ({ children }: { children: React.ReactNode }) => (
+            <DynamicSessionWrapper sessionId={activeSessionId}>
+                {children}
+            </DynamicSessionWrapper>
+        );
+
+        const { result, rerender } = renderHook(() => useAgentSessionState(), {
+            wrapper: Wrapper,
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSessionLoading).toBe(false);
+            expect(result.current.session?.id).toBe('session-1');
+        });
+
+        activeSessionId = 'session-2';
+        rerender();
+
+        await waitFor(() => {
+            expect(result.current.isSessionLoading).toBe(true);
+        });
+
+        expect(result.current.session?.id).toBe('session-1');
+
+        await act(async () => {
+            resolveNextSession?.({
+                session: {
+                    id: 'session-2',
+                    name: 'Session session-2',
+                    status: 'idle',
+                    model: 'test-model',
+                    provider: 'test-provider',
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                    yoloMode: false,
+                },
+                messages: {
+                    items: [],
+                    hasMoreBefore: false,
+                    oldestCursor: null,
+                },
+                pendingApprovals: [],
+                runtimeState: READY_RUNTIME_STATE,
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSessionLoading).toBe(false);
+            expect(result.current.session?.id).toBe('session-2');
+        });
+    });
+
     describe('Event Handling', () => {
         it('ignores stale runtime-state snapshots that arrive after a newer one', async () => {
             let eventHandler: ((event: unknown) => void) | undefined;

--- a/src/context/__tests__/AgentSessionContext.test.tsx
+++ b/src/context/__tests__/AgentSessionContext.test.tsx
@@ -318,6 +318,10 @@ describe('AgentSessionContext (Local)', () => {
 
         expect(result.current.session?.id).toBe('session-1');
 
+        await waitFor(() => {
+            expect(resolveNextSession).toBeDefined();
+        });
+
         await act(async () => {
             resolveNextSession?.({
                 session: {

--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -37,6 +37,10 @@ import { AgentResourceAttachmentProvider } from './hooks/useAgentResourceAttachm
 
 const logger = getLogger('AgentChatView');
 
+function getSessionLoadingLabel(isStartingSession: boolean): string {
+  return isStartingSession ? 'Starting session...' : 'Loading session...';
+}
+
 const InitializationStatusDisplay = () => {
   const { initializationStep } = useAgentSessionState();
   if (!initializationStep) return null;
@@ -198,7 +202,7 @@ export default function AgentChatView() {
 
   if (shouldProvideSession && routeSessionId) {
     return (
-      <AgentSessionProvider sessionId={routeSessionId} key={routeSessionId}>
+      <AgentSessionProvider sessionId={routeSessionId}>
         <AgentChatView />
       </AgentSessionProvider>
     );
@@ -214,20 +218,21 @@ export default function AgentChatView() {
 
   const { session, isSessionLoading } = optionalSessionState;
   const attachmentSessionId = session?.id ?? routeSessionId ?? '';
+  const isStartingSession =
+    session?.status === 'idle' && session?.id === routeSessionId;
+  const sessionLoadingLabel = getSessionLoadingLabel(isStartingSession);
+  const shouldShowBlockingLoader = isSessionLoading && !session;
+  const shouldShowOptimisticLoadingOverlay = isSessionLoading && !!session;
 
   return (
     <AgentResourceAttachmentProvider sessionId={attachmentSessionId}>
-      {isSessionLoading ? (
+      {shouldShowBlockingLoader ? (
         <div className="flex h-full items-center justify-center p-4">
           <div className="flex flex-col items-center gap-3">
             <LoadingSpinner
               size="lg"
               className="border-4"
-              label={
-                session?.status === 'idle'
-                  ? 'Starting session...'
-                  : 'Loading session...'
-              }
+              label={sessionLoadingLabel}
             />
 
             <div className="flex flex-col items-center gap-1">
@@ -235,9 +240,7 @@ export default function AgentChatView() {
                 className="text-muted-foreground font-medium animate-pulse"
                 aria-hidden="true"
               >
-                {session?.status === 'idle'
-                  ? 'Starting session...'
-                  : 'Loading session...'}
+                {sessionLoadingLabel}
               </div>
 
               <div className="text-xs text-muted-foreground/70 h-4">
@@ -253,13 +256,37 @@ export default function AgentChatView() {
           </div>
         </div>
       ) : (
-        <AgentChatProvider>
-          <AgentPlanningProvider>
-            <AgentWorkspaceProvider>
-              <AgentChatInner />
-            </AgentWorkspaceProvider>
-          </AgentPlanningProvider>
-        </AgentChatProvider>
+        <div className="relative h-full">
+          <AgentChatProvider>
+            <AgentPlanningProvider>
+              <AgentWorkspaceProvider>
+                <AgentChatInner />
+              </AgentWorkspaceProvider>
+            </AgentPlanningProvider>
+          </AgentChatProvider>
+
+          {shouldShowOptimisticLoadingOverlay && (
+            <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/60 backdrop-blur-[1px]">
+              <div className="flex flex-col items-center gap-3 rounded-xl border border-border/60 bg-background/90 px-6 py-5 shadow-lg">
+                <LoadingSpinner
+                  size="lg"
+                  className="border-4"
+                  label={sessionLoadingLabel}
+                />
+
+                <div className="flex flex-col items-center gap-1">
+                  <div className="text-muted-foreground font-medium">
+                    {sessionLoadingLabel}
+                  </div>
+
+                  <div className="text-xs text-muted-foreground/70 h-4">
+                    <InitializationStatusDisplay />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </AgentResourceAttachmentProvider>
   );

--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -275,7 +275,10 @@ export default function AgentChatView() {
                 />
 
                 <div className="flex flex-col items-center gap-1">
-                  <div className="text-muted-foreground font-medium">
+                  <div
+                    className="text-muted-foreground font-medium"
+                    aria-hidden="true"
+                  >
                     {sessionLoadingLabel}
                   </div>
 

--- a/src/features/agent/AgentSessionRoute.tsx
+++ b/src/features/agent/AgentSessionRoute.tsx
@@ -16,7 +16,7 @@ export default function AgentSessionRoute() {
   }
 
   return (
-    <AgentSessionProvider sessionId={sessionId} key={sessionId}>
+    <AgentSessionProvider sessionId={sessionId}>
       <AgentChatView />
     </AgentSessionProvider>
   );

--- a/src/features/agent/__tests__/AgentChatView.test.tsx
+++ b/src/features/agent/__tests__/AgentChatView.test.tsx
@@ -1,0 +1,240 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentSessionStateContextValue } from '@/context/agent-session/types';
+import type { AgentSession } from '@/models/agent';
+import type { SessionRuntimeState } from '@/models/agent-ipc';
+import AgentChatView from '../AgentChatView';
+
+const mocks = vi.hoisted(() => ({
+  agentSessionState: undefined as AgentSessionStateContextValue | undefined,
+}));
+
+function createBaseRuntimeState(): SessionRuntimeState {
+  return {
+    sequence: 0,
+    phase: 'not_started',
+    proxy: {
+      exists: false,
+      mode: 'none',
+      ready: false,
+    },
+    initialization: {
+      result: 'pending',
+    },
+    servers: [],
+  };
+}
+
+function createBaseSessionState(): AgentSessionStateContextValue {
+  return {
+    session: null,
+    messages: [],
+    isSessionLoading: false,
+    isLoadingOlderMessages: false,
+    hasOlderMessages: false,
+    error: null,
+    llmError: null,
+    workflowStatus: 'idle',
+    workflowPhase: 'idle',
+    runtimeState: createBaseRuntimeState(),
+    initializationStep: null,
+    pendingApprovals: [],
+    yoloModeEnabled: false,
+  };
+}
+
+function createSessionState(
+  overrides: Partial<AgentSessionStateContextValue> = {},
+): AgentSessionStateContextValue {
+  return {
+    ...createBaseSessionState(),
+    ...overrides,
+  };
+}
+
+function createMockSession(): AgentSession {
+  return {
+    id: 'session-1',
+    name: 'Session One',
+    status: 'idle',
+    model: 'gpt-5.4',
+    provider: 'openai',
+    assistant: {
+      id: 'assistant-1',
+      name: 'Assistant One',
+      systemPrompt: 'You are helpful.',
+      allowedBuiltInServiceAliases: [],
+      deletionProtected: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    yoloMode: false,
+  };
+}
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ sessionId: 'session-2' }),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  AgentSessionProvider: (props: { children: ReactNode; sessionId: string }) => (
+    <>{props.children}</>
+  ),
+  useOptionalAgentSessionState: () =>
+    mocks.agentSessionState ?? createBaseSessionState(),
+  useAgentSessionState: () => mocks.agentSessionState ?? createBaseSessionState(),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  AgentChatProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="chat-provider">{children}</div>
+  ),
+  useAgentChatActions: () => ({
+    injectMessages: vi.fn(),
+  }),
+  useAgentChatState: () => ({
+    workflowStatus: 'idle' as const,
+  }),
+}));
+
+vi.mock('@/context/AgentWorkspaceContext', () => ({
+  AgentWorkspaceProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  useAgentWorkspace: () => ({
+    showWorkspacePanel: false,
+  }),
+}));
+
+vi.mock('@/context/AgentPlanningContext', () => ({
+  AgentPlanningProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  useAgentPlanning: () => ({
+    showPlanningPanel: false,
+  }),
+}));
+
+vi.mock('../hooks/useAgentResourceAttachment', () => ({
+  AgentResourceAttachmentProvider: (props: {
+    children: ReactNode;
+    sessionId: string;
+  }) => <>{props.children}</>,
+}));
+
+vi.mock('../components/AgentChatHeader', () => ({
+  AgentChatHeader: () => <div>mock-header</div>,
+}));
+
+vi.mock('../components/AgentChatStatusBar', () => ({
+  AgentChatStatusBar: () => <div>mock-status-bar</div>,
+}));
+
+vi.mock('../components/AgentChatMessages', () => ({
+  AgentChatMessages: () => <div>mock-messages</div>,
+}));
+
+vi.mock('../components/AgentChatInput', () => ({
+  AgentChatInput: () => <div>mock-input</div>,
+}));
+
+vi.mock('../components/AgentChatAttachedFiles', () => ({
+  AgentChatAttachedFiles: () => <div>mock-attached-files</div>,
+}));
+
+vi.mock('../components/AgentWorkspacePanel', () => ({
+  AgentWorkspacePanel: () => <div>mock-workspace-panel</div>,
+}));
+
+vi.mock('../components/AgentPlanningPanel', () => ({
+  AgentPlanningPanel: () => <div>mock-planning-panel</div>,
+}));
+
+vi.mock('../components/AgentPlanningUpdates', () => ({
+  AgentPlanningUpdates: () => <div>mock-planning-updates</div>,
+}));
+
+vi.mock('@/components/ui/LoadingSpinner', () => ({
+  default: ({ label }: { label?: string }) => <div>{label ?? 'spinner'}</div>,
+}));
+
+vi.mock('@/lib/backend/agent-commands', () => ({
+  agentCallBuiltinTool: vi.fn(),
+}));
+
+vi.mock('@/lib/chat-utils', () => ({
+  createToolMessagePair: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: () => 'tool-call-id',
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('AgentChatView', () => {
+  beforeEach(() => {
+    mocks.agentSessionState = createSessionState();
+  });
+
+  it('shows the blocking loader when there is no hydrated session yet', () => {
+    mocks.agentSessionState = createSessionState({
+      isSessionLoading: true,
+      runtimeState: {
+        ...createBaseRuntimeState(),
+        phase: 'hydrating',
+      },
+      initializationStep: {
+        step: 'Opening session',
+        status: 'running' as const,
+      },
+    });
+
+    render(<AgentChatView />);
+
+    expect(screen.getAllByText('Loading session...')).not.toHaveLength(0);
+    expect(screen.queryByText('mock-messages')).not.toBeInTheDocument();
+  });
+
+  it('keeps the current chat mounted while the next session is hydrating', () => {
+    mocks.agentSessionState = createSessionState({
+      session: createMockSession(),
+      isSessionLoading: true,
+      runtimeState: {
+        ...createBaseRuntimeState(),
+        phase: 'hydrating',
+      },
+      initializationStep: {
+        step: 'Opening session',
+        status: 'running' as const,
+      },
+    });
+
+    render(<AgentChatView />);
+
+    expect(screen.getByText('mock-messages')).toBeInTheDocument();
+    expect(screen.getByText('mock-header')).toBeInTheDocument();
+    expect(screen.getAllByText('Loading session...')).not.toHaveLength(0);
+    expect(screen.getByTestId('chat-provider')).toBeInTheDocument();
+  });
+});

--- a/src/features/agent/context/AgentResourceAttachmentContext.tsx
+++ b/src/features/agent/context/AgentResourceAttachmentContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useCallback, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import useSWR from 'swr';
 import { getLogger } from '@/lib/logger';
 import { createFileSizeErrorMessage } from '@/lib/workspace-sync-service';
@@ -65,6 +71,14 @@ export function AgentResourceAttachmentProvider({
 
   const [pendingFiles, setPendingFiles] = useState<AttachmentReference[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setPendingFiles((previousFiles) => {
+      cleanupPendingAttachmentBlobs(previousFiles);
+      return [];
+    });
+    setIsLoading(false);
+  }, [sessionId]);
 
   // Use SWR to fetch session files via Agent V2 session-specific proxy
   const { data: sessionFiles = [], mutate: mutateSessionFiles } = useSWR(

--- a/src/features/agent/context/__tests__/AgentResourceAttachmentContext.test.tsx
+++ b/src/features/agent/context/__tests__/AgentResourceAttachmentContext.test.tsx
@@ -1,0 +1,89 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AgentResourceAttachmentProvider,
+  useAgentResourceAttachment,
+} from '../AgentResourceAttachmentContext';
+
+const mockMutate = vi.fn();
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: [],
+    mutate: mockMutate,
+  })),
+}));
+
+vi.mock('@/hooks/use-settings', () => ({
+  useSettings: () => ({
+    value: {
+      system: {
+        maxFileUploadSizeMB: 50,
+      },
+    },
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/agent/api/agent-backend', () => ({
+  agentCallBuiltinTool: vi.fn(),
+  deleteAgentFile: vi.fn(),
+}));
+
+vi.mock('@/features/agent/lib/resource-attachment-operations', () => ({
+  addAgentAttachment: vi.fn(),
+}));
+
+describe('AgentResourceAttachmentContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears pending files when the session id changes', async () => {
+    const cleanupBlob = vi.fn();
+    let activeSessionId = 'session-1';
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <AgentResourceAttachmentProvider sessionId={activeSessionId}>
+        {children}
+      </AgentResourceAttachmentProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useAgentResourceAttachment(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.addPendingFiles([
+        {
+          url: 'file:///tmp/example.txt',
+          filename: 'example.txt',
+          mimeType: 'text/plain',
+          blobCleanup: cleanupBlob,
+        },
+      ]);
+    });
+
+    expect(result.current.pendingFiles).toHaveLength(1);
+    expect(result.current.pendingFiles[0]?.sessionId).toBe('session-1');
+
+    activeSessionId = 'session-2';
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.pendingFiles).toEqual([]);
+    });
+
+    expect(cleanupBlob).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary\n- remove forced AgentSessionProvider remounts tied to sessionId\n- keep the current chat UI mounted while the next session hydrates with a loading overlay\n- add regression tests for provider handoff and optimistic session rendering\n\nCloses #1130