### PR TITLE
Fix missing LLM cancel wiring

### DIFF
--- a/src/lib/ai-service/__tests__/gemini.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/gemini.cancel.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Message } from '@/models/chat';
+
+const generateContentStreamMock = vi.fn();
+const generateContentMock = vi.fn();
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: vi.fn().mockImplementation(() => ({
+    models: {
+      generateContentStream: generateContentStreamMock,
+      generateContent: generateContentMock,
+    },
+  })),
+  FinishReason: {
+    STOP: 'STOP',
+  },
+  FunctionCallingConfigMode: {
+    ANY: 'ANY',
+    AUTO: 'AUTO',
+    MODE_UNSPECIFIED: 'MODE_UNSPECIFIED',
+    NONE: 'NONE',
+    VALIDATED: 'VALIDATED',
+  },
+  Type: {
+    OBJECT: 'OBJECT',
+    STRING: 'STRING',
+    NUMBER: 'NUMBER',
+    BOOLEAN: 'BOOLEAN',
+    ARRAY: 'ARRAY',
+  },
+  HarmCategory: {},
+  HarmBlockThreshold: {},
+}));
+
+vi.mock('../../logger', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../gemini/models', () => ({
+  getDefaultModel: () => 'gemini-2.5-flash',
+  fetchGeminiModels: vi.fn(),
+}));
+
+function createEmptyStream(): AsyncIterable<never> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => ({
+          done: true,
+          value: undefined as never,
+        }),
+      };
+    },
+  };
+}
+
+function createUserMessage(text: string): Message {
+  return {
+    id: `msg-${text}`,
+    sessionId: 'session-1',
+    threadId: 'thread-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+  };
+}
+
+async function consumeStream(
+  stream: AsyncGenerator<string, void, void>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
+describe('GeminiService cancellation wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateContentStreamMock.mockResolvedValue(createEmptyStream());
+  });
+
+  it('passes an AbortSignal through stream config and aborts it on cancel', async () => {
+    const { GeminiService } = await import('../gemini');
+    const service = new GeminiService('test-key');
+
+    await consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'gemini-2.5-flash',
+      }),
+    );
+
+    const request = generateContentStreamMock.mock.calls[0]?.[0] as
+      | { config?: { abortSignal?: AbortSignal } }
+      | undefined;
+
+    expect(request?.config?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(request?.config?.abortSignal?.aborted).toBe(false);
+
+    service.cancel();
+
+    expect(request?.config?.abortSignal?.aborted).toBe(true);
+  });
+
+  it('passes an AbortSignal through non-stream config', async () => {
+    generateContentMock.mockResolvedValueOnce({
+      candidates: [
+        {
+          finishReason: 'STOP',
+          content: { parts: [{ text: 'ok' }] },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+    });
+
+    const { GeminiService } = await import('../gemini');
+    const service = new GeminiService('test-key');
+
+    await service.sampleText('hello', {
+      modelName: 'gemini-2.5-flash',
+    });
+
+    const request = generateContentMock.mock.calls[0]?.[0] as
+      | { config?: { abortSignal?: AbortSignal } }
+      | undefined;
+
+    expect(request?.config?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/lib/ai-service/__tests__/groq.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/groq.cancel.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Message } from '@/models/chat';
+
+const createMock = vi.fn();
+
+vi.mock('groq-sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: createMock,
+      },
+    },
+  })),
+}));
+
+vi.mock('../../logger', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function createEmptyStream(): AsyncIterable<never> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => ({
+          done: true,
+          value: undefined as never,
+        }),
+      };
+    },
+  };
+}
+
+function createUserMessage(text: string): Message {
+  return {
+    id: `msg-${text}`,
+    sessionId: 'session-1',
+    threadId: 'thread-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+  };
+}
+
+async function consumeStream(
+  stream: AsyncGenerator<string, void, void>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
+describe('GroqService cancellation wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes an AbortSignal to streaming requests and aborts it on cancel', async () => {
+    createMock.mockResolvedValueOnce(createEmptyStream());
+
+    const { GroqService } = await import('../groq');
+    const service = new GroqService('test-key');
+
+    await consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'llama-3.1-8b-instant',
+      }),
+    );
+
+    const requestOptions = createMock.mock.calls[0]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+
+    expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(requestOptions?.signal?.aborted).toBe(false);
+
+    service.cancel();
+
+    expect(requestOptions?.signal?.aborted).toBe(true);
+  });
+
+  it('passes an AbortSignal to non-streaming requests', async () => {
+    createMock.mockResolvedValueOnce({
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: { content: 'ok' },
+        },
+      ],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+      model: 'llama-3.1-8b-instant',
+    });
+
+    const { GroqService } = await import('../groq');
+    const service = new GroqService('test-key');
+
+    await service.sampleText('hello', {
+      modelName: 'llama-3.1-8b-instant',
+    });
+
+    const requestOptions = createMock.mock.calls[0]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+
+    expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/lib/ai-service/__tests__/openai.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/openai.cancel.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Message } from '@/models/chat';
+
+const createMock = vi.fn();
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: createMock,
+      },
+    },
+  })),
+}));
+
+vi.mock('../../logger', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../../llm-config-manager', () => ({
+  llmConfigManager: {
+    getModelsForProvider: vi.fn().mockReturnValue({}),
+    getModel: vi.fn().mockReturnValue(null),
+  },
+}));
+
+vi.mock('../message-normalizer', () => ({
+  filterSystemErrors: vi.fn().mockImplementation((msgs: Message[]) => msgs),
+  repairMalformedToolCalls: vi.fn().mockImplementation((msgs: Message[]) => msgs),
+  validateToolCallPairing: vi.fn().mockImplementation((msgs: Message[]) => msgs),
+}));
+
+vi.mock('../model-capabilities', () => ({
+  supportsThinking: vi.fn().mockResolvedValue(false),
+  getContextWindow: vi.fn().mockResolvedValue(128000),
+}));
+
+function createUserMessage(text: string): Message {
+  return {
+    id: `msg-${text}`,
+    sessionId: 'session-1',
+    threadId: 'thread-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+  };
+}
+
+function createEmptyStream(): AsyncIterable<never> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => ({
+          done: true,
+          value: undefined as never,
+        }),
+      };
+    },
+  };
+}
+
+async function consumeStream(
+  stream: AsyncGenerator<string, void, void>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
+describe('OpenAIService cancellation wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reuses the original AbortSignal for stream retries after cancel', async () => {
+    createMock
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValueOnce(createEmptyStream());
+
+    const { OpenAIService } = await import('../openai');
+    const service = new OpenAIService('sk-test', { retryDelay: 0 });
+
+    const streamPromise = consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'gpt-4o-mini',
+      }),
+    );
+
+    await vi.runAllTimersAsync();
+    service.cancel();
+    await vi.runAllTimersAsync();
+    await streamPromise;
+
+    const firstOptions = createMock.mock.calls[0]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+    const secondOptions = createMock.mock.calls[1]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(firstOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(secondOptions?.signal).toBe(firstOptions?.signal);
+    expect(secondOptions?.signal?.aborted).toBe(true);
+  });
+
+  it('reuses the original AbortSignal for non-stream retries after cancel', async () => {
+    createMock
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            finish_reason: 'stop',
+            message: { content: 'ok' },
+          },
+        ],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+        model: 'gpt-4o-mini',
+      });
+
+    const { OpenAIService } = await import('../openai');
+    const service = new OpenAIService('sk-test', { retryDelay: 0 });
+
+    const samplePromise = service.sampleText('hello', {
+      modelName: 'gpt-4o-mini',
+    });
+
+    await vi.runAllTimersAsync();
+    service.cancel();
+    await vi.runAllTimersAsync();
+    await samplePromise;
+
+    const firstOptions = createMock.mock.calls[0]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+    const secondOptions = createMock.mock.calls[1]?.[1] as
+      | { signal?: AbortSignal }
+      | undefined;
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(firstOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(secondOptions?.signal).toBe(firstOptions?.signal);
+    expect(secondOptions?.signal?.aborted).toBe(true);
+  });
+});

