### PR TITLE
Lighten startup initialization path

### DIFF
--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -15,7 +15,7 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::{App, Emitter, Listener, Manager};
 
@@ -47,6 +47,129 @@ impl LegacySkillMigrationSummary {
             && self.skipped_existing_user_skills == 0
             && !self.removed_legacy_root_dir
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StartupSettingsSnapshot {
+    web_action_timeout: std::time::Duration,
+    http_port: u16,
+    http_expose: bool,
+    search_index_frequency_minutes: u64,
+    active_agents: u32,
+    suspended_agents: u32,
+    active_processes: u32,
+    suspended_processes: u32,
+}
+
+async fn load_startup_settings() -> StartupSettingsSnapshot {
+    use crate::agent::concurrency::{
+        DEFAULT_MAX_ACTIVE_AGENTS, DEFAULT_MAX_ACTIVE_PROCESSES, DEFAULT_MAX_SUSPENDED_AGENTS,
+        DEFAULT_MAX_SUSPENDED_PROCESSES,
+    };
+    use crate::state::get_settings_repository;
+
+    let settings_repo = get_settings_repository();
+    let system_settings = match settings_repo.get("systemSettings").await {
+        Ok(Some(model)) => serde_json::from_str::<SystemSettings>(&model.value).unwrap_or_default(),
+        _ => SystemSettings::default(),
+    };
+
+    let advanced_settings = match settings_repo.get("advancedSettings").await {
+        Ok(Some(model)) => {
+            serde_json::from_str::<serde_json::Value>(&model.value).unwrap_or_default()
+        }
+        _ => serde_json::Value::Null,
+    };
+
+    let get_u32 = |key: &str, default: u32| -> u32 {
+        advanced_settings
+            .get(key)
+            .and_then(|value| value.as_u64())
+            .map(|value| value.clamp(1, 256) as u32)
+            .unwrap_or(default)
+    };
+
+    StartupSettingsSnapshot {
+        web_action_timeout: std::time::Duration::from_secs(
+            system_settings.web_action_timeout_seconds.unwrap_or(30),
+        ),
+        http_port: system_settings.http_server_port.unwrap_or(3030),
+        http_expose: system_settings.http_server_expose.unwrap_or(false),
+        search_index_frequency_minutes: system_settings.search_index_frequency_minutes.unwrap_or(5),
+        active_agents: get_u32("maxConcurrentActiveSessions", DEFAULT_MAX_ACTIVE_AGENTS),
+        suspended_agents: get_u32("maxSuspendedSessions", DEFAULT_MAX_SUSPENDED_AGENTS),
+        active_processes: get_u32("maxConcurrentActiveProcesses", DEFAULT_MAX_ACTIVE_PROCESSES),
+        suspended_processes: get_u32("maxSuspendedProcesses", DEFAULT_MAX_SUSPENDED_PROCESSES),
+    }
+}
+
+fn spawn_managed_skills_startup_work(bundled_skills_dir: PathBuf, system_skills_dir: PathBuf) {
+    crate::state::begin_managed_skills_sync();
+
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = async {
+            match migrate_legacy_skills_to_managed_storage().await {
+                Ok(summary) if summary.is_noop() => {
+                    log::debug!("No legacy skills migration work was needed");
+                }
+                Ok(summary) => {
+                    info!(
+                        "✅ Legacy skills migration completed (removed snapshots: {}, migrated user skills: {}, skipped existing user skills: {}, removed legacy root: {})",
+                        summary.removed_legacy_snapshot_entries,
+                        summary.migrated_user_skills,
+                        summary.skipped_existing_user_skills,
+                        summary.removed_legacy_root_dir
+                    );
+                }
+                Err(error) => {
+                    log::warn!("⚠️  Failed to migrate legacy skills: {}", error);
+                }
+            }
+
+            if let Err(error) =
+                sync_managed_system_skills_snapshot(&bundled_skills_dir, &system_skills_dir)
+            {
+                log::warn!("⚠️  Failed to sync managed system skills snapshot: {}", error);
+            } else {
+                info!("✅ Managed system skills snapshot synchronized");
+            }
+
+            crate::services::skill_service::invalidate_skill_scan_cache();
+
+            if let Err(error) = crate::services::skill_service::prewarm_managed_skill_scans().await
+            {
+                log::warn!("⚠️  Failed to prewarm managed skill cache: {}", error);
+            }
+
+            Ok::<(), String>(())
+        }
+        .await
+        {
+            log::warn!("⚠️  Managed skills startup preparation finished with warnings: {}", e);
+        }
+
+        crate::state::complete_managed_skills_sync();
+    });
+}
+
+fn spawn_startup_maintenance_tasks(
+    session_manager: crate::session::SessionManager,
+    search_index_frequency_minutes: u64,
+) {
+    tauri::async_runtime::spawn(async move {
+        match session_manager.cleanup_old_sessions(24, 5).await {
+            Ok(count) => info!(
+                "🧹 Session cleanup completed: removed {} old sessions",
+                count
+            ),
+            Err(error) => log::error!("❌ Session cleanup failed: {}", error),
+        }
+    });
+
+    let _indexing_worker = crate::search::IndexingWorker::new(std::time::Duration::from_secs(
+        search_index_frequency_minutes * 60,
+    ));
+    info!("✅ Background message indexing worker started");
 }
 
 /// Migration decision for a legacy skill directory from AppData/skills.
