### PR TITLE
⚡ Bolt: Remove O(N) array clone and reverse in AgentChatContext

### DIFF
--- a/src/context/AgentChatContext.tsx
+++ b/src/context/AgentChatContext.tsx
@@ -27,6 +27,19 @@ import { getLogger } from '../lib/logger';
 import { useLLMService, useStreamingMessage } from './LLMServiceContext';
 
 const logger = getLogger('AgentChatContext');
+
+/**
+ * ⚡ Bolt: Optimized helper to find the last persisted assistant message without O(N) array clone and reverse
+ */
+const findLastPersistedAssistantMessage = (messages: Message[]): Message | undefined => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant' && !messages[i].isStreaming) {
+      return messages[i];
+    }
+  }
+  return undefined;
+};
+
 export { isAssistantStreamingMessageSuperseded } from '@/lib/message-utils';
 
 /**
@@ -255,9 +268,7 @@ export function AgentChatProvider({ children }: AgentChatProviderProps) {
       return;
     }
 
-    const lastPersistedAssistantMessage = [...sessionMessages]
-      .reverse()
-      .find((message) => message.role === 'assistant' && !message.isStreaming);
+    const lastPersistedAssistantMessage = findLastPersistedAssistantMessage(sessionMessages);
 
     if (!lastPersistedAssistantMessage) {
       return;
@@ -291,9 +302,7 @@ export function AgentChatProvider({ children }: AgentChatProviderProps) {
 
     const displayed = [...sessionMessages];
     const displayedIds = new Set(displayed.map((message) => message.id));
-    const lastPersistedAssistantMessage = [...sessionMessages]
-      .reverse()
-      .find((message) => message.role === 'assistant' && !message.isStreaming);
+    const lastPersistedAssistantMessage = findLastPersistedAssistantMessage(sessionMessages);
 
     // Append pending messages (optimistic UI)
     if (pendingMessages.length > 0) {


### PR DESCRIPTION
**💡 What:**
Replaced the `[...sessionMessages].reverse().find(...)` pattern with an optimized `findLastPersistedAssistantMessage` helper function that uses a backwards `for` loop. 

**🎯 Why:**
Using `[...array].reverse()` creates a shallow clone (`O(N)`) and reverses the array (`O(N)`) on every hook/render execution. When working with large lists (like `sessionMessages` containing many chat entries), this introduces unnecessary memory allocation, garbage collection pressure, and computational overhead just to find a single recent item. The backward `for` loop accomplishes the exact same result with `O(1)` best-case / `O(N)` worst-case time complexity, with zero memory allocation.

**📊 Impact:**
Eliminates a double-`O(N)` operation and its associated memory footprint (`O(N)` memory allocation) inside frequent React contexts rendering/effect cycles in `AgentChatContext.tsx`.

**🔬 Measurement:**
Tested locally with large arrays to confirm `for` loop implementation effectively scales better than the clone/reverse, and all unit tests in `AgentChatContext.test.tsx` pass without regressions.

---
*PR created automatically by Jules for task [13317536356203262659](https://jules.google.com/task/13317536356203262659) started by @fritzprix*