### PR TITLE
Align compaction summary wrappers

### DIFF
--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -63,11 +63,13 @@ pub(crate) struct BackgroundCompactionHandles {
 fn build_incremental_compact_summary_message(
     session_id: &str,
     summary: &str,
+    compacted_messages: &[Message],
     created_at: i64,
 ) -> Message {
-    super::request::build_compact_summary_message(
+    super::request::build_compact_summary_message_for_messages(
         session_id,
-        super::request::build_compact_summary_text(summary, &[]),
+        summary,
+        compacted_messages,
         created_at,
     )
 }
@@ -171,6 +173,7 @@ fn build_compaction_request_payload(
             compact_messages.push(build_incremental_compact_summary_message(
                 session_id,
                 &record.summary,
+                &messages[..=compacted_to_idx],
                 created_at,
             ));
             compact_messages.extend(messages[first_delta_message_idx..split_idx].iter().cloned());

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -14,9 +14,9 @@ pub use context::{
 };
 pub use orchestration::request_llm_completion_with_recovery;
 pub use request::{
-    build_compact_context_selection_options, build_compact_summary_text,
-    merge_consecutive_user_messages, normalize_request_messages, request_llm_completion,
-    resolve_preserved_calibration_ratio,
+    build_compact_context_selection_options, build_compact_summary_message_for_messages,
+    build_compact_summary_text, merge_consecutive_user_messages, normalize_request_messages,
+    request_llm_completion, resolve_preserved_calibration_ratio,
 };
 
 // Crate-internal re-exports for intra-module visibility

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -112,6 +112,19 @@ pub fn build_compact_summary_message(session_id: &str, text: String, created_at:
     }
 }
 
+pub fn build_compact_summary_message_for_messages(
+    session_id: &str,
+    summary: &str,
+    compacted_messages: &[Message],
+    created_at: i64,
+) -> Message {
+    build_compact_summary_message(
+        session_id,
+        build_compact_summary_text(summary, compacted_messages),
+        created_at,
+    )
+}
+
 const COMPACT_TOOL_SNAPSHOT_LIMIT: usize = 5;
 const COMPACT_ARGUMENT_PREVIEW_LIMIT: usize = 96;
 const COMPACT_RESULT_PREVIEW_LIMIT: usize = 140;
@@ -573,9 +586,10 @@ pub async fn request_llm_completion(
                 (messages, false)
             } else if let Some(to_idx) = messages.iter().position(|m| m.id == record.to_id) {
                 let now_ms = chrono::Utc::now().timestamp_millis();
-                let summary_msg = build_compact_summary_message(
+                let summary_msg = build_compact_summary_message_for_messages(
                     &session_id,
-                    build_compact_summary_text(&record.summary, &messages[..=to_idx]),
+                    &record.summary,
+                    &messages[..=to_idx],
                     now_ms,
                 );
                 let summary_tokens =

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -1,12 +1,13 @@
 use serde_json::json;
 use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
-    build_compact_context_selection_options, build_compact_summary_text,
-    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
-    merge_consecutive_user_messages, normalize_request_messages,
-    resolve_context_management_settings, resolve_preserved_calibration_ratio,
-    should_skip_same_tail_compaction, should_trigger_background_compaction,
-    should_trigger_post_response_compaction, uses_compaction_strategy,
+    build_compact_context_selection_options, build_compact_summary_message_for_messages,
+    build_compact_summary_text, find_preflight_compaction_split_index,
+    fit_compaction_request_messages_to_limit, merge_consecutive_user_messages,
+    normalize_request_messages, resolve_context_management_settings,
+    resolve_preserved_calibration_ratio, should_skip_same_tail_compaction,
+    should_trigger_background_compaction, should_trigger_post_response_compaction,
+    uses_compaction_strategy,
 };
 use tauri_mcp_agent_lib::agent::llm::context_selector::*;
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
@@ -1366,4 +1367,40 @@ fn test_build_compact_summary_text_caps_long_argument_preview() {
     assert!(summary.contains("workspace__writeFile("));
     assert!(summary.contains("path=src/huge.ts"));
     assert!(!summary.contains(&"a".repeat(150)));
+}
+
+#[test]
+fn test_build_compact_summary_message_for_messages_reuses_normal_request_wrapper() {
+    let mut assistant = make_message("assistant-shared", "assistant", "Running command");
+    assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "call_shared".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "workspace__runCommand".to_string(),
+            arguments: "{\"command\":\"git status\"}".to_string(),
+        },
+    }]);
+
+    let mut tool = make_message("tool-shared", "tool", "On branch dev/0.7.x");
+    tool.tool_call_id = Some("call_shared".to_string());
+
+    let summary_message = build_compact_summary_message_for_messages(
+        "test-session",
+        "Earlier work was summarized.",
+        &[assistant, tool],
+        42,
+    );
+
+    assert_eq!(summary_message.id, "compact-summary-test-session");
+    assert_eq!(summary_message.role, "assistant");
+    assert_eq!(summary_message.source.as_deref(), Some("compact-summary"));
+
+    let MCPContent::Text { text, .. } = &summary_message.content[0] else {
+        panic!("expected compact summary text");
+    };
+    assert!(text.contains("### Previous Conversation Summary"));
+    assert!(text.contains("### Recent Tool Call Snapshot (latest 5)"));
+    assert!(
+        text.contains("workspace__runCommand(command=git status) -> success: On branch dev/0.7.x")
+    );
 }


### PR DESCRIPTION
## Summary
- reuse the same compact summary wrapper builder for normal requests and incremental compaction anchors
- keep recent tool snapshot rendering consistent between the two paths
- add regression coverage for the shared summary wrapper behavior

## Validation
- cargo test --test llm_context_tests
- pnpm refactor:validate