### PR TITLE
Fix compaction active request preservation

### DIFF
--- a/src-tauri/src/agent/lifecycle/cache.rs
+++ b/src-tauri/src/agent/lifecycle/cache.rs
@@ -54,7 +54,7 @@ pub async fn init_session_with_messages(
         let has_incomplete_turn = page
             .items
             .iter()
-            .rfind(|m| m.source.as_deref() != Some("recovery"))
+            .rfind(|m| !m.is_recovery_message())
             .map(|m| m.role == "user")
             .unwrap_or(false);
 

--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -2,6 +2,7 @@ use crate::agent::context::registry::ContextRegistry;
 use crate::agent::events::AgentEventDispatcher;
 use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
 use crate::agent::tauri_events::TauriEventDispatcher;
+use crate::models::chat::MESSAGE_SOURCE_RECOVERY;
 use crate::repositories::message_repository::MessageRepository as MessageRepositoryTrait;
 use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::SessionStatus;
@@ -75,7 +76,7 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
                 tool_use: None,
                 created_at: now,
                 updated_at: now,
-                source: Some("recovery".to_string()),
+                source: Some(MESSAGE_SOURCE_RECOVERY.to_string()),
                 error: None,
                 metadata: None,
             });

--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -2,7 +2,7 @@ use crate::agent::context::registry::ContextRegistry;
 use crate::agent::events::AgentEventDispatcher;
 use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
 use crate::agent::tauri_events::TauriEventDispatcher;
-use crate::models::chat::MESSAGE_SOURCE_RECOVERY;
+use crate::models::chat::MessageSource;
 use crate::repositories::message_repository::MessageRepository as MessageRepositoryTrait;
 use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::SessionStatus;
@@ -76,7 +76,7 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
                 tool_use: None,
                 created_at: now,
                 updated_at: now,
-                source: Some(MESSAGE_SOURCE_RECOVERY.to_string()),
+                source: Some(MessageSource::Recovery),
                 error: None,
                 metadata: None,
             });

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -362,6 +362,38 @@ fn estimate_compaction_non_message_tokens(
     (system_prompt_tokens, tools_tokens)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionSelectionPreview {
+    pub compacted_ids: Vec<String>,
+    pub preserved_ids: Vec<String>,
+}
+
+fn build_compaction_selection_preview(
+    messages: &[Message],
+    split_idx: usize,
+) -> CompactionSelectionPreview {
+    let split_idx = split_idx.min(messages.len());
+
+    CompactionSelectionPreview {
+        compacted_ids: messages[..split_idx]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+        preserved_ids: messages[split_idx..]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+    }
+}
+
+pub fn preview_preflight_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
+    build_compaction_selection_preview(messages, find_preflight_compaction_split_index(messages))
+}
+
+pub fn preview_background_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
+    build_compaction_selection_preview(messages, find_background_compaction_split_index(messages))
+}
+
 /// Determines the compactable prefix for preflight compaction.
 ///
 /// Unlike background compaction, preflight compaction must preserve the newest
@@ -373,7 +405,7 @@ fn estimate_compaction_non_message_tokens(
 /// - latest `user`/non-tool tail: preserve the last message
 /// - latest `tool` tail: compact as much as `find_compaction_split_index()` allows
 /// - unresolved tool chain: preserve the full unresolved tail
-pub fn find_preflight_compaction_split_index(messages: &[Message]) -> usize {
+fn find_preflight_compaction_split_index(messages: &[Message]) -> usize {
     if messages.is_empty() {
         return 0;
     }
@@ -401,7 +433,7 @@ fn find_latest_external_request_block_start(messages: &[Message]) -> Option<usiz
     Some(block_start)
 }
 
-pub fn find_background_compaction_split_index(messages: &[Message]) -> usize {
+fn find_background_compaction_split_index(messages: &[Message]) -> usize {
     let unresolved_boundary =
         crate::agent::llm::context_selector::find_compaction_split_index(messages);
 

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -127,7 +127,8 @@ const INSTRUCTION_HINT_TEXT_LIMIT: usize = 320;
 static BACKTICK_REFERENCE_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"`([^`\r\n]+)`").expect("valid backtick regex"));
 static PATH_REFERENCE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)\b(?:[a-z]:[\\/])?[\w./\\-]+\.[a-z0-9]{1,12}\b"#).expect("valid path regex")
+    Regex::new(r#"(?i)\b(?:[a-z]:[\\/]|\.{1,2}[\\/]|[^\\/\s]+[\\/])[\w./\\-]*\.[a-z0-9]{1,12}\b"#)
+        .expect("valid path regex")
 });
 static SYMBOL_REFERENCE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
@@ -215,12 +216,18 @@ fn format_reference_candidate(candidate: &str) -> String {
     }
 }
 
