### PR TITLE
Refine external request source semantics

### DIFF
--- a/src-tauri/src/models/chat.rs
+++ b/src-tauri/src/models/chat.rs
@@ -81,6 +81,13 @@ impl MessageSource {
     fn is_internal_synthetic_user_source(&self) -> bool {
         matches!(self, Self::CompactionInstruction | Self::Recovery)
     }
+
+    fn is_external_request_source(&self) -> bool {
+        matches!(
+            self,
+            Self::Api | Self::SwarmLegacy | Self::Channel | Self::ScheduledTask
+        )
+    }
 }
 
 impl Serialize for MessageSource {
@@ -173,6 +180,10 @@ impl Message {
     }
 
     pub fn is_external_request_message(&self) -> bool {
-        self.role == "user" && !self.is_internal_synthetic_user_message()
+        self.role == "user"
+            && !self.is_internal_synthetic_user_message()
+            && self
+                .source_with_legacy_fallback()
+                .is_none_or(|source| source.is_external_request_source())
     }
 }

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -240,6 +240,40 @@ fn test_find_background_compaction_split_index_preserves_latest_external_request
 }
 
 #[test]
+fn test_find_background_compaction_split_index_preserves_channel_request_block() {
+    let mut request = make_message("m0", "user", "Request from channel");
+    request.source = Some(MessageSource::Channel);
+    let assistant = make_message("m1", "assistant", "Working on channel request");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_preserves_scheduled_task_request_block() {
+    let mut request = make_message("m0", "user", "Run scheduled sync");
+    request.source = Some(MessageSource::ScheduledTask);
+    let assistant = make_message("m1", "assistant", "Working on scheduled task");
+
+    let preview = preview_background_compaction_selection(&[request, assistant]);
+    assert!(preview.compacted_ids.is_empty());
+    assert_eq!(preview.preserved_ids, vec!["m0", "m1"]);
+}
+
+#[test]
+fn test_find_background_compaction_split_index_does_not_treat_ui_messages_as_external_requests() {
+    let mut request = make_message("m0", "user", "UI-triggered helper event");
+    request.source = Some(MessageSource::Ui);
+
+    assert!(!request.is_external_request_message());
+
+    let preview = preview_background_compaction_selection(&[request]);
+    assert_eq!(preview.compacted_ids, vec!["m0"]);
+    assert!(preview.preserved_ids.is_empty());
+}
+
+#[test]
 fn test_build_post_response_compaction_snapshot_appends_pending_message_once() {
     let request = make_message("m0", "user", "Latest real request");
     let pending = make_message("m1", "assistant", "Pending assistant turn");

--- a/src-tauri/tests/message_source_tests.rs
+++ b/src-tauri/tests/message_source_tests.rs
@@ -72,3 +72,16 @@ fn message_source_serializes_to_wire_strings() {
         Some(&serde_json::json!("swarm_legacy"))
     );
 }
+
+#[test]
+fn external_request_message_semantics_match_source_policy() {
+    assert!(make_message(None).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Api)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::SwarmLegacy)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::Channel)).is_external_request_message());
+    assert!(make_message(Some(MessageSource::ScheduledTask)).is_external_request_message());
+
+    assert!(!make_message(Some(MessageSource::Ui)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::Tool)).is_external_request_message());
+    assert!(!make_message(Some(MessageSource::AgentTool)).is_external_request_message());
+}


### PR DESCRIPTION
## Summary
- tighten external-request classification to explicit ingress sources instead of treating every non-synthetic user message as external
- preserve compaction protection for `api`, `swarm_legacy`, `channel`, and `scheduled_task`
- keep `ui` out of the protected external-request set by default and add regression coverage for all source-policy cases

## Testing
- cargo test --manifest-path .\src-tauri\Cargo.toml --test llm_context_tests --test message_source_tests --test tool_result_spillover_tests
- pnpm refactor:validate