@@ -405,7 +528,6 @@ pub fn remove_legacy_skills_dir_if_empty(
 }
 
 async fn migrate_legacy_skills_to_managed_storage(
-    _app: &App,
 ) -> Result<LegacySkillMigrationSummary, Box<dyn std::error::Error>> {
     use std::fs;
 
@@ -526,59 +648,17 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     app.manage(dropped_file_service);
     info!("✅ DroppedFileService initialized");
 
-    // Migrate legacy AppData/skills user content into the managed user_skills directory.
-    tauri::async_runtime::block_on(async {
-        match migrate_legacy_skills_to_managed_storage(app).await {
-            Ok(summary) if summary.is_noop() => {
-                log::debug!("No legacy skills migration work was needed");
-            }
-            Ok(summary) => {
-                info!(
-                    "✅ Legacy skills migration completed (removed snapshots: {}, migrated user skills: {}, skipped existing user skills: {}, removed legacy root: {})",
-                    summary.removed_legacy_snapshot_entries,
-                    summary.migrated_user_skills,
-                    summary.skipped_existing_user_skills,
-                    summary.removed_legacy_root_dir
-                );
-            }
-            Err(e) => {
-                log::warn!("⚠️  Failed to migrate legacy skills: {}", e);
-            }
-        }
-    });
+    let session_manager = crate::session::get_session_manager()
+        .map_err(std::io::Error::other)?
+        .clone();
+    let resource_dir = app.path().resource_dir()?;
+    let bundled_skills_dir = resource_dir.join("bundled_skills");
+    let system_skills_dir = session_manager
+        .get_base_data_dir()
+        .join(SYSTEM_SKILLS_DIR_NAME);
+    spawn_managed_skills_startup_work(bundled_skills_dir, system_skills_dir);
 
-    // Keep the app-data managed system snapshot aligned with bundled_skills so the
-    // runtime system skills directory never depends on the packaged install path.
-    if let Err(e) = {
-        let resource_dir = app.path().resource_dir()?;
-        let bundled_skills_dir = resource_dir.join("bundled_skills");
-        let system_skills_dir = crate::session::get_session_manager()
-            .map_err(std::io::Error::other)?
-            .get_base_data_dir()
-            .join(SYSTEM_SKILLS_DIR_NAME);
-        sync_managed_system_skills_snapshot(&bundled_skills_dir, &system_skills_dir)
-    } {
-        log::warn!("⚠️  Failed to sync managed system skills snapshot: {}", e);
-    } else {
-        info!("✅ Managed system skills snapshot synchronized");
-    }
-
-    // Fetch System Settings
-    let (web_action_timeout, http_port, http_expose) = tauri::async_runtime::block_on(async {
-        use crate::state::get_settings_repository;
-        let settings_repo = get_settings_repository();
-        match settings_repo.get("systemSettings").await {
-            Ok(Some(model)) => {
-                let s: SystemSettings = serde_json::from_str(&model.value).unwrap_or_default();
-                (
-                    std::time::Duration::from_secs(s.web_action_timeout_seconds.unwrap_or(30)),
-                    s.http_server_port.unwrap_or(3030),
-                    s.http_server_expose.unwrap_or(false),
-                )
-            }
-            _ => (std::time::Duration::from_secs(30), 3030, false),
-        }
-    });
+    let startup_settings = tauri::async_runtime::block_on(load_startup_settings());
 
     // MCP HTTP endpoint is enabled via env var or --mcp CLI flag
     let mcp_enabled =
@@ -589,11 +669,12 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
             app.handle().clone(),
         ),
     );
-    let browser_server = InteractiveBrowserServer::new(browser_env, web_action_timeout);
+    let browser_server =
+        InteractiveBrowserServer::new(browser_env, startup_settings.web_action_timeout);
     app.manage(browser_server);
     info!(
         "✅ Interactive Browser Server initialized with timeout: {:?}",
-        web_action_timeout
+        startup_settings.web_action_timeout
     );
 
     // Initialize Agent Session Manager with proxy manager
@@ -614,60 +695,36 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
 
     app.manage(agent_session_manager);
 
