### PR TITLE
⚗️ Distill: Optimize MCP response for listAgentTypes

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Initial Distill Journal
+## 2024-05-24 - Distill Pagination Threshold
+**Learning:** Added limit and offset variables to listAgentTypes MCP tool inside session_api.
+**Action:** Reduced tool response sizes to limit context bloat.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3862,7 +3862,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/mcp/builtin/session_api/handlers.rs
+++ b/src-tauri/src/mcp/builtin/session_api/handlers.rs
@@ -568,9 +568,14 @@ pub async fn handle_tool_call(
             Ok(success_result(message, session_responses))
         }
         "listAgentTypes" => {
+            let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20);
+            let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
+
             let assistant_repo = crate::state::get_assistant_repository();
+            let total_count = assistant_repo.count_assistants().await.unwrap_or(0);
+
             let assistants = assistant_repo
-                .list_assistants()
+                .list_assistants_paginated(limit, offset)
                 .await
                 .map_err(|e| format!("Failed to list assistants: {}", e))?;
             let data = serde_json::to_value(&assistants)
@@ -583,9 +588,17 @@ pub async fn handle_tool_call(
                 .unwrap_or_default();
 
             let message = if assistants.is_empty() {
-                "No assistant types available.".to_string()
+                format!("No assistant types available at offset {}.", offset)
             } else {
-                let mut lines = vec![format!("Available assistant types ({}):", assistants.len())];
+                let mut lines = vec![
+                    format!(
+                        "Available assistant types (Showing {} of {}):",
+                        assistants.len(),
+                        total_count
+                    ),
+                    "| Name | ID | Model | Description |".to_string(),
+                    "|---|---|---|---|".to_string(),
+                ];
 
                 for assistant in &assistants {
                     let id = assistant
@@ -595,7 +608,9 @@ pub async fn handle_tool_call(
                     let name = assistant
                         .get("name")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("Unnamed");
+                        .unwrap_or("Unnamed")
+                        .replace('|', "\\|")
+                        .replace('\n', " ");
 
                     let config = assistant.get("config").cloned().unwrap_or(json!({}));
                     let parsed_config = if let Some(s) = config.as_str() {
@@ -603,19 +618,28 @@ pub async fn handle_tool_call(
                     } else {
                         config
                     };
-                    let description = extract_assistant_description(&parsed_config);
+                    let description = extract_assistant_description(&parsed_config)
+                        .replace('|', "\\|")
+                        .replace('\n', " ");
                     let model = parsed_config
                         .get("model")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown");
+                        .unwrap_or("Unknown")
+                        .replace('|', "\\|")
+                        .replace('\n', " ");
 
                     lines.push(format!(
-                        "- {} [ID: {}]\n  model: {}\n  description: {}",
+                        "| {} | `{}` | {} | {} |",
                         name, id, model, description
                     ));
                 }
 
-                lines.join("\n")
+                let mut msg = lines.join("\n");
+
+                if offset + limit < total_count {
+                    msg.push_str(&format!("\n\n*(Showing {}/{} results. Call this tool again with offset: {} to see more)*", assistants.len(), total_count, offset + limit));
+                }
+                msg
             };
 
             Ok(success_result(message, data))

--- a/src-tauri/src/mcp/builtin/session_api/tools.rs
+++ b/src-tauri/src/mcp/builtin/session_api/tools.rs
@@ -273,7 +273,30 @@ pub fn list_assistants_tool() -> MCPTool {
         name: "listAgentTypes".to_string(),
         title: Some("List Agent Types".to_string()),
         description: "List available agent types (assistants) you can spawn. Call this to discover which specialists exist before delegating tasks.".to_string(),
-        input_schema: object_prop(vec![], vec![], None),
+        input_schema: object_prop(
+            vec![
+                (
+                    "limit".to_string(),
+                    integer_prop_with_default(
+                        None,
+                        Some(100),
+                        20,
+                        Some("Maximum number of agent types to return (pagination limit)."),
+                    ),
+                ),
+                (
+                    "offset".to_string(),
+                    integer_prop_with_default(
+                        None,
+                        None,
+                        0,
+                        Some("Number of agent types to skip (pagination offset)."),
+                    ),
+                ),
+            ],
+            vec![],
+            None,
+        ),
         output_schema: None,
         annotations: None,
     }


### PR DESCRIPTION
💡 What: Added `limit` and `offset` pagination to the `listAgentTypes` tool schema. Also transformed the response to return a condensed Markdown table instead of a bulleted list, quoting ID values so they are easily accessible for chained calls. Appended a pagination hint to explicitly instruct the agent on how to fetch further results when appropriate.

🎯 Why: To prevent Context Overflow caused by `listAgentTypes` returning an unbounded JSON payload alongside a bulleted list of all assistants. Sending thousands of tokens for unneeded configuration metadata exhausts the context window. 

📉 Token Impact: Reduces output size significantly (from unbounded growth proportional to assistants) and bounds it to a default subset of 20 elements, mapped into a space-efficient Markdown table.

🛠️ Error Recovery: If `assistants.is_empty()` returns true due to an offset limit, the tool responds with "No assistant types available at offset X." giving the LLM immediate actionable feedback about the offset bounding rather than a raw "404" empty array.

---
*PR created automatically by Jules for task [13705614862248514541](https://jules.google.com/task/13705614862248514541) started by @fritzprix*