+fn is_reference_candidate(text: &str) -> bool {
+    PATH_REFERENCE_RE.is_match(text) || IDENTIFIER_RE.is_match(text)
+}
+
 fn extract_reference_candidates_from_text(text: &str) -> Vec<String> {
     let mut references = Vec::new();
 
     for captures in BACKTICK_REFERENCE_RE.captures_iter(text) {
         if let Some(candidate) = captures.get(1).map(|capture| capture.as_str().trim()) {
-            push_unique_limited(&mut references, candidate.to_string(), usize::MAX);
+            if is_reference_candidate(candidate) {
+                push_unique_limited(&mut references, candidate.to_string(), usize::MAX);
+            }
         }
     }
 
@@ -238,6 +245,78 @@ fn extract_reference_candidates_from_text(text: &str) -> Vec<String> {
     }
 
     references
+}
+
+fn extract_compact_summary_body(message: &Message) -> Option<String> {
+    if !message.is_compact_summary() {
+        return None;
+    }
+
+    let text = extract_message_text_fragments(message).join("\n");
+    let body = text.strip_prefix("### Previous Conversation Summary\n\n")?;
+    let summary_only = body
+        .split("\n\n### Recent Tool Call Snapshot (latest 5)\n")
+        .next()
+        .unwrap_or(body)
+        .trim();
+
+    if summary_only.is_empty() {
+        None
+    } else {
+        Some(summary_only.to_string())
+    }
+}
+
+fn extract_summary_section_bullets(summary: &str, section_heading: &str) -> Vec<String> {
+    let mut bullets = Vec::new();
+    let mut in_section = false;
+    let markdown_heading = format!("### {}", section_heading);
+
+    for line in summary.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == markdown_heading || trimmed == section_heading {
+            in_section = true;
+            continue;
+        }
+
+        if trimmed.starts_with("### ") || trimmed.ends_with(':') {
+            in_section = false;
+        }
+
+        if in_section {
+            if let Some(bullet) = trimmed.strip_prefix("- ") {
+                let normalized = bullet.trim();
+                if !normalized.is_empty() {
+                    bullets.push(normalized.to_string());
+                }
+            }
+        }
+    }
+
+    bullets
+}
+
+fn collect_prior_summary_hints(
+    message: &Message,
+    active_request: &mut Vec<String>,
+    required_references: &mut Vec<String>,
+) {
+    let Some(summary_body) = extract_compact_summary_body(message) else {
+        return;
+    };
+
+    for bullet in extract_summary_section_bullets(&summary_body, "Active Request") {
+        push_unique_limited(
+            active_request,
+            truncate_instruction_text(&bullet, INSTRUCTION_HINT_TEXT_LIMIT),
+            ACTIVE_REQUEST_BULLET_LIMIT,
+        );
+    }
+
+    for bullet in extract_summary_section_bullets(&summary_body, "Required References") {
+        push_unique_limited(required_references, bullet, REQUIRED_REFERENCE_BULLET_LIMIT);
+    }
 }
 
 fn collect_reference_candidates_from_json_value(
@@ -288,15 +367,24 @@ fn collect_reference_candidates_from_message(message: &Message, references: &mut
 }
 
 pub fn build_compaction_preservation_hints(messages: &[Message]) -> CompactionPreservationHints {
+    let mut active_request = Vec::new();
+    let mut required_references = Vec::new();
+
+    if let Some(previous_summary) = messages.iter().find(|message| message.is_compact_summary()) {
+        collect_prior_summary_hints(
+            previous_summary,
+            &mut active_request,
+            &mut required_references,
+        );
+    }
+
     let Some(active_request_start) = find_latest_external_request_block_start(messages) else {
         return CompactionPreservationHints {
-            active_request: Vec::new(),
-            required_references: Vec::new(),
+            active_request,
+            required_references,
         };
     };
 
-    let mut active_request = Vec::new();
-    let mut required_references = Vec::new();
     let request_block_end = messages[active_request_start..]
         .iter()
         .take_while(|message| message.is_external_request_message())

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -62,6 +62,29 @@ pub(crate) struct BackgroundCompactionHandles {
     pub(crate) last_compacted_tail_id_arc: Arc<RwLock<Option<String>>>,
 }
 
+struct InFlightResetGuard {
+    flag: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl InFlightResetGuard {
+    fn new(flag: Arc<AtomicBool>) -> Self {
+        Self { flag, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InFlightResetGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.flag.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
 fn build_incremental_compact_summary_message(
     session_id: &str,
     summary: &str,
@@ -874,12 +897,12 @@ impl<'a> BackgroundCompactionTrigger<'a> {
             return Ok(false);
         }
 
+        let mut in_flight_guard = InFlightResetGuard::new(handles.compact_in_flight_arc.clone());
         let current_tail_id = messages.last().map(|m| m.id.clone());
         let last_compacted_tail = handles.last_compacted_tail_id_arc.read().await.clone();
         let same_tail = current_tail_id.as_deref() == last_compacted_tail.as_deref();
 
         if same_tail && should_skip_same_tail_compaction(messages, split_idx) {
-            handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
             log::debug!(
                 "⏭️ Compaction skipped (same tail): session={}, tail={}",
                 session_id,
@@ -908,7 +931,6 @@ impl<'a> BackgroundCompactionTrigger<'a> {
                 started_at_ms,
             )
         else {
-            handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
             log::debug!(
                 "⏭️ Compaction skipped (no new delta beyond previous summary): session={}, tail={}",
                 session_id,
@@ -917,16 +939,12 @@ impl<'a> BackgroundCompactionTrigger<'a> {
             return Ok(false);
         };
 
-        *handles.last_compacted_tail_id_arc.write().await = current_tail_id.clone();
         let compact_started_at_ms_handle = {
             let active = active_sessions.read().await;
             active
                 .get(session_id)
                 .map(|session| session.compaction.started_at_ms.clone())
         };
-        if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-            *compact_started_at_ms_handle.write().await = Some(started_at_ms);
-        }
 
         let settings = load_context_management_settings().await;
         let safe_input_token_limit =
@@ -960,6 +978,9 @@ impl<'a> BackgroundCompactionTrigger<'a> {
         let app = app_handle.clone();
         let state_session_id = session_id.to_string();
         let state_session_name = session_name.to_string();
+        let in_flight_flag = handles.compact_in_flight_arc.clone();
+        let last_compacted_tail_id_arc = handles.last_compacted_tail_id_arc.clone();
+        let tail_id_for_task = current_tail_id.clone();
         tokio::spawn(async move {
             if let Err(e) = emit_compact_started(
                 &app,
@@ -968,11 +989,20 @@ impl<'a> BackgroundCompactionTrigger<'a> {
                 false,
             ) {
                 log::error!("Failed to emit llm:compact-state: {}", e);
+                in_flight_flag.store(false, Ordering::SeqCst);
+                return;
             }
             if let Err(e) = emit_compact_request(&app, compact_event) {
                 log::error!("Failed to emit llm:compact-request: {}", e);
+                in_flight_flag.store(false, Ordering::SeqCst);
+                return;
+            }
+            *last_compacted_tail_id_arc.write().await = tail_id_for_task;
+            if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
+                *compact_started_at_ms_handle.write().await = Some(started_at_ms);
             }
         });
+        in_flight_guard.disarm();
         log::info!(
             "🔧 Background compaction triggered: session={}, from_id={}, to_id={}, split_idx={}, compacted_delta_count={}, reused_prior_summary={}, tail={}, started_at_ms={}",
             session_id,
@@ -1159,12 +1189,12 @@ pub(crate) async fn try_trigger_preflight_compaction(
         return Ok(true);
     }
 
+    let mut in_flight_guard = InFlightResetGuard::new(compact_in_flight_arc.clone());
     let current_tail_id = messages.last().map(|m| m.id.clone());
     let last_compacted_tail = last_compacted_tail_id_arc.read().await.clone();
     if current_tail_id.as_deref() == last_compacted_tail.as_deref()
         && should_skip_same_tail_compaction(messages, split_idx)
     {
-        compact_in_flight_arc.store(false, Ordering::SeqCst);
         log::debug!(
             "⏭️ Preflight compaction skipped (same tail): session={}, tail={}, split_idx={}",
             session_id,
@@ -1185,7 +1215,6 @@ pub(crate) async fn try_trigger_preflight_compaction(
             started_at_ms,
         )
     else {
-        compact_in_flight_arc.store(false, Ordering::SeqCst);
         log::debug!(
             "⏭️ Preflight compaction skipped (no new delta beyond previous summary): session={}, tail={}, split_idx={}",
             session_id,
@@ -1195,19 +1224,12 @@ pub(crate) async fn try_trigger_preflight_compaction(
         return Ok(false);
     };
 
-    if resume_completion_after_compact {
-        awaiting_compact_arc.store(true, Ordering::SeqCst);
-    }
-    *last_compacted_tail_id_arc.write().await = current_tail_id.clone();
     let compact_started_at_ms_handle = {
         let active = active_sessions.read().await;
         active
             .get(session_id)
             .map(|session| session.compaction.started_at_ms.clone())
     };
-    if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-        *compact_started_at_ms_handle.write().await = Some(started_at_ms);
-    }
 
     let settings = load_context_management_settings().await;
     let safe_input_token_limit =
@@ -1245,6 +1267,14 @@ pub(crate) async fn try_trigger_preflight_compaction(
         resume_completion_after_compact,
     )?;
     emit_compact_request(app_handle, compact_event)?;
+    if resume_completion_after_compact {
+        awaiting_compact_arc.store(true, Ordering::SeqCst);
+    }
+    *last_compacted_tail_id_arc.write().await = current_tail_id.clone();
+    if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
+        *compact_started_at_ms_handle.write().await = Some(started_at_ms);
+    }
+    in_flight_guard.disarm();
 
     if resume_completion_after_compact {
         log::info!(

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -3,6 +3,8 @@ use crate::agent::state::DeferredWorkflowStep;
 use crate::mcp::types::MCPContent;
 use crate::models::chat::{Message, MessageSource};
 use crate::repositories::CompactContextRecord;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -77,9 +79,11 @@ fn build_incremental_compact_summary_message(
 const COMPACTION_SECTION_SCHEMA: &str = "Use EXACTLY these sections in this order:\n\
 1. Stable Context\n\
 2. Key Decisions & Constraints\n\
-3. Current State\n\
-4. Recent Tool Results\n\
-5. Next Actions";
+3. Active Request\n\
+4. Required References\n\
+5. Current State\n\
+6. Recent Tool Results\n\
+7. Next Actions";
 
 const COMPACTION_RULES: &[&str] = &[
     "Use terse bullet points, not prose paragraphs.",
@@ -87,15 +91,19 @@ const COMPACTION_RULES: &[&str] = &[
     "Minimize adjectives, adverbs, filler, and repetition.",
     "Do not restate obvious chronology or narration.",
     "Preserve durable facts, decisions, constraints, user preferences, and unresolved work.",
-    "If the messages include an active external request, preserve the requested outcome, named technologies, explicit user choices, and blocking constraints with enough fidelity to continue the workflow safely.",
+    "If the messages include an unresolved external request, you MUST record it in Active Request.",
+    "If the unresolved request depends on earlier discovered context, you MUST record the minimum file paths, symbol names, entities, or identifiers needed to execute it in Required References.",
     "Keep volatile/recent details in Current State, Recent Tool Results, or Next Actions.",
     "Do not paraphrase away concrete requirements such as technology choices, limits, file targets, or requested deliverables when they are still relevant to pending work.",
+    "Do not replace exact file paths, symbol names, or user-named targets with vague descriptions when they are still operationally relevant.",
     "If a detail is recoverable from recent tool results, do not duplicate it in stable sections.",
 ];
 
 const COMPACTION_SECTION_LIMITS: &[&str] = &[
     "Stable Context: at most 6 bullets",
     "Key Decisions & Constraints: at most 6 bullets",
+    "Active Request: at most 4 bullets",
+    "Required References: at most 5 bullets",
     "Current State: at most 6 bullets",
     "Recent Tool Results: at most 5 bullets",
     "Next Actions: at most 5 bullets",
@@ -110,6 +118,31 @@ CRITICAL RESIDUAL RULE: Every fact, decision, action, and context item recorded 
 Do NOT drop durable information from the prior summary. \
 You may tighten wording, remove duplication, and relocate items into the required sections, but you must preserve the same meaning and operational usefulness. \
 Your new summary = (prior summary, preserved faithfully and reorganized if needed) + (new messages, summarised under the same schema).";
+
+const ACTIVE_REQUEST_BULLET_LIMIT: usize = 4;
+const REQUIRED_REFERENCE_BULLET_LIMIT: usize = 5;
+const REFERENCE_CONTEXT_WINDOW_MESSAGES: usize = 8;
+const INSTRUCTION_HINT_TEXT_LIMIT: usize = 320;
+
+static BACKTICK_REFERENCE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"`([^`\r\n]+)`").expect("valid backtick regex"));
+static PATH_REFERENCE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)\b(?:[a-z]:[\\/])?[\w./\\-]+\.[a-z0-9]{1,12}\b"#).expect("valid path regex")
+});
+static SYMBOL_REFERENCE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"\b(?:interface|type|class|enum|trait|struct|function|fn|const|let)\s+([A-Za-z_][A-Za-z0-9_]*)",
+    )
+    .expect("valid symbol regex")
+});
+static IDENTIFIER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]{1,79}$").expect("valid identifier regex"));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionPreservationHints {
+    pub active_request: Vec<String>,
+    pub required_references: Vec<String>,
+}
 
 fn render_bulleted_lines(lines: &[&str]) -> String {
     lines
@@ -129,8 +162,227 @@ fn build_base_compaction_instruction() -> String {
     )
 }
 
+fn normalize_instruction_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_instruction_text(text: &str, limit: usize) -> String {
+    let normalized = normalize_instruction_text(text);
+    if normalized.chars().count() <= limit {
+        return normalized;
+    }
+
+    let truncated = normalized
+        .chars()
+        .take(limit.saturating_sub(1))
+        .collect::<String>();
+    format!("{}…", truncated.trim_end())
+}
+
+fn extract_message_text_fragments(message: &Message) -> Vec<String> {
+    message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => {
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn push_unique_limited(values: &mut Vec<String>, candidate: String, limit: usize) {
+    if candidate.is_empty() || values.iter().any(|existing| existing == &candidate) {
+        return;
+    }
+
+    if values.len() < limit {
+        values.push(candidate);
+    }
+}
+
+fn format_reference_candidate(candidate: &str) -> String {
+    if PATH_REFERENCE_RE.is_match(candidate) {
+        format!("Preserve file path `{}`", candidate)
+    } else {
+        format!("Preserve identifier `{}`", candidate)
+    }
+}
+
+fn extract_reference_candidates_from_text(text: &str) -> Vec<String> {
+    let mut references = Vec::new();
+
+    for captures in BACKTICK_REFERENCE_RE.captures_iter(text) {
+        if let Some(candidate) = captures.get(1).map(|capture| capture.as_str().trim()) {
+            push_unique_limited(&mut references, candidate.to_string(), usize::MAX);
+        }
+    }
+
+    for candidate in PATH_REFERENCE_RE
+        .find_iter(text)
+        .map(|capture| capture.as_str())
+    {
+        push_unique_limited(&mut references, candidate.to_string(), usize::MAX);
+    }
+
+    for captures in SYMBOL_REFERENCE_RE.captures_iter(text) {
+        if let Some(candidate) = captures.get(1).map(|capture| capture.as_str()) {
+            push_unique_limited(&mut references, candidate.to_string(), usize::MAX);
+        }
+    }
+
+    references
+}
+
+fn collect_reference_candidates_from_json_value(
+    value: &serde_json::Value,
+    references: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::String(text) => {
+            let extracted = extract_reference_candidates_from_text(text);
+            if extracted.is_empty() && IDENTIFIER_RE.is_match(text) {
+                push_unique_limited(references, text.clone(), usize::MAX);
+            } else {
+                for candidate in extracted {
+                    push_unique_limited(references, candidate, usize::MAX);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_reference_candidates_from_json_value(item, references);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for value in map.values() {
+                collect_reference_candidates_from_json_value(value, references);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_reference_candidates_from_message(message: &Message, references: &mut Vec<String>) {
+    for text in extract_message_text_fragments(message) {
+        for candidate in extract_reference_candidates_from_text(&text) {
+            push_unique_limited(references, candidate, usize::MAX);
+        }
+    }
+
+    if let Some(tool_calls) = &message.tool_calls {
+        for tool_call in tool_calls {
+            if let Ok(arguments) =
+                serde_json::from_str::<serde_json::Value>(&tool_call.function.arguments)
+            {
+                collect_reference_candidates_from_json_value(&arguments, references);
+            }
+        }
+    }
+}
+
+pub fn build_compaction_preservation_hints(messages: &[Message]) -> CompactionPreservationHints {
+    let Some(active_request_start) = find_latest_external_request_block_start(messages) else {
+        return CompactionPreservationHints {
+            active_request: Vec::new(),
+            required_references: Vec::new(),
+        };
+    };
+
+    let mut active_request = Vec::new();
+    let mut required_references = Vec::new();
+    let request_block_end = messages[active_request_start..]
+        .iter()
+        .take_while(|message| message.is_external_request_message())
+        .count()
+        + active_request_start;
+
+    for message in &messages[active_request_start..request_block_end] {
+        for fragment in extract_message_text_fragments(message) {
+            push_unique_limited(
+                &mut active_request,
+                truncate_instruction_text(&fragment, INSTRUCTION_HINT_TEXT_LIMIT),
+                ACTIVE_REQUEST_BULLET_LIMIT,
+            );
+            for candidate in extract_reference_candidates_from_text(&fragment) {
+                push_unique_limited(
+                    &mut required_references,
+                    format_reference_candidate(&candidate),
+                    REQUIRED_REFERENCE_BULLET_LIMIT,
+                );
+            }
+        }
+    }
+
+    let reference_window_start =
+        active_request_start.saturating_sub(REFERENCE_CONTEXT_WINDOW_MESSAGES);
+    let mut raw_reference_candidates = Vec::new();
+    for message in &messages[reference_window_start..request_block_end] {
+        collect_reference_candidates_from_message(message, &mut raw_reference_candidates);
+    }
+
+    for candidate in raw_reference_candidates {
+        push_unique_limited(
+            &mut required_references,
+            format_reference_candidate(&candidate),
+            REQUIRED_REFERENCE_BULLET_LIMIT,
+        );
+    }
+
+    CompactionPreservationHints {
+        active_request,
+        required_references,
+    }
+}
+
+fn build_compaction_hint_block(messages: &[Message]) -> Option<String> {
+    let hints = build_compaction_preservation_hints(messages);
+    if hints.active_request.is_empty() && hints.required_references.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    if !hints.active_request.is_empty() {
+        parts.push(format!(
+            "Active Request candidates:\n{}",
+            hints
+                .active_request
+                .iter()
+                .map(|line| format!("- {}", line))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
+    if !hints.required_references.is_empty() {
+        parts.push(format!(
+            "Required References candidates:\n{}",
+            hints
+                .required_references
+                .iter()
+                .map(|line| format!("- {}", line))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
+    Some(format!(
+        "Preservation hints for this compaction input:\n{}",
+        parts.join("\n\n")
+    ))
+}
+
 fn build_compaction_instruction(messages: &[Message]) -> String {
-    let instruction = build_base_compaction_instruction();
+    let mut instruction = build_base_compaction_instruction();
+    if let Some(hint_block) = build_compaction_hint_block(messages) {
+        instruction = format!("{}\n\n{}", instruction, hint_block);
+    }
 
     if messages.first().map(Message::is_compact_summary) == Some(true) {
         return format!(

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::agent::state::DeferredWorkflowStep;
 use crate::mcp::types::MCPContent;
-use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACTION_INSTRUCTION};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -166,7 +166,7 @@ fn build_compaction_instruction_message(
         usage: None,
         created_at,
         updated_at: created_at,
-        source: Some(MESSAGE_SOURCE_COMPACTION_INSTRUCTION.to_string()),
+        source: Some(MessageSource::CompactionInstruction),
         error: None,
         metadata: None,
     }

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::agent::state::DeferredWorkflowStep;
 use crate::mcp::types::MCPContent;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACTION_INSTRUCTION};
 use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -74,41 +74,68 @@ fn build_incremental_compact_summary_message(
     )
 }
 
-fn build_compaction_instruction(messages: &[Message]) -> String {
-    let mut instruction =
-        "Summarise the previous conversation history using strict compact Markdown.\n\n\
-Use EXACTLY these sections in this order:\n\
+const COMPACTION_SECTION_SCHEMA: &str = "Use EXACTLY these sections in this order:\n\
 1. Stable Context\n\
 2. Key Decisions & Constraints\n\
 3. Current State\n\
 4. Recent Tool Results\n\
-5. Next Actions\n\n\
-Compression rules:\n\
-- Use terse bullet points, not prose paragraphs.\n\
-- Prefer noun phrases and short action statements.\n\
-- Minimize adjectives, adverbs, filler, and repetition.\n\
-- Do not restate obvious chronology or narration.\n\
-- Preserve durable facts, decisions, constraints, user preferences, and unresolved work.\n\
-- Keep volatile/recent details in Current State, Recent Tool Results, or Next Actions.\n\
-- If a detail is recoverable from recent tool results, do not duplicate it in stable sections.\n\n\
-Section limits:\n\
-- Stable Context: at most 6 bullets\n\
-- Key Decisions & Constraints: at most 6 bullets\n\
-- Current State: at most 6 bullets\n\
-- Recent Tool Results: at most 5 bullets\n\
-- Next Actions: at most 5 bullets\n\
-- Each bullet should be one short sentence or fragment.\n\n\
-IMPORTANT: Do NOT attempt to use tools in this response. Just output plain text."
-            .to_string();
+5. Next Actions";
 
-    if messages.first().map(|message| message.is_compact_summary()) == Some(true) {
-        instruction = format!(
-            "The first message is a previously accumulated compact summary that represents ALL earlier conversation history.\n\n\
+const COMPACTION_RULES: &[&str] = &[
+    "Use terse bullet points, not prose paragraphs.",
+    "Prefer noun phrases and short action statements.",
+    "Minimize adjectives, adverbs, filler, and repetition.",
+    "Do not restate obvious chronology or narration.",
+    "Preserve durable facts, decisions, constraints, user preferences, and unresolved work.",
+    "If the messages include an active external request, preserve the requested outcome, named technologies, explicit user choices, and blocking constraints with enough fidelity to continue the workflow safely.",
+    "Keep volatile/recent details in Current State, Recent Tool Results, or Next Actions.",
+    "Do not paraphrase away concrete requirements such as technology choices, limits, file targets, or requested deliverables when they are still relevant to pending work.",
+    "If a detail is recoverable from recent tool results, do not duplicate it in stable sections.",
+];
+
+const COMPACTION_SECTION_LIMITS: &[&str] = &[
+    "Stable Context: at most 6 bullets",
+    "Key Decisions & Constraints: at most 6 bullets",
+    "Current State: at most 6 bullets",
+    "Recent Tool Results: at most 5 bullets",
+    "Next Actions: at most 5 bullets",
+    "Each bullet should be one short sentence or fragment.",
+];
+
+const COMPACTION_OUTPUT_CONSTRAINT: &str =
+    "IMPORTANT: Do NOT attempt to use tools in this response. Just output plain text.";
+
+const INCREMENTAL_COMPACTION_RESIDUAL_PREFIX: &str = "The first message is a previously accumulated compact summary that represents ALL earlier conversation history.\n\n\
 CRITICAL RESIDUAL RULE: Every fact, decision, action, and context item recorded in that prior summary MUST be preserved verbatim or re-stated with equivalent fidelity in your new summary. \
 Do NOT drop durable information from the prior summary. \
 You may tighten wording, remove duplication, and relocate items into the required sections, but you must preserve the same meaning and operational usefulness. \
-Your new summary = (prior summary, preserved faithfully and reorganized if needed) + (new messages, summarised under the same schema).\n\n{}",
-            instruction
+Your new summary = (prior summary, preserved faithfully and reorganized if needed) + (new messages, summarised under the same schema).";
+
+fn render_bulleted_lines(lines: &[&str]) -> String {
+    lines
+        .iter()
+        .map(|line| format!("- {}", line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_base_compaction_instruction() -> String {
+    format!(
+        "Summarise the previous conversation history using strict compact Markdown.\n\n{}\n\nCompression rules:\n{}\n\nSection limits:\n{}\n\n{}",
+        COMPACTION_SECTION_SCHEMA,
+        render_bulleted_lines(COMPACTION_RULES),
+        render_bulleted_lines(COMPACTION_SECTION_LIMITS),
+        COMPACTION_OUTPUT_CONSTRAINT
+    )
+}
+
+fn build_compaction_instruction(messages: &[Message]) -> String {
+    let instruction = build_base_compaction_instruction();
+
+    if messages.first().map(Message::is_compact_summary) == Some(true) {
+        return format!(
+            "{}\n\n{}",
+            INCREMENTAL_COMPACTION_RESIDUAL_PREFIX, instruction
         );
     }
 
@@ -139,7 +166,7 @@ fn build_compaction_instruction_message(
         usage: None,
         created_at,
         updated_at: created_at,
-        source: Some("compaction-instruction".to_string()),
+        source: Some(MESSAGE_SOURCE_COMPACTION_INSTRUCTION.to_string()),
         error: None,
         metadata: None,
     }
@@ -361,6 +388,33 @@ pub fn find_preflight_compaction_split_index(messages: &[Message]) -> usize {
     }
 }
 
+fn find_latest_external_request_block_start(messages: &[Message]) -> Option<usize> {
+    let latest_request_idx = messages
+        .iter()
+        .rposition(Message::is_external_request_message)?;
+
+    let mut block_start = latest_request_idx;
+    while block_start > 0 && messages[block_start - 1].is_external_request_message() {
+        block_start -= 1;
+    }
+
+    Some(block_start)
+}
+
+pub fn find_background_compaction_split_index(messages: &[Message]) -> usize {
+    let unresolved_boundary =
+        crate::agent::llm::context_selector::find_compaction_split_index(messages);
+
+    // Post-response compaction must keep the currently active external request in
+    // raw tail, but unresolved tool chains still take precedence so we never
+    // compact an assistant tool-call owner away from its pending tool results.
+    let Some(active_request_start) = find_latest_external_request_block_start(messages) else {
+        return unresolved_boundary;
+    };
+
+    std::cmp::min(unresolved_boundary, active_request_start)
+}
+
 pub fn should_skip_same_tail_compaction(messages: &[Message], split_idx: usize) -> bool {
     let has_compact_summary = messages
         .first()
@@ -398,7 +452,7 @@ async fn load_merged_compaction_messages(
             .read()
             .await
             .iter()
-            .filter(|m| m.source.as_deref() != Some("recovery"))
+            .filter(|m| !m.is_recovery_message())
             .cloned()
             .collect::<Vec<_>>();
 
@@ -411,7 +465,159 @@ async fn load_merged_compaction_messages(
     ))
 }
 
-pub(crate) async fn trigger_background_compaction(
+struct BackgroundCompactionTrigger<'a> {
+    session_id: &'a str,
+    session_name: &'a str,
+    messages: &'a [Message],
+    split_idx: usize,
+    parent_request: Option<CompactionParentRequest>,
+}
+
+impl<'a> BackgroundCompactionTrigger<'a> {
+    async fn execute(
+        self,
+        active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+        app_handle: &AppHandle,
+        handles: &BackgroundCompactionHandles,
+    ) -> Result<bool, String> {
+        let Self {
+            session_id,
+            session_name,
+            messages,
+            split_idx,
+            parent_request,
+        } = self;
+
+        if split_idx == 0 {
+            return Ok(false);
+        }
+
+        let claimed_in_flight = handles
+            .compact_in_flight_arc
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok();
+
+        if !claimed_in_flight {
+            log::debug!("⏭️ Compaction skipped (in_flight): session={}", session_id);
+            return Ok(false);
+        }
+
+        let current_tail_id = messages.last().map(|m| m.id.clone());
+        let last_compacted_tail = handles.last_compacted_tail_id_arc.read().await.clone();
+        let same_tail = current_tail_id.as_deref() == last_compacted_tail.as_deref();
+
+        if same_tail && should_skip_same_tail_compaction(messages, split_idx) {
+            handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
+            log::debug!(
+                "⏭️ Compaction skipped (same tail): session={}, tail={}",
+                session_id,
+                current_tail_id.as_deref().unwrap_or("?")
+            );
+            return Ok(false);
+        }
+        let started_at_ms = chrono::Utc::now().timestamp_millis();
+        let compact_context_record = {
+            let active = active_sessions.read().await;
+            active
+                .get(session_id)
+                .map(|session| session.compact_context.clone())
+        };
+        let compact_context_record = if let Some(compact_context_handle) = compact_context_record {
+            compact_context_handle.read().await.clone()
+        } else {
+            None
+        };
+        let Some((compact_msgs, from_id, to_id, compacted_delta_count, reused_prior_summary)) =
+            build_compaction_request_payload(
+                session_id,
+                messages,
+                split_idx,
+                compact_context_record.as_ref(),
+                started_at_ms,
+            )
+        else {
+            handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
+            log::debug!(
+                "⏭️ Compaction skipped (no new delta beyond previous summary): session={}, tail={}",
+                session_id,
+                current_tail_id.as_deref().unwrap_or("?")
+            );
+            return Ok(false);
+        };
+
+        *handles.last_compacted_tail_id_arc.write().await = current_tail_id.clone();
+        let compact_started_at_ms_handle = {
+            let active = active_sessions.read().await;
+            active
+                .get(session_id)
+                .map(|session| session.compaction.started_at_ms.clone())
+        };
+        if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
+            *compact_started_at_ms_handle.write().await = Some(started_at_ms);
+        }
+
+        let settings = load_context_management_settings().await;
+        let safe_input_token_limit =
+            std::cmp::min(settings.max_input_context, settings.model_max_limit);
+        let resolved_parent_request =
+            resolve_parent_request(active_sessions, session_id, parent_request).await;
+        let (system_prompt_tokens, tools_tokens) =
+            estimate_compaction_non_message_tokens(resolved_parent_request.as_ref());
+        let compact_msgs = fit_compaction_request_messages_to_limit(
+            &compact_msgs,
+            resolved_parent_request
+                .as_ref()
+                .map(|request| request.provider.as_str())
+                .unwrap_or("openai"),
+            safe_input_token_limit,
+            system_prompt_tokens,
+            tools_tokens,
+        )?;
+
+        let compact_event = CompactRequest {
+            session_id: session_id.to_string(),
+            session_name: session_name.to_string(),
+            messages: compact_msgs,
+            from_id,
+            to_id,
+            parent_request: resolved_parent_request,
+            resume_completion_after_compact: false,
+        };
+        let log_from_id = compact_event.from_id.clone();
+        let log_to_id = compact_event.to_id.clone();
+        let app = app_handle.clone();
+        let state_session_id = session_id.to_string();
+        let state_session_name = session_name.to_string();
+        tokio::spawn(async move {
+            if let Err(e) = emit_compact_started(
+                &app,
+                state_session_id.clone(),
+                Some(state_session_name),
+                false,
+            ) {
+                log::error!("Failed to emit llm:compact-state: {}", e);
+            }
+            if let Err(e) = emit_compact_request(&app, compact_event) {
+                log::error!("Failed to emit llm:compact-request: {}", e);
+            }
+        });
+        log::info!(
+            "🔧 Background compaction triggered: session={}, from_id={}, to_id={}, split_idx={}, compacted_delta_count={}, reused_prior_summary={}, tail={}, started_at_ms={}",
+            session_id,
+            log_from_id,
+            log_to_id,
+            split_idx,
+            compacted_delta_count,
+            reused_prior_summary,
+            current_tail_id.as_deref().unwrap_or("?"),
+            started_at_ms
+        );
+
+        Ok(true)
+    }
+}
+
+pub(crate) async fn trigger_post_response_background_compaction(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     app_handle: &AppHandle,
     session_id: &str,
@@ -420,133 +626,15 @@ pub(crate) async fn trigger_background_compaction(
     parent_request: Option<CompactionParentRequest>,
     handles: &BackgroundCompactionHandles,
 ) -> Result<bool, String> {
-    let split_idx = crate::agent::llm::context_selector::find_compaction_split_index(messages);
-    if split_idx == 0 {
-        return Ok(false);
-    }
-
-    let claimed_in_flight = handles
-        .compact_in_flight_arc
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok();
-
-    if !claimed_in_flight {
-        log::debug!("⏭️ Compaction skipped (in_flight): session={}", session_id);
-        return Ok(false);
-    }
-
-    let current_tail_id = messages.last().map(|m| m.id.clone());
-    let last_compacted_tail = handles.last_compacted_tail_id_arc.read().await.clone();
-    let same_tail = current_tail_id.as_deref() == last_compacted_tail.as_deref();
-
-    if same_tail && should_skip_same_tail_compaction(messages, split_idx) {
-        handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
-        log::debug!(
-            "⏭️ Compaction skipped (same tail): session={}, tail={}",
-            session_id,
-            current_tail_id.as_deref().unwrap_or("?")
-        );
-        return Ok(false);
-    }
-    let started_at_ms = chrono::Utc::now().timestamp_millis();
-    let compact_context_record = {
-        let active = active_sessions.read().await;
-        active
-            .get(session_id)
-            .map(|session| session.compact_context.clone())
-    };
-    let compact_context_record = if let Some(compact_context_handle) = compact_context_record {
-        compact_context_handle.read().await.clone()
-    } else {
-        None
-    };
-    let Some((compact_msgs, from_id, to_id, compacted_delta_count, reused_prior_summary)) =
-        build_compaction_request_payload(
-            session_id,
-            messages,
-            split_idx,
-            compact_context_record.as_ref(),
-            started_at_ms,
-        )
-    else {
-        handles.compact_in_flight_arc.store(false, Ordering::SeqCst);
-        log::debug!(
-            "⏭️ Compaction skipped (no new delta beyond previous summary): session={}, tail={}",
-            session_id,
-            current_tail_id.as_deref().unwrap_or("?")
-        );
-        return Ok(false);
-    };
-
-    *handles.last_compacted_tail_id_arc.write().await = current_tail_id.clone();
-    let compact_started_at_ms_handle = {
-        let active = active_sessions.read().await;
-        active
-            .get(session_id)
-            .map(|session| session.compaction.started_at_ms.clone())
-    };
-    if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-        *compact_started_at_ms_handle.write().await = Some(started_at_ms);
-    }
-
-    let settings = load_context_management_settings().await;
-    let safe_input_token_limit =
-        std::cmp::min(settings.max_input_context, settings.model_max_limit);
-    let resolved_parent_request =
-        resolve_parent_request(active_sessions, session_id, parent_request).await;
-    let (system_prompt_tokens, tools_tokens) =
-        estimate_compaction_non_message_tokens(resolved_parent_request.as_ref());
-    let compact_msgs = fit_compaction_request_messages_to_limit(
-        &compact_msgs,
-        resolved_parent_request
-            .as_ref()
-            .map(|request| request.provider.as_str())
-            .unwrap_or("openai"),
-        safe_input_token_limit,
-        system_prompt_tokens,
-        tools_tokens,
-    )?;
-
-    let compact_event = CompactRequest {
-        session_id: session_id.to_string(),
-        session_name: session_name.to_string(),
-        messages: compact_msgs,
-        from_id,
-        to_id,
-        parent_request: resolved_parent_request,
-        resume_completion_after_compact: false,
-    };
-    let log_from_id = compact_event.from_id.clone();
-    let log_to_id = compact_event.to_id.clone();
-    let app = app_handle.clone();
-    let state_session_id = session_id.to_string();
-    let state_session_name = session_name.to_string();
-    tokio::spawn(async move {
-        if let Err(e) = emit_compact_started(
-            &app,
-            state_session_id.clone(),
-            Some(state_session_name),
-            false,
-        ) {
-            log::error!("Failed to emit llm:compact-state: {}", e);
-        }
-        if let Err(e) = emit_compact_request(&app, compact_event) {
-            log::error!("Failed to emit llm:compact-request: {}", e);
-        }
-    });
-    log::info!(
-        "🔧 Background compaction triggered: session={}, from_id={}, to_id={}, split_idx={}, compacted_delta_count={}, reused_prior_summary={}, tail={}, started_at_ms={}",
+    BackgroundCompactionTrigger {
         session_id,
-        log_from_id,
-        log_to_id,
-        split_idx,
-        compacted_delta_count,
-        reused_prior_summary,
-        current_tail_id.as_deref().unwrap_or("?"),
-        started_at_ms
-    );
-
-    Ok(true)
+        session_name,
+        messages,
+        parent_request,
+        split_idx: find_background_compaction_split_index(messages),
+    }
+    .execute(active_sessions, app_handle, handles)
+    .await
 }
 
 pub async fn trigger_post_response_compaction_if_needed(
@@ -602,7 +690,7 @@ pub async fn trigger_post_response_compaction_if_needed(
 
     finalize_workflow_after_compact.store(true, Ordering::SeqCst);
     *deferred_workflow_step_handle.write().await = Some(deferred_step);
-    let triggered = trigger_background_compaction(
+    let triggered = trigger_post_response_background_compaction(
         active_sessions,
         app_handle,
         session_id,

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -4,11 +4,12 @@ pub(crate) mod orchestration;
 pub(crate) mod request;
 
 pub use compaction::{
-    fit_compaction_request_messages_to_limit, preview_background_compaction_selection,
-    preview_preflight_compaction_selection, should_skip_same_tail_compaction,
-    should_trigger_background_compaction, should_trigger_post_response_compaction,
-    trigger_manual_compaction_for_session, trigger_post_response_compaction_if_needed,
-    trigger_preflight_compaction_for_session, CompactionSelectionPreview,
+    build_compaction_preservation_hints, fit_compaction_request_messages_to_limit,
+    preview_background_compaction_selection, preview_preflight_compaction_selection,
+    should_skip_same_tail_compaction, should_trigger_background_compaction,
+    should_trigger_post_response_compaction, trigger_manual_compaction_for_session,
+    trigger_post_response_compaction_if_needed, trigger_preflight_compaction_for_session,
+    CompactionPreservationHints, CompactionSelectionPreview,
 };
 pub use context::{
     resolve_context_management_settings, uses_compaction_strategy, ContextManagementSettings,

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -4,14 +4,12 @@ pub(crate) mod orchestration;
 pub(crate) mod request;
 
 pub use compaction::{
-    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
-    should_skip_same_tail_compaction,
+    fit_compaction_request_messages_to_limit, preview_background_compaction_selection,
+    preview_preflight_compaction_selection, should_skip_same_tail_compaction,
     should_trigger_background_compaction, should_trigger_post_response_compaction,
     trigger_manual_compaction_for_session, trigger_post_response_compaction_if_needed,
     trigger_preflight_compaction_for_session,
 };
-#[doc(hidden)]
-pub use compaction::find_background_compaction_split_index;
 pub use context::{
     resolve_context_management_settings, uses_compaction_strategy, ContextManagementSettings,
 };

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -5,10 +5,13 @@ pub(crate) mod request;
 
 pub use compaction::{
     find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
-    should_skip_same_tail_compaction, should_trigger_background_compaction,
-    should_trigger_post_response_compaction, trigger_manual_compaction_for_session,
-    trigger_post_response_compaction_if_needed, trigger_preflight_compaction_for_session,
+    should_skip_same_tail_compaction,
+    should_trigger_background_compaction, should_trigger_post_response_compaction,
+    trigger_manual_compaction_for_session, trigger_post_response_compaction_if_needed,
+    trigger_preflight_compaction_for_session,
 };
+#[doc(hidden)]
+pub use compaction::find_background_compaction_split_index;
 pub use context::{
     resolve_context_management_settings, uses_compaction_strategy, ContextManagementSettings,
 };

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -2,7 +2,7 @@ use crate::agent::references::build_default_registry;
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACT_SUMMARY};
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::CompactContextRepository;
 use crate::repositories::{SessionRepository, SessionStatus};
@@ -95,7 +95,7 @@ pub fn build_compact_summary_message(session_id: &str, text: String, created_at:
             text,
             is_error: None,
         }],
-        source: Some("compact-summary".to_string()),
+        source: Some(MESSAGE_SOURCE_COMPACT_SUMMARY.to_string()),
         created_at,
         updated_at: created_at,
         tool_calls: None,
@@ -443,7 +443,7 @@ pub async fn request_llm_completion(
         let messages_lock = session.messages.read().await;
         messages_lock
             .iter()
-            .filter(|m| m.source.as_deref() != Some("recovery"))
+            .filter(|m| !m.is_recovery_message())
             .cloned()
             .collect::<Vec<_>>()
     };

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -2,7 +2,7 @@ use crate::agent::references::build_default_registry;
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACT_SUMMARY};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::CompactContextRepository;
 use crate::repositories::{SessionRepository, SessionStatus};
@@ -95,7 +95,7 @@ pub fn build_compact_summary_message(session_id: &str, text: String, created_at:
             text,
             is_error: None,
         }],
-        source: Some(MESSAGE_SOURCE_COMPACT_SUMMARY.to_string()),
+        source: Some(MessageSource::CompactSummary),
         created_at,
         updated_at: created_at,
         tool_calls: None,

--- a/src-tauri/src/agent/session_manager/channel.rs
+++ b/src-tauri/src/agent/session_manager/channel.rs
@@ -1,7 +1,7 @@
 use super::AgentSessionManager;
 use crate::agent::channel_routing::{resolve_auto_routed_channel_target, ChannelRouteCandidate};
 use crate::mcp::types::ChannelNotification;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MESSAGE_SOURCE_CHANNEL};
 use std::collections::HashMap;
 
 pub async fn inject_channel_notification(
@@ -90,7 +90,7 @@ fn build_channel_message(
         usage: None,
         created_at: now,
         updated_at: now,
-        source: Some("channel".to_string()),
+        source: Some(MESSAGE_SOURCE_CHANNEL.to_string()),
         error: None,
         metadata: Some(serde_json::json!({
             "channel": {

--- a/src-tauri/src/agent/session_manager/channel.rs
+++ b/src-tauri/src/agent/session_manager/channel.rs
@@ -1,7 +1,7 @@
 use super::AgentSessionManager;
 use crate::agent::channel_routing::{resolve_auto_routed_channel_target, ChannelRouteCandidate};
 use crate::mcp::types::ChannelNotification;
-use crate::models::chat::{Message, MESSAGE_SOURCE_CHANNEL};
+use crate::models::chat::{Message, MessageSource};
 use std::collections::HashMap;
 
 pub async fn inject_channel_notification(
@@ -90,7 +90,7 @@ fn build_channel_message(
         usage: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_CHANNEL.to_string()),
+        source: Some(MessageSource::Channel),
         error: None,
         metadata: Some(serde_json::json!({
             "channel": {

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::{Message, MESSAGE_SOURCE_TOOL};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::settings_repository::SettingsRepository;
 use crate::services::WorkspaceService;
 use base64::engine::general_purpose;
@@ -198,7 +198,7 @@ pub fn create_tool_result_message(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: structured_content.map(|value| {
             serde_json::json!({
@@ -247,7 +247,7 @@ pub fn create_error_tool_result(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata,
     }
@@ -614,7 +614,7 @@ pub fn create_tool_result_message_with_content(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: build_tool_message_metadata(tool_error, structured_content),
     }

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MESSAGE_SOURCE_TOOL};
 use crate::repositories::settings_repository::SettingsRepository;
 use crate::services::WorkspaceService;
 use base64::engine::general_purpose;
@@ -198,7 +198,7 @@ pub fn create_tool_result_message(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some("tool".to_string()),
+        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
         error: None,
         metadata: structured_content.map(|value| {
             serde_json::json!({
@@ -247,7 +247,7 @@ pub fn create_error_tool_result(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some("tool".to_string()),
+        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
         error: None,
         metadata,
     }
@@ -614,7 +614,7 @@ pub fn create_tool_result_message_with_content(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some("tool".to_string()),
+        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
         error: None,
         metadata: build_tool_message_metadata(tool_error, structured_content),
     }

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -4,7 +4,7 @@ use crate::mcp::types::ChannelNotification;
 use crate::mcp::types::ChannelPermissionVerdict;
 use crate::mcp::types::ServiceContext;
 use crate::models::chat::Message;
-use crate::models::chat::MESSAGE_SOURCE_UI;
+use crate::models::chat::MessageSource;
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::{CompactContextRecord, SessionMetadata, SessionRepository};
 use crate::services::AgentService;
@@ -219,7 +219,7 @@ fn create_ui_tool_call_message(
             usage: None,
             created_at: now,
             updated_at: now,
-            source: Some(MESSAGE_SOURCE_UI.to_string()),
+            source: Some(MessageSource::Ui),
             error: None,
             metadata: None,
         },

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -3,19 +3,19 @@ use crate::commands::messages_commands::MessageSlice;
 use crate::mcp::types::ChannelNotification;
 use crate::mcp::types::ChannelPermissionVerdict;
 use crate::mcp::types::ServiceContext;
+use crate::models::chat::Message;
+use crate::models::chat::MESSAGE_SOURCE_UI;
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::{CompactContextRecord, SessionMetadata, SessionRepository};
-use crate::state::get_session_repository;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use tauri::{command, AppHandle, State};
-
-use crate::models::chat::Message;
 use crate::services::AgentService;
+use crate::state::get_session_repository;
 use crate::{
     agent::tools::{create_error_tool_result, create_tool_result_message},
     agent::types::{ToolCall, ToolCallFunction},
 };
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tauri::{command, AppHandle, State};
 
 /// Request to create a new agent session
 #[derive(Debug, Serialize, Deserialize)]
@@ -219,7 +219,7 @@ fn create_ui_tool_call_message(
             usage: None,
             created_at: now,
             updated_at: now,
-            source: Some("ui".to_string()),
+            source: Some(MESSAGE_SOURCE_UI.to_string()),
             error: None,
             metadata: None,
         },

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -233,7 +233,7 @@ pub async fn message_to_session(
         manager,
         &session_id,
         message_text,
-        Some("agent_tool".to_string()),
+        Some(MessageSource::AgentTool),
     )
     .await
     {
@@ -524,3 +524,4 @@ pub async fn compact_session_context(
     Ok(SuccessHint::new(message, vec![])
         .to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
+use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -9,6 +9,7 @@ use crate::mcp::builtin::session_api::utils::{
     build_agent_tool_data, check_session_next_actions, read_required_string,
 };
 use crate::mcp::types::MCPResult;
+use crate::models::chat::MessageSource;
 use crate::repositories::SessionStatus;
 
 use super::super::AgentServer;
@@ -524,4 +525,3 @@ pub async fn compact_session_context(
     Ok(SuccessHint::new(message, vec![])
         .to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
-use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -5,6 +5,7 @@ use tokio::time::sleep;
 use crate::agent::AgentSessionManager;
 use crate::mcp::builtin::error_guidance::ErrorCategory;
 use crate::mcp::types::MCPResult;
+use crate::models::chat::MessageSource;
 use crate::repositories::assistant_repository::AssistantRepository;
 use crate::repositories::session_repository::SessionRepository;
 
@@ -662,4 +663,3 @@ pub async fn handle_tool_call(
         _ => Err(format!("Unknown tool: {}", tool_name)),
     }
 }
-use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -109,7 +109,7 @@ pub async fn handle_tool_call(
             let response = crate::services::AgentService::spawn_agent_with_source(
                 manager,
                 request,
-                Some("swarm_legacy".to_string()),
+                Some(MessageSource::SwarmLegacy),
             )
             .await
             .map_err(|e| {
@@ -390,7 +390,7 @@ pub async fn handle_tool_call(
                 manager,
                 &session_id,
                 content,
-                Some("swarm_legacy".to_string()),
+                Some(MessageSource::SwarmLegacy),
             )
             .await
             {
@@ -662,3 +662,4 @@ pub async fn handle_tool_call(
         _ => Err(format!("Unknown tool: {}", tool_name)),
     }
 }
+use crate::models::chat::MessageSource;

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -139,9 +139,10 @@ pub struct Message {
 
 impl Message {
     fn source_with_legacy_fallback(&self) -> Option<MessageSource> {
-        self.source
-            .clone()
-            .or_else(|| MessageSource::from_id(&self.id))
+        match self.source.as_ref() {
+            Some(MessageSource::Unknown(_)) | None => MessageSource::from_id(&self.id),
+            Some(source) => Some(source.clone()),
+        }
     }
 
     pub fn is_compact_summary(&self) -> bool {

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -3,12 +3,61 @@ use crate::mcp::types::MCPContent;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub(crate) const MESSAGE_SOURCE_CHANNEL: &str = "channel";
+pub(crate) const MESSAGE_SOURCE_COMPACT_SUMMARY: &str = "compact-summary";
+pub(crate) const MESSAGE_SOURCE_COMPACTION_INSTRUCTION: &str = "compaction-instruction";
+pub(crate) const MESSAGE_SOURCE_RECOVERY: &str = "recovery";
+pub(crate) const MESSAGE_SOURCE_SCHEDULED_TASK: &str = "scheduled_task";
+pub(crate) const MESSAGE_SOURCE_TOOL: &str = "tool";
+pub(crate) const MESSAGE_SOURCE_UI: &str = "ui";
+
+const COMPACT_SUMMARY_ID_PREFIX: &str = "compact-summary-";
+const COMPACTION_INSTRUCTION_ID_PREFIX: &str = "compaction-instruction-";
+
 /// Default timestamp generator for serde deserialization fallback
 fn default_timestamp() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KnownMessageSource {
+    Channel,
+    CompactSummary,
+    CompactionInstruction,
+    Recovery,
+    ScheduledTask,
+    Tool,
+    Ui,
+}
+
+impl KnownMessageSource {
+    fn from_source(source: &str) -> Option<Self> {
+        match source {
+            MESSAGE_SOURCE_CHANNEL => Some(Self::Channel),
+            MESSAGE_SOURCE_COMPACT_SUMMARY => Some(Self::CompactSummary),
+            MESSAGE_SOURCE_COMPACTION_INSTRUCTION => Some(Self::CompactionInstruction),
+            MESSAGE_SOURCE_RECOVERY => Some(Self::Recovery),
+            MESSAGE_SOURCE_SCHEDULED_TASK => Some(Self::ScheduledTask),
+            MESSAGE_SOURCE_TOOL => Some(Self::Tool),
+            MESSAGE_SOURCE_UI => Some(Self::Ui),
+            _ => None,
+        }
+    }
+
+    fn from_id(id: &str) -> Option<Self> {
+        if id.starts_with(COMPACT_SUMMARY_ID_PREFIX) {
+            return Some(Self::CompactSummary);
+        }
+
+        if id.starts_with(COMPACTION_INSTRUCTION_ID_PREFIX) {
+            return Some(Self::CompactionInstruction);
+        }
+
+        None
+    }
 }
 
 /// Message data model matching the frontend TypeScript Message interface.
@@ -47,12 +96,40 @@ pub struct Message {
 }
 
 impl Message {
+    fn known_source(&self) -> Option<KnownMessageSource> {
+        self.source
+            .as_deref()
+            .and_then(KnownMessageSource::from_source)
+            .or_else(|| KnownMessageSource::from_id(&self.id))
+    }
+
     pub fn is_compact_summary(&self) -> bool {
-        self.source.as_deref() == Some("compact-summary") || self.id.starts_with("compact-summary-")
+        matches!(
+            self.known_source(),
+            Some(KnownMessageSource::CompactSummary)
+        )
     }
 
     pub fn is_compaction_instruction(&self) -> bool {
-        self.source.as_deref() == Some("compaction-instruction")
-            || self.id.starts_with("compaction-instruction-")
+        matches!(
+            self.known_source(),
+            Some(KnownMessageSource::CompactionInstruction)
+        )
+    }
+
+    pub fn is_recovery_message(&self) -> bool {
+        matches!(self.known_source(), Some(KnownMessageSource::Recovery))
+    }
+
+    pub fn is_internal_synthetic_user_message(&self) -> bool {
+        self.role == "user"
+            && matches!(
+                self.known_source(),
+                Some(KnownMessageSource::CompactionInstruction | KnownMessageSource::Recovery)
+            )
+    }
+
+    pub fn is_external_request_message(&self) -> bool {
+        self.role == "user" && !self.is_internal_synthetic_user_message()
     }
 }

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -1,15 +1,7 @@
 use crate::agent::types::ToolCall;
 use crate::mcp::types::MCPContent;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-pub(crate) const MESSAGE_SOURCE_CHANNEL: &str = "channel";
-pub(crate) const MESSAGE_SOURCE_COMPACT_SUMMARY: &str = "compact-summary";
-pub(crate) const MESSAGE_SOURCE_COMPACTION_INSTRUCTION: &str = "compaction-instruction";
-pub(crate) const MESSAGE_SOURCE_RECOVERY: &str = "recovery";
-pub(crate) const MESSAGE_SOURCE_SCHEDULED_TASK: &str = "scheduled_task";
-pub(crate) const MESSAGE_SOURCE_TOOL: &str = "tool";
-pub(crate) const MESSAGE_SOURCE_UI: &str = "ui";
 
 const COMPACT_SUMMARY_ID_PREFIX: &str = "compact-summary-";
 const COMPACTION_INSTRUCTION_ID_PREFIX: &str = "compaction-instruction-";
@@ -22,8 +14,12 @@ fn default_timestamp() -> i64 {
         .as_millis() as i64
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KnownMessageSource {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MessageSource {
+    Assistant,
+    Api,
+    AgentTool,
+    SwarmLegacy,
     Channel,
     CompactSummary,
     CompactionInstruction,
@@ -31,19 +27,42 @@ enum KnownMessageSource {
     ScheduledTask,
     Tool,
     Ui,
+    Unknown(String),
 }
 
-impl KnownMessageSource {
-    fn from_source(source: &str) -> Option<Self> {
-        match source {
-            MESSAGE_SOURCE_CHANNEL => Some(Self::Channel),
-            MESSAGE_SOURCE_COMPACT_SUMMARY => Some(Self::CompactSummary),
-            MESSAGE_SOURCE_COMPACTION_INSTRUCTION => Some(Self::CompactionInstruction),
-            MESSAGE_SOURCE_RECOVERY => Some(Self::Recovery),
-            MESSAGE_SOURCE_SCHEDULED_TASK => Some(Self::ScheduledTask),
-            MESSAGE_SOURCE_TOOL => Some(Self::Tool),
-            MESSAGE_SOURCE_UI => Some(Self::Ui),
-            _ => None,
+impl MessageSource {
+    pub fn from_raw(source: impl Into<String>) -> Self {
+        let source = source.into();
+        match source.as_str() {
+            "assistant" => Self::Assistant,
+            "api" => Self::Api,
+            "agent_tool" => Self::AgentTool,
+            "swarm_legacy" => Self::SwarmLegacy,
+            "channel" => Self::Channel,
+            "compact-summary" => Self::CompactSummary,
+            "compaction-instruction" => Self::CompactionInstruction,
+            "recovery" => Self::Recovery,
+            "scheduled_task" => Self::ScheduledTask,
+            "tool" => Self::Tool,
+            "ui" => Self::Ui,
+            _ => Self::Unknown(source),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Assistant => "assistant",
+            Self::Api => "api",
+            Self::AgentTool => "agent_tool",
+            Self::SwarmLegacy => "swarm_legacy",
+            Self::Channel => "channel",
+            Self::CompactSummary => "compact-summary",
+            Self::CompactionInstruction => "compaction-instruction",
+            Self::Recovery => "recovery",
+            Self::ScheduledTask => "scheduled_task",
+            Self::Tool => "tool",
+            Self::Ui => "ui",
+            Self::Unknown(source) => source.as_str(),
         }
     }
 
@@ -57,6 +76,29 @@ impl KnownMessageSource {
         }
 
         None
+    }
+
+    fn is_internal_synthetic_user_source(&self) -> bool {
+        matches!(self, Self::CompactionInstruction | Self::Recovery)
+    }
+}
+
+impl Serialize for MessageSource {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let source = String::deserialize(deserializer)?;
+        Ok(Self::from_raw(source))
     }
 }
 
@@ -88,7 +130,7 @@ pub struct Message {
     pub created_at: i64, // Unix timestamp in milliseconds
     #[serde(default = "default_timestamp")]
     pub updated_at: i64, // Unix timestamp in milliseconds
-    pub source: Option<String>,
+    pub source: Option<MessageSource>,
     /// Error information as structured value
     pub error: Option<serde_json::Value>,
     /// Optional metadata for tool execution tracking (mirrors frontend Message.metadata)
@@ -96,37 +138,38 @@ pub struct Message {
 }
 
 impl Message {
-    fn known_source(&self) -> Option<KnownMessageSource> {
+    fn source_with_legacy_fallback(&self) -> Option<MessageSource> {
         self.source
-            .as_deref()
-            .and_then(KnownMessageSource::from_source)
-            .or_else(|| KnownMessageSource::from_id(&self.id))
+            .clone()
+            .or_else(|| MessageSource::from_id(&self.id))
     }
 
     pub fn is_compact_summary(&self) -> bool {
         matches!(
-            self.known_source(),
-            Some(KnownMessageSource::CompactSummary)
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::CompactSummary)
         )
     }
 
     pub fn is_compaction_instruction(&self) -> bool {
         matches!(
-            self.known_source(),
-            Some(KnownMessageSource::CompactionInstruction)
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::CompactionInstruction)
         )
     }
 
     pub fn is_recovery_message(&self) -> bool {
-        matches!(self.known_source(), Some(KnownMessageSource::Recovery))
+        matches!(
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::Recovery)
+        )
     }
 
     pub fn is_internal_synthetic_user_message(&self) -> bool {
         self.role == "user"
-            && matches!(
-                self.known_source(),
-                Some(KnownMessageSource::CompactionInstruction | KnownMessageSource::Recovery)
-            )
+            && self
+                .source_with_legacy_fallback()
+                .is_some_and(|source| source.is_internal_synthetic_user_source())
     }
 
     pub fn is_external_request_message(&self) -> bool {

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -81,6 +81,13 @@ impl MessageSource {
     fn is_internal_synthetic_user_source(&self) -> bool {
         matches!(self, Self::CompactionInstruction | Self::Recovery)
     }
+
+    fn is_external_request_source(&self) -> bool {
+        matches!(
+            self,
+            Self::Api | Self::SwarmLegacy | Self::Channel | Self::ScheduledTask
+        )
+    }
 }
 
 impl Serialize for MessageSource {
@@ -173,6 +180,10 @@ impl Message {
     }
 
     pub fn is_external_request_message(&self) -> bool {
-        self.role == "user" && !self.is_internal_synthetic_user_message()
+        self.role == "user"
+            && !self.is_internal_synthetic_user_message()
+            && self
+                .source_with_legacy_fallback()
+                .is_none_or(|source| source.is_external_request_source())
     }
 }

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -1,5 +1,5 @@
 use super::error::DbError;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MessageSource};
 use crate::utils::pagination::Page;
 use async_trait::async_trait;
 use sea_orm::{
@@ -290,7 +290,7 @@ impl SqliteMessageRepository {
             tool_use,
             created_at: model.created_at,
             updated_at: model.updated_at,
-            source: model.source,
+            source: model.source.map(MessageSource::from_raw),
             error,
             usage,
             metadata: None,
@@ -339,7 +339,10 @@ impl SqliteMessageRepository {
             tool_use: Set(tool_use_json),
             created_at: Set(message.created_at),
             updated_at: Set(message.updated_at),
-            source: Set(message.source.clone()),
+            source: Set(message
+                .source
+                .as_ref()
+                .map(|source| source.as_str().to_string())),
             error: Set(error_json),
             usage: Set(usage_json),
         })

--- a/src-tauri/src/scheduled/runner.rs
+++ b/src-tauri/src/scheduled/runner.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::agent::{AgentConfig, AgentSessionManager};
 use crate::mcp::types::MCPContent;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MESSAGE_SOURCE_SCHEDULED_TASK};
 use crate::repositories::{AssistantRepository, ScheduledTaskRepository, SessionRepository};
 use crate::scheduled::ScheduleTimezone;
 use crate::services::WorkspaceService;
@@ -242,7 +242,7 @@ async fn execute_task(
         tool_use: None,
         created_at: now_ts,
         updated_at: now_ts,
-        source: Some("scheduled_task".to_string()),
+        source: Some(MESSAGE_SOURCE_SCHEDULED_TASK.to_string()),
         error: None,
         metadata: None,
     };

--- a/src-tauri/src/scheduled/runner.rs
+++ b/src-tauri/src/scheduled/runner.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::agent::{AgentConfig, AgentSessionManager};
 use crate::mcp::types::MCPContent;
-use crate::models::chat::{Message, MESSAGE_SOURCE_SCHEDULED_TASK};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::{AssistantRepository, ScheduledTaskRepository, SessionRepository};
 use crate::scheduled::ScheduleTimezone;
 use crate::services::WorkspaceService;
@@ -242,7 +242,7 @@ async fn execute_task(
         tool_use: None,
         created_at: now_ts,
         updated_at: now_ts,
-        source: Some(MESSAGE_SOURCE_SCHEDULED_TASK.to_string()),
+        source: Some(MessageSource::ScheduledTask),
         error: None,
         metadata: None,
     };

--- a/src-tauri/src/server/handlers/messages.rs
+++ b/src-tauri/src/server/handlers/messages.rs
@@ -1,4 +1,5 @@
 use crate::agent::AgentSessionManager;
+use crate::models::chat::MessageSource;
 use std::sync::Arc;
 use warp::{http::StatusCode, Rejection, Reply};
 
@@ -59,7 +60,7 @@ pub async fn send_message(
         &manager,
         &id,
         body.content,
-        body.source.or_else(|| Some("api".to_string())),
+        body.source.or(Some(MessageSource::Api)),
     )
     .await
     {

--- a/src-tauri/src/server/handlers/sessions.rs
+++ b/src-tauri/src/server/handlers/sessions.rs
@@ -1,4 +1,5 @@
 use crate::agent::AgentSessionManager;
+use crate::models::chat::MessageSource;
 use std::sync::Arc;
 use warp::{http::StatusCode, Rejection, Reply};
 
@@ -12,7 +13,7 @@ pub async fn create_session(
     match crate::services::AgentService::spawn_agent_with_source(
         &manager,
         body,
-        Some("api".to_string()),
+        Some(MessageSource::Api),
     )
     .await
     {

--- a/src-tauri/src/server/handlers/types.rs
+++ b/src-tauri/src/server/handlers/types.rs
@@ -1,4 +1,5 @@
 pub use crate::agent::types::CreateSessionRequest;
+use crate::models::chat::MessageSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
@@ -10,7 +11,7 @@ pub struct HealthResponse {
 #[derive(Debug, Deserialize)]
 pub struct SendMessageRequest {
     pub content: String,
-    pub source: Option<String>,
+    pub source: Option<MessageSource>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -1,7 +1,7 @@
 use crate::agent::types::{CreateSessionRequest, CreateSessionResponse, SessionLineageMeta};
 use crate::agent::AgentSessionManager;
 use crate::mcp::types::MCPContent;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::SessionMetadata;
 use crate::session::get_session_manager;
 use std::collections::HashMap;
@@ -179,7 +179,7 @@ impl AgentService {
         manager: &AgentSessionManager,
         body: CreateSessionRequest,
     ) -> Result<CreateSessionResponse, String> {
-        Self::spawn_agent_with_source(manager, body, Some("agent_tool".to_string())).await
+        Self::spawn_agent_with_source(manager, body, Some(MessageSource::AgentTool)).await
     }
 
     /// Create a new session with assistant ID and initial request, tagging the initial
@@ -187,7 +187,7 @@ impl AgentService {
     pub async fn spawn_agent_with_source(
         manager: &AgentSessionManager,
         body: CreateSessionRequest,
-        message_source: Option<String>,
+        message_source: Option<MessageSource>,
     ) -> Result<CreateSessionResponse, String> {
         use crate::repositories::assistant_repository::AssistantRepository;
         use crate::repositories::session_repository::SessionRepository;
@@ -539,7 +539,7 @@ impl AgentService {
         manager: &AgentSessionManager,
         session_id: &str,
         content: String,
-        source: Option<String>,
+        source: Option<MessageSource>,
     ) -> Result<SendSessionMessageResponse, String> {
         let persisted_session = manager
             .get_session(session_id)

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -2,12 +2,13 @@ use serde_json::json;
 use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_message_for_messages,
-    build_compact_summary_text, fit_compaction_request_messages_to_limit,
-    merge_consecutive_user_messages, normalize_request_messages,
-    preview_background_compaction_selection, preview_preflight_compaction_selection,
-    resolve_context_management_settings, resolve_preserved_calibration_ratio,
-    should_skip_same_tail_compaction, should_trigger_background_compaction,
-    should_trigger_post_response_compaction, uses_compaction_strategy,
+    build_compact_summary_text, build_compaction_preservation_hints,
+    fit_compaction_request_messages_to_limit, merge_consecutive_user_messages,
+    normalize_request_messages, preview_background_compaction_selection,
+    preview_preflight_compaction_selection, resolve_context_management_settings,
+    resolve_preserved_calibration_ratio, should_skip_same_tail_compaction,
+    should_trigger_background_compaction, should_trigger_post_response_compaction,
+    uses_compaction_strategy,
 };
 use tauri_mcp_agent_lib::agent::llm::context_selector::*;
 use tauri_mcp_agent_lib::agent::llm::response::build_post_response_compaction_snapshot;
@@ -271,6 +272,71 @@ fn test_find_background_compaction_split_index_does_not_treat_ui_messages_as_ext
     let preview = preview_background_compaction_selection(&[request]);
     assert_eq!(preview.compacted_ids, vec!["m0"]);
     assert!(preview.preserved_ids.is_empty());
+}
+
+#[test]
+fn test_build_compaction_preservation_hints_capture_active_request_and_references() {
+    let mut read_file = make_message("m0", "assistant", "Reading types file");
+    read_file.tool_calls = Some(vec![AgentToolCall {
+        id: "call_A".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "read_file".to_string(),
+            arguments: json!({
+                "path": "src/lib/types.ts"
+            })
+            .to_string(),
+        },
+    }]);
+
+    let mut tool_result = make_message(
+        "m1",
+        "tool",
+        "interface InterfaceA { id: string }\ninterface InterfaceB { name: string }",
+    );
+    tool_result.tool_call_id = Some("call_A".to_string());
+
+    let request = make_message(
+        "m2",
+        "user",
+        "Rename `InterfaceB` to `InterfaceC` after the `read_file` result.",
+    );
+
+    let hints = build_compaction_preservation_hints(&[read_file, tool_result, request]);
+    assert_eq!(hints.active_request.len(), 1);
+    assert!(hints.active_request[0].contains("InterfaceB"));
+    assert!(hints.active_request[0].contains("InterfaceC"));
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("src/lib/types.ts")),
+        "required references should keep the referenced file path"
+    );
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("InterfaceB")),
+        "required references should keep the referenced existing symbol"
+    );
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("InterfaceC")),
+        "required references should keep the requested target symbol"
+    );
+}
+
+#[test]
+fn test_build_compaction_preservation_hints_ignore_synthetic_user_messages() {
+    let mut synthetic = make_message("compaction-instruction-legacy", "user", "Synthetic message");
+    synthetic.source = Some(MessageSource::CompactionInstruction);
+
+    let hints = build_compaction_preservation_hints(&[synthetic]);
+    assert!(hints.active_request.is_empty());
+    assert!(hints.required_references.is_empty());
 }
 
 #[test]

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -340,6 +340,102 @@ fn test_build_compaction_preservation_hints_ignore_synthetic_user_messages() {
 }
 
 #[test]
+fn test_build_compaction_preservation_hints_carry_forward_prior_summary_open_requests() {
+    let prior_summary = "\
+### Stable Context
+- Existing work item
+
+### Key Decisions & Constraints
+- Keep refactor incremental
+
+### Active Request
+- Refactor `src/lib/file-b.ts`
+
+### Required References
+- Preserve file path `src/lib/file-b.ts`
+- Preserve identifier `InterfaceB`
+
+### Current State
+- Refactor still pending
+
+### Recent Tool Results
+- read_file(path=src/lib/file-b.ts) -> success
+
+### Next Actions
+- Update references";
+    let summary_message = make_compact_summary_message(
+        "m0",
+        "assistant",
+        &build_compact_summary_text(prior_summary, &[]),
+    );
+    let request = make_message("m1", "user", "Also update `src/lib/file-c.ts`.");
+
+    let hints = build_compaction_preservation_hints(&[summary_message, request]);
+
+    assert!(
+        hints
+            .active_request
+            .iter()
+            .any(|hint| hint.contains("src/lib/file-b.ts")),
+        "prior unresolved request should be carried forward from the previous summary"
+    );
+    assert!(
+        hints
+            .active_request
+            .iter()
+            .any(|hint| hint.contains("src/lib/file-c.ts")),
+        "new request should still be included"
+    );
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("InterfaceB")),
+        "prior required references should be carried forward from the previous summary"
+    );
+}
+
+#[test]
+fn test_build_compaction_preservation_hints_filter_non_identifier_backticks_and_non_paths() {
+    let request = make_message(
+        "m0",
+        "user",
+        "Run `pnpm refactor:validate`, keep version 18.3 noted, and rename `ActualSymbol` in `src/lib/types.ts`.",
+    );
+
+    let hints = build_compaction_preservation_hints(&[request]);
+
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("ActualSymbol")),
+        "real identifier references should be preserved"
+    );
+    assert!(
+        hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("src/lib/types.ts")),
+        "real file paths should be preserved"
+    );
+    assert!(
+        !hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("pnpm refactor:validate")),
+        "command-like backtick spans should not consume required reference slots"
+    );
+    assert!(
+        !hints
+            .required_references
+            .iter()
+            .any(|hint| hint.contains("18.3")),
+        "bare dotted values should not be treated as file paths"
+    );
+}
+
+#[test]
 fn test_build_post_response_compaction_snapshot_appends_pending_message_once() {
     let request = make_message("m0", "user", "Latest real request");
     let pending = make_message("m1", "assistant", "Pending assistant turn");

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -2,14 +2,15 @@ use serde_json::json;
 use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_message_for_messages,
-    build_compact_summary_text, find_preflight_compaction_split_index,
-    fit_compaction_request_messages_to_limit, merge_consecutive_user_messages,
-    normalize_request_messages, resolve_context_management_settings,
-    resolve_preserved_calibration_ratio, should_skip_same_tail_compaction,
-    should_trigger_background_compaction, should_trigger_post_response_compaction,
-    uses_compaction_strategy,
+    build_compact_summary_text, find_background_compaction_split_index,
+    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
+    merge_consecutive_user_messages, normalize_request_messages,
+    resolve_context_management_settings, resolve_preserved_calibration_ratio,
+    should_skip_same_tail_compaction, should_trigger_background_compaction,
+    should_trigger_post_response_compaction, uses_compaction_strategy,
 };
 use tauri_mcp_agent_lib::agent::llm::context_selector::*;
+use tauri_mcp_agent_lib::agent::llm::response::build_post_response_compaction_snapshot;
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
 use tauri_mcp_agent_lib::agent::types::{ToolCall as AgentToolCall, ToolCallFunction};
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
@@ -176,6 +177,70 @@ fn test_find_preflight_compaction_split_index_keeps_unresolved_tool_chain_tail()
 
     let idx = find_preflight_compaction_split_index(&[intro, assistant, tool_result]);
     assert_eq!(idx, 1);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_preserves_active_request_before_deferred_tool_execution(
+) {
+    let request = make_message("m0", "user", "Refactor auth to JWT");
+
+    let mut assistant = make_message("m1", "assistant", "Calling tools");
+    assistant.tool_calls = Some(vec![AgentToolCall {
+        id: "call_A".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "toolA".to_string(),
+            arguments: "{}".to_string(),
+        },
+    }]);
+
+    let idx = find_background_compaction_split_index(&[request, assistant]);
+    assert_eq!(idx, 0);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_ignores_internal_synthetic_user_messages() {
+    let mut synthetic = make_message("m1", "user", "Synthetic compaction prompt");
+    synthetic.source = Some("compaction-instruction".to_string());
+
+    assert!(!synthetic.is_external_request_message());
+
+    let idx = find_background_compaction_split_index(&[synthetic]);
+    assert_eq!(idx, 1);
+}
+
+#[test]
+fn test_internal_synthetic_user_message_uses_compaction_instruction_id_fallback() {
+    let synthetic = make_message(
+        "compaction-instruction-legacy",
+        "user",
+        "Synthetic compaction prompt",
+    );
+
+    assert!(synthetic.is_internal_synthetic_user_message());
+    assert!(!synthetic.is_external_request_message());
+}
+
+#[test]
+fn test_find_background_compaction_split_index_preserves_latest_external_request_block() {
+    let older = make_message("m0", "user", "Older request");
+
+    let newer = make_message("m1", "user", "Latest real request");
+    let assistant = make_message("m2", "assistant", "Working on latest request");
+
+    let idx = find_background_compaction_split_index(&[older, newer, assistant]);
+    assert_eq!(idx, 0);
+}
+
+#[test]
+fn test_build_post_response_compaction_snapshot_appends_pending_message_once() {
+    let request = make_message("m0", "user", "Latest real request");
+    let pending = make_message("m1", "assistant", "Pending assistant turn");
+
+    let snapshot = build_post_response_compaction_snapshot(&[request], Some(&pending));
+    assert_eq!(snapshot.len(), 2);
+    assert_eq!(snapshot[0].id, "m0");
+    assert_eq!(snapshot[1].id, "m1");
 }
 
 #[test]
@@ -887,9 +952,8 @@ fn test_conservative_preflight_prompt_tokens_fallback_biases_full_estimate_upwar
 #[test]
 fn test_conservative_preflight_prompt_tokens_uses_latest_prompt_anchor() {
     let earlier_user = make_message("u1", "user", &"Earlier context ".repeat(1200));
-    let older_anchor_clone_for_bpe;
     let older_anchor = make_message("a1", "assistant", "Older grounded output");
-    older_anchor_clone_for_bpe = older_anchor.clone();
+    let older_anchor_clone_for_bpe = older_anchor.clone();
 
     let newer_user = make_message(
         "u2",
@@ -1182,7 +1246,7 @@ fn test_truncate_single_oversized_message_to_fit_conservative_limit_truncates_us
     let limit = 600;
 
     let truncated = truncate_single_oversized_message_to_fit_conservative_limit(
-        &[oversized.clone()],
+        std::slice::from_ref(&oversized),
         limit,
         10,
         5,
@@ -1274,9 +1338,14 @@ fn test_fit_compaction_request_messages_to_limit_rejects_summary_only_payload() 
 fn test_fit_compaction_request_messages_to_limit_truncates_single_raw_message() {
     let oversized = make_message("user-1", "user", &"very large compact input ".repeat(600));
 
-    let fitted =
-        fit_compaction_request_messages_to_limit(&[oversized.clone()], "openai", 600, 10, 5)
-            .expect("single raw message should be truncated to fit compaction request");
+    let fitted = fit_compaction_request_messages_to_limit(
+        std::slice::from_ref(&oversized),
+        "openai",
+        600,
+        10,
+        5,
+    )
+    .expect("single raw message should be truncated to fit compaction request");
 
     assert_eq!(fitted.len(), 1);
     assert_ne!(

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -14,7 +14,7 @@ use tauri_mcp_agent_lib::agent::llm::response::build_post_response_compaction_sn
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
 use tauri_mcp_agent_lib::agent::types::{ToolCall as AgentToolCall, ToolCallFunction};
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
-use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 
 fn make_message(id: &str, role: &str, text: &str) -> Message {
     Message {
@@ -48,7 +48,7 @@ fn make_message_simple(role: &str, text: &str) -> Message {
 
 fn make_compact_summary_message(id: &str, role: &str, text: &str) -> Message {
     let mut message = make_message(id, role, text);
-    message.source = Some("compact-summary".to_string());
+    message.source = Some(MessageSource::CompactSummary);
     message
 }
 
@@ -201,7 +201,7 @@ fn test_find_background_compaction_split_index_preserves_active_request_before_d
 #[test]
 fn test_find_background_compaction_split_index_ignores_internal_synthetic_user_messages() {
     let mut synthetic = make_message("m1", "user", "Synthetic compaction prompt");
-    synthetic.source = Some("compaction-instruction".to_string());
+    synthetic.source = Some(MessageSource::CompactionInstruction);
 
     assert!(!synthetic.is_external_request_message());
 
@@ -1462,7 +1462,7 @@ fn test_build_compact_summary_message_for_messages_reuses_normal_request_wrapper
 
     assert_eq!(summary_message.id, "compact-summary-test-session");
     assert_eq!(summary_message.role, "assistant");
-    assert_eq!(summary_message.source.as_deref(), Some("compact-summary"));
+    assert_eq!(summary_message.source, Some(MessageSource::CompactSummary));
 
     let MCPContent::Text { text, .. } = &summary_message.content[0] else {
         panic!("expected compact summary text");

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -240,6 +240,40 @@ fn test_find_background_compaction_split_index_preserves_latest_external_request
 }
 
 #[test]
+fn test_find_background_compaction_split_index_preserves_channel_request_block() {
+    let mut request = make_message("m0", "user", "Request from channel");
+    request.source = Some(MessageSource::Channel);
+    let assistant = make_message("m1", "assistant", "Working on channel request");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_preserves_scheduled_task_request_block() {
+    let mut request = make_message("m0", "user", "Run scheduled sync");
+    request.source = Some(MessageSource::ScheduledTask);
+    let assistant = make_message("m1", "assistant", "Working on scheduled task");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_does_not_treat_ui_messages_as_external_requests() {
+    let mut request = make_message("m0", "user", "UI-triggered helper event");
+    request.source = Some(MessageSource::Ui);
+
+    assert!(!request.is_external_request_message());
+
+    let preview = preview_background_compaction_selection(&[request]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert!(preview.preserved_ids.is_empty());
+}
+
+#[test]
 fn test_build_post_response_compaction_snapshot_appends_pending_message_once() {
     let request = make_message("m0", "user", "Latest real request");
     let pending = make_message("m1", "assistant", "Pending assistant turn");

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -2,9 +2,9 @@ use serde_json::json;
 use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_message_for_messages,
-    build_compact_summary_text, find_background_compaction_split_index,
-    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
+    build_compact_summary_text, fit_compaction_request_messages_to_limit,
     merge_consecutive_user_messages, normalize_request_messages,
+    preview_background_compaction_selection, preview_preflight_compaction_selection,
     resolve_context_management_settings, resolve_preserved_calibration_ratio,
     should_skip_same_tail_compaction, should_trigger_background_compaction,
     should_trigger_post_response_compaction, uses_compaction_strategy,
@@ -114,8 +114,9 @@ fn test_find_preflight_compaction_split_index_preserves_latest_user_turn() {
     let earlier = make_message("m0", "assistant", "Earlier context");
     let latest_user = make_message("m1", "user", &"latest request ".repeat(200));
 
-    let idx = find_preflight_compaction_split_index(&[earlier, latest_user]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[earlier, latest_user]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1"]);
 }
 
 #[test]
@@ -123,8 +124,9 @@ fn test_find_preflight_compaction_split_index_preserves_latest_non_tool_turn() {
     let earlier = make_message("m0", "user", "Earlier user context");
     let latest_assistant = make_message("m1", "assistant", "Latest non-tool turn");
 
-    let idx = find_preflight_compaction_split_index(&[earlier, latest_assistant]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[earlier, latest_assistant]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1"]);
 }
 
 #[test]
@@ -144,8 +146,9 @@ fn test_find_preflight_compaction_split_index_allows_compacting_latest_tool_resu
     let mut tool_result = make_message("m2", "tool", &"very large tool result ".repeat(200));
     tool_result.tool_call_id = Some("call_A".to_string());
 
-    let idx = find_preflight_compaction_split_index(&[intro, assistant, tool_result]);
-    assert_eq!(idx, 3);
+    let preview = preview_preflight_compaction_selection(&[intro, assistant, tool_result]);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -175,8 +178,9 @@ fn test_find_preflight_compaction_split_index_keeps_unresolved_tool_chain_tail()
     let mut tool_result = make_message("m2", "tool", "result A");
     tool_result.tool_call_id = Some("call_A".to_string());
 
-    let idx = find_preflight_compaction_split_index(&[intro, assistant, tool_result]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[intro, assistant, tool_result]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1", "m2"]);
 }
 
 #[test]
@@ -194,8 +198,9 @@ fn test_find_background_compaction_split_index_preserves_active_request_before_d
         },
     }]);
 
-    let idx = find_background_compaction_split_index(&[request, assistant]);
-    assert_eq!(idx, 0);
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
 }
 
 #[test]
@@ -205,8 +210,9 @@ fn test_find_background_compaction_split_index_ignores_internal_synthetic_user_m
 
     assert!(!synthetic.is_external_request_message());
 
-    let idx = find_background_compaction_split_index(&[synthetic]);
-    assert_eq!(idx, 1);
+    let preview = preview_background_compaction_selection(&[synthetic]);
+    assert_eq!(preview.compacted_ids, vec!["m1"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -228,8 +234,9 @@ fn test_find_background_compaction_split_index_preserves_latest_external_request
     let newer = make_message("m1", "user", "Latest real request");
     let assistant = make_message("m2", "assistant", "Working on latest request");
 
-    let idx = find_background_compaction_split_index(&[older, newer, assistant]);
-    assert_eq!(idx, 0);
+    let preview = preview_background_compaction_selection(&[older, newer, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1", "m2"]);
 }
 
 #[test]
@@ -277,8 +284,9 @@ fn test_preflight_compaction_split_after_removing_incomplete_tool_chains() {
         current_tool,
     ]);
 
-    let idx = find_preflight_compaction_split_index(&cleaned);
-    assert_eq!(idx, cleaned.len());
+    let preview = preview_preflight_compaction_selection(&cleaned);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2", "m3"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -321,10 +329,9 @@ fn test_normalize_request_messages_removes_stale_incomplete_tool_chains_before_c
     assert!(normalized[1].tool_calls.is_none());
     assert_eq!(normalized[2].id, "m2");
     assert_eq!(normalized[3].id, "m3");
-    assert_eq!(
-        find_preflight_compaction_split_index(&normalized),
-        normalized.len()
-    );
+    let preview = preview_preflight_compaction_selection(&normalized);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2", "m3"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -1,0 +1,74 @@
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
+
+fn make_message(source: Option<MessageSource>) -> Message {
+    Message {
+        id: "msg-1".to_string(),
+        session_id: "session-1".to_string(),
+        role: "user".to_string(),
+        content: vec![MCPContent::Text {
+            text: "hello".to_string(),
+            is_error: None,
+        }],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: None,
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        created_at: 1,
+        updated_at: 1,
+        source,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[test]
+fn message_source_deserializes_known_values_to_typed_variants() {
+    let message: Message = serde_json::from_value(serde_json::json!({
+        "id": "msg-1",
+        "sessionId": "session-1",
+        "role": "user",
+        "content": [{ "type": "text", "text": "hello" }],
+        "createdAt": 1,
+        "updatedAt": 1,
+        "source": "channel"
+    }))
+    .expect("message should deserialize");
+
+    assert_eq!(message.source, Some(MessageSource::Channel));
+}
+
+#[test]
+fn message_source_deserializes_unknown_values_without_failing() {
+    let message: Message = serde_json::from_value(serde_json::json!({
+        "id": "msg-1",
+        "sessionId": "session-1",
+        "role": "user",
+        "content": [{ "type": "text", "text": "hello" }],
+        "createdAt": 1,
+        "updatedAt": 1,
+        "source": "future-source"
+    }))
+    .expect("message should deserialize");
+
+    assert_eq!(
+        message.source,
+        Some(MessageSource::Unknown("future-source".to_string()))
+    );
+}
+
+#[test]
+fn message_source_serializes_to_wire_strings() {
+    let message = make_message(Some(MessageSource::SwarmLegacy));
+
+    let value = serde_json::to_value(&message).expect("message should serialize");
+    assert_eq!(
+        value.get("source"),
+        Some(&serde_json::json!("swarm_legacy"))
+    );
+}

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -72,3 +72,16 @@ fn message_source_serializes_to_wire_strings() {
         Some(&serde_json::json!("swarm_legacy"))
     );
 }
+
+#[test]
+fn external_request_message_semantics_match_source_policy() {
+    assert!(make_message(None).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Api)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::SwarmLegacy)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Channel)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::ScheduledTask)).is_external_request_message());
+
+    assert!(!make_message(Some(MessageSource::Ui)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::Tool)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::AgentTool)).is_external_request_message());
+}

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -72,3 +72,18 @@ fn message_source_serializes_to_wire_strings() {
         Some(&serde_json::json!("swarm_legacy"))
     );
 }
+
+#[test]
+fn unknown_source_still_uses_legacy_id_fallback_for_classification_helpers() {
+    let mut compact_summary =
+        make_message(Some(MessageSource::Unknown("future-source".to_string())));
+    compact_summary.id = "compact-summary-legacy".to_string();
+    assert!(compact_summary.is_compact_summary());
+
+    let mut compaction_instruction =
+        make_message(Some(MessageSource::Unknown("future-source".to_string())));
+    compaction_instruction.id = "compaction-instruction-legacy".to_string();
+    assert!(compaction_instruction.is_compaction_instruction());
+    assert!(compaction_instruction.is_internal_synthetic_user_message());
+    assert!(!compaction_instruction.is_external_request_message());
+}

--- a/src-tauri/tests/tool_result_spillover_tests.rs
+++ b/src-tauri/tests/tool_result_spillover_tests.rs
@@ -7,7 +7,7 @@ use tauri_mcp_agent_lib::agent::tools::{
     TOOL_RESULT_SPILLOVER_THRESHOLD_BYTES,
 };
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, ServiceInfo};
-use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 use tauri_mcp_agent_lib::repositories::{
     MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
     SqliteSessionRepository,
@@ -90,7 +90,7 @@ fn make_tool_message(session_id: &str, tool_call_id: &str, text: &str) -> Messag
         usage: None,
         created_at: 0,
         updated_at: 0,
-        source: Some("tool".to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: None,
     }
@@ -153,7 +153,7 @@ async fn spillover_pointer_is_what_gets_persisted_to_repository() {
         usage: None,
         created_at: 0,
         updated_at: 0,
-        source: Some("tool".to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: None,
     };


### PR DESCRIPTION
## Summary

- preserve the active external request block in the raw tail during post-response/background compaction
- centralize message source classification helpers and restore legacy compaction-instruction id fallback
- split the compaction instruction builder into smaller readable pieces and add regression coverage

## Validation

- cargo test --manifest-path .\src-tauri\Cargo.toml --test llm_context_tests
- cargo clippy --manifest-path .\src-tauri\Cargo.toml --test llm_context_tests -- -D warnings

## Notes

- `src/lib/generated/builtin-services.ts` was intentionally left out because it is unrelated to this Rust compaction work.
- Follow-up cleanup/debt is tracked separately in #1178 and #1179.