-    // SP1 + SP2: Initialize SessionBus and ConcurrencyGate from advanced settings.
-    // Read values with fallback to hardcoded defaults when settings are absent.
-    tauri::async_runtime::block_on(async {
-        use crate::agent::concurrency::{
-            ConcurrencyGate, DEFAULT_MAX_ACTIVE_AGENTS, DEFAULT_MAX_ACTIVE_PROCESSES,
-            DEFAULT_MAX_SUSPENDED_AGENTS, DEFAULT_MAX_SUSPENDED_PROCESSES,
-        };
+    {
+        use crate::agent::concurrency::ConcurrencyGate;
         use crate::agent::session_bus::SessionBus;
-        use crate::state::get_settings_repository;
-
-        let (active_agents, suspended_agents, active_procs, suspended_procs) =
-            match get_settings_repository().get("advancedSettings").await {
-                Ok(Some(model)) => {
-                    let json: serde_json::Value =
-                        serde_json::from_str(&model.value).unwrap_or_default();
-                    let get_u32 = |key: &str, default: u32| -> u32 {
-                        json.get(key)
-                            .and_then(|v| v.as_u64())
-                            .map(|v| v.clamp(1, 256) as u32)
-                            .unwrap_or(default)
-                    };
-                    (
-                        get_u32("maxConcurrentActiveSessions", DEFAULT_MAX_ACTIVE_AGENTS),
-                        get_u32("maxSuspendedSessions", DEFAULT_MAX_SUSPENDED_AGENTS),
-                        get_u32("maxConcurrentActiveProcesses", DEFAULT_MAX_ACTIVE_PROCESSES),
-                        get_u32("maxSuspendedProcesses", DEFAULT_MAX_SUSPENDED_PROCESSES),
-                    )
-                }
-                _ => (
-                    DEFAULT_MAX_ACTIVE_AGENTS,
-                    DEFAULT_MAX_SUSPENDED_AGENTS,
-                    DEFAULT_MAX_ACTIVE_PROCESSES,
-                    DEFAULT_MAX_SUSPENDED_PROCESSES,
-                ),
-            };
 
         crate::state::init_session_bus(SessionBus::new());
         crate::state::init_concurrency_gate(ConcurrencyGate::new(
-            active_agents,
-            suspended_agents,
-            active_procs,
-            suspended_procs,
+            startup_settings.active_agents,
+            startup_settings.suspended_agents,
+            startup_settings.active_processes,
+            startup_settings.suspended_processes,
         ));
 
         info!(
             "✅ ConcurrencyGate initialized: active_agents={} suspended_agents={} \
              active_processes={} suspended_processes={}",
-            active_agents, suspended_agents, active_procs, suspended_procs,
+            startup_settings.active_agents,
+            startup_settings.suspended_agents,
+            startup_settings.active_processes,
+            startup_settings.suspended_processes,
         );
-    });
+    }
 
     // Initialize global AppHandle for event emission from builtin tools
     crate::state::init_app_handle(app.handle().clone());
     info!("✅ Global AppHandle initialized for event emission");
+
+    spawn_startup_maintenance_tasks(
+        session_manager,
+        startup_settings.search_index_frequency_minutes,
+    );
 
     // Spawn HTTP Server for External Features
     let server_manager = app
@@ -677,19 +734,27 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     tauri::async_runtime::spawn(async move {
         if let Err(e) = crate::server::init(
             std::sync::Arc::new(server_manager),
-            http_port,
-            http_expose,
+            startup_settings.http_port,
+            startup_settings.http_expose,
             mcp_enabled,
         )
         .await
         {
-            log::error!("Failed to start HTTP server on port {}: {}", http_port, e);
+            log::error!(
+                "Failed to start HTTP server on port {}: {}",
+                startup_settings.http_port,
+                e
+            );
         }
     });
     info!(
         "✅ HTTP Server spawned on {}:{}",
-        if http_expose { "0.0.0.0" } else { "127.0.0.1" },
-        http_port
+        if startup_settings.http_expose {
+            "0.0.0.0"
+        } else {
+            "127.0.0.1"
+        },
+        startup_settings.http_port
     );
 
     // Spawn session recovery in background
@@ -735,6 +800,9 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     app.listen("frontend-ready", |_| {
         info!("🖥️  Frontend signaled readiness");
         crate::lifecycle::frontend_ready::mark_as_ready();
+        if let Some(elapsed_ms) = crate::state::startup_elapsed_ms() {
+            info!("⏱️ Startup metric: frontend ready after {}ms", elapsed_ms);
+        }
     });
     info!("✅ Frontend readiness listener registered");
 

--- a/src-tauri/src/lifecycle/mod.rs
+++ b/src-tauri/src/lifecycle/mod.rs
@@ -10,9 +10,8 @@ pub mod retry_utils;
 pub mod schema_version; // Schema version tracking (matches migration #10 table layout)
 pub mod settings;
 
-use crate::search;
 use crate::session::get_session_manager;
-use crate::state::set_sqlite_db_url;
+use crate::state::{set_sqlite_db_url, start_startup_timer};
 use database_error::DatabaseError;
 use log::info;
 
