### PR TITLE
⚗️ Distill: Optimize MCP response for getChildAgents and list_delegated_sessions

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -218,7 +218,10 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
     Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
 
-async fn list_delegated_sessions(caller_session_id: &str, args: &Value) -> Result<MCPResult, String> {
+async fn list_delegated_sessions(
+    caller_session_id: &str,
+    args: &Value,
+) -> Result<MCPResult, String> {
     let session_repo = crate::state::get_session_repository();
     use crate::repositories::session_repository::SessionRepository;
 

--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -97,7 +97,7 @@ pub async fn list_agents_or_sessions(
 
     match list_type {
         "configs" => list_agent_configs(server, &args).await,
-        "sessions" => list_delegated_sessions(caller_session_id).await,
+        "sessions" => list_delegated_sessions(caller_session_id, &args).await,
         _ => Ok(guided_error(
             ErrorCategory::InvalidInput,
             format!(
@@ -186,6 +186,16 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
         }));
     }
 
+    if offset.saturating_add(limit) < total {
+        text_summary.push_str(&format!(
+            "\n*(Showing {} to {} of {} total results. Call this tool again with offset: {} to see more)*",
+            offset + 1,
+            offset + results.len(),
+            total,
+            offset.saturating_add(limit)
+        ));
+    }
+
     let hint = SuccessHint::new(
         text_summary,
         vec!["Use startSession(agentId=\"...\") to delegate work".to_string()],
@@ -208,7 +218,7 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
     Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
 
-async fn list_delegated_sessions(caller_session_id: &str) -> Result<MCPResult, String> {
+async fn list_delegated_sessions(caller_session_id: &str, args: &Value) -> Result<MCPResult, String> {
     let session_repo = crate::state::get_session_repository();
     use crate::repositories::session_repository::SessionRepository;
 
@@ -229,19 +239,25 @@ async fn list_delegated_sessions(caller_session_id: &str) -> Result<MCPResult, S
         }
     };
 
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
+    let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+    let total = child_ids.len();
+    let paged_child_ids: Vec<_> = child_ids.into_iter().skip(offset).take(limit).collect();
+
     let mut results = Vec::new();
-    for child_id in &child_ids {
+    for child_id in &paged_child_ids {
         if let Ok(Some(child_data)) = session_repo.get_session(child_id).await {
             let status = format!("{:?}", child_data.status).to_lowercase();
             results.push(json!({
-                "id": child_id,
+                "id": child_id.clone(),
                 "name": child_data.name.unwrap_or_else(|| "Unnamed".to_string()),
                 "status": status
             }));
         }
     }
 
-    let mut message = format!("Found {} sub-agent sessions.\n\n", results.len());
+    let mut message = format!("Found {} sub-agent sessions.\n\n", total);
     if !results.is_empty() {
         message.push_str("| Name | Session ID | Status |\n");
         message.push_str("|---|---|---|\n");
@@ -266,6 +282,21 @@ async fn list_delegated_sessions(caller_session_id: &str) -> Result<MCPResult, S
                 name_clean, id_clean, status_clean
             ));
         }
+
+        if offset.saturating_add(limit) < total {
+            message.push_str(&format!(
+                "\n*(Showing {} to {} of {} total results. Call this tool again with offset: {} to see more)*",
+                offset + 1,
+                offset + results.len(),
+                total,
+                offset.saturating_add(limit)
+            ));
+        }
+    } else if total > 0 {
+        message.push_str(&format!(
+            "No results for this page (offset {}, limit {}). Try a smaller offset.\n",
+            offset, limit
+        ));
     }
 
     let hint = SuccessHint::new(
@@ -286,6 +317,6 @@ async fn list_delegated_sessions(caller_session_id: &str) -> Result<MCPResult, S
     );
     response_data.insert("type".to_string(), Value::String("sessions".to_string()));
     response_data.insert("sessions".to_string(), Value::Array(results));
-    response_data.insert("total".to_string(), json!(child_ids.len()));
+    response_data.insert("total".to_string(), json!(total));
     Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
 }

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -507,24 +507,16 @@ pub async fn handle_tool_call(
                 .get_child_session_ids(&parent_session_id)
                 .await
                 .map_err(|e| format!("Failed to fetch child sessions: {}", e))?;
-            let data = json!({
-                "parentSessionId": parent_session_id,
-                "count": child_ids.len(),
-                "children": child_ids,
-            });
 
-            let child_ids = data
-                .get("children")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|value| value.as_str().map(str::to_string))
-                .collect::<Vec<_>>();
+            let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
+            let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+            let total = child_ids.len();
+            let paged_child_ids: Vec<_> = child_ids.into_iter().skip(offset).take(limit).collect();
 
             let mut session_responses: Vec<AgentSessionResponse> = Vec::new();
 
-            for child_id in &child_ids {
+            for child_id in &paged_child_ids {
                 // Fetch each child session data to map it properly
                 if let Ok(Some(session)) = session_repo.get_session(child_id).await {
                     let child_data = match session_metadata_to_value(&session) {
@@ -542,29 +534,66 @@ pub async fn handle_tool_call(
             }
 
             let mut message = format!(
-                "Fetched {} direct sub-agents for commander session {}",
-                session_responses.len(),
+                "Fetched {} direct sub-agents for commander session {}.\n\n",
+                total,
                 parent_session_id
             );
 
             if session_responses.is_empty() {
-                message.push_str(
-                    "\n\nNo direct sub-agents online. Next step: spawnAgent to deploy a worker.",
-                );
-            } else {
-                message.push_str("\n\nDirect unit roster:\n");
-                for resp in &session_responses {
+                if total > 0 {
                     message.push_str(&format!(
-                        "- {} (ID: {}) status={}\n",
-                        resp.name, resp.id, resp.status
+                        "No results for this page (offset {}, limit {}). Try a smaller offset.\n",
+                        offset, limit
                     ));
-                    if let Some(summary) = &resp.latest_result {
-                        message.push_str(&format!("  latest assistant: {}\n", summary));
-                    }
+                } else {
+                    message.push_str(
+                        "No direct sub-agents online. Next step: spawnAgent to deploy a worker.",
+                    );
+                }
+            } else {
+                message.push_str("| Name | Session ID | Status | Latest Result |\n");
+                message.push_str("|---|---|---|---|\n");
+                for resp in &session_responses {
+                    let name_clean = resp.name.replace('|', "\\|").replace('\n', " ");
+                    let id_clean = resp.id.replace('|', "\\|").replace('\n', " ");
+                    let status_clean = resp.status.replace('|', "\\|").replace('\n', " ");
+                    let latest_clean = resp
+                        .latest_result
+                        .as_deref()
+                        .unwrap_or("-")
+                        .replace('|', "\\|")
+                        .replace('\n', " ");
+
+                    let latest_trunc = if latest_clean.chars().count() > 80 {
+                        format!("{}...", latest_clean.chars().take(77).collect::<String>())
+                    } else {
+                        latest_clean
+                    };
+
+                    message.push_str(&format!(
+                        "| {} | `{}` | {} | {} |\n",
+                        name_clean, id_clean, status_clean, latest_trunc
+                    ));
+                }
+
+                if offset.saturating_add(limit) < total {
+                    message.push_str(&format!(
+                        "\n*(Showing {} to {} of {} total results. Call this tool again with offset: {} to see more)*",
+                        offset + 1,
+                        offset + session_responses.len(),
+                        total,
+                        offset.saturating_add(limit)
+                    ));
                 }
             }
 
-            Ok(success_result(message, session_responses))
+            Ok(success_result(message, json!({
+                "parentSessionId": parent_session_id,
+                "count": total,
+                "offset": offset,
+                "limit": limit,
+                "children": session_responses,
+            })))
         }
         "listAgentTypes" => {
             let assistant_repo = crate::state::get_assistant_repository();

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -535,8 +535,7 @@ pub async fn handle_tool_call(
 
             let mut message = format!(
                 "Fetched {} direct sub-agents for commander session {}.\n\n",
-                total,
-                parent_session_id
+                total, parent_session_id
             );
 
             if session_responses.is_empty() {
@@ -587,13 +586,16 @@ pub async fn handle_tool_call(
                 }
             }
 
-            Ok(success_result(message, json!({
-                "parentSessionId": parent_session_id,
-                "count": total,
-                "offset": offset,
-                "limit": limit,
-                "children": session_responses,
-            })))
+            Ok(success_result(
+                message,
+                json!({
+                    "parentSessionId": parent_session_id,
+                    "count": total,
+                    "offset": offset,
+                    "limit": limit,
+                    "children": session_responses,
+                }),
+            ))
         }
         "listAgentTypes" => {
             let assistant_repo = crate::state::get_assistant_repository();

--- a/src-tauri/src/mcp/builtin/session_api/tools.rs
+++ b/src-tauri/src/mcp/builtin/session_api/tools.rs
@@ -218,7 +218,30 @@ pub fn get_child_sessions_tool() -> MCPTool {
         name: "getChildAgents".to_string(),
         title: Some("Get Child Agents".to_string()),
         description: "List all agents directly spawned by the calling session.".to_string(),
-        input_schema: object_prop(vec![], vec![], None),
+        input_schema: object_prop(
+            vec![
+                (
+                    "limit".to_string(),
+                    integer_prop_with_default(
+                        Some(1),
+                        Some(100),
+                        20,
+                        Some("Maximum number of child sessions to return."),
+                    ),
+                ),
+                (
+                    "offset".to_string(),
+                    integer_prop_with_default(
+                        Some(0),
+                        None,
+                        0,
+                        Some("Pagination offset (0-based)."),
+                    ),
+                ),
+            ],
+            vec![],
+            None,
+        ),
         output_schema: None,
         annotations: None,
     }


### PR DESCRIPTION
💡 What: 
- Added `limit` and `offset` arguments to `getChildAgents` (`get_child_sessions_tool`) in `src-tauri/src/mcp/builtin/session_api/tools.rs` to allow paginating the list of child agents.
- Modified the `getChildAgents` backend handler in `src-tauri/src/mcp/builtin/session_api/handlers.rs` to paginate results and map them into a structured, dense Markdown table explicitly quoting Session IDs for easy agent chaining. Added context limits logic.
- Updated `list_delegated_sessions` in `src-tauri/src/mcp/builtin/agent/handlers/configs.rs` to actually use `offset` and `limit` to trim rows in the response properly, and render a Markdown table as before. Appended pagination hint text: `\n*(Showing X to Y of Z total results. Call this tool again with offset: Y to see more)*`.

🎯 Why: 
The `getChildAgents` and `list_delegated_sessions` tools were unpaginated, pulling the entire sub-agent structure directly into the string buffer. Since an agent could theoretically spawn hundreds of nested children over a long session, dumping unpaginated data crashes the token economy and causes context window exhaustion for the LLM. Now we enforce hard pagination bounds to feed the agent clear, digestible blocks of context.

📉 Token Impact:
Responses are now limited to 20 sub-agent rows by default, drastically clipping the context bloat for massive trees (from potentially O(N) tokens down to an O(K limit) fixed token block). The structure is also densely packed into a markdown table to save JSON syntactic overhead.

🛠️ Error Recovery:
Included helpful guidance messages when queries exceed limits (e.g. `No results for this page (offset X, limit Y). Try a smaller offset.`) to help the LLM self-correct its offset parameter.

---
*PR created automatically by Jules for task [4383309217465317504](https://jules.google.com/task/4383309217465317504) started by @fritzprix*