### PR TITLE
Improve startup skill sync and StrictMode startup logging

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3862,7 +3862,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,25 +1,9 @@
 use std::env;
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
-    fs::create_dir_all(dst)?;
-
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            fs::copy(&src_path, &dst_path)?;
-        }
-    }
-
-    Ok(())
-}
+#[path = "build_support/bundled_skills.rs"]
+mod bundled_skills;
 
 fn profile_output_dir(out_dir: &Path) -> Option<PathBuf> {
     out_dir
@@ -48,10 +32,7 @@ fn sync_bundled_skills_into_profile_output() -> io::Result<()> {
     };
 
     let deployed_dir = profile_dir.join("bundled_skills");
-    if deployed_dir.exists() {
-        fs::remove_dir_all(&deployed_dir)?;
-    }
-    copy_dir_recursive(&source_dir, &deployed_dir)
+    bundled_skills::mirror_bundled_skills(&source_dir, &deployed_dir)
 }
 
 fn main() {

--- a/src-tauri/build_support/bundled_skills.rs
+++ b/src-tauri/build_support/bundled_skills.rs
@@ -1,0 +1,50 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const SKILL_FILE_NAME: &str = "SKILL.md";
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_bundled_skill_dir(path: &Path) -> bool {
+    path.is_dir() && path.join(SKILL_FILE_NAME).is_file()
+}
+
+pub fn mirror_bundled_skills(source_dir: &Path, deployed_dir: &Path) -> io::Result<()> {
+    if !source_dir.exists() {
+        return Ok(());
+    }
+
+    if deployed_dir.exists() {
+        fs::remove_dir_all(deployed_dir)?;
+    }
+    fs::create_dir_all(deployed_dir)?;
+
+    for entry in fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        if !is_valid_bundled_skill_dir(&src_path) {
+            continue;
+        }
+
+        copy_dir_recursive(&src_path, &deployed_dir.join(entry.file_name()))?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -3,11 +3,19 @@ use crate::lifecycle::settings::SystemSettings;
 use crate::logger;
 use crate::repositories;
 use crate::repositories::settings_repository::SettingsRepository;
+use crate::services::skill_service::{
+    LEGACY_SYSTEM_SKILLS_DIR_NAME, MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME, SKILL_FILE_NAME,
+    SYSTEM_SKILLS_DIR_NAME, USER_SKILLS_DIR_NAME,
+};
 use crate::services::{DroppedFileService, InteractiveBrowserServer, SecureFileManager};
 use crate::state;
 use log::info;
 #[cfg(target_os = "linux")]
 use log::warn;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 use std::sync::Arc;
 use tauri::{App, Emitter, Listener, Manager};
 
@@ -15,6 +23,14 @@ use tauri::{App, Emitter, Listener, Manager};
 /// Used to distinguish bundled skills from user-created ones so that skills
 /// removed from the bundle can be cleaned up automatically on the next launch.
 const BUNDLED_SKILL_MARKER: &str = ".bundled_skill";
+const MANAGED_SYSTEM_SKILLS_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BundledSkillsManifest {
+    schema_version: u32,
+    skills: BTreeMap<String, String>,
+}
 
 /// Migration decision for a legacy skill directory from AppData/skills.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,33 +58,253 @@ pub fn classify_legacy_skill_for_managed_storage(
     }
 }
 