@@ -27,6 +26,7 @@ pub fn should_quarantine_on_init_failure(error: &DatabaseError) -> bool {
 
 /// A synchronous wrapper to initialize and run the application with SQLite support.
 pub fn run_with_sqlite_sync(db_url: String) {
+    start_startup_timer();
     // Set the SQLite URL
     set_sqlite_db_url(db_url.clone());
     info!("🔄 Initializing LibrAgent with SQLite support: {db_url}");
@@ -93,40 +93,15 @@ pub fn run_with_sqlite_sync(db_url: String) {
             }
         };
 
-        // Initialize Repositories and get System Settings
-        let system_settings = repositories::init_repositories(&db).await;
-
-        let index_freq_mins = system_settings.search_index_frequency_minutes.unwrap_or(5);
-        let retention_hours = 24;
-
-        info!(
-            "⚙️ System Configuration: Index Frequency = {}m, Workspace Retention = {}h",
-            index_freq_mins, retention_hours
-        );
-
-        // Perform session cleanup
-        match session_manager
-            .cleanup_old_sessions(retention_hours, 5)
-            .await
-        {
-            Ok(count) => info!(
-                "🧹 Session cleanup completed: removed {} old sessions",
-                count
-            ),
-            Err(e) => log::error!("❌ Session cleanup failed: {}", e),
-        }
-
-        // Start background indexing worker
-        let _indexing_worker =
-            search::IndexingWorker::new(std::time::Duration::from_secs(index_freq_mins * 60));
-        info!("✅ Background message indexing worker started");
+        // Initialize repositories required by app setup and command handlers.
+        repositories::init_repositories(&db).await;
 
         // Global MCPServerManager initialization is intentionally skipped.
         // Session-isolated MCP architecture uses MCPServiceProxyManager initialized in repositories.
         let _ = db;
+        let _ = session_manager;
         info!("✅ Session-isolated MCP architecture initialized");
     });
-
     // Call the main run function
     crate::run();
 }

