### PR TITLE
🎨 Palette: Add tooltip to API key visibility toggle

### DIFF
--- a/src/features/settings/components/ProviderCard.tsx
+++ b/src/features/settings/components/ProviderCard.tsx
@@ -9,6 +9,9 @@ import {
   Input,
   Checkbox,
   Button,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
 } from '@/components/ui';
 import { Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -72,25 +75,34 @@ function ProviderCardBase({
               }}
               className="bg-background border text-foreground w-full pr-10"
             />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-              onClick={() => setShowApiKey((v) => !v)}
-              aria-label={
-                showApiKey
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                  onClick={() => setShowApiKey((v) => !v)}
+                  aria-label={
+                    showApiKey
+                      ? t('settings.provider.hideApiKey', 'Hide API key')
+                      : t('settings.provider.showApiKey', 'Show API key')
+                  }
+                  aria-pressed={showApiKey}
+                >
+                  {showApiKey ? (
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Eye className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {showApiKey
                   ? t('settings.provider.hideApiKey', 'Hide API key')
-                  : t('settings.provider.showApiKey', 'Show API key')
-              }
-              aria-pressed={showApiKey}
-            >
-              {showApiKey ? (
-                <EyeOff className="h-4 w-4 text-muted-foreground" />
-              ) : (
-                <Eye className="h-4 w-4 text-muted-foreground" />
-              )}
-            </Button>
+                  : t('settings.provider.showApiKey', 'Show API key')}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
 

--- a/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
+++ b/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
@@ -54,6 +54,13 @@ vi.mock('@/components/ui', () => ({
   CardContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   Checkbox: ({
     checked,
     onCheckedChange,


### PR DESCRIPTION
💡 What: Wrapped the API key toggle button in a Tooltip.
🎯 Why: Improves the UX by clarifying the action of the icon-only button for mouse users.
📸 Before/After: N/A.
♿ Accessibility: Enhances visual context for the toggle action alongside the existing aria-label.

---
*PR created automatically by Jules for task [2825991364371846428](https://jules.google.com/task/2825991364371846428) started by @fritzprix*