### PR TITLE
Type Message.source across Rust boundary

### DIFF
--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -2,7 +2,7 @@ use crate::agent::context::registry::ContextRegistry;
 use crate::agent::events::AgentEventDispatcher;
 use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
 use crate::agent::tauri_events::TauriEventDispatcher;
-use crate::models::chat::MESSAGE_SOURCE_RECOVERY;
+use crate::models::chat::MessageSource;
 use crate::repositories::message_repository::MessageRepository as MessageRepositoryTrait;
 use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::SessionStatus;
@@ -76,7 +76,7 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
                 tool_use: None,
                 created_at: now,
                 updated_at: now,
-                source: Some(MESSAGE_SOURCE_RECOVERY.to_string()),
+                source: Some(MessageSource::Recovery),
                 error: None,
                 metadata: None,
             });

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -362,6 +362,38 @@ fn estimate_compaction_non_message_tokens(
     (system_prompt_tokens, tools_tokens)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionSelectionPreview {
+    pub compacted_ids: Vec<String>,
+    pub preserved_ids: Vec<String>,
+}
+
+fn build_compaction_selection_preview(
+    messages: &[Message],
+    split_idx: usize,
+) -> CompactionSelectionPreview {
+    let split_idx = split_idx.min(messages.len());
+
+    CompactionSelectionPreview {
+        compacted_ids: messages[..split_idx]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+        preserved_ids: messages[split_idx..]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+    }
+}
+
+pub fn preview_preflight_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
+    build_compaction_selection_preview(messages, find_preflight_compaction_split_index(messages))
+}
+
+pub fn preview_background_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
+    build_compaction_selection_preview(messages, find_background_compaction_split_index(messages))
+}
+
 /// Determines the compactable prefix for preflight compaction.
 ///
 /// Unlike background compaction, preflight compaction must preserve the newest