--- a/src-tauri/src/search/background_worker.rs
+++ b/src-tauri/src/search/background_worker.rs
@@ -16,7 +16,7 @@ pub struct IndexingWorker {
     /// Flag to signal worker shutdown
     shutdown: Arc<AtomicBool>,
     /// Worker task handle
-    task_handle: Option<tokio::task::JoinHandle<()>>,
+    task_handle: Option<tauri::async_runtime::JoinHandle<()>>,
 }
 
 impl IndexingWorker {
@@ -28,7 +28,7 @@ impl IndexingWorker {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
 
-        let task_handle = tokio::spawn(async move {
+        let task_handle = tauri::async_runtime::spawn(async move {
             worker_loop(shutdown_clone, check_interval).await;
         });
 

--- a/src-tauri/src/services/skill_service/cache.rs
+++ b/src-tauri/src/services/skill_service/cache.rs
@@ -1,0 +1,102 @@
+use super::contracts::SkillMetadata;
+use super::directories::{get_system_skills_directory, get_user_skills_directory};
+use super::scanning::scan_skills_internal;
+use crate::state::{get_skills_catalog_revision, invalidate_skills_catalog};
+use log::warn;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{OnceLock, RwLock};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct SkillScanCacheKey {
+    root: String,
+    source: Option<String>,
+    origin: Option<String>,
+    revision: u64,
+}
+
+#[derive(Default)]
+struct SkillScanCache {
+    entries: RwLock<HashMap<SkillScanCacheKey, Vec<SkillMetadata>>>,
+}
+
+fn skill_scan_cache() -> &'static SkillScanCache {
+    static SKILL_SCAN_CACHE: OnceLock<SkillScanCache> = OnceLock::new();
+    SKILL_SCAN_CACHE.get_or_init(SkillScanCache::default)
+}
+
+fn build_cache_key(
+    root_path: &Path,
+    source_tag: Option<&str>,
+    origin_tag: Option<&str>,
+) -> SkillScanCacheKey {
+    SkillScanCacheKey {
+        root: root_path.to_string_lossy().to_string(),
+        source: source_tag.map(str::to_string),
+        origin: origin_tag.map(str::to_string),
+        revision: get_skills_catalog_revision(),
+    }
+}
+
+pub fn invalidate_skill_scan_cache() -> u64 {
+    match skill_scan_cache().entries.write() {
+        Ok(mut entries) => entries.clear(),
+        Err(error) => warn!("Failed to clear skill scan cache after mutation: {}", error),
+    }
+
+    invalidate_skills_catalog()
+}
+
+pub async fn scan_skills_internal_cached(
+    root_path: &Path,
+    source_tag: Option<String>,
+    origin_tag: Option<String>,
+) -> Result<Vec<SkillMetadata>, String> {
+    let key = build_cache_key(root_path, source_tag.as_deref(), origin_tag.as_deref());
+
+    match skill_scan_cache().entries.read() {
+        Ok(entries) => {
+            if let Some(cached) = entries.get(&key) {
+                return Ok(cached.clone());
+            }
+        }
+        Err(error) => warn!(
+            "Failed to read skill scan cache; falling back to rescan: {}",
+            error
+        ),
+    }
+
+    let scanned = scan_skills_internal(root_path, source_tag, origin_tag).await?;
+
+    match skill_scan_cache().entries.write() {
+        Ok(mut entries) => {
+            entries.insert(key, scanned.clone());
+        }
+        Err(error) => warn!(
+            "Failed to update skill scan cache; returning uncached scan result: {}",
+            error
+        ),
+    }
+
+    Ok(scanned)
+}
+
+pub async fn prewarm_managed_skill_scans() -> Result<(), String> {
+    let system_dir = get_system_skills_directory()?;
+    let user_dir = get_user_skills_directory()?;
+
+    let _ = scan_skills_internal_cached(
+        &system_dir,
+        Some("global".to_string()),
+        Some("system".to_string()),
+    )
+    .await?;
+    let _ = scan_skills_internal_cached(
+        &user_dir,
+        Some("global".to_string()),
+        Some("user".to_string()),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/src-tauri/src/services/skill_service/cache.rs
+++ b/src-tauri/src/services/skill_service/cache.rs
@@ -67,6 +67,11 @@ pub async fn scan_skills_internal_cached(
     }
 
     let scanned = scan_skills_internal(root_path, source_tag, origin_tag).await?;
+    let current_revision = get_skills_catalog_revision();
+
+    if key.revision != current_revision {
+        return Ok(scanned);
+    }
 
     match skill_scan_cache().entries.write() {
         Ok(mut entries) => {

--- a/src-tauri/src/services/skill_service/directories.rs
+++ b/src-tauri/src/services/skill_service/directories.rs
@@ -2,8 +2,9 @@ use super::contracts::{
     ManagedSkillsOverview, SkillMetadata, LEGACY_SYSTEM_SKILLS_DIR_NAME, SYSTEM_SKILLS_DIR_NAME,
     USER_SKILLS_DIR_NAME,
 };
-use super::scan_skills_internal;
+use super::scan_skills_internal_cached;
 use crate::session::get_session_manager;
+use crate::state::wait_for_managed_skills_sync;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -54,16 +55,18 @@ fn merge_skill_layers(skill_layers: Vec<Vec<SkillMetadata>>) -> Vec<SkillMetadat
 }
 
 pub async fn get_managed_skills_overview() -> Result<ManagedSkillsOverview, String> {
+    wait_for_managed_skills_sync().await;
+
     let system_dir = get_system_skills_directory()?;
     let user_dir = get_user_skills_directory()?;
 
-    let mut system_skills = scan_skills_internal(
+    let mut system_skills = scan_skills_internal_cached(
         &system_dir,
         Some("global".to_string()),
         Some("system".to_string()),
     )
     .await?;
-    let mut user_skills = scan_skills_internal(
+    let mut user_skills = scan_skills_internal_cached(
         &user_dir,
         Some("global".to_string()),
         Some("user".to_string()),
@@ -89,6 +92,8 @@ pub async fn resolve_skills(
     assistant_dir: Option<PathBuf>,
     workspace_dir: Option<PathBuf>,
 ) -> Result<Vec<SkillMetadata>, String> {
+    wait_for_managed_skills_sync().await;
+
     let mut skill_layers = Vec::new();
 
     let sources: Vec<(Option<PathBuf>, &str, &str)> = vec![
@@ -103,7 +108,7 @@ pub async fn resolve_skills(
             continue;
         };
 
-        let mut scanned = scan_skills_internal(
+        let mut scanned = scan_skills_internal_cached(
             &directory,
             Some(source.to_string()),
             Some(origin.to_string()),

--- a/src-tauri/src/services/skill_service/importing.rs
+++ b/src-tauri/src/services/skill_service/importing.rs
@@ -72,6 +72,30 @@ fn invalidate_skill_cache_after_success<T>(result: Result<T, String>) -> Result<
     result
 }
 
+struct SkillCacheInvalidationGuard {
+    should_invalidate: bool,
+}
+
+impl SkillCacheInvalidationGuard {
+    fn new() -> Self {
+        Self {
+            should_invalidate: false,
+        }
+    }
+
+    fn mark_mutated(&mut self) {
+        self.should_invalidate = true;
+    }
+}
+
+impl Drop for SkillCacheInvalidationGuard {
+    fn drop(&mut self) {
+        if self.should_invalidate {
+            invalidate_skill_scan_cache();
+        }
+    }
+}
+
 pub async fn delete_user_skill(skill_name: String) -> Result<String, String> {
     let user_dir = get_user_skills_directory()?;
     invalidate_skill_cache_after_success(remove_skill_name_from_directory(&user_dir, &skill_name))
@@ -163,11 +187,7 @@ pub async fn import_assistant_skills(
 ) -> Result<String, String> {
     let assistant_skills_dir = get_assistant_skills_directory(&assistant_id)?;
     let prepared = prepare_local_skill_import(file_path).await?;
-    let result = invalidate_skill_cache_after_success(install_prepared_skills_to_directory(
-        prepared,
-        assistant_skills_dir,
-        true,
-    ))?;
+    let result = install_prepared_skills_to_directory(prepared, assistant_skills_dir, true)?;
     Ok(format!(
         "Successfully imported {} skills",
         result.imported_names.len()
@@ -482,8 +502,7 @@ async fn install_user_prepared_skills(
         _temp_dir,
         discovered_skills: selected_skills,
     };
-    let mut result =
-        install_prepared_skills_to_directory(prepared, user_dir.clone(), overwrite_existing)?;
+    let mut result = install_prepared_skills_to_directory(prepared, user_dir, overwrite_existing)?;
 
     if overwrite_existing {
         let conflict_names = retained_conflicts
@@ -498,7 +517,7 @@ async fn install_user_prepared_skills(
     }
 
     result.skipped_names = skipped_names;
-    invalidate_skill_cache_after_success(Ok(result))
+    Ok(result)
 }
 
 fn install_prepared_skills_to_directory(
@@ -508,6 +527,7 @@ fn install_prepared_skills_to_directory(
 ) -> Result<SkillImportResult, String> {
     fs::create_dir_all(&target_dir).map_err(|error| error.to_string())?;
 
+    let mut cache_invalidation_guard = SkillCacheInvalidationGuard::new();
     let mut existing_skill_roots = discover_existing_skill_roots(&target_dir)?;
     let mut overwritten_names = Vec::new();
     let mut imported_names = Vec::new();
@@ -522,6 +542,7 @@ fn install_prepared_skills_to_directory(
                 ));
             }
             fs::remove_dir_all(existing_root).map_err(|error| error.to_string())?;
+            cache_invalidation_guard.mark_mutated();
             overwritten_names.push(skill.metadata.name.clone());
         }
 
@@ -534,9 +555,11 @@ fn install_prepared_skills_to_directory(
                 ));
             }
             fs::remove_dir_all(&target_path).map_err(|error| error.to_string())?;
+            cache_invalidation_guard.mark_mutated();
         }
 
         copy_dir_recursive(&skill.root_dir, &target_path)?;
+        cache_invalidation_guard.mark_mutated();
         imported_names.push(skill.metadata.name.clone());
     }
 

--- a/src-tauri/src/services/skill_service/importing.rs
+++ b/src-tauri/src/services/skill_service/importing.rs
@@ -1,3 +1,4 @@
+use super::cache::{invalidate_skill_scan_cache, scan_skills_internal_cached};
 use super::contracts::{
     DiscoveredSkillRoot, PreparedSkillImport, SkillImportCandidate, SkillImportConflict,
     SkillImportPreview, SkillImportResult, SkillMetadata, GITHUB_DOWNLOAD_CONNECT_TIMEOUT_SECS,
@@ -8,8 +9,9 @@ use super::directories::{
     resolve_skills,
 };
 use super::github::parse_github_repo_url;
-use super::scanning::{copy_dir_recursive, parse_skill_metadata, scan_skills_internal};
+use super::scanning::{copy_dir_recursive, parse_skill_metadata};
 use crate::session::get_session_manager;
+use crate::state::wait_for_managed_skills_sync;
 use log::warn;
 use reqwest::header::USER_AGENT;
 use sha2::{Digest, Sha256};
@@ -63,16 +65,25 @@ pub async fn install_github_skills(
     .await
 }
 
+fn invalidate_skill_cache_after_success<T>(result: Result<T, String>) -> Result<T, String> {
+    if result.is_ok() {
+        invalidate_skill_scan_cache();
+    }
+    result
+}
+
 pub async fn delete_user_skill(skill_name: String) -> Result<String, String> {
     let user_dir = get_user_skills_directory()?;
-    remove_skill_name_from_directory(&user_dir, &skill_name)?;
-    Ok(format!("Successfully deleted user skill '{}'", skill_name))
+    invalidate_skill_cache_after_success(remove_skill_name_from_directory(&user_dir, &skill_name))
+        .map(|_| format!("Successfully deleted user skill '{}'", skill_name))
 }
 
 pub async fn reset_user_skills() -> Result<String, String> {
     let user_dir = get_user_skills_directory()?;
     if user_dir.exists() {
-        fs::remove_dir_all(&user_dir).map_err(|error| error.to_string())?;
+        invalidate_skill_cache_after_success(
+            fs::remove_dir_all(&user_dir).map_err(|error| error.to_string()),
+        )?;
         Ok("Successfully reset user skills".to_string())
     } else {
         Ok("No user skills to reset".to_string())
@@ -106,7 +117,7 @@ pub async fn copy_global_to_assistant(
 
     let storage_name = skill_storage_directory_name(&source_skill.name)?;
     let target_path = assistant_skills_dir.join(storage_name);
-    copy_dir_recursive(&source_root, &target_path)?;
+    invalidate_skill_cache_after_success(copy_dir_recursive(&source_root, &target_path))?;
 
     Ok(format!(
         "Successfully copied skill '{}' to assistant '{}'",
@@ -119,7 +130,10 @@ pub async fn delete_assistant_skill(
     skill_name: String,
 ) -> Result<String, String> {
     let assistant_skills_dir = get_assistant_skills_directory(&assistant_id)?;
-    remove_skill_name_from_directory(&assistant_skills_dir, &skill_name)?;
+    invalidate_skill_cache_after_success(remove_skill_name_from_directory(
+        &assistant_skills_dir,
+        &skill_name,
+    ))?;
 
     Ok(format!(
         "Successfully deleted assistant skill '{}'",
@@ -131,7 +145,9 @@ pub async fn reset_assistant_skills(assistant_id: String) -> Result<String, Stri
     let assistant_skills_dir = get_assistant_skills_directory(&assistant_id)?;
 
     if assistant_skills_dir.exists() {
-        fs::remove_dir_all(&assistant_skills_dir).map_err(|error| error.to_string())?;
+        invalidate_skill_cache_after_success(
+            fs::remove_dir_all(&assistant_skills_dir).map_err(|error| error.to_string()),
+        )?;
         Ok(format!(
             "Successfully reset skills for assistant '{}'",
             assistant_id
@@ -147,7 +163,11 @@ pub async fn import_assistant_skills(
 ) -> Result<String, String> {
     let assistant_skills_dir = get_assistant_skills_directory(&assistant_id)?;
     let prepared = prepare_local_skill_import(file_path).await?;
-    let result = install_prepared_skills_to_directory(prepared, assistant_skills_dir, true)?;
+    let result = invalidate_skill_cache_after_success(install_prepared_skills_to_directory(
+        prepared,
+        assistant_skills_dir,
+        true,
+    ))?;
     Ok(format!(
         "Successfully imported {} skills",
         result.imported_names.len()
@@ -321,15 +341,17 @@ async fn prepare_github_skill_import(repo_url: String) -> Result<PreparedSkillIm
 async fn build_user_import_preview(
     discovered_skills: &[DiscoveredSkillRoot],
 ) -> Result<SkillImportPreview, String> {
+    wait_for_managed_skills_sync().await;
+
     let system_dir = get_system_skills_directory()?;
     let user_dir = get_user_skills_directory()?;
-    let system_skills = scan_skills_internal(
+    let system_skills = scan_skills_internal_cached(
         &system_dir,
         Some("global".to_string()),
         Some("system".to_string()),
     )
     .await?;
-    let user_skills = scan_skills_internal(
+    let user_skills = scan_skills_internal_cached(
         &user_dir,
         Some("global".to_string()),
         Some("user".to_string()),
@@ -476,7 +498,7 @@ async fn install_user_prepared_skills(
     }
 
     result.skipped_names = skipped_names;
-    Ok(result)
+    invalidate_skill_cache_after_success(Ok(result))
 }
 
 fn install_prepared_skills_to_directory(

--- a/src-tauri/src/services/skill_service/mod.rs
+++ b/src-tauri/src/services/skill_service/mod.rs
@@ -1,9 +1,11 @@
+mod cache;
 mod contracts;
 mod directories;
 mod github;
 mod importing;
 mod scanning;
 
+pub use cache::{invalidate_skill_scan_cache, prewarm_managed_skill_scans};
 pub use contracts::{
     GitHubRepoSpec, ManagedSkillsOverview, SkillImportCandidate, SkillImportConflict,
     SkillImportPreview, SkillImportResult, SkillMetadata, LEGACY_SYSTEM_SKILLS_DIR_NAME,
@@ -29,4 +31,4 @@ pub use scanning::{
     scan_skills_directory,
 };
 
-pub(crate) use scanning::scan_skills_internal;
+pub(crate) use cache::scan_skills_internal_cached;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,10 +15,11 @@ use crate::repositories::{
 };
 use sea_orm::DatabaseConnection;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 use tauri::AppHandle;
-use tokio::sync::RwLock as TokioRwLock;
+use tokio::sync::{Notify, RwLock as TokioRwLock};
 
 /// A global, thread-safe, once-initialized instance of the `MCPServiceProxyManager`.
 static MCP_SERVICE_PROXY_MANAGER: OnceLock<Arc<MCPServiceProxyManager>> = OnceLock::new();
@@ -78,6 +79,27 @@ static CONCURRENCY_GATE: OnceLock<ConcurrencyGate> = OnceLock::new();
 /// Shared Arc from AgentSessionManager so external subsystems (e.g. builtin MCP tools)
 /// can read per-session cancellation tokens without going through Tauri managed state.
 static ACTIVE_SESSIONS: OnceLock<Arc<TokioRwLock<HashMap<String, AgentSession>>>> = OnceLock::new();
+/// A global revision for skill-directory derived caches.
+static SKILLS_CATALOG_REVISION: OnceLock<AtomicU64> = OnceLock::new();
+/// Coordinates background startup preparation of managed skills directories.
+static MANAGED_SKILLS_SYNC_STATE: OnceLock<ManagedSkillsSyncState> = OnceLock::new();
+static STARTUP_TIMER: OnceLock<Instant> = OnceLock::new();
+
+struct ManagedSkillsSyncState {
+    ready: AtomicBool,
+    notify: Notify,
+}
+
+fn skills_catalog_revision() -> &'static AtomicU64 {
+    SKILLS_CATALOG_REVISION.get_or_init(|| AtomicU64::new(0))
+}
+
+fn managed_skills_sync_state() -> &'static ManagedSkillsSyncState {
+    MANAGED_SKILLS_SYNC_STATE.get_or_init(|| ManagedSkillsSyncState {
+        ready: AtomicBool::new(true),
+        notify: Notify::new(),
+    })
+}
 
 /// Initialize the global AppHandle
 /// Should be called once during application setup
@@ -107,6 +129,48 @@ pub fn set_sqlite_db_url(url: String) {
 /// An `Option` containing a reference to the URL string, or `None` if not yet set.
 pub fn get_sqlite_db_url() -> Option<&'static String> {
     SQLITE_DB_URL.get()
+}
+
+pub fn start_startup_timer() {
+    let _ = STARTUP_TIMER.set(Instant::now());
+}
+
+pub fn startup_elapsed_ms() -> Option<u128> {
+    STARTUP_TIMER
+        .get()
+        .map(|started_at| started_at.elapsed().as_millis())
+}
+
+pub fn get_skills_catalog_revision() -> u64 {
+    skills_catalog_revision().load(Ordering::Relaxed)
+}
+
+pub fn invalidate_skills_catalog() -> u64 {
+    skills_catalog_revision().fetch_add(1, Ordering::Relaxed) + 1
+}
+
+pub fn begin_managed_skills_sync() {
+    managed_skills_sync_state()
+        .ready
+        .store(false, Ordering::Release);
+}
+
+pub fn complete_managed_skills_sync() {
+    let state = managed_skills_sync_state();
+    state.ready.store(true, Ordering::Release);
+    state.notify.notify_waiters();
+}
+
+pub async fn wait_for_managed_skills_sync() {
+    let state = managed_skills_sync_state();
+
+    loop {
+        let notified = state.notify.notified();
+        if state.ready.load(Ordering::Acquire) {
+            break;
+        }
+        notified.await;
+    }
 }
 
 /// Sets the global database connection.

--- a/src-tauri/tests/skill_scan_cache_tests.rs
+++ b/src-tauri/tests/skill_scan_cache_tests.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri_mcp_agent_lib::services::skill_service::{
+    get_managed_skills_overview, get_user_skills_directory, invalidate_skill_scan_cache,
+    skill_storage_directory_name, SKILL_FILE_NAME,
+};
+use uuid::Uuid;
+
+fn unique_skill_name(prefix: &str) -> String {
+    format!("{}-{}", prefix, Uuid::new_v4())
+}
+
+fn create_skill_dir(root: &Path, skill_name: &str, description: &str) -> PathBuf {
+    let storage_name = skill_storage_directory_name(skill_name).expect("storage name");
+    let skill_dir = root.join(storage_name);
+    fs::create_dir_all(&skill_dir).expect("create skill dir");
+    fs::write(
+        skill_dir.join(SKILL_FILE_NAME),
+        format!(
+            "---\nname: {}\ndescription: {}\n---\n# {}\n",
+            skill_name, description, skill_name
+        ),
+    )
+    .expect("write skill file");
+    skill_dir
+}
+
+fn remove_if_exists(path: &Path) {
+    if path.exists() {
+        fs::remove_dir_all(path).expect("remove test skill dir");
+    }
+}
+
+#[tokio::test]
+async fn managed_skills_overview_uses_cache_until_invalidated() {
+    let user_dir = get_user_skills_directory().expect("user dir");
+    let skill_name = unique_skill_name("cache-regression");
+    let skill_dir = create_skill_dir(&user_dir, &skill_name, "cached skill");
+
+    invalidate_skill_scan_cache();
+
+    let initial = get_managed_skills_overview()
+        .await
+        .expect("initial overview");
+    assert!(
+        initial
+            .user_skills
+            .iter()
+            .any(|skill| skill.name == skill_name),
+        "initial scan should include the created skill"
+    );
+
+    remove_if_exists(&skill_dir);
+
+    let cached = get_managed_skills_overview()
+        .await
+        .expect("cached overview");
+    assert!(
+        cached
+            .user_skills
+            .iter()
+            .any(|skill| skill.name == skill_name),
+        "cached overview should still expose the removed skill before invalidation"
+    );
+
+    invalidate_skill_scan_cache();
+
+    let refreshed = get_managed_skills_overview()
+        .await
+        .expect("refreshed overview");
+    assert!(
+        refreshed
+            .user_skills
+            .iter()
+            .all(|skill| skill.name != skill_name),
+        "overview should refresh after invalidation"
+    );
+}

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
- move non-critical startup work out of the blocking startup/setup path
- add revision-based skill scan caching plus managed-skills startup synchronization
- fix the indexing worker runtime spawn and tighten skill cache maintenance/invalidation

## Validation
- pnpm refactor:validate