--- a/src/lib/ai-service/anthropic.ts
+++ b/src/lib/ai-service/anthropic.ts
@@ -611,17 +611,23 @@ export class AnthropicService extends BaseAIService<
     const model =
       options?.modelName || config.defaultModel || this.getDefaultModel();
     const s = options?.samplingOptions;
+    const abortSignal = this.getAbortSignal();
 
     const response = await this.withRetry(() =>
-      this.anthropic.messages.create({
-        model,
-        max_tokens: s?.maxTokens ?? config.maxTokens ?? 4096,
-        temperature: s?.temperature ?? config.temperature,
-        top_p: s?.topP,
-        top_k: s?.topK,
-        stop_sequences: s?.stopSequences,
-        messages: [{ role: 'user', content: prompt }],
-      }),
+      this.anthropic.messages.create(
+        {
+          model,
+          max_tokens: s?.maxTokens ?? config.maxTokens ?? 4096,
+          temperature: s?.temperature ?? config.temperature,
+          top_p: s?.topP,
+          top_k: s?.topK,
+          stop_sequences: s?.stopSequences,
+          messages: [{ role: 'user', content: prompt }],
+        },
+        {
+          signal: abortSignal,
+        },
+      ),
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');

--- a/src/lib/ai-service/gemini/service.ts
+++ b/src/lib/ai-service/gemini/service.ts
@@ -255,6 +255,7 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
       options,
     );
     try {
+      const abortSignal = this.getAbortSignal();
       const normalizedContextInjection = this.prepareContextInjection(
         options.systemPrompt,
         options.sessionContext,
@@ -323,6 +324,7 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
       const createGeminiConfig = (): GeminiServiceConfig => {
         const geminiConfig: GeminiServiceConfig = {
           responseMimeType: 'text/plain',
+          abortSignal,
         };
 
         if (geminiTools) {
@@ -389,13 +391,13 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
         return createStream(geminiConfig);
       });
 
-      if (this.getAbortSignal().aborted) {
+      if (abortSignal.aborted) {
         this.logger.debug('Stream aborted before iteration');
         return;
       }
 
       // Use the stream processing logic from stream.ts
-      yield* processGeminiStream(result, this.getAbortSignal(), this.logger);
+      yield* processGeminiStream(result, abortSignal, this.logger);
     } catch (error) {
       if (
         error instanceof Error &&
@@ -544,11 +546,13 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
     const model =
       options?.modelName || rawConfig.defaultModel || getDefaultModel();
     const s = options?.samplingOptions;
+    const abortSignal = this.getAbortSignal();
 
     const response = await this.withRetry(() =>
       this.genAI.models.generateContent({
         model,
         config: {
+          abortSignal,
           maxOutputTokens: s?.maxTokens ?? rawConfig.maxTokens,
           temperature: s?.temperature ?? rawConfig.temperature,
           topP: s?.topP,

--- a/src/lib/ai-service/gemini/types.ts
+++ b/src/lib/ai-service/gemini/types.ts
@@ -11,6 +11,7 @@ import {
  */
 export interface GeminiServiceConfig {
   responseMimeType: string;
+  abortSignal?: AbortSignal;
   tools?: Array<{ functionDeclarations: FunctionDeclaration[] }>;
   toolConfig?: {
     functionCallingConfig?: {

--- a/src/lib/ai-service/groq.ts
+++ b/src/lib/ai-service/groq.ts
@@ -97,6 +97,7 @@ export class GroqService extends BaseAIService<
       messages,
       options,
     );
+    const abortSignal = this.getAbortSignal();
 
     try {
       const groqMessages = this.convertMessages(
@@ -110,20 +111,27 @@ export class GroqService extends BaseAIService<
       );
 
       const chatCompletion = await this.withRetry(() =>
-        this.groq.chat.completions.create({
-          messages: groqMessages,
-          model:
-            options.modelName || config.defaultModel || 'llama-3.1-8b-instant',
-          temperature: config.temperature,
-          max_tokens: config.maxTokens,
-          reasoning_format: model?.supportReasoning ? 'parsed' : undefined,
-          stream: true,
-          tools: tools,
-          tool_choice: options.availableTools ? 'auto' : undefined,
-        }),
+        this.groq.chat.completions.create(
+          {
+            messages: groqMessages,
+            model:
+              options.modelName ||
+              config.defaultModel ||
+              'llama-3.1-8b-instant',
+            temperature: config.temperature,
+            max_tokens: config.maxTokens,
+            reasoning_format: model?.supportReasoning ? 'parsed' : undefined,
+            stream: true,
+            tools: tools,
+            tool_choice: options.availableTools ? 'auto' : undefined,
+          },
+          {
+            signal: abortSignal,
+          },
+        ),
       );
 
-      if (this.getAbortSignal().aborted) {
+      if (abortSignal.aborted) {
         this.logger.info('Stream aborted before iteration');
         return;
       }
@@ -133,7 +141,7 @@ export class GroqService extends BaseAIService<
       let firstChunkReceived = false;
 
       for await (const chunk of chatCompletion) {
-        if (this.getAbortSignal().aborted) {
+        if (abortSignal.aborted) {
           this.logger.info('Stream aborted during iteration');
           break;
         }
@@ -386,19 +394,25 @@ export class GroqService extends BaseAIService<
     const config = this.mergeConfig(options);
     const model = options?.modelName || config.defaultModel || '';
     const s = options?.samplingOptions;
+    const abortSignal = this.getAbortSignal();
 
     const response = await this.withRetry(() =>
-      this.groq.chat.completions.create({
-        model,
-        stream: false,
-        messages: [{ role: 'user', content: prompt }],
-        max_tokens: s?.maxTokens ?? config.maxTokens,
-        temperature: s?.temperature ?? config.temperature,
-        top_p: s?.topP,
-        presence_penalty: s?.presencePenalty,
-        frequency_penalty: s?.frequencyPenalty,
-        stop: s?.stopSequences,
-      }),
+      this.groq.chat.completions.create(
+        {
+          model,
+          stream: false,
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: s?.maxTokens ?? config.maxTokens,
+          temperature: s?.temperature ?? config.temperature,
+          top_p: s?.topP,
+          presence_penalty: s?.presencePenalty,
+          frequency_penalty: s?.frequencyPenalty,
+          stop: s?.stopSequences,
+        },
+        {
+          signal: abortSignal,
+        },
+      ),
     );
 
     const choice = response.choices[0];

--- a/src/lib/ai-service/openai.ts
+++ b/src/lib/ai-service/openai.ts
@@ -300,16 +300,17 @@ export class OpenAIService extends BaseAIService<
         request,
       });
 
+      const abortSignal = this.getAbortSignal();
       const completion = await this.withRetry(() =>
         this.openai.chat.completions.create(request, {
-          signal: this.getAbortSignal(),
+          signal: abortSignal,
           headers: {
             'x-libragent-request-id': requestId,
           },
         }),
       );
 
-      if (this.getAbortSignal().aborted) {
+      if (abortSignal.aborted) {
         this.logger.debug('Stream aborted before iteration');
         return;
       }
@@ -318,7 +319,7 @@ export class OpenAIService extends BaseAIService<
       const startTime = performance.now();
       let firstChunkReceived = false;
       for await (const chunk of completion) {
-        if (this.getAbortSignal().aborted) {
+        if (abortSignal.aborted) {
           this.logger.info('Stream aborted during iteration');
           break;
         }
@@ -564,9 +565,10 @@ export class OpenAIService extends BaseAIService<
       request,
     });
 
+    const abortSignal = this.getAbortSignal();
     const response = await this.withRetry(() =>
       this.openai.chat.completions.create(request, {
-        signal: this.getAbortSignal(),
+        signal: abortSignal,
         headers: {
           'x-libragent-request-id': requestId,
         },

--- a/src/lib/ai-service/openai.ts
+++ b/src/lib/ai-service/openai.ts
@@ -566,6 +566,7 @@ export class OpenAIService extends BaseAIService<
 
     const response = await this.withRetry(() =>
       this.openai.chat.completions.create(request, {
+        signal: this.getAbortSignal(),
         headers: {
           'x-libragent-request-id': requestId,
         },


### PR DESCRIPTION
## Summary
- wire AbortSignal into Groq streaming and non-stream requests
- pass Gemini abortSignal through request config so cancel reaches the SDK path
- add coverage for Groq/Gemini cancel wiring and keep existing cancel regression tests green
- add missing cancel signal for OpenAI and Anthropic non-stream sample calls

## Notes
- Full repo validation was intentionally not completed on this machine.
- Targeted cancel-related tests passed locally.