@@ -373,7 +405,7 @@ fn estimate_compaction_non_message_tokens(
 /// - latest `user`/non-tool tail: preserve the last message
 /// - latest `tool` tail: compact as much as `find_compaction_split_index()` allows
 /// - unresolved tool chain: preserve the full unresolved tail
-pub fn find_preflight_compaction_split_index(messages: &[Message]) -> usize {
+fn find_preflight_compaction_split_index(messages: &[Message]) -> usize {
     if messages.is_empty() {
         return 0;
     }
@@ -401,7 +433,7 @@ fn find_latest_external_request_block_start(messages: &[Message]) -> Option<usiz
     Some(block_start)
 }
 
-pub fn find_background_compaction_split_index(messages: &[Message]) -> usize {
+fn find_background_compaction_split_index(messages: &[Message]) -> usize {
     let unresolved_boundary =
         crate::agent::llm::context_selector::find_compaction_split_index(messages);
 

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::agent::state::DeferredWorkflowStep;
 use crate::mcp::types::MCPContent;
-use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACTION_INSTRUCTION};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -166,7 +166,7 @@ fn build_compaction_instruction_message(
         usage: None,
         created_at,
         updated_at: created_at,
-        source: Some(MESSAGE_SOURCE_COMPACTION_INSTRUCTION.to_string()),
+        source: Some(MessageSource::CompactionInstruction),
         error: None,
         metadata: None,
     }

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -4,14 +4,12 @@ pub(crate) mod orchestration;
 pub(crate) mod request;
 
 pub use compaction::{
-    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
-    should_skip_same_tail_compaction,
+    fit_compaction_request_messages_to_limit, preview_background_compaction_selection,
+    preview_preflight_compaction_selection, should_skip_same_tail_compaction,
     should_trigger_background_compaction, should_trigger_post_response_compaction,
     trigger_manual_compaction_for_session, trigger_post_response_compaction_if_needed,
     trigger_preflight_compaction_for_session,
 };
-#[doc(hidden)]
-pub use compaction::find_background_compaction_split_index;
 pub use context::{
     resolve_context_management_settings, uses_compaction_strategy, ContextManagementSettings,
 };

--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -2,7 +2,7 @@ use crate::agent::references::build_default_registry;
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::{Message, MESSAGE_SOURCE_COMPACT_SUMMARY};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::CompactContextRepository;
 use crate::repositories::{SessionRepository, SessionStatus};
@@ -95,7 +95,7 @@ pub fn build_compact_summary_message(session_id: &str, text: String, created_at:
             text,
             is_error: None,
         }],
-        source: Some(MESSAGE_SOURCE_COMPACT_SUMMARY.to_string()),
+        source: Some(MessageSource::CompactSummary),
         created_at,
         updated_at: created_at,
         tool_calls: None,

--- a/src-tauri/src/agent/session_manager/channel.rs
+++ b/src-tauri/src/agent/session_manager/channel.rs
@@ -1,7 +1,7 @@
 use super::AgentSessionManager;
 use crate::agent::channel_routing::{resolve_auto_routed_channel_target, ChannelRouteCandidate};
 use crate::mcp::types::ChannelNotification;
-use crate::models::chat::{Message, MESSAGE_SOURCE_CHANNEL};
+use crate::models::chat::{Message, MessageSource};
 use std::collections::HashMap;
 
 pub async fn inject_channel_notification(
@@ -90,7 +90,7 @@ fn build_channel_message(
         usage: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_CHANNEL.to_string()),
+        source: Some(MessageSource::Channel),
         error: None,
         metadata: Some(serde_json::json!({
             "channel": {

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -1,7 +1,7 @@
 use crate::agent::state::AgentSession;
 use crate::mcp::types::MCPContent;
 use crate::mcp::MCPServiceProxyManager;
-use crate::models::chat::{Message, MESSAGE_SOURCE_TOOL};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::settings_repository::SettingsRepository;
 use crate::services::WorkspaceService;
 use base64::engine::general_purpose;
@@ -198,7 +198,7 @@ pub fn create_tool_result_message(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: structured_content.map(|value| {
             serde_json::json!({
@@ -247,7 +247,7 @@ pub fn create_error_tool_result(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata,
     }
@@ -614,7 +614,7 @@ pub fn create_tool_result_message_with_content(
         tool_use: None,
         created_at: now,
         updated_at: now,
-        source: Some(MESSAGE_SOURCE_TOOL.to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: build_tool_message_metadata(tool_error, structured_content),
     }

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -4,7 +4,7 @@ use crate::mcp::types::ChannelNotification;
 use crate::mcp::types::ChannelPermissionVerdict;
 use crate::mcp::types::ServiceContext;
 use crate::models::chat::Message;
-use crate::models::chat::MESSAGE_SOURCE_UI;
+use crate::models::chat::MessageSource;
 use crate::repositories::message_repository::MessageRepository;
 use crate::repositories::{CompactContextRecord, SessionMetadata, SessionRepository};
 use crate::services::AgentService;
@@ -219,7 +219,7 @@ fn create_ui_tool_call_message(
             usage: None,
             created_at: now,
             updated_at: now,
-            source: Some(MESSAGE_SOURCE_UI.to_string()),
+            source: Some(MessageSource::Ui),
             error: None,
             metadata: None,
         },

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -233,7 +233,7 @@ pub async fn message_to_session(
         manager,
         &session_id,
         message_text,
-        Some("agent_tool".to_string()),
+        Some(MessageSource::AgentTool),
     )
     .await
     {
@@ -524,3 +524,4 @@ pub async fn compact_session_context(
     Ok(SuccessHint::new(message, vec![])
         .to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
+use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -9,6 +9,7 @@ use crate::mcp::builtin::session_api::utils::{
     build_agent_tool_data, check_session_next_actions, read_required_string,
 };
 use crate::mcp::types::MCPResult;
+use crate::models::chat::MessageSource;
 use crate::repositories::SessionStatus;
 
 use super::super::AgentServer;
@@ -524,4 +525,3 @@ pub async fn compact_session_context(
     Ok(SuccessHint::new(message, vec![])
         .to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
-use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -5,6 +5,7 @@ use tokio::time::sleep;
 use crate::agent::AgentSessionManager;
 use crate::mcp::builtin::error_guidance::ErrorCategory;
 use crate::mcp::types::MCPResult;
+use crate::models::chat::MessageSource;
 use crate::repositories::assistant_repository::AssistantRepository;
 use crate::repositories::session_repository::SessionRepository;
 
@@ -662,4 +663,3 @@ pub async fn handle_tool_call(
         _ => Err(format!("Unknown tool: {}", tool_name)),
     }
 }
-use crate::models::chat::MessageSource;

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -109,7 +109,7 @@ pub async fn handle_tool_call(
             let response = crate::services::AgentService::spawn_agent_with_source(
                 manager,
                 request,
-                Some("swarm_legacy".to_string()),
+                Some(MessageSource::SwarmLegacy),
             )
             .await
             .map_err(|e| {
@@ -390,7 +390,7 @@ pub async fn handle_tool_call(
                 manager,
                 &session_id,
                 content,
-                Some("swarm_legacy".to_string()),
+                Some(MessageSource::SwarmLegacy),
             )
             .await
             {
@@ -662,3 +662,4 @@ pub async fn handle_tool_call(
         _ => Err(format!("Unknown tool: {}", tool_name)),
     }
 }
+use crate::models::chat::MessageSource;

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -139,9 +139,10 @@ pub struct Message {
 
 impl Message {
     fn source_with_legacy_fallback(&self) -> Option<MessageSource> {
-        self.source
-            .clone()
-            .or_else(|| MessageSource::from_id(&self.id))
+        match self.source.as_ref() {
+            Some(MessageSource::Unknown(_)) | None => MessageSource::from_id(&self.id),
+            Some(source) => Some(source.clone()),
+        }
     }
 
     pub fn is_compact_summary(&self) -> bool {

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -1,15 +1,7 @@
 use crate::agent::types::ToolCall;
 use crate::mcp::types::MCPContent;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-pub(crate) const MESSAGE_SOURCE_CHANNEL: &str = "channel";
-pub(crate) const MESSAGE_SOURCE_COMPACT_SUMMARY: &str = "compact-summary";
-pub(crate) const MESSAGE_SOURCE_COMPACTION_INSTRUCTION: &str = "compaction-instruction";
-pub(crate) const MESSAGE_SOURCE_RECOVERY: &str = "recovery";
-pub(crate) const MESSAGE_SOURCE_SCHEDULED_TASK: &str = "scheduled_task";
-pub(crate) const MESSAGE_SOURCE_TOOL: &str = "tool";
-pub(crate) const MESSAGE_SOURCE_UI: &str = "ui";
 
 const COMPACT_SUMMARY_ID_PREFIX: &str = "compact-summary-";
 const COMPACTION_INSTRUCTION_ID_PREFIX: &str = "compaction-instruction-";
@@ -22,8 +14,12 @@ fn default_timestamp() -> i64 {
         .as_millis() as i64
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KnownMessageSource {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MessageSource {
+    Assistant,
+    Api,
+    AgentTool,
+    SwarmLegacy,
     Channel,
     CompactSummary,
     CompactionInstruction,
@@ -31,19 +27,42 @@ enum KnownMessageSource {
     ScheduledTask,
     Tool,
     Ui,
+    Unknown(String),
 }
 
-impl KnownMessageSource {
-    fn from_source(source: &str) -> Option<Self> {
-        match source {
-            MESSAGE_SOURCE_CHANNEL => Some(Self::Channel),
-            MESSAGE_SOURCE_COMPACT_SUMMARY => Some(Self::CompactSummary),
-            MESSAGE_SOURCE_COMPACTION_INSTRUCTION => Some(Self::CompactionInstruction),
-            MESSAGE_SOURCE_RECOVERY => Some(Self::Recovery),
-            MESSAGE_SOURCE_SCHEDULED_TASK => Some(Self::ScheduledTask),
-            MESSAGE_SOURCE_TOOL => Some(Self::Tool),
-            MESSAGE_SOURCE_UI => Some(Self::Ui),
-            _ => None,
+impl MessageSource {
+    pub fn from_raw(source: impl Into<String>) -> Self {
+        let source = source.into();
+        match source.as_str() {
+            "assistant" => Self::Assistant,
+            "api" => Self::Api,
+            "agent_tool" => Self::AgentTool,
+            "swarm_legacy" => Self::SwarmLegacy,
+            "channel" => Self::Channel,
+            "compact-summary" => Self::CompactSummary,
+            "compaction-instruction" => Self::CompactionInstruction,
+            "recovery" => Self::Recovery,
+            "scheduled_task" => Self::ScheduledTask,
+            "tool" => Self::Tool,
+            "ui" => Self::Ui,
+            _ => Self::Unknown(source),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Assistant => "assistant",
+            Self::Api => "api",
+            Self::AgentTool => "agent_tool",
+            Self::SwarmLegacy => "swarm_legacy",
+            Self::Channel => "channel",
+            Self::CompactSummary => "compact-summary",
+            Self::CompactionInstruction => "compaction-instruction",
+            Self::Recovery => "recovery",
+            Self::ScheduledTask => "scheduled_task",
+            Self::Tool => "tool",
+            Self::Ui => "ui",
+            Self::Unknown(source) => source.as_str(),
         }
     }
 
@@ -57,6 +76,29 @@ impl KnownMessageSource {
         }
 
         None
+    }
+
+    fn is_internal_synthetic_user_source(&self) -> bool {
+        matches!(self, Self::CompactionInstruction | Self::Recovery)
+    }
+}
+
+impl Serialize for MessageSource {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let source = String::deserialize(deserializer)?;
+        Ok(Self::from_raw(source))
     }
 }
 
@@ -88,7 +130,7 @@ pub struct Message {
     pub created_at: i64, // Unix timestamp in milliseconds
     #[serde(default = "default_timestamp")]
     pub updated_at: i64, // Unix timestamp in milliseconds
-    pub source: Option<String>,
+    pub source: Option<MessageSource>,
     /// Error information as structured value
     pub error: Option<serde_json::Value>,
     /// Optional metadata for tool execution tracking (mirrors frontend Message.metadata)
@@ -96,37 +138,38 @@ pub struct Message {
 }
 
 impl Message {
-    fn known_source(&self) -> Option<KnownMessageSource> {
+    fn source_with_legacy_fallback(&self) -> Option<MessageSource> {
         self.source
-            .as_deref()
-            .and_then(KnownMessageSource::from_source)
-            .or_else(|| KnownMessageSource::from_id(&self.id))
+            .clone()
+            .or_else(|| MessageSource::from_id(&self.id))
     }
 
     pub fn is_compact_summary(&self) -> bool {
         matches!(
-            self.known_source(),
-            Some(KnownMessageSource::CompactSummary)
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::CompactSummary)
         )
     }
 
     pub fn is_compaction_instruction(&self) -> bool {
         matches!(
-            self.known_source(),
-            Some(KnownMessageSource::CompactionInstruction)
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::CompactionInstruction)
         )
     }
 
     pub fn is_recovery_message(&self) -> bool {
-        matches!(self.known_source(), Some(KnownMessageSource::Recovery))
+        matches!(
+            self.source_with_legacy_fallback(),
+            Some(MessageSource::Recovery)
+        )
     }
 
     pub fn is_internal_synthetic_user_message(&self) -> bool {
         self.role == "user"
-            && matches!(
-                self.known_source(),
-                Some(KnownMessageSource::CompactionInstruction | KnownMessageSource::Recovery)
-            )
+            && self
+                .source_with_legacy_fallback()
+                .is_some_and(|source| source.is_internal_synthetic_user_source())
     }
 
     pub fn is_external_request_message(&self) -> bool {

--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -81,6 +81,13 @@ impl MessageSource {
     fn is_internal_synthetic_user_source(&self) -> bool {
         matches!(self, Self::CompactionInstruction | Self::Recovery)
     }
+
+    fn is_external_request_source(&self) -> bool {
+        matches!(
+            self,
+            Self::Api | Self::SwarmLegacy | Self::Channel | Self::ScheduledTask
+        )
+    }
 }
 
 impl Serialize for MessageSource {
@@ -173,6 +180,10 @@ impl Message {
     }
 
     pub fn is_external_request_message(&self) -> bool {
-        self.role == "user" && !self.is_internal_synthetic_user_message()
+        self.role == "user"
+            && !self.is_internal_synthetic_user_message()
+            && self
+                .source_with_legacy_fallback()
+                .is_none_or(|source| source.is_external_request_source())
     }
 }

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -1,5 +1,5 @@
 use super::error::DbError;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MessageSource};
 use crate::utils::pagination::Page;
 use async_trait::async_trait;
 use sea_orm::{
@@ -290,7 +290,7 @@ impl SqliteMessageRepository {
             tool_use,
             created_at: model.created_at,
             updated_at: model.updated_at,
-            source: model.source,
+            source: model.source.map(MessageSource::from_raw),
             error,
             usage,
             metadata: None,
@@ -339,7 +339,10 @@ impl SqliteMessageRepository {
             tool_use: Set(tool_use_json),
             created_at: Set(message.created_at),
             updated_at: Set(message.updated_at),
-            source: Set(message.source.clone()),
+            source: Set(message
+                .source
+                .as_ref()
+                .map(|source| source.as_str().to_string())),
             error: Set(error_json),
             usage: Set(usage_json),
         })

--- a/src-tauri/src/scheduled/runner.rs
+++ b/src-tauri/src/scheduled/runner.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::agent::{AgentConfig, AgentSessionManager};
 use crate::mcp::types::MCPContent;
-use crate::models::chat::{Message, MESSAGE_SOURCE_SCHEDULED_TASK};
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::{AssistantRepository, ScheduledTaskRepository, SessionRepository};
 use crate::scheduled::ScheduleTimezone;
 use crate::services::WorkspaceService;
@@ -242,7 +242,7 @@ async fn execute_task(
         tool_use: None,
         created_at: now_ts,
         updated_at: now_ts,
-        source: Some(MESSAGE_SOURCE_SCHEDULED_TASK.to_string()),
+        source: Some(MessageSource::ScheduledTask),
         error: None,
         metadata: None,
     };

--- a/src-tauri/src/server/handlers/messages.rs
+++ b/src-tauri/src/server/handlers/messages.rs
@@ -1,4 +1,5 @@
 use crate::agent::AgentSessionManager;
+use crate::models::chat::MessageSource;
 use std::sync::Arc;
 use warp::{http::StatusCode, Rejection, Reply};
 
@@ -59,7 +60,7 @@ pub async fn send_message(
         &manager,
         &id,
         body.content,
-        body.source.or_else(|| Some("api".to_string())),
+        body.source.or(Some(MessageSource::Api)),
     )
     .await
     {

--- a/src-tauri/src/server/handlers/sessions.rs
+++ b/src-tauri/src/server/handlers/sessions.rs
@@ -1,4 +1,5 @@
 use crate::agent::AgentSessionManager;
+use crate::models::chat::MessageSource;
 use std::sync::Arc;
 use warp::{http::StatusCode, Rejection, Reply};
 
@@ -12,7 +13,7 @@ pub async fn create_session(
     match crate::services::AgentService::spawn_agent_with_source(
         &manager,
         body,
-        Some("api".to_string()),
+        Some(MessageSource::Api),
     )
     .await
     {

--- a/src-tauri/src/server/handlers/types.rs
+++ b/src-tauri/src/server/handlers/types.rs
@@ -1,4 +1,5 @@
 pub use crate::agent::types::CreateSessionRequest;
+use crate::models::chat::MessageSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
@@ -10,7 +11,7 @@ pub struct HealthResponse {
 #[derive(Debug, Deserialize)]
 pub struct SendMessageRequest {
     pub content: String,
-    pub source: Option<String>,
+    pub source: Option<MessageSource>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/services/agent_service.rs
+++ b/src-tauri/src/services/agent_service.rs
@@ -1,7 +1,7 @@
 use crate::agent::types::{CreateSessionRequest, CreateSessionResponse, SessionLineageMeta};
 use crate::agent::AgentSessionManager;
 use crate::mcp::types::MCPContent;
-use crate::models::chat::Message;
+use crate::models::chat::{Message, MessageSource};
 use crate::repositories::SessionMetadata;
 use crate::session::get_session_manager;
 use std::collections::HashMap;
@@ -179,7 +179,7 @@ impl AgentService {
         manager: &AgentSessionManager,
         body: CreateSessionRequest,
     ) -> Result<CreateSessionResponse, String> {
-        Self::spawn_agent_with_source(manager, body, Some("agent_tool".to_string())).await
+        Self::spawn_agent_with_source(manager, body, Some(MessageSource::AgentTool)).await
     }
 
     /// Create a new session with assistant ID and initial request, tagging the initial
@@ -187,7 +187,7 @@ impl AgentService {
     pub async fn spawn_agent_with_source(
         manager: &AgentSessionManager,
         body: CreateSessionRequest,
-        message_source: Option<String>,
+        message_source: Option<MessageSource>,
     ) -> Result<CreateSessionResponse, String> {
         use crate::repositories::assistant_repository::AssistantRepository;
         use crate::repositories::session_repository::SessionRepository;
@@ -539,7 +539,7 @@ impl AgentService {
         manager: &AgentSessionManager,
         session_id: &str,
         content: String,
-        source: Option<String>,
+        source: Option<MessageSource>,
     ) -> Result<SendSessionMessageResponse, String> {
         let persisted_session = manager
             .get_session(session_id)

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -14,7 +14,7 @@ use tauri_mcp_agent_lib::agent::llm::response::build_post_response_compaction_sn
 use tauri_mcp_agent_lib::agent::llm::token_utils::*;
 use tauri_mcp_agent_lib::agent::types::{ToolCall as AgentToolCall, ToolCallFunction};
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
-use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 
 fn make_message(id: &str, role: &str, text: &str) -> Message {
     Message {
@@ -48,7 +48,7 @@ fn make_message_simple(role: &str, text: &str) -> Message {
 
 fn make_compact_summary_message(id: &str, role: &str, text: &str) -> Message {
     let mut message = make_message(id, role, text);
-    message.source = Some("compact-summary".to_string());
+    message.source = Some(MessageSource::CompactSummary);
     message
 }
 
@@ -201,7 +201,7 @@ fn test_find_background_compaction_split_index_preserves_active_request_before_d
 #[test]
 fn test_find_background_compaction_split_index_ignores_internal_synthetic_user_messages() {
     let mut synthetic = make_message("m1", "user", "Synthetic compaction prompt");
-    synthetic.source = Some("compaction-instruction".to_string());
+    synthetic.source = Some(MessageSource::CompactionInstruction);
 
     assert!(!synthetic.is_external_request_message());
 
@@ -1462,7 +1462,7 @@ fn test_build_compact_summary_message_for_messages_reuses_normal_request_wrapper
 
     assert_eq!(summary_message.id, "compact-summary-test-session");
     assert_eq!(summary_message.role, "assistant");
-    assert_eq!(summary_message.source.as_deref(), Some("compact-summary"));
+    assert_eq!(summary_message.source, Some(MessageSource::CompactSummary));
 
     let MCPContent::Text { text, .. } = &summary_message.content[0] else {
         panic!("expected compact summary text");

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -240,6 +240,40 @@ fn test_find_background_compaction_split_index_preserves_latest_external_request
 }
 
 #[test]
+fn test_find_background_compaction_split_index_preserves_channel_request_block() {
+    let mut request = make_message("m0", "user", "Request from channel");
+    request.source = Some(MessageSource::Channel);
+    let assistant = make_message("m1", "assistant", "Working on channel request");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_preserves_scheduled_task_request_block() {
+    let mut request = make_message("m0", "user", "Run scheduled sync");
+    request.source = Some(MessageSource::ScheduledTask);
+    let assistant = make_message("m1", "assistant", "Working on scheduled task");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_does_not_treat_ui_messages_as_external_requests() {
+    let mut request = make_message("m0", "user", "UI-triggered helper event");
+    request.source = Some(MessageSource::Ui);
+
+    assert!(!request.is_external_request_message());
+
+    let preview = preview_background_compaction_selection(&[request]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert!(preview.preserved_ids.is_empty());
+}
+
+#[test]
 fn test_build_post_response_compaction_snapshot_appends_pending_message_once() {
     let request = make_message("m0", "user", "Latest real request");
     let pending = make_message("m1", "assistant", "Pending assistant turn");

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -2,9 +2,9 @@ use serde_json::json;
 use std::collections::HashMap;
 use tauri_mcp_agent_lib::agent::llm::completion::{
     build_compact_context_selection_options, build_compact_summary_message_for_messages,
-    build_compact_summary_text, find_background_compaction_split_index,
-    find_preflight_compaction_split_index, fit_compaction_request_messages_to_limit,
+    build_compact_summary_text, fit_compaction_request_messages_to_limit,
     merge_consecutive_user_messages, normalize_request_messages,
+    preview_background_compaction_selection, preview_preflight_compaction_selection,
     resolve_context_management_settings, resolve_preserved_calibration_ratio,
     should_skip_same_tail_compaction, should_trigger_background_compaction,
     should_trigger_post_response_compaction, uses_compaction_strategy,
@@ -114,8 +114,9 @@ fn test_find_preflight_compaction_split_index_preserves_latest_user_turn() {
     let earlier = make_message("m0", "assistant", "Earlier context");
     let latest_user = make_message("m1", "user", &"latest request ".repeat(200));
 
-    let idx = find_preflight_compaction_split_index(&[earlier, latest_user]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[earlier, latest_user]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1"]);
 }
 
 #[test]
@@ -123,8 +124,9 @@ fn test_find_preflight_compaction_split_index_preserves_latest_non_tool_turn() {
     let earlier = make_message("m0", "user", "Earlier user context");
     let latest_assistant = make_message("m1", "assistant", "Latest non-tool turn");
 
-    let idx = find_preflight_compaction_split_index(&[earlier, latest_assistant]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[earlier, latest_assistant]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1"]);
 }
 
 #[test]
@@ -144,8 +146,9 @@ fn test_find_preflight_compaction_split_index_allows_compacting_latest_tool_resu
     let mut tool_result = make_message("m2", "tool", &"very large tool result ".repeat(200));
     tool_result.tool_call_id = Some("call_A".to_string());
 
-    let idx = find_preflight_compaction_split_index(&[intro, assistant, tool_result]);
-    assert_eq!(idx, 3);
+    let preview = preview_preflight_compaction_selection(&[intro, assistant, tool_result]);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -175,8 +178,9 @@ fn test_find_preflight_compaction_split_index_keeps_unresolved_tool_chain_tail()
     let mut tool_result = make_message("m2", "tool", "result A");
     tool_result.tool_call_id = Some("call_A".to_string());
 
-    let idx = find_preflight_compaction_split_index(&[intro, assistant, tool_result]);
-    assert_eq!(idx, 1);
+    let preview = preview_preflight_compaction_selection(&[intro, assistant, tool_result]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert_eq!(preview.preserved_ids, vec!["m1", "m2"]);
 }
 
 #[test]
@@ -194,8 +198,9 @@ fn test_find_background_compaction_split_index_preserves_active_request_before_d
         },
     }]);
 
-    let idx = find_background_compaction_split_index(&[request, assistant]);
-    assert_eq!(idx, 0);
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
 }
 
 #[test]
@@ -205,8 +210,9 @@ fn test_find_background_compaction_split_index_ignores_internal_synthetic_user_m
 
     assert!(!synthetic.is_external_request_message());
 
-    let idx = find_background_compaction_split_index(&[synthetic]);
-    assert_eq!(idx, 1);
+    let preview = preview_background_compaction_selection(&[synthetic]);
+    assert_eq!(preview.compacted_ids, vec!["m1"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -228,8 +234,9 @@ fn test_find_background_compaction_split_index_preserves_latest_external_request
     let newer = make_message("m1", "user", "Latest real request");
     let assistant = make_message("m2", "assistant", "Working on latest request");
 
-    let idx = find_background_compaction_split_index(&[older, newer, assistant]);
-    assert_eq!(idx, 0);
+    let preview = preview_background_compaction_selection(&[older, newer, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1", "m2"]);
 }
 
 #[test]
@@ -277,8 +284,9 @@ fn test_preflight_compaction_split_after_removing_incomplete_tool_chains() {
         current_tool,
     ]);
 
-    let idx = find_preflight_compaction_split_index(&cleaned);
-    assert_eq!(idx, cleaned.len());
+    let preview = preview_preflight_compaction_selection(&cleaned);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2", "m3"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]
@@ -321,10 +329,9 @@ fn test_normalize_request_messages_removes_stale_incomplete_tool_chains_before_c
     assert!(normalized[1].tool_calls.is_none());
     assert_eq!(normalized[2].id, "m2");
     assert_eq!(normalized[3].id, "m3");
-    assert_eq!(
-        find_preflight_compaction_split_index(&normalized),
-        normalized.len()
-    );
+    let preview = preview_preflight_compaction_selection(&normalized);
+    assert_eq!(preview.compacted_ids, vec!["m0", "m1", "m2", "m3"]);
+    assert!(preview.preserved_ids.is_empty());
 }
 
 #[test]

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -1,0 +1,74 @@
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
+
+fn make_message(source: Option<MessageSource>) -> Message {
+    Message {
+        id: "msg-1".to_string(),
+        session_id: "session-1".to_string(),
+        role: "user".to_string(),
+        content: vec![MCPContent::Text {
+            text: "hello".to_string(),
+            is_error: None,
+        }],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: None,
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        created_at: 1,
+        updated_at: 1,
+        source,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[test]
+fn message_source_deserializes_known_values_to_typed_variants() {
+    let message: Message = serde_json::from_value(serde_json::json!({
+        "id": "msg-1",
+        "sessionId": "session-1",
+        "role": "user",
+        "content": [{ "type": "text", "text": "hello" }],
+        "createdAt": 1,
+        "updatedAt": 1,
+        "source": "channel"
+    }))
+    .expect("message should deserialize");
+
+    assert_eq!(message.source, Some(MessageSource::Channel));
+}
+
+#[test]
+fn message_source_deserializes_unknown_values_without_failing() {
+    let message: Message = serde_json::from_value(serde_json::json!({
+        "id": "msg-1",
+        "sessionId": "session-1",
+        "role": "user",
+        "content": [{ "type": "text", "text": "hello" }],
+        "createdAt": 1,
+        "updatedAt": 1,
+        "source": "future-source"
+    }))
+    .expect("message should deserialize");
+
+    assert_eq!(
+        message.source,
+        Some(MessageSource::Unknown("future-source".to_string()))
+    );
+}
+
+#[test]
+fn message_source_serializes_to_wire_strings() {
+    let message = make_message(Some(MessageSource::SwarmLegacy));
+
+    let value = serde_json::to_value(&message).expect("message should serialize");
+    assert_eq!(
+        value.get("source"),
+        Some(&serde_json::json!("swarm_legacy"))
+    );
+}

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -72,3 +72,16 @@ fn message_source_serializes_to_wire_strings() {
         Some(&serde_json::json!("swarm_legacy"))
     );
 }
+
+#[test]
+fn external_request_message_semantics_match_source_policy() {
+    assert!(make_message(None).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Api)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::SwarmLegacy)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Channel)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::ScheduledTask)).is_external_request_message());
+
+    assert!(!make_message(Some(MessageSource::Ui)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::Tool)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::AgentTool)).is_external_request_message());
+}

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -72,3 +72,18 @@ fn message_source_serializes_to_wire_strings() {
         Some(&serde_json::json!("swarm_legacy"))
     );
 }
+
+#[test]
+fn unknown_source_still_uses_legacy_id_fallback_for_classification_helpers() {
+    let mut compact_summary =
+        make_message(Some(MessageSource::Unknown("future-source".to_string())));
+    compact_summary.id = "compact-summary-legacy".to_string();
+    assert!(compact_summary.is_compact_summary());
+
+    let mut compaction_instruction =
+        make_message(Some(MessageSource::Unknown("future-source".to_string())));
+    compaction_instruction.id = "compaction-instruction-legacy".to_string();
+    assert!(compaction_instruction.is_compaction_instruction());
+    assert!(compaction_instruction.is_internal_synthetic_user_message());
+    assert!(!compaction_instruction.is_external_request_message());
+}

--- a/src-tauri/tests/tool_result_spillover_tests.rs
+++ b/src-tauri/tests/tool_result_spillover_tests.rs
@@ -7,7 +7,7 @@ use tauri_mcp_agent_lib::agent::tools::{
     TOOL_RESULT_SPILLOVER_THRESHOLD_BYTES,
 };
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, ServiceInfo};
-use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 use tauri_mcp_agent_lib::repositories::{
     MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
     SqliteSessionRepository,
@@ -90,7 +90,7 @@ fn make_tool_message(session_id: &str, tool_call_id: &str, text: &str) -> Messag
         usage: None,
         created_at: 0,
         updated_at: 0,
-        source: Some("tool".to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: None,
     }
@@ -153,7 +153,7 @@ async fn spillover_pointer_is_what_gets_persisted_to_repository() {
         usage: None,
         created_at: 0,
         updated_at: 0,
-        source: Some("tool".to_string()),
+        source: Some(MessageSource::Tool),
         error: None,
         metadata: None,
     };


### PR DESCRIPTION
## Summary

- replace the Rust chat model's stringly-typed `source` field with a typed `MessageSource` enum
- preserve known source variants while safely round-tripping unknown values instead of failing deserialization
- update repository, service, HTTP/API handler, MCP handler, and regression-test call sites to use the typed model
- add focused integration coverage for known and unknown source serde behavior

## Validation

- cargo test --manifest-path .\src-tauri\Cargo.toml --test message_source_tests --test llm_context_tests
- cargo clippy --manifest-path .\src-tauri\Cargo.toml --test message_source_tests --test llm_context_tests -- -D warnings

## Notes

- This PR is stacked on top of #1181.
- `src/lib/generated/builtin-services.ts` remains intentionally untouched.
- This addresses issue #1179 scope item 1, but does not yet settle broader source semantics or save-time summary validation.