-/// Replaces the AppData/skills bundled snapshot with an exact mirror of the
-/// currently bundled skills shipped in application resources.
-pub fn sync_legacy_global_skills_to_bundled_snapshot(
-    bundled_skills_dir: &std::path::Path,
-    legacy_skills_dir: &std::path::Path,
-) -> Result<(), String> {
-    if legacy_skills_dir.exists() {
-        std::fs::remove_dir_all(legacy_skills_dir).map_err(|e| e.to_string())?;
+fn collect_skill_directory_names(skills_dir: &Path) -> Result<BTreeSet<String>, String> {
+    if !skills_dir.exists() {
+        return Ok(BTreeSet::new());
     }
-    std::fs::create_dir_all(legacy_skills_dir).map_err(|e| e.to_string())?;
 
+    let mut names = BTreeSet::new();
+    for entry in std::fs::read_dir(skills_dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+
+        names.insert(entry.file_name().to_string_lossy().to_string());
+    }
+
+    Ok(names)
+}
+
+fn normalized_relative_path(root: &Path, path: &Path) -> Result<String, String> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|error| format!("Failed to strip prefix for {}: {}", path.display(), error))?;
+    Ok(relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().replace('\\', "/"))
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
+fn hash_skill_directory(skill_dir: &Path) -> Result<String, String> {
+    let mut files = walkdir::WalkDir::new(skill_dir)
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to scan {}: {}", skill_dir.display(), error))?
+        .into_iter()
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| {
+            let path = entry.into_path();
+            let normalized = normalized_relative_path(skill_dir, &path)?;
+            Ok((normalized, path))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut hasher = Sha256::new();
+    for (relative_path, full_path) in files {
+        hasher.update(relative_path.as_bytes());
+        hasher.update([0]);
+        hasher.update(
+            std::fs::read(&full_path)
+                .map_err(|error| format!("Failed to read {}: {}", full_path.display(), error))?,
+        );
+        hasher.update([0]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn build_bundled_skills_manifest(skills_dir: &Path) -> Result<BundledSkillsManifest, String> {
+    let mut manifest = BundledSkillsManifest {
+        schema_version: MANAGED_SYSTEM_SKILLS_MANIFEST_SCHEMA_VERSION,
+        skills: BTreeMap::new(),
+    };
+
+    if !skills_dir.exists() {
+        return Ok(manifest);
+    }
+
+    let mut entries = std::fs::read_dir(skills_dir)
+        .map_err(|error| format!("Failed to read {}: {}", skills_dir.display(), error))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read directory entry: {}", error))?;
+    entries.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+
+    for entry in entries {
+        let skill_path = entry.path();
+        if !skill_path.is_dir() {
+            continue;
+        }
+
+        if !skill_path.join(SKILL_FILE_NAME).is_file() {
+            continue;
+        }
+
+        let skill_dir_name = entry.file_name().to_string_lossy().to_string();
+        manifest
+            .skills
+            .insert(skill_dir_name, hash_skill_directory(&skill_path)?);
+    }
+
+    Ok(manifest)
+}
+
+fn write_manifest_atomically(
+    manifest_path: &Path,
+    manifest: &BundledSkillsManifest,
+) -> Result<(), String> {
+    let payload = serde_json::to_vec_pretty(manifest)
+        .map_err(|error| format!("Failed to serialize manifest: {}", error))?;
+    let temp_path = manifest_path.with_extension("json.tmp");
+
+    std::fs::write(&temp_path, payload)
+        .map_err(|error| format!("Failed to write {}: {}", temp_path.display(), error))?;
+
+    if manifest_path.exists() {
+        std::fs::remove_file(manifest_path)
+            .map_err(|error| format!("Failed to replace {}: {}", manifest_path.display(), error))?;
+    }
+
+    std::fs::rename(&temp_path, manifest_path).map_err(|error| {
+        format!(
+            "Failed to finalize manifest {}: {}",
+            manifest_path.display(),
+            error
+        )
+    })?;
+
+    Ok(())
+}
+
+fn replace_skill_directory_atomically(source_dir: &Path, target_dir: &Path) -> Result<(), String> {
+    let parent = target_dir
+        .parent()
+        .ok_or_else(|| format!("Invalid managed skill path: {}", target_dir.display()))?;
+    let skill_name = target_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "Invalid managed skill directory name: {}",
+                target_dir.display()
+            )
+        })?;
+
+    let temp_dir = parent.join(format!(".sync-tmp-{}", skill_name));
+    let backup_dir = parent.join(format!(".sync-backup-{}", skill_name));
+
+    if temp_dir.exists() {
+        std::fs::remove_dir_all(&temp_dir).map_err(|error| {
+            format!("Failed to clear temp dir {}: {}", temp_dir.display(), error)
+        })?;
+    }
+    if backup_dir.exists() {
+        std::fs::remove_dir_all(&backup_dir).map_err(|error| {
+            format!(
+                "Failed to clear backup dir {}: {}",
+                backup_dir.display(),
+                error
+            )
+        })?;
+    }
+
+    copy_dir_recursive_path(source_dir, &temp_dir).map_err(|e| e.to_string())?;
+
+    let moved_existing_to_backup = if target_dir.exists() {
+        std::fs::rename(target_dir, &backup_dir).map_err(|error| {
+            format!(
+                "Failed to move existing managed skill {} aside: {}",
+                target_dir.display(),
+                error
+            )
+        })?;
+        true
+    } else {
+        false
+    };
+
+    match std::fs::rename(&temp_dir, target_dir) {
+        Ok(()) => {
+            if moved_existing_to_backup {
+                std::fs::remove_dir_all(&backup_dir).map_err(|error| {
+                    format!(
+                        "Failed to remove backup dir {}: {}",
+                        backup_dir.display(),
+                        error
+                    )
+                })?;
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            if moved_existing_to_backup && !target_dir.exists() {
+                let _ = std::fs::rename(&backup_dir, target_dir);
+            }
+            Err(format!(
+                "Failed to activate managed skill {}: {}",
+                target_dir.display(),
+                error
+            ))
+        }
+    }
+}
+
+/// Synchronize the managed system skills snapshot with the packaged bundled skills.
+///
+/// This keeps a runtime-owned app-data mirror instead of treating packaged resources
+/// as the live source of truth, while avoiding full delete-and-recopy work when only
+/// a subset of bundled skills changed.
+pub fn sync_managed_system_skills_snapshot(
+    bundled_skills_dir: &std::path::Path,
+    system_skills_dir: &std::path::Path,
+) -> Result<(), String> {
     if !bundled_skills_dir.exists() {
         return Ok(());
     }
 
-    for entry in std::fs::read_dir(bundled_skills_dir).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let source_path = entry.path();
-        if !source_path.is_dir() {
-            continue;
-        }
+    std::fs::create_dir_all(system_skills_dir).map_err(|e| e.to_string())?;
 
-        let target_path = legacy_skills_dir.join(entry.file_name());
-        copy_dir_recursive_path(&source_path, &target_path).map_err(|e| e.to_string())?;
-        std::fs::write(target_path.join(BUNDLED_SKILL_MARKER), "").map_err(|e| e.to_string())?;
+    let source_manifest = build_bundled_skills_manifest(bundled_skills_dir)?;
+    let installed_manifest = build_bundled_skills_manifest(system_skills_dir)?;
+    let source_skill_names = source_manifest
+        .skills
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let installed_skill_names = collect_skill_directory_names(system_skills_dir)?;
+    let manifest_path = system_skills_dir.join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME);
+
+    if installed_manifest == source_manifest && installed_skill_names == source_skill_names {
+        if !manifest_path.exists() {
+            write_manifest_atomically(&manifest_path, &source_manifest)?;
+        }
+        return Ok(());
     }
 
+    for obsolete_skill in installed_skill_names.difference(&source_skill_names) {
+        std::fs::remove_dir_all(system_skills_dir.join(obsolete_skill)).map_err(|error| {
+            format!(
+                "Failed to delete obsolete managed skill {}: {}",
+                obsolete_skill, error
+            )
+        })?;
+    }
+
+    for (skill_name, source_hash) in &source_manifest.skills {
+        let target_dir = system_skills_dir.join(skill_name);
+        let needs_update =
+            installed_manifest.skills.get(skill_name) != Some(source_hash) || !target_dir.exists();
+
+        if needs_update {
+            replace_skill_directory_atomically(&bundled_skills_dir.join(skill_name), &target_dir)?;
+        }
+    }
+
+    write_manifest_atomically(&manifest_path, &source_manifest)?;
     Ok(())
 }
 
@@ -84,8 +320,8 @@ async fn migrate_legacy_skills_to_managed_storage(
         .map_err(std::io::Error::other)?
         .get_base_data_dir()
         .clone();
-    let legacy_skills_dir = base_data_dir.join("skills");
-    let user_skills_dir = base_data_dir.join("user_skills");
+    let legacy_skills_dir = base_data_dir.join(LEGACY_SYSTEM_SKILLS_DIR_NAME);
+    let user_skills_dir = base_data_dir.join(USER_SKILLS_DIR_NAME);
 
     if !legacy_skills_dir.exists() {
         return Ok(());
@@ -199,20 +435,20 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // Keep the AppData/skills bundled snapshot aligned with bundled_skills so the
+    // Keep the app-data managed system snapshot aligned with bundled_skills so the
     // runtime system skills directory never depends on the packaged install path.
     if let Err(e) = {
         let resource_dir = app.path().resource_dir()?;
         let bundled_skills_dir = resource_dir.join("bundled_skills");
-        let legacy_skills_dir = crate::session::get_session_manager()
+        let system_skills_dir = crate::session::get_session_manager()
             .map_err(std::io::Error::other)?
             .get_base_data_dir()
-            .join("skills");
-        sync_legacy_global_skills_to_bundled_snapshot(&bundled_skills_dir, &legacy_skills_dir)
+            .join(SYSTEM_SKILLS_DIR_NAME);
+        sync_managed_system_skills_snapshot(&bundled_skills_dir, &system_skills_dir)
     } {
-        log::warn!("⚠️  Failed to sync bundled skills snapshot: {}", e);
+        log::warn!("⚠️  Failed to sync managed system skills snapshot: {}", e);
     } else {
-        info!("✅ Bundled skills snapshot synchronized");
+        info!("✅ Managed system skills snapshot synchronized");
     }
 
     // Fetch System Settings

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -169,6 +169,27 @@ fn build_bundled_skills_manifest(skills_dir: &Path) -> Result<BundledSkillsManif
     Ok(manifest)
 }
 
+fn load_persisted_bundled_skills_manifest(
+    manifest_path: &Path,
+) -> Result<Option<BundledSkillsManifest>, String> {
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let payload = std::fs::read(manifest_path)
+        .map_err(|error| format!("Failed to read {}: {}", manifest_path.display(), error))?;
+    let manifest = match serde_json::from_slice::<BundledSkillsManifest>(&payload) {
+        Ok(manifest) => manifest,
+        Err(_) => return Ok(None),
+    };
+
+    if manifest.schema_version != MANAGED_SYSTEM_SKILLS_MANIFEST_SCHEMA_VERSION {
+        return Ok(None);
+    }
+
+    Ok(Some(manifest))
+}
+
 fn write_manifest_atomically(
     manifest_path: &Path,
     manifest: &BundledSkillsManifest,
@@ -176,24 +197,59 @@ fn write_manifest_atomically(
     let payload = serde_json::to_vec_pretty(manifest)
         .map_err(|error| format!("Failed to serialize manifest: {}", error))?;
     let temp_path = manifest_path.with_extension("json.tmp");
+    let backup_path = manifest_path.with_extension("json.bak");
 
     std::fs::write(&temp_path, payload)
         .map_err(|error| format!("Failed to write {}: {}", temp_path.display(), error))?;
 
-    if manifest_path.exists() {
-        std::fs::remove_file(manifest_path)
-            .map_err(|error| format!("Failed to replace {}: {}", manifest_path.display(), error))?;
+    if backup_path.exists() {
+        std::fs::remove_file(&backup_path).map_err(|error| {
+            format!(
+                "Failed to clear backup manifest {}: {}",
+                backup_path.display(),
+                error
+            )
+        })?;
     }
 
-    std::fs::rename(&temp_path, manifest_path).map_err(|error| {
-        format!(
-            "Failed to finalize manifest {}: {}",
-            manifest_path.display(),
-            error
-        )
-    })?;
+    let moved_existing_to_backup = if manifest_path.exists() {
+        std::fs::rename(manifest_path, &backup_path).map_err(|error| {
+            format!(
+                "Failed to move existing manifest {} aside: {}",
+                manifest_path.display(),
+                error
+            )
+        })?;
+        true
+    } else {
+        false
+    };
 
-    Ok(())
+    match std::fs::rename(&temp_path, manifest_path) {
+        Ok(()) => {
+            if moved_existing_to_backup {
+                std::fs::remove_file(&backup_path).map_err(|error| {
+                    format!(
+                        "Failed to remove backup manifest {}: {}",
+                        backup_path.display(),
+                        error
+                    )
+                })?;
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&temp_path);
+            if moved_existing_to_backup && !manifest_path.exists() {
+                let _ = std::fs::rename(&backup_path, manifest_path);
+            }
+            Err(format!(
+                "Failed to finalize manifest {}: {}",
+                manifest_path.display(),
+                error
+            ))
+        }
+    }
 }
 
 fn replace_skill_directory_atomically(source_dir: &Path, target_dir: &Path) -> Result<(), String> {
@@ -285,18 +341,22 @@ pub fn sync_managed_system_skills_snapshot(
 
     std::fs::create_dir_all(system_skills_dir).map_err(|e| e.to_string())?;
 
+    let manifest_path = system_skills_dir.join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME);
     let source_manifest = build_bundled_skills_manifest(bundled_skills_dir)?;
-    let installed_manifest = build_bundled_skills_manifest(system_skills_dir)?;
     let source_skill_names = source_manifest
         .skills
         .keys()
         .cloned()
         .collect::<BTreeSet<_>>();
     let installed_skill_names = collect_skill_directory_names(system_skills_dir)?;
-    let manifest_path = system_skills_dir.join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME);
+    let persisted_manifest = load_persisted_bundled_skills_manifest(&manifest_path)?;
+    let installed_manifest = match persisted_manifest.as_ref() {
+        Some(manifest) => manifest.clone(),
+        None => build_bundled_skills_manifest(system_skills_dir)?,
+    };
 
     if installed_manifest == source_manifest && installed_skill_names == source_skill_names {
-        if !manifest_path.exists() {
+        if persisted_manifest.is_none() {
             write_manifest_atomically(&manifest_path, &source_manifest)?;
         }
         return Ok(());

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -32,6 +32,23 @@ struct BundledSkillsManifest {
     skills: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LegacySkillMigrationSummary {
+    removed_legacy_snapshot_entries: usize,
+    migrated_user_skills: usize,
+    skipped_existing_user_skills: usize,
+    removed_legacy_root_dir: bool,
+}
+
+impl LegacySkillMigrationSummary {
+    fn is_noop(&self) -> bool {
+        self.removed_legacy_snapshot_entries == 0
+            && self.migrated_user_skills == 0
+            && self.skipped_existing_user_skills == 0
+            && !self.removed_legacy_root_dir
+    }
+}
+
 /// Migration decision for a legacy skill directory from AppData/skills.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LegacySkillMigrationAction {
@@ -311,9 +328,25 @@ pub fn sync_managed_system_skills_snapshot(
 /// Move legacy user-managed skills from AppData/skills into AppData/user_skills.
 /// Old `.bundled_skill` snapshot entries are always discarded so the bundled
 /// system snapshot can be rebuilt as an exact copy of the current bundle.
+pub fn remove_legacy_skills_dir_if_empty(
+    legacy_skills_dir: &Path,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    if !legacy_skills_dir.exists() {
+        return Ok(false);
+    }
+
+    let mut entries = std::fs::read_dir(legacy_skills_dir)?;
+    if entries.next().is_some() {
+        return Ok(false);
+    }
+
+    std::fs::remove_dir(legacy_skills_dir)?;
+    Ok(true)
+}
+
 async fn migrate_legacy_skills_to_managed_storage(
     _app: &App,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<LegacySkillMigrationSummary, Box<dyn std::error::Error>> {
     use std::fs;
 
     let base_data_dir = crate::session::get_session_manager()
@@ -324,10 +357,11 @@ async fn migrate_legacy_skills_to_managed_storage(
     let user_skills_dir = base_data_dir.join(USER_SKILLS_DIR_NAME);
 
     if !legacy_skills_dir.exists() {
-        return Ok(());
+        return Ok(LegacySkillMigrationSummary::default());
     }
 
     fs::create_dir_all(&user_skills_dir)?;
+    let mut summary = LegacySkillMigrationSummary::default();
 
     for entry in fs::read_dir(&legacy_skills_dir)? {
         let entry = entry?;
@@ -346,6 +380,7 @@ async fn migrate_legacy_skills_to_managed_storage(
                 skill_name
             );
             fs::remove_dir_all(&legacy_skill_dir)?;
+            summary.removed_legacy_snapshot_entries += 1;
             continue;
         }
 
@@ -354,6 +389,7 @@ async fn migrate_legacy_skills_to_managed_storage(
                 "⏭️  Managed user skill already exists, leaving legacy copy untouched: {:?}",
                 skill_name
             );
+            summary.skipped_existing_user_skills += 1;
             continue;
         }
 
@@ -363,6 +399,7 @@ async fn migrate_legacy_skills_to_managed_storage(
                     "📦 Migrated legacy skill into managed storage: {:?}",
                     skill_name
                 );
+                summary.migrated_user_skills += 1;
             }
             Err(error) => {
                 log::warn!(
@@ -372,11 +409,14 @@ async fn migrate_legacy_skills_to_managed_storage(
                 );
                 copy_dir_recursive(&legacy_skill_dir, &target_skill_dir)?;
                 fs::remove_dir_all(&legacy_skill_dir)?;
+                summary.migrated_user_skills += 1;
             }
         }
     }
 
-    Ok(())
+    summary.removed_legacy_root_dir = remove_legacy_skills_dir_if_empty(&legacy_skills_dir)?;
+
+    Ok(summary)
 }
 
 /// Recursively copy directory contents
@@ -428,10 +468,22 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
 
     // Migrate legacy AppData/skills user content into the managed user_skills directory.
     tauri::async_runtime::block_on(async {
-        if let Err(e) = migrate_legacy_skills_to_managed_storage(app).await {
-            log::warn!("⚠️  Failed to migrate legacy skills: {}", e);
-        } else {
-            info!("✅ Legacy skills migration completed");
+        match migrate_legacy_skills_to_managed_storage(app).await {
+            Ok(summary) if summary.is_noop() => {
+                log::debug!("No legacy skills migration work was needed");
+            }
+            Ok(summary) => {
+                info!(
+                    "✅ Legacy skills migration completed (removed snapshots: {}, migrated user skills: {}, skipped existing user skills: {}, removed legacy root: {})",
+                    summary.removed_legacy_snapshot_entries,
+                    summary.migrated_user_skills,
+                    summary.skipped_existing_user_skills,
+                    summary.removed_legacy_root_dir
+                );
+            }
+            Err(e) => {
+                log::warn!("⚠️  Failed to migrate legacy skills: {}", e);
+            }
         }
     });
 

--- a/src-tauri/src/services/session_directory_service.rs
+++ b/src-tauri/src/services/session_directory_service.rs
@@ -27,7 +27,11 @@ impl SessionDirectoryService {
             .map_err(|e| format!("Failed to create config directory: {e}"))?;
 
         fs::create_dir_all(base_data_dir.join("skills"))
-            .map_err(|e| format!("Failed to create skills directory: {e}"))?;
+            .map_err(|e| format!("Failed to create legacy skills directory: {e}"))?;
+        fs::create_dir_all(base_data_dir.join("system_skills"))
+            .map_err(|e| format!("Failed to create system skills directory: {e}"))?;
+        fs::create_dir_all(base_data_dir.join("user_skills"))
+            .map_err(|e| format!("Failed to create user skills directory: {e}"))?;
 
         // Create default workspace
         let default_workspace = base_data_dir.join("workspaces").join("default");

--- a/src-tauri/src/services/session_directory_service.rs
+++ b/src-tauri/src/services/session_directory_service.rs
@@ -26,8 +26,6 @@ impl SessionDirectoryService {
         fs::create_dir_all(base_data_dir.join("config"))
             .map_err(|e| format!("Failed to create config directory: {e}"))?;
 
-        fs::create_dir_all(base_data_dir.join("skills"))
-            .map_err(|e| format!("Failed to create legacy skills directory: {e}"))?;
         fs::create_dir_all(base_data_dir.join("system_skills"))
             .map_err(|e| format!("Failed to create system skills directory: {e}"))?;
         fs::create_dir_all(base_data_dir.join("user_skills"))

--- a/src-tauri/src/services/skill_service/contracts.rs
+++ b/src-tauri/src/services/skill_service/contracts.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 pub const SKILL_FILE_NAME: &str = "SKILL.md";
-pub(super) const USER_SKILLS_DIR_NAME: &str = "user_skills";
+pub const USER_SKILLS_DIR_NAME: &str = "user_skills";
+pub const SYSTEM_SKILLS_DIR_NAME: &str = "system_skills";
+pub const LEGACY_SYSTEM_SKILLS_DIR_NAME: &str = "skills";
+pub const MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME: &str = ".bundled_manifest.json";
 pub(super) const GITHUB_DOWNLOAD_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub(super) const GITHUB_DOWNLOAD_TIMEOUT_SECS: u64 = 30;
 pub(super) const MAX_GITHUB_ARCHIVE_BYTES: u64 = 100 * 1024 * 1024;

--- a/src-tauri/src/services/skill_service/directories.rs
+++ b/src-tauri/src/services/skill_service/directories.rs
@@ -1,4 +1,7 @@
-use super::contracts::{ManagedSkillsOverview, SkillMetadata, USER_SKILLS_DIR_NAME};
+use super::contracts::{
+    ManagedSkillsOverview, SkillMetadata, LEGACY_SYSTEM_SKILLS_DIR_NAME, SYSTEM_SKILLS_DIR_NAME,
+    USER_SKILLS_DIR_NAME,
+};
 use super::scan_skills_internal;
 use crate::session::get_session_manager;
 use std::collections::HashSet;
@@ -13,7 +16,10 @@ pub async fn get_configured_skills_directory() -> Result<String, String> {
 }
 
 pub fn get_system_skills_directory() -> Result<PathBuf, String> {
-    get_legacy_global_skills_directory()
+    let session_manager = get_session_manager()?;
+    Ok(session_manager
+        .get_base_data_dir()
+        .join(SYSTEM_SKILLS_DIR_NAME))
 }
 
 pub fn get_user_skills_directory() -> Result<PathBuf, String> {
@@ -25,7 +31,9 @@ pub fn get_user_skills_directory() -> Result<PathBuf, String> {
 
 pub fn get_legacy_global_skills_directory() -> Result<PathBuf, String> {
     let session_manager = get_session_manager()?;
-    Ok(session_manager.get_base_data_dir().join("skills"))
+    Ok(session_manager
+        .get_base_data_dir()
+        .join(LEGACY_SYSTEM_SKILLS_DIR_NAME))
 }
 
 fn merge_skill_layers(skill_layers: Vec<Vec<SkillMetadata>>) -> Vec<SkillMetadata> {

--- a/src-tauri/src/services/skill_service/mod.rs
+++ b/src-tauri/src/services/skill_service/mod.rs
@@ -6,7 +6,9 @@ mod scanning;
 
 pub use contracts::{
     GitHubRepoSpec, ManagedSkillsOverview, SkillImportCandidate, SkillImportConflict,
-    SkillImportPreview, SkillImportResult, SkillMetadata, SKILL_FILE_NAME,
+    SkillImportPreview, SkillImportResult, SkillMetadata, LEGACY_SYSTEM_SKILLS_DIR_NAME,
+    MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME, SKILL_FILE_NAME, SYSTEM_SKILLS_DIR_NAME,
+    USER_SKILLS_DIR_NAME,
 };
 pub use directories::{
     collect_allowed_skill_roots, get_assistant_skills_directory, get_configured_skills_directory,

--- a/src-tauri/tests/bundled_skills_build_mirror_tests.rs
+++ b/src-tauri/tests/bundled_skills_build_mirror_tests.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+#[path = "../build_support/bundled_skills.rs"]
+mod bundled_skills;
+
+fn write_skill(dir: &Path, name: &str, description: &str, body: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {}\ndescription: {}\n---\n{}\n",
+            name, description, body
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn mirror_bundled_skills_copies_only_valid_skill_directories() {
+    let source_root = TempDir::new().unwrap();
+    let deployed_root = TempDir::new().unwrap();
+
+    write_skill(
+        &source_root.path().join("teamwork"),
+        "teamwork",
+        "Bundled teamwork",
+        "expected bundled body",
+    );
+    fs::create_dir_all(source_root.path().join("dummy-test")).unwrap();
+
+    bundled_skills::mirror_bundled_skills(source_root.path(), deployed_root.path()).unwrap();
+
+    assert!(deployed_root
+        .path()
+        .join("teamwork")
+        .join("SKILL.md")
+        .exists());
+    assert!(!deployed_root.path().join("dummy-test").exists());
+}
+
+#[test]
+fn mirror_bundled_skills_removes_stale_output_for_invalidated_skill_directory() {
+    let source_root = TempDir::new().unwrap();
+    let deployed_root = TempDir::new().unwrap();
+
+    let source_dummy = source_root.path().join("dummy-test");
+    write_skill(
+        &source_dummy,
+        "dummy-test",
+        "Bundled dummy",
+        "present on first sync",
+    );
+
+    bundled_skills::mirror_bundled_skills(source_root.path(), deployed_root.path()).unwrap();
+    assert!(deployed_root
+        .path()
+        .join("dummy-test")
+        .join("SKILL.md")
+        .exists());
+
+    fs::remove_file(source_dummy.join("SKILL.md")).unwrap();
+
+    bundled_skills::mirror_bundled_skills(source_root.path(), deployed_root.path()).unwrap();
+
+    assert!(!deployed_root.path().join("dummy-test").exists());
+}

--- a/src-tauri/tests/legacy_skill_migration_tests.rs
+++ b/src-tauri/tests/legacy_skill_migration_tests.rs
@@ -133,7 +133,7 @@ fn sync_managed_system_skills_removes_extras_and_restores_missing_bundled_skills
 }
 
 #[test]
-fn sync_managed_system_skills_restores_tampered_skill_contents() {
+fn sync_managed_system_skills_restores_tampered_skill_contents_when_manifest_is_missing() {
     let bundled_root = TempDir::new().unwrap();
     let system_root = TempDir::new().unwrap();
 
@@ -147,6 +147,48 @@ fn sync_managed_system_skills_restores_tampered_skill_contents() {
 
     sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
 
+    fs::write(
+        system_root.path().join("teamwork").join("SKILL.md"),
+        "---\nname: teamwork\ndescription: Tampered\n---\nlocal drift\n",
+    )
+    .unwrap();
+    fs::remove_file(
+        system_root
+            .path()
+            .join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME),
+    )
+    .unwrap();
+
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
+
+    let teamwork_skill =
+        fs::read_to_string(system_root.path().join("teamwork").join("SKILL.md")).unwrap();
+    assert!(teamwork_skill.contains("Bundled teamwork"));
+    assert!(teamwork_skill.contains("expected bundled body"));
+}
+
+#[test]
+fn sync_managed_system_skills_rebuilds_invalid_manifest_before_comparing() {
+    let bundled_root = TempDir::new().unwrap();
+    let system_root = TempDir::new().unwrap();
+
+    let bundled_teamwork = bundled_root.path().join("teamwork");
+    write_skill(
+        &bundled_teamwork,
+        "teamwork",
+        "Bundled teamwork",
+        "expected bundled body",
+    );
+
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
+
+    fs::write(
+        system_root
+            .path()
+            .join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME),
+        b"{not-json",
+    )
+    .unwrap();
     fs::write(
         system_root.path().join("teamwork").join("SKILL.md"),
         "---\nname: teamwork\ndescription: Tampered\n---\nlocal drift\n",

--- a/src-tauri/tests/legacy_skill_migration_tests.rs
+++ b/src-tauri/tests/legacy_skill_migration_tests.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::Path;
 use tauri_mcp_agent_lib::lifecycle::app_setup::{
-    classify_legacy_skill_for_managed_storage, sync_managed_system_skills_snapshot,
-    LegacySkillMigrationAction,
+    classify_legacy_skill_for_managed_storage, remove_legacy_skills_dir_if_empty,
+    sync_managed_system_skills_snapshot, LegacySkillMigrationAction,
 };
 use tauri_mcp_agent_lib::services::skill_service::MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME;
 use tempfile::TempDir;
@@ -182,4 +182,27 @@ fn sync_managed_system_skills_ignores_empty_source_directories() {
 
     assert!(system_root.path().join("teamwork").exists());
     assert!(!system_root.path().join("dummy-test").exists());
+}
+
+#[test]
+fn remove_legacy_skills_dir_if_empty_removes_only_empty_roots() {
+    let legacy_root = TempDir::new().unwrap();
+    let empty_legacy_dir = legacy_root.path().join("skills");
+    fs::create_dir_all(&empty_legacy_dir).unwrap();
+
+    let removed = remove_legacy_skills_dir_if_empty(&empty_legacy_dir).unwrap();
+    assert!(removed);
+    assert!(!empty_legacy_dir.exists());
+
+    fs::create_dir_all(&empty_legacy_dir).unwrap();
+    write_skill(
+        &empty_legacy_dir.join("custom-skill"),
+        "custom-skill",
+        "Custom",
+        "user content",
+    );
+
+    let removed_non_empty = remove_legacy_skills_dir_if_empty(&empty_legacy_dir).unwrap();
+    assert!(!removed_non_empty);
+    assert!(empty_legacy_dir.exists());
 }

--- a/src-tauri/tests/legacy_skill_migration_tests.rs
+++ b/src-tauri/tests/legacy_skill_migration_tests.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::path::Path;
 use tauri_mcp_agent_lib::lifecycle::app_setup::{
-    classify_legacy_skill_for_managed_storage, sync_legacy_global_skills_to_bundled_snapshot,
+    classify_legacy_skill_for_managed_storage, sync_managed_system_skills_snapshot,
     LegacySkillMigrationAction,
 };
+use tauri_mcp_agent_lib::services::skill_service::MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME;
 use tempfile::TempDir;
 
 fn write_skill(dir: &Path, name: &str, description: &str, body: &str) {
@@ -87,9 +88,9 @@ fn modified_legacy_bundled_skill_is_deleted_instead_of_migrated() {
 }
 
 #[test]
-fn sync_legacy_global_skills_removes_extras_and_restores_missing_bundled_skills() {
+fn sync_managed_system_skills_removes_extras_and_restores_missing_bundled_skills() {
     let bundled_root = TempDir::new().unwrap();
-    let legacy_root = TempDir::new().unwrap();
+    let system_root = TempDir::new().unwrap();
 
     let bundled_teamwork = bundled_root.path().join("teamwork");
     let bundled_delegate = bundled_root.path().join("delegate");
@@ -106,35 +107,79 @@ fn sync_legacy_global_skills_removes_extras_and_restores_missing_bundled_skills(
         "delegate body",
     );
 
-    let legacy_teamwork = legacy_root.path().join("teamwork");
-    let legacy_extra = legacy_root.path().join("custom-extra");
+    let system_teamwork = system_root.path().join("teamwork");
+    let system_extra = system_root.path().join("custom-extra");
     write_skill(
-        &legacy_teamwork,
+        &system_teamwork,
         "teamwork",
         "Old modified",
         "outdated body",
     );
-    write_skill(&legacy_extra, "custom-extra", "Extra", "extra body");
-    fs::write(legacy_teamwork.join(".bundled_skill"), "").unwrap();
-    fs::write(legacy_extra.join(".bundled_skill"), "").unwrap();
+    write_skill(&system_extra, "custom-extra", "Extra", "extra body");
 
-    sync_legacy_global_skills_to_bundled_snapshot(bundled_root.path(), legacy_root.path()).unwrap();
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
 
-    assert!(legacy_root.path().join("teamwork").exists());
-    assert!(legacy_root.path().join("delegate").exists());
-    assert!(!legacy_root.path().join("custom-extra").exists());
+    assert!(system_root.path().join("teamwork").exists());
+    assert!(system_root.path().join("delegate").exists());
+    assert!(!system_root.path().join("custom-extra").exists());
 
     let teamwork_skill =
-        fs::read_to_string(legacy_root.path().join("teamwork").join("SKILL.md")).unwrap();
+        fs::read_to_string(system_root.path().join("teamwork").join("SKILL.md")).unwrap();
     assert!(teamwork_skill.contains("Bundled teamwork"));
-    assert!(legacy_root
+    assert!(system_root
         .path()
-        .join("teamwork")
-        .join(".bundled_skill")
+        .join(MANAGED_SYSTEM_SKILLS_MANIFEST_FILE_NAME)
         .exists());
-    assert!(legacy_root
-        .path()
-        .join("delegate")
-        .join(".bundled_skill")
-        .exists());
+}
+
+#[test]
+fn sync_managed_system_skills_restores_tampered_skill_contents() {
+    let bundled_root = TempDir::new().unwrap();
+    let system_root = TempDir::new().unwrap();
+
+    let bundled_teamwork = bundled_root.path().join("teamwork");
+    write_skill(
+        &bundled_teamwork,
+        "teamwork",
+        "Bundled teamwork",
+        "expected bundled body",
+    );
+
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
+
+    fs::write(
+        system_root.path().join("teamwork").join("SKILL.md"),
+        "---\nname: teamwork\ndescription: Tampered\n---\nlocal drift\n",
+    )
+    .unwrap();
+
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
+
+    let teamwork_skill =
+        fs::read_to_string(system_root.path().join("teamwork").join("SKILL.md")).unwrap();
+    assert!(teamwork_skill.contains("Bundled teamwork"));
+    assert!(teamwork_skill.contains("expected bundled body"));
+}
+
+#[test]
+fn sync_managed_system_skills_ignores_empty_source_directories() {
+    let bundled_root = TempDir::new().unwrap();
+    let system_root = TempDir::new().unwrap();
+
+    let bundled_teamwork = bundled_root.path().join("teamwork");
+    write_skill(
+        &bundled_teamwork,
+        "teamwork",
+        "Bundled teamwork",
+        "expected bundled body",
+    );
+    fs::create_dir_all(bundled_root.path().join("dummy-test")).unwrap();
+
+    let stale_dummy = system_root.path().join("dummy-test");
+    write_skill(&stale_dummy, "dummy-test", "Old dummy", "stale content");
+
+    sync_managed_system_skills_snapshot(bundled_root.path(), system_root.path()).unwrap();
+
+    assert!(system_root.path().join("teamwork").exists());
+    assert!(!system_root.path().join("dummy-test").exists());
 }

--- a/src-tauri/tests/session_directory_service_tests.rs
+++ b/src-tauri/tests/session_directory_service_tests.rs
@@ -1,0 +1,24 @@
+use tauri_mcp_agent_lib::services::skill_service::{
+    LEGACY_SYSTEM_SKILLS_DIR_NAME, SYSTEM_SKILLS_DIR_NAME, USER_SKILLS_DIR_NAME,
+};
+use tauri_mcp_agent_lib::services::SessionDirectoryService;
+use tempfile::TempDir;
+
+#[test]
+fn session_directory_service_skips_legacy_skills_directory() {
+    let base_data_dir = TempDir::new().unwrap();
+    let service = SessionDirectoryService::new(base_data_dir.path().to_path_buf()).unwrap();
+
+    assert!(service
+        .get_base_data_dir()
+        .join(SYSTEM_SKILLS_DIR_NAME)
+        .exists());
+    assert!(service
+        .get_base_data_dir()
+        .join(USER_SKILLS_DIR_NAME)
+        .exists());
+    assert!(!service
+        .get_base_data_dir()
+        .join(LEGACY_SYSTEM_SKILLS_DIR_NAME)
+        .exists());
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { lazy, Suspense, useEffect } from 'react';
-import { emit } from '@tauri-apps/api/event';
 import { Toaster } from '../components/ui/sonner';
 import AppSidebar from '../components/layout/AppSidebar';
 import { ThemeToggle } from '../components/common/ThemeToggle';
@@ -19,6 +18,7 @@ import { GlobalEventProvider } from '@/context/GlobalEventContext';
 import { UpdateProvider } from '@/context/UpdateContext';
 import { useSettings } from '../context/SettingsContext';
 import { markStartupMilestone } from '@/lib/performance/startup-metrics';
+import { emitFrontendReadyOnce } from './frontend-ready';
 import '../styles/globals.css';
 
 // Lazy-load route components to reduce initial bundle and improve first paint
@@ -81,9 +81,7 @@ function App() {
     markStartupMilestone('app-mounted');
 
     // Signal to backend that frontend is ready to receive events
-    emit('frontend-ready').catch((e) => {
-      console.error('Failed to emit frontend-ready event', e);
-    });
+    void emitFrontendReadyOnce();
   }, []);
 
   useEffect(() => {

--- a/src/app/frontend-ready.test.ts
+++ b/src/app/frontend-ready.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { emit } from '@tauri-apps/api/event';
+
+import {
+  __resetFrontendReadyForTests,
+  emitFrontendReadyOnce,
+} from './frontend-ready';
+
+const { loggerError } = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: loggerError,
+  }),
+}));
+
+describe('frontend-ready', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetFrontendReadyForTests();
+  });
+
+  it('dedupes concurrent and repeated frontend-ready emits', async () => {
+    let resolveEmit: (() => void) | undefined;
+
+    vi.mocked(emit).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEmit = resolve;
+        }),
+    );
+
+    const firstEmit = emitFrontendReadyOnce();
+    const secondEmit = emitFrontendReadyOnce();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    resolveEmit?.();
+    await Promise.all([firstEmit, secondEmit]);
+
+    await emitFrontendReadyOnce();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries frontend-ready after an emit failure', async () => {
+    vi.mocked(emit)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    await emitFrontendReadyOnce();
+    await emitFrontendReadyOnce();
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(loggerError).toHaveBeenCalledWith(
+      'Failed to emit frontend-ready event',
+      expect.any(Error),
+    );
+  });
+});

--- a/src/app/frontend-ready.ts
+++ b/src/app/frontend-ready.ts
@@ -1,0 +1,36 @@
+import { emit } from '@tauri-apps/api/event';
+
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('FrontendReady');
+
+let hasEmittedFrontendReady = false;
+let frontendReadyPromise: Promise<void> | null = null;
+
+export async function emitFrontendReadyOnce(): Promise<void> {
+  if (hasEmittedFrontendReady) {
+    return;
+  }
+
+  if (frontendReadyPromise) {
+    return frontendReadyPromise;
+  }
+
+  frontendReadyPromise = emit('frontend-ready')
+    .then(() => {
+      hasEmittedFrontendReady = true;
+    })
+    .catch((error: unknown) => {
+      logger.error('Failed to emit frontend-ready event', error);
+    })
+    .finally(() => {
+      frontendReadyPromise = null;
+    });
+
+  return frontendReadyPromise;
+}
+
+export function __resetFrontendReadyForTests() {
+  hasEmittedFrontendReady = false;
+  frontendReadyPromise = null;
+}

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -38,6 +38,63 @@ import type {
 const logger = getLogger('AgentSessionListContext');
 const RESERVED_AGENT_SUBROUTES = new Set(['draft']);
 
+let cachedSessionMetadataList: AgentSessionMetadata[] | null = null;
+let cachedSessionMetadataPromise: Promise<AgentSessionMetadata[]> | null = null;
+
+type SessionMetadataLoadSource = 'cache' | 'inflight' | 'network';
+
+interface SessionMetadataLoadHandle {
+  source: SessionMetadataLoadSource;
+  promise: Promise<AgentSessionMetadata[]>;
+}
+
+function invalidateSessionListStartupCache() {
+  cachedSessionMetadataList = null;
+  cachedSessionMetadataPromise = null;
+}
+
+function loadSessionMetadataList(
+  forceRefresh = false,
+): SessionMetadataLoadHandle {
+  if (!forceRefresh && cachedSessionMetadataList !== null) {
+    return {
+      source: 'cache',
+      promise: Promise.resolve(cachedSessionMetadataList),
+    };
+  }
+
+  if (!forceRefresh && cachedSessionMetadataPromise) {
+    return {
+      source: 'inflight',
+      promise: cachedSessionMetadataPromise,
+    };
+  }
+
+  const request = Promise.resolve(
+    safeInvoke<AgentSessionMetadata[]>('agent_get_all_sessions'),
+  )
+    .then((response) => {
+      const sessionMetadataList = Array.isArray(response) ? response : [];
+      cachedSessionMetadataList = sessionMetadataList;
+      return sessionMetadataList;
+    })
+    .finally(() => {
+      if (cachedSessionMetadataPromise === request) {
+        cachedSessionMetadataPromise = null;
+      }
+    });
+
+  cachedSessionMetadataPromise = request;
+  return {
+    source: 'network',
+    promise: request,
+  };
+}
+
+export function __resetAgentSessionListStartupCacheForTests() {
+  invalidateSessionListStartupCache();
+}
+
 // --- STATE CONTEXT ---
 interface AgentSessionListStateContextValue {
   sessions: AgentSession[];
@@ -60,7 +117,7 @@ interface AgentSessionListActionsContextValue {
   /**
    * Load all agent sessions
    */
-  loadSessions: () => Promise<void>;
+  loadSessions: (forceRefresh?: boolean) => Promise<void>;
 
   /**
    * Delete an agent session
@@ -114,6 +171,7 @@ export function AgentSessionListProvider({
   const [isSessionsListLoading, setIsSessionsListLoading] = useState(false);
   const pendingApprovalKeysRef = useRef(new Set<string>());
   const startupLoadRecordedRef = useRef(false);
+  const sessionListMutationVersionRef = useRef(0);
   const activeSessionId = useMemo(() => {
     const sessionId = matchPath('/agent/:sessionId', location.pathname)?.params
       .sessionId;
@@ -135,19 +193,35 @@ export function AgentSessionListProvider({
     return session.lastAttentionAt.getTime() > session.lastViewedAt.getTime();
   }, []);
 
+  const mutateSessions = useCallback(
+    (updater: (previousSessions: AgentSession[]) => AgentSession[]) => {
+      sessionListMutationVersionRef.current += 1;
+      invalidateSessionListStartupCache();
+      setSessions(updater);
+    },
+    [],
+  );
+
   /**
    * Load all agent sessions
    */
-  const loadSessions = useCallback(async () => {
-    logger.info('Loading all agent sessions');
+  const loadSessions = useCallback(async (forceRefresh = false) => {
+    const { source, promise } = loadSessionMetadataList(forceRefresh);
+    const shouldLogLoad = forceRefresh || source === 'network';
+
+    if (shouldLogLoad) {
+      logger.info('Loading all agent sessions');
+    }
+
     setIsSessionsListLoading(true);
+    const mutationVersion = sessionListMutationVersionRef.current;
 
     try {
-      // Call Rust backend to get all sessions
-      const response = await safeInvoke<AgentSessionMetadata[]>(
-        'agent_get_all_sessions',
-      );
-      const sessionMetadataList = Array.isArray(response) ? response : [];
+      const sessionMetadataList = await promise;
+
+      if (mutationVersion !== sessionListMutationVersionRef.current) {
+        return;
+      }
 
       setSessions((prev) => {
         const pendingApprovalCounts = new Map(
@@ -166,10 +240,16 @@ export function AgentSessionListProvider({
           ),
         );
       });
-      logger.info('Loaded sessions', { count: sessionMetadataList.length });
+      if (shouldLogLoad) {
+        logger.info('Loaded sessions', { count: sessionMetadataList.length });
+      }
     } catch (err) {
-      logger.error('Failed to load sessions', err);
-      setSessions([]);
+      if (shouldLogLoad) {
+        logger.error('Failed to load sessions', err);
+      }
+      if (mutationVersion === sessionListMutationVersionRef.current) {
+        setSessions([]);
+      }
     } finally {
       setIsSessionsListLoading(false);
       if (!startupLoadRecordedRef.current) {
@@ -286,7 +366,7 @@ export function AgentSessionListProvider({
         };
 
         // Add to list
-        setSessions((prev) => [session, ...prev]);
+        mutateSessions((prev) => [session, ...prev]);
 
         logger.info('Agent session created successfully', {
           sessionId: session.id,
@@ -302,6 +382,7 @@ export function AgentSessionListProvider({
       advanced.defaultSessionMaxDepth,
       advanced.defaultSessionMaxFanout,
       modelId,
+      mutateSessions,
       provider,
     ],
   );
@@ -340,7 +421,7 @@ export function AgentSessionListProvider({
         const idsToRemove = new Set(deletedIds);
 
         // Remove the session and ALL its descendants from the UI using the authoritative list from Rust
-        setSessions((prev) => prev.filter((s) => !idsToRemove.has(s.id)));
+        mutateSessions((prev) => prev.filter((s) => !idsToRemove.has(s.id)));
 
         // Clean up LLM state outside the updater to avoid double-invocation in StrictMode
         idsToRemove.forEach((id) => clearSessionState(id));
@@ -351,7 +432,7 @@ export function AgentSessionListProvider({
         throw err;
       }
     },
-    [clearSessionState],
+    [clearSessionState, mutateSessions],
   );
 
   /**
@@ -374,7 +455,7 @@ export function AgentSessionListProvider({
         const orphanedIds = new Set(response?.data?.orphanedIds || []);
 
         // Remove the session; update explicitly orphaned children to have no parent
-        setSessions((prev) =>
+        mutateSessions((prev) =>
           prev
             .filter((s) => s.id !== actualDeletedId)
             .map((s) =>
@@ -388,7 +469,7 @@ export function AgentSessionListProvider({
         throw err;
       }
     },
-    [clearSessionState],
+    [clearSessionState, mutateSessions],
   );
 
   /**
@@ -401,7 +482,7 @@ export function AgentSessionListProvider({
       const newValue = !(session?.isBookmarked ?? false);
 
       // Optimistic: set locally with the known new value
-      setSessions((prev) =>
+      mutateSessions((prev) =>
         prev.map((s) =>
           s.id === sessionId ? { ...s, isBookmarked: newValue } : s,
         ),
@@ -423,7 +504,7 @@ export function AgentSessionListProvider({
         throw err;
       }
     },
-    [sessions],
+    [mutateSessions, sessions],
   );
 
   const markSessionViewed = useCallback(
@@ -471,7 +552,7 @@ export function AgentSessionListProvider({
   // Subscribe to agent:event for session resource updates via centralized hook
   useBackendResource('session', () => {
     logger.debug('Agent updated session resource, refreshing session list...');
-    loadSessions();
+    loadSessions(true);
   });
 
   useEffect(() => {
@@ -649,7 +730,7 @@ export function AgentSessionListProvider({
     return () => {
       if (unlisten) unlisten();
     };
-  }, [activeSessionId, markSessionViewed]);
+  }, [activeSessionId, clearPendingApproval, markSessionViewed]);
 
   const notificationSessions = useMemo(
     () =>

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -40,6 +40,7 @@ const RESERVED_AGENT_SUBROUTES = new Set(['draft']);
 
 let cachedSessionMetadataList: AgentSessionMetadata[] | null = null;
 let cachedSessionMetadataPromise: Promise<AgentSessionMetadata[]> | null = null;
+let sessionMetadataCacheGeneration = 0;
 
 type SessionMetadataLoadSource = 'cache' | 'inflight' | 'network';
 
@@ -49,6 +50,7 @@ interface SessionMetadataLoadHandle {
 }
 
 function invalidateSessionListStartupCache() {
+  sessionMetadataCacheGeneration += 1;
   cachedSessionMetadataList = null;
   cachedSessionMetadataPromise = null;
 }
@@ -56,6 +58,10 @@ function invalidateSessionListStartupCache() {
 function loadSessionMetadataList(
   forceRefresh = false,
 ): SessionMetadataLoadHandle {
+  if (forceRefresh) {
+    invalidateSessionListStartupCache();
+  }
+
   if (!forceRefresh && cachedSessionMetadataList !== null) {
     return {
       source: 'cache',
@@ -70,12 +76,18 @@ function loadSessionMetadataList(
     };
   }
 
+  const requestGeneration = sessionMetadataCacheGeneration;
   const request = Promise.resolve(
     safeInvoke<AgentSessionMetadata[]>('agent_get_all_sessions'),
   )
     .then((response) => {
       const sessionMetadataList = Array.isArray(response) ? response : [];
-      cachedSessionMetadataList = sessionMetadataList;
+      if (
+        requestGeneration === sessionMetadataCacheGeneration &&
+        cachedSessionMetadataPromise === request
+      ) {
+        cachedSessionMetadataList = sessionMetadataList;
+      }
       return sessionMetadataList;
     })
     .finally(() => {
@@ -172,6 +184,9 @@ export function AgentSessionListProvider({
   const pendingApprovalKeysRef = useRef(new Set<string>());
   const startupLoadRecordedRef = useRef(false);
   const sessionListMutationVersionRef = useRef(0);
+  const latestSessionListPromiseRef = useRef<Promise<
+    AgentSessionMetadata[]
+  > | null>(null);
   const activeSessionId = useMemo(() => {
     const sessionId = matchPath('/agent/:sessionId', location.pathname)?.params
       .sessionId;
@@ -207,6 +222,7 @@ export function AgentSessionListProvider({
    */
   const loadSessions = useCallback(async (forceRefresh = false) => {
     const { source, promise } = loadSessionMetadataList(forceRefresh);
+    latestSessionListPromiseRef.current = promise;
     const shouldLogLoad = forceRefresh || source === 'network';
 
     if (shouldLogLoad) {
@@ -219,7 +235,10 @@ export function AgentSessionListProvider({
     try {
       const sessionMetadataList = await promise;
 
-      if (mutationVersion !== sessionListMutationVersionRef.current) {
+      if (
+        mutationVersion !== sessionListMutationVersionRef.current ||
+        promise !== latestSessionListPromiseRef.current
+      ) {
         return;
       }
 
@@ -247,12 +266,20 @@ export function AgentSessionListProvider({
       if (shouldLogLoad) {
         logger.error('Failed to load sessions', err);
       }
-      if (mutationVersion === sessionListMutationVersionRef.current) {
+      if (
+        mutationVersion === sessionListMutationVersionRef.current &&
+        promise === latestSessionListPromiseRef.current
+      ) {
         setSessions([]);
       }
     } finally {
-      setIsSessionsListLoading(false);
-      if (!startupLoadRecordedRef.current) {
+      if (promise === latestSessionListPromiseRef.current) {
+        setIsSessionsListLoading(false);
+      }
+      if (
+        promise === latestSessionListPromiseRef.current &&
+        !startupLoadRecordedRef.current
+      ) {
         startupLoadRecordedRef.current = true;
         markStartupMilestone('session-list-settled');
       }

--- a/src/context/SkillsContext.tsx
+++ b/src/context/SkillsContext.tsx
@@ -13,6 +13,43 @@ import { SkillMetadata } from '@/types/skills';
 
 const logger = getLogger('SkillsContext');
 
+let cachedManagedSkills: SkillMetadata[] | null = null;
+let cachedManagedSkillsPromise: Promise<SkillMetadata[]> | null = null;
+
+async function loadManagedSkills(
+  forceRefresh = false,
+): Promise<SkillMetadata[]> {
+  if (!forceRefresh && cachedManagedSkills !== null) {
+    return cachedManagedSkills;
+  }
+
+  if (!forceRefresh && cachedManagedSkillsPromise) {
+    return cachedManagedSkillsPromise;
+  }
+
+  const request = safeInvoke<{ effectiveSkills: SkillMetadata[] }>(
+    'get_managed_skills_overview',
+  )
+    .then((overview) => {
+      const result = overview.effectiveSkills ?? [];
+      cachedManagedSkills = result;
+      return result;
+    })
+    .finally(() => {
+      if (cachedManagedSkillsPromise === request) {
+        cachedManagedSkillsPromise = null;
+      }
+    });
+
+  cachedManagedSkillsPromise = request;
+  return request;
+}
+
+export function __resetSkillsContextCacheForTests() {
+  cachedManagedSkills = null;
+  cachedManagedSkillsPromise = null;
+}
+
 interface SkillsContextType {
   skills: SkillMetadata[];
   isLoading: boolean;
@@ -23,21 +60,20 @@ interface SkillsContextType {
 const SkillsContext = createContext<SkillsContextType | undefined>(undefined);
 
 export function SkillsProvider({ children }: { children: React.ReactNode }) {
-  const [skills, setSkills] = useState<SkillMetadata[]>([]);
+  const [skills, setSkills] = useState<SkillMetadata[]>(
+    cachedManagedSkills ?? [],
+  );
   // Start as true so toast never fires before the first fetch completes
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(cachedManagedSkills === null);
   const [error, setError] = useState<string | null>(null);
   const { isLoading: settingsLoading } = useSettings();
 
-  const fetchSkills = useCallback(async () => {
+  const fetchSkills = useCallback(async (forceRefresh = false) => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const overview = await safeInvoke<{ effectiveSkills: SkillMetadata[] }>(
-        'get_managed_skills_overview',
-      );
-      const result = overview.effectiveSkills ?? [];
+      const result = await loadManagedSkills(forceRefresh);
       logger.info('Discovered skills:', {
         count: result.length,
         skills: result,
@@ -66,7 +102,7 @@ export function SkillsProvider({ children }: { children: React.ReactNode }) {
         skills,
         isLoading,
         error,
-        refreshSkills: fetchSkills,
+        refreshSkills: () => fetchSkills(true),
       }}
     >
       {children}

--- a/src/context/SkillsContext.tsx
+++ b/src/context/SkillsContext.tsx
@@ -3,8 +3,9 @@ import React, {
   createContext,
   useContext,
   useEffect,
-  useState,
   useCallback,
+  useRef,
+  useState,
 } from 'react';
 import { getLogger } from '@/lib/logger';
 import { useSettings } from '@/hooks/use-settings';
@@ -15,10 +16,21 @@ const logger = getLogger('SkillsContext');
 
 let cachedManagedSkills: SkillMetadata[] | null = null;
 let cachedManagedSkillsPromise: Promise<SkillMetadata[]> | null = null;
+let managedSkillsCacheGeneration = 0;
+
+function invalidateManagedSkillsCache() {
+  managedSkillsCacheGeneration += 1;
+  cachedManagedSkills = null;
+  cachedManagedSkillsPromise = null;
+}
 
 async function loadManagedSkills(
   forceRefresh = false,
 ): Promise<SkillMetadata[]> {
+  if (forceRefresh) {
+    invalidateManagedSkillsCache();
+  }
+
   if (!forceRefresh && cachedManagedSkills !== null) {
     return cachedManagedSkills;
   }
@@ -27,12 +39,18 @@ async function loadManagedSkills(
     return cachedManagedSkillsPromise;
   }
 
+  const requestGeneration = managedSkillsCacheGeneration;
   const request = safeInvoke<{ effectiveSkills: SkillMetadata[] }>(
     'get_managed_skills_overview',
   )
     .then((overview) => {
       const result = overview.effectiveSkills ?? [];
-      cachedManagedSkills = result;
+      if (
+        requestGeneration === managedSkillsCacheGeneration &&
+        cachedManagedSkillsPromise === request
+      ) {
+        cachedManagedSkills = result;
+      }
       return result;
     })
     .finally(() => {
@@ -46,8 +64,7 @@ async function loadManagedSkills(
 }
 
 export function __resetSkillsContextCacheForTests() {
-  cachedManagedSkills = null;
-  cachedManagedSkillsPromise = null;
+  invalidateManagedSkillsCache();
 }
 
 interface SkillsContextType {
@@ -67,25 +84,37 @@ export function SkillsProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(cachedManagedSkills === null);
   const [error, setError] = useState<string | null>(null);
   const { isLoading: settingsLoading } = useSettings();
+  const fetchRequestVersionRef = useRef(0);
 
   const fetchSkills = useCallback(async (forceRefresh = false) => {
+    const requestVersion = ++fetchRequestVersionRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const result = await loadManagedSkills(forceRefresh);
+      if (requestVersion !== fetchRequestVersionRef.current) {
+        return;
+      }
+
       logger.info('Discovered skills:', {
         count: result.length,
         skills: result,
       });
       setSkills(result);
     } catch (err) {
+      if (requestVersion !== fetchRequestVersionRef.current) {
+        return;
+      }
+
       const errMsg = err instanceof Error ? err.message : String(err);
       logger.warn('Failed to scan skills directory', err);
       setError(`Failed to scan skills: ${errMsg}`);
       setSkills([]);
     } finally {
-      setIsLoading(false);
+      if (requestVersion === fetchRequestVersionRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 

--- a/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+    __resetAgentSessionListStartupCacheForTests,
     AgentSessionListProvider,
     useAgentSessionListState,
     useAgentSessionListActions,
@@ -80,6 +81,7 @@ describe('AgentSessionListContext – toggleBookmark', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        __resetAgentSessionListStartupCacheForTests();
         (listen as ReturnType<typeof vi.fn>).mockResolvedValue(vi.fn());
     });
 

--- a/src/context/__tests__/AgentSessionListContext-delete.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-delete.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+    __resetAgentSessionListStartupCacheForTests,
     AgentSessionListProvider,
     useAgentSessionListState,
     useAgentSessionListActions,
@@ -75,6 +76,7 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        __resetAgentSessionListStartupCacheForTests();
         (listen as ReturnType<typeof vi.fn>).mockResolvedValue(mockUnlisten);
     });
 

--- a/src/context/__tests__/AgentSessionListContext-events.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-events.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+    __resetAgentSessionListStartupCacheForTests,
     AgentSessionListProvider,
     useAgentSessionListState,
     useAgentSessionListActions,
@@ -86,6 +87,7 @@ describe('AgentSessionListContext – statusChanged event (crash recovery)', () 
 
     beforeEach(() => {
         vi.clearAllMocks();
+        __resetAgentSessionListStartupCacheForTests();
         agentEventHandler = undefined;
 
         (listen as ReturnType<typeof vi.fn>).mockImplementation(

--- a/src/context/__tests__/AgentSessionListContext.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+    __resetAgentSessionListStartupCacheForTests,
     AgentSessionListProvider,
     useAgentSessionListState,
     useAgentSessionListActions,
@@ -9,6 +10,14 @@ import { safeInvoke } from '@/lib/backend/core';
 import { listen } from '@tauri-apps/api/event';
 import type { Assistant } from '@/models/chat';
 import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+const { loggerInfo, loggerDebug, loggerWarn, loggerError } = vi.hoisted(() => ({
+    loggerInfo: vi.fn(),
+    loggerDebug: vi.fn(),
+    loggerWarn: vi.fn(),
+    loggerError: vi.fn(),
+}));
 
 // Mock Assistant for creating sessions
 const mockAssistant: Assistant = {
@@ -32,10 +41,10 @@ vi.mock('@tauri-apps/api/event', () => ({
 // Mock logger
 vi.mock('@/lib/logger', () => ({
     getLogger: () => ({
-        info: vi.fn(),
-        debug: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
+        info: loggerInfo,
+        debug: loggerDebug,
+        warn: loggerWarn,
+        error: loggerError,
     }),
 }));
 
@@ -91,6 +100,7 @@ describe('AgentSessionListContext', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        __resetAgentSessionListStartupCacheForTests();
         // Default: listen resolves to an unlisten function
         (listen as ReturnType<typeof vi.fn>).mockResolvedValue(mockUnlisten);
     });
@@ -130,6 +140,41 @@ describe('AgentSessionListContext', () => {
         });
 
         expect(safeInvoke).toHaveBeenCalledWith('agent_get_all_sessions');
+    });
+
+    it('dedupes the initial session load across StrictMode remounts', async () => {
+        (safeInvoke as ReturnType<typeof vi.fn>).mockResolvedValue([
+            {
+                id: 'session-1',
+                name: 'Test Session',
+                status: 'idle',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            }
+        ]);
+
+        function StrictWrapper({ children }: { children: React.ReactNode }) {
+            return (
+                <React.StrictMode>
+                    <TestWrapper>{children}</TestWrapper>
+                </React.StrictMode>
+            );
+        }
+
+        renderHook(() => useAgentSessionListState(), {
+            wrapper: StrictWrapper,
+        });
+
+        await waitFor(() => {
+            expect(safeInvoke).toHaveBeenCalledTimes(1);
+        });
+
+        expect(
+            loggerInfo.mock.calls.filter(([message]) => message === 'Loading all agent sessions')
+        ).toHaveLength(1);
+        expect(
+            loggerInfo.mock.calls.filter(([message]) => message === 'Loaded sessions')
+        ).toHaveLength(1);
     });
 
     it('does not mark the draft route as a viewed session', async () => {

--- a/src/context/__tests__/AgentSessionListContext.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext.test.tsx
@@ -87,6 +87,17 @@ export function TestWrapper({ children }: { children: React.ReactNode }) {
     );
 }
 
+function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, resolve, reject };
+}
+
 function DraftRouteWrapper({ children }: { children: React.ReactNode }) {
     return (
         <MemoryRouter initialEntries={['/agent/draft']}>
@@ -192,6 +203,85 @@ describe('AgentSessionListContext', () => {
             'agent_mark_session_viewed',
             expect.objectContaining({ sessionId: 'draft' }),
         );
+    });
+
+    it('keeps the loading flag and latest data when an older request resolves after refresh', async () => {
+        const staleSessions = createDeferred<
+            Array<{
+                id: string;
+                name: string;
+                status: 'idle';
+                createdAt: number;
+                updatedAt: number;
+            }>
+        >();
+        const refreshedSessions = createDeferred<
+            Array<{
+                id: string;
+                name: string;
+                status: 'idle';
+                createdAt: number;
+                updatedAt: number;
+            }>
+        >();
+
+        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
+            if (cmd !== 'agent_get_all_sessions') {
+                return Promise.resolve();
+            }
+
+            return (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.length === 1
+                ? staleSessions.promise
+                : refreshedSessions.promise;
+        });
+
+        const { result } = renderHook(
+            () => ({ state: useAgentSessionListState(), actions: useAgentSessionListActions() }),
+            { wrapper: TestWrapper }
+        );
+
+        await waitFor(() => {
+            expect((safeInvoke as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+            expect(result.current.state.isSessionsListLoading).toBe(true);
+        });
+
+        act(() => {
+            void result.current.actions.loadSessions(true);
+        });
+
+        await waitFor(() => {
+            expect((safeInvoke as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+        });
+
+        staleSessions.resolve([
+            {
+                id: 'session-1',
+                name: 'Stale Session',
+                status: 'idle',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            }
+        ]);
+        await Promise.resolve();
+
+        expect(result.current.state.isSessionsListLoading).toBe(true);
+        expect(result.current.state.sessions).toEqual([]);
+
+        refreshedSessions.resolve([
+            {
+                id: 'session-2',
+                name: 'Fresh Session',
+                status: 'idle',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            }
+        ]);
+
+        await waitFor(() => {
+            expect(result.current.state.isSessionsListLoading).toBe(false);
+            expect(result.current.state.sessions).toHaveLength(1);
+            expect(result.current.state.sessions[0].id).toBe('session-2');
+        });
     });
 
     it('should create a new session', async () => {

--- a/src/context/__tests__/LLMServiceContext.test.tsx
+++ b/src/context/__tests__/LLMServiceContext.test.tsx
@@ -10,7 +10,15 @@ import { AIServiceFactory } from '@/lib/ai-service/factory';
 import * as agentCommands from '@/lib/backend/agent-commands';
 import type { Message } from '@/models/chat';
 import { SettingsProvider } from '../SettingsContext';
-import type { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
+import { __resetLLMListenerStartupLogStateForTests } from '../llm/useLLMListener';
+
+const { loggerInfo, loggerDebug, loggerWarn, loggerError } = vi.hoisted(() => ({
+  loggerInfo: vi.fn(),
+  loggerDebug: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+}));
 
 // Mock Tauri APIs
 vi.mock('@tauri-apps/api/event', () => ({
@@ -38,10 +46,10 @@ vi.mock('@/lib/ai-service/factory', () => ({
 // Mock logger
 vi.mock('@/lib/logger', () => ({
   getLogger: () => ({
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
+    info: loggerInfo,
+    debug: loggerDebug,
+    warn: loggerWarn,
+    error: loggerError,
   }),
 }));
 
@@ -75,6 +83,7 @@ describe('LLMServiceContext – Core', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetLLMListenerStartupLogStateForTests();
 
     // Setup listen mock
     (listen as ReturnType<typeof vi.fn>).mockResolvedValue(mockUnlisten);
@@ -106,9 +115,9 @@ describe('LLMServiceContext – Core', () => {
     ]);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
 
   describe('Provider Setup', () => {
     it('should provide context value', () => {
@@ -170,6 +179,43 @@ describe('LLMServiceContext – Core', () => {
           expect.any(Function),
         );
       });
+    });
+
+    it('dedupes startup listener lifecycle logs across StrictMode remounts', async () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <React.StrictMode>
+          <TestWrapper>{children}</TestWrapper>
+        </React.StrictMode>
+      );
+
+      renderHook(() => useLLMService(), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(loggerInfo).toHaveBeenCalledWith(
+          'LLM completion request listener registered',
+        );
+      });
+
+      expect(
+        loggerInfo.mock.calls.filter(
+          ([message]) =>
+            message === '🎧 Initializing LLM completion request listener',
+        ),
+      ).toHaveLength(1);
+      expect(
+        loggerInfo.mock.calls.filter(
+          ([message]) =>
+            message === 'Setting up LLM completion request listener',
+        ),
+      ).toHaveLength(1);
+      expect(
+        loggerInfo.mock.calls.filter(
+          ([message]) =>
+            message === 'LLM completion request listener registered',
+        ),
+      ).toHaveLength(1);
     });
 
     it('should cleanup on unmount', async () => {

--- a/src/context/__tests__/SettingsContext.test.tsx
+++ b/src/context/__tests__/SettingsContext.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { safeInvoke } from '@/lib/backend/core';
@@ -48,5 +49,90 @@ describe('SettingsContext', () => {
 
     expect(safeInvoke).toHaveBeenCalledTimes(1);
     expect(safeInvoke).toHaveBeenCalledWith('list_settings');
+  });
+
+  it('does not let an older settings fetch overwrite a refreshed cache', async () => {
+    type SettingDto = {
+      key: string;
+      value: string;
+      createdAt: number;
+      updatedAt: number;
+    };
+
+    const createDeferred = <T,>() => {
+      let resolve!: (value: T) => void;
+      let reject!: (reason?: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
+      return { promise, resolve, reject };
+    };
+
+    const staleSettings = createDeferred<SettingDto[]>();
+    const freshSettings = createDeferred<SettingDto[]>();
+
+    vi.mocked(safeInvoke).mockImplementation((command: string) => {
+      if (command === 'list_settings') {
+        const listCalls = vi
+          .mocked(safeInvoke)
+          .mock.calls.filter(([cmd]) => cmd === 'list_settings').length;
+        return listCalls === 1 ? staleSettings.promise : freshSettings.promise;
+      }
+
+      if (command === 'update_settings') {
+        return Promise.resolve([]);
+      }
+
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SettingsProvider>{children}</SettingsProvider>
+    );
+
+    const { result, unmount } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => {
+      expect(safeInvoke).toHaveBeenCalledWith('list_settings');
+    });
+
+    act(() => {
+      void result.current.update({ uiLanguage: 'ko' });
+    });
+
+    await waitFor(() => {
+      expect(safeInvoke).toHaveBeenCalledWith('update_settings', {
+        settings: { uiLanguage: 'ko' },
+      });
+      expect(vi.mocked(safeInvoke)).toHaveBeenCalledTimes(3);
+    });
+
+    freshSettings.resolve([
+      { key: 'uiLanguage', value: 'ko', createdAt: 0, updatedAt: 0 },
+    ]);
+
+    await waitFor(() => {
+      expect(result.current.value.uiLanguage).toBe('ko');
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    staleSettings.resolve([
+      { key: 'uiLanguage', value: 'en', createdAt: 0, updatedAt: 0 },
+    ]);
+    await Promise.resolve();
+
+    expect(result.current.value.uiLanguage).toBe('ko');
+
+    unmount();
+
+    const cachedRender = renderHook(() => useSettings(), { wrapper });
+    await waitFor(() => {
+      expect(cachedRender.result.current.value.uiLanguage).toBe('ko');
+      expect(cachedRender.result.current.isLoading).toBe(false);
+    });
+
+    expect(vi.mocked(safeInvoke)).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/context/__tests__/SettingsContext.test.tsx
+++ b/src/context/__tests__/SettingsContext.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { safeInvoke } from '@/lib/backend/core';
+import {
+  SettingsProvider,
+  useSettings,
+} from '../SettingsContext';
+import { __resetRustSettingsServiceCacheForTests } from '@/lib/services/rust-settings-service';
+
+vi.mock('@/lib/backend/core', () => ({
+  safeInvoke: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/performance/startup-metrics', () => ({
+  markStartupMilestone: vi.fn(),
+}));
+
+describe('SettingsContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetRustSettingsServiceCacheForTests();
+  });
+
+  it('dedupes the initial settings fetch across StrictMode remounts', async () => {
+    vi.mocked(safeInvoke).mockResolvedValue([]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <React.StrictMode>
+        <SettingsProvider>{children}</SettingsProvider>
+      </React.StrictMode>
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(safeInvoke).toHaveBeenCalledTimes(1);
+    expect(safeInvoke).toHaveBeenCalledWith('list_settings');
+  });
+});

--- a/src/context/__tests__/SkillsContext.test.tsx
+++ b/src/context/__tests__/SkillsContext.test.tsx
@@ -42,6 +42,17 @@ const MOCK_SKILLS: SkillMetadata[] = [
   },
 ];
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function wrapper({ children }: { children: ReactNode }) {
   return <SkillsProvider>{children}</SkillsProvider>;
 }
@@ -196,6 +207,72 @@ describe('SkillsContext', () => {
 
       await act(async () => {
         await result.current.refreshSkills();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores stale in-flight startup results after a forced refresh', async () => {
+      mockUseSettings.mockReturnValue({
+        value: { system: {} },
+        isLoading: false,
+      } as ReturnType<typeof useSettings>);
+
+      const staleOverview = createDeferred<{ effectiveSkills: SkillMetadata[] }>();
+      const refreshedOverview = createDeferred<{
+        effectiveSkills: SkillMetadata[];
+      }>();
+      const refreshedSkills: SkillMetadata[] = [
+        {
+          name: 'Fresh Skill',
+          description: 'Updated skill',
+          path: '/skills/fresh/SKILL.md',
+        },
+      ];
+
+      mockInvoke.mockImplementation((command: unknown) => {
+        if (command !== 'get_managed_skills_overview') {
+          return Promise.resolve([]);
+        }
+
+        return mockInvoke.mock.calls.length === 1
+          ? staleOverview.promise
+          : refreshedOverview.promise;
+      });
+
+      const { result, unmount } = renderHook(() => useSkills(), { wrapper });
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        void result.current.refreshSkills();
+      });
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledTimes(2);
+      });
+
+      refreshedOverview.resolve({ effectiveSkills: refreshedSkills });
+
+      await waitFor(() => {
+        expect(result.current.skills).toEqual(refreshedSkills);
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      staleOverview.resolve({ effectiveSkills: MOCK_SKILLS });
+      await Promise.resolve();
+      await waitFor(() => {
+        expect(result.current.skills).toEqual(refreshedSkills);
+      });
+
+      unmount();
+
+      const cachedRender = renderHook(() => useSkills(), { wrapper });
+      await waitFor(() => {
+        expect(cachedRender.result.current.skills).toEqual(refreshedSkills);
+        expect(cachedRender.result.current.isLoading).toBe(false);
       });
 
       expect(mockInvoke).toHaveBeenCalledTimes(2);

--- a/src/context/__tests__/SkillsContext.test.tsx
+++ b/src/context/__tests__/SkillsContext.test.tsx
@@ -1,7 +1,11 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ReactNode } from 'react';
-import { SkillsProvider, useSkills } from '../SkillsContext';
+import React, { type ReactNode } from 'react';
+import {
+  __resetSkillsContextCacheForTests,
+  SkillsProvider,
+  useSkills,
+} from '../SkillsContext';
 
 // Mock Tauri APIs
 vi.mock('@/lib/backend/core', () => ({
@@ -45,6 +49,7 @@ function wrapper({ children }: { children: ReactNode }) {
 describe('SkillsContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetSkillsContextCacheForTests();
     mockInvoke.mockImplementation((cmd: unknown) => {
       if (cmd === 'get_managed_skills_overview') {
         return Promise.resolve({
@@ -66,6 +71,27 @@ describe('SkillsContext', () => {
 
       await waitFor(() => {
         expect(mockInvoke).toHaveBeenCalledWith('get_managed_skills_overview');
+      });
+    });
+
+    it('reuses the same startup fetch across StrictMode remounts', async () => {
+      mockUseSettings.mockReturnValue({
+        value: { system: {} },
+        isLoading: false,
+      } as ReturnType<typeof useSettings>);
+
+      function strictWrapper({ children }: { children: ReactNode }) {
+        return (
+          <React.StrictMode>
+            <SkillsProvider>{children}</SkillsProvider>
+          </React.StrictMode>
+        );
+      }
+
+      renderHook(() => useSkills(), { wrapper: strictWrapper });
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -168,7 +194,9 @@ describe('SkillsContext', () => {
         expect(mockInvoke).toHaveBeenCalledTimes(1);
       });
 
-      await result.current.refreshSkills();
+      await act(async () => {
+        await result.current.refreshSkills();
+      });
 
       expect(mockInvoke).toHaveBeenCalledTimes(2);
     });

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -4,7 +4,7 @@ import {
   handleCompactResponse,
   handleCompactError,
 } from '@/lib/backend/agent-commands';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { toast } from 'sonner';
 
@@ -41,6 +41,20 @@ import {
 } from './listener-utils';
 
 const logger = getLogger('useLLMListener');
+const startupLifecycleLogKeys = new Set<string>();
+
+function logStartupLifecycleOnce(key: string, message: string) {
+  if (startupLifecycleLogKeys.has(key)) {
+    return;
+  }
+
+  startupLifecycleLogKeys.add(key);
+  logger.info(message);
+}
+
+export function __resetLLMListenerStartupLogStateForTests() {
+  startupLifecycleLogKeys.clear();
+}
 
 interface UseLLMListenerProps {
   settingsRef: React.MutableRefObject<Settings>;
@@ -83,26 +97,20 @@ export function useLLMListener({
   setCompactedRangeForSession,
   setAwaitingCompactForSession,
 }: UseLLMListenerProps) {
-  // Track listener setup to prevent duplicate registration in React Strict Mode
-  const listenerSetupRef = useRef(false);
-
   useEffect(() => {
-    // Prevent duplicate listener registration in React Strict Mode
-    if (listenerSetupRef.current) {
-      logger.info(
-        '⚠️ LLM listener already set up, skipping duplicate registration',
-      );
-      return;
-    }
-
-    listenerSetupRef.current = true;
-    logger.info('🎧 Initializing LLM completion request listener');
+    logStartupLifecycleOnce(
+      'completion-initializing',
+      '🎧 Initializing LLM completion request listener',
+    );
 
     let isMounted = true;
     let unlisten: (() => void) | undefined;
 
     const setupListener = async () => {
-      logger.info('Setting up LLM completion request listener');
+      logStartupLifecycleOnce(
+        'completion-setting-up',
+        'Setting up LLM completion request listener',
+      );
 
       const unlistenFn = await listen<CompletionRequest>(
         'llm:completion-request',
@@ -372,13 +380,13 @@ export function useLLMListener({
       );
 
       if (!isMounted) {
-        logger.info(
-          'LLM listener setup completed after unmount, cleaning up immediately',
-        );
         unlistenFn();
       } else {
         unlisten = unlistenFn;
-        logger.info('LLM completion request listener registered');
+        logStartupLifecycleOnce(
+          'completion-registered',
+          'LLM completion request listener registered',
+        );
       }
     };
 
@@ -460,7 +468,10 @@ export function useLLMListener({
         unlistenFn();
       } else {
         unlistenCompact = unlistenFn;
-        logger.info('LLM compact request listener registered');
+        logStartupLifecycleOnce(
+          'compact-request-registered',
+          'LLM compact request listener registered',
+        );
       }
     };
 
@@ -517,7 +528,10 @@ export function useLLMListener({
         unlistenFn();
       } else {
         unlistenCompactState = unlistenFn;
-        logger.info('LLM compact state listener registered');
+        logStartupLifecycleOnce(
+          'compact-state-registered',
+          'LLM compact state listener registered',
+        );
       }
     };
 
@@ -537,8 +551,6 @@ export function useLLMListener({
         unlistenCompactState();
         logger.info('LLM compact state listener cleaned up');
       }
-      // Reset listener setup ref on unmount
-      listenerSetupRef.current = false;
     };
   }, []); // ⚠️ CRITICAL: Empty dependency array to prevent re-registering listener
 }

--- a/src/lib/services/rust-settings-service.ts
+++ b/src/lib/services/rust-settings-service.ts
@@ -33,82 +33,111 @@ interface SettingDto {
   updatedAt: number;
 }
 
+let cachedSettingsValue: Settings | null = null;
+let cachedSettingsPromise: Promise<Settings> | null = null;
+
+function mapDtosToSettings(dtos: SettingDto[]): Settings {
+  const settingsMap = new Map<string, SettingValue>();
+  dtos.forEach((dto) => {
+    settingsMap.set(dto.key, dto.value);
+  });
+
+  const getTypedValue = <T extends SettingValue>(
+    key: string,
+    defaultValue: T,
+    validator?: (val: unknown) => val is T,
+  ): T => {
+    const value = settingsMap.get(key);
+    if (value !== undefined) {
+      if (validator && !validator(value)) {
+        logger.warn(`Invalid value for setting key: ${key}, using default`, {
+          value,
+          defaultValue,
+        });
+        return defaultValue;
+      }
+      return value as T;
+    }
+    return defaultValue;
+  };
+
+  const storedSystem = getTypedValue('systemSettings', DEFAULT_SETTING.system);
+
+  return {
+    ...DEFAULT_SETTING,
+    serviceConfigs: {
+      ...DEFAULT_SETTING.serviceConfigs,
+      ...getTypedValue('serviceConfigs', DEFAULT_SETTING.serviceConfigs),
+    },
+    preferredModel: getTypedValue(
+      'preferredModel',
+      DEFAULT_SETTING.preferredModel,
+    ),
+    fallbackModel:
+      (settingsMap.get('fallbackModel') as ModelChoice | null | undefined) ??
+      DEFAULT_SETTING.fallbackModel,
+    contextStrategy: getTypedValue(
+      'contextStrategy',
+      DEFAULT_SETTING.contextStrategy,
+    ),
+    windowSize: getTypedValue('windowSize', DEFAULT_SETTING.windowSize),
+    maxInputContext: getTypedValue(
+      'maxInputContext',
+      DEFAULT_SETTING.maxInputContext,
+    ),
+    uiLanguage: getTypedValue('uiLanguage', DEFAULT_SETTING.uiLanguage),
+    toolCallGroupVisibleCount: getTypedValue(
+      'toolCallGroupVisibleCount',
+      DEFAULT_SETTING.toolCallGroupVisibleCount,
+    ),
+    agentHubUrl: getTypedValue('agentHubUrl', DEFAULT_SETTING.agentHubUrl),
+    advanced: getTypedValue('advancedSettings', DEFAULT_SETTING.advanced),
+    display: getTypedValue('displaySettings', DEFAULT_SETTING.display),
+    system: {
+      ...DEFAULT_SETTING.system,
+      ...storedSystem,
+    },
+  };
+}
+
+function invalidateSettingsCache() {
+  cachedSettingsValue = null;
+  cachedSettingsPromise = null;
+}
+
+async function loadSettings(forceRefresh = false): Promise<Settings> {
+  if (!forceRefresh && cachedSettingsValue) {
+    return cachedSettingsValue;
+  }
+
+  if (!forceRefresh && cachedSettingsPromise) {
+    return cachedSettingsPromise;
+  }
+
+  const request = safeInvoke<SettingDto[]>('list_settings')
+    .then((dtos) => {
+      const settings = mapDtosToSettings(dtos);
+      cachedSettingsValue = settings;
+      return settings;
+    })
+    .finally(() => {
+      if (cachedSettingsPromise === request) {
+        cachedSettingsPromise = null;
+      }
+    });
+
+  cachedSettingsPromise = request;
+  return request;
+}
+
+export function __resetRustSettingsServiceCacheForTests() {
+  invalidateSettingsCache();
+}
+
 export class RustSettingsService implements ISettingsService {
   async getSettings(): Promise<Settings> {
     try {
-      const dtos = await safeInvoke<SettingDto[]>('list_settings');
-
-      // Convert list of settings to Settings object
-      const settingsMap = new Map<string, SettingValue>();
-      dtos.forEach((dto) => {
-        settingsMap.set(dto.key, dto.value);
-      });
-
-      // Helper function to safely get typed value with fallback
-      const getTypedValue = <T extends SettingValue>(
-        key: string,
-        defaultValue: T,
-        validator?: (val: unknown) => val is T,
-      ): T => {
-        const value = settingsMap.get(key);
-        if (value !== undefined) {
-          if (validator && !validator(value)) {
-            logger.warn(
-              `Invalid value for setting key: ${key}, using default`,
-              { value, defaultValue },
-            );
-            return defaultValue;
-          }
-          return value as T;
-        }
-        return defaultValue;
-      };
-
-      // Construct settings object with defaults
-      const storedSystem = getTypedValue(
-        'systemSettings',
-        DEFAULT_SETTING.system,
-      );
-
-      const settings: Settings = {
-        ...DEFAULT_SETTING,
-        serviceConfigs: {
-          ...DEFAULT_SETTING.serviceConfigs,
-          ...getTypedValue('serviceConfigs', DEFAULT_SETTING.serviceConfigs),
-        },
-        preferredModel: getTypedValue(
-          'preferredModel',
-          DEFAULT_SETTING.preferredModel,
-        ),
-        fallbackModel:
-          (settingsMap.get('fallbackModel') as
-            | ModelChoice
-            | null
-            | undefined) ?? DEFAULT_SETTING.fallbackModel,
-        contextStrategy: getTypedValue(
-          'contextStrategy',
-          DEFAULT_SETTING.contextStrategy,
-        ),
-        windowSize: getTypedValue('windowSize', DEFAULT_SETTING.windowSize),
-        maxInputContext: getTypedValue(
-          'maxInputContext',
-          DEFAULT_SETTING.maxInputContext,
-        ),
-        uiLanguage: getTypedValue('uiLanguage', DEFAULT_SETTING.uiLanguage),
-        toolCallGroupVisibleCount: getTypedValue(
-          'toolCallGroupVisibleCount',
-          DEFAULT_SETTING.toolCallGroupVisibleCount,
-        ),
-        agentHubUrl: getTypedValue('agentHubUrl', DEFAULT_SETTING.agentHubUrl),
-        advanced: getTypedValue('advancedSettings', DEFAULT_SETTING.advanced),
-        display: getTypedValue('displaySettings', DEFAULT_SETTING.display),
-        system: {
-          ...DEFAULT_SETTING.system,
-          ...storedSystem,
-        },
-      };
-
-      return settings;
+      return await loadSettings();
     } catch (error) {
       logger.error('Failed to get settings', error);
       throw error;
@@ -182,13 +211,14 @@ export class RustSettingsService implements ISettingsService {
 
       // Perform a single batch update
       if (Object.keys(changes).length > 0) {
+        invalidateSettingsCache();
         await safeInvoke<SettingDto[]>('update_settings', {
           settings: changes,
         });
+        return await loadSettings(true);
       }
 
-      // Return updated settings
-      return this.getSettings();
+      return await this.getSettings();
     } catch (error) {
       logger.error('Failed to update settings', error);
       throw error;

--- a/src/lib/services/rust-settings-service.ts
+++ b/src/lib/services/rust-settings-service.ts
@@ -35,6 +35,13 @@ interface SettingDto {
 
 let cachedSettingsValue: Settings | null = null;
 let cachedSettingsPromise: Promise<Settings> | null = null;
+let settingsCacheGeneration = 0;
+
+function invalidateCachedSettingsState() {
+  settingsCacheGeneration += 1;
+  cachedSettingsValue = null;
+  cachedSettingsPromise = null;
+}
 
 function mapDtosToSettings(dtos: SettingDto[]): Settings {
   const settingsMap = new Map<string, SettingValue>();
@@ -101,11 +108,14 @@ function mapDtosToSettings(dtos: SettingDto[]): Settings {
 }
 
 function invalidateSettingsCache() {
-  cachedSettingsValue = null;
-  cachedSettingsPromise = null;
+  invalidateCachedSettingsState();
 }
 
 async function loadSettings(forceRefresh = false): Promise<Settings> {
+  if (forceRefresh) {
+    invalidateCachedSettingsState();
+  }
+
   if (!forceRefresh && cachedSettingsValue) {
     return cachedSettingsValue;
   }
@@ -114,10 +124,16 @@ async function loadSettings(forceRefresh = false): Promise<Settings> {
     return cachedSettingsPromise;
   }
 
+  const requestGeneration = settingsCacheGeneration;
   const request = safeInvoke<SettingDto[]>('list_settings')
     .then((dtos) => {
       const settings = mapDtosToSettings(dtos);
-      cachedSettingsValue = settings;
+      if (
+        requestGeneration === settingsCacheGeneration &&
+        cachedSettingsPromise === request
+      ) {
+        cachedSettingsValue = settings;
+      }
       return settings;
     })
     .finally(() => {
@@ -211,7 +227,7 @@ export class RustSettingsService implements ISettingsService {
 
       // Perform a single batch update
       if (Object.keys(changes).length > 0) {
-        invalidateSettingsCache();
+        invalidateCachedSettingsState();
         await safeInvoke<SettingDto[]>('update_settings', {
           settings: changes,
         });


### PR DESCRIPTION
## Summary
- stop recreating the legacy skills directory and remove the empty legacy root after migration
- dedupe startup settings, managed-skills, and agent-session fetches across React StrictMode remounts
- make frontend-ready emission and startup listener/session-list logs one-shot so dev startup logs match real work
- add frontend and Rust regression coverage for the startup cleanup and dedupe paths

## Verification
- pnpm refactor:validate
- extracted fresh startup logs and confirmed one readiness log, one session-list load log, one LLM listener init/register log, zero after-unmount probe logs, and StartupMetrics IPC count of 3