### PR TITLE
Improve history and knowledge performance

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -19,12 +19,9 @@ This guide provides solutions to common problems you might encounter while devel
    sudo apt-get install -y libwebkit2gtk-4.1-dev
    ```
 
-2. **Set Environment Variables**: The application attempts to set these, but you can also set them manually before running `pnpm tauri dev`:
+2. **Use a Proper Desktop Session**: Run the app in a real Linux desktop session with a working display server and current graphics drivers. Containerized or headless environments often expose WebKit rendering failures that are not fixable from app code alone.
 
-   ```bash
-   export WEBKIT_DISABLE_COMPOSITING_MODE=1
-   export WEBKIT_DISABLE_DMABUF_RENDERER=1
-   ```
+3. **Avoid Forcing Software Rendering Flags**: Do not set WebKit or GL fallback flags unless you are debugging a driver bug. They frequently trade blank-screen issues for much worse rendering performance.
 
 **Source Reference**: [`src-tauri/src/lib.rs`](../src-tauri/src/lib.rs) (Lines 188-250)
 

--- a/src-tauri/migration/src/lib.rs
+++ b/src-tauri/migration/src/lib.rs
@@ -30,6 +30,7 @@ mod m20260327_000025_add_stores_session_index;
 mod m20260405_000026_add_group_fields_to_scheduled_tasks;
 mod m20260405_000027_add_org_fields_to_sessions;
 mod m20260406_000028_create_gemini_context_caches;
+mod m20260506_000029_add_session_list_indexes;
 
 pub struct Migrator;
 
@@ -65,6 +66,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260405_000026_add_group_fields_to_scheduled_tasks::Migration),
             Box::new(m20260405_000027_add_org_fields_to_sessions::Migration),
             Box::new(m20260406_000028_create_gemini_context_caches::Migration),
+            Box::new(m20260506_000029_add_session_list_indexes::Migration),
         ]
     }
 }

--- a/src-tauri/migration/src/m20260506_000029_add_session_list_indexes.rs
+++ b/src-tauri/migration/src/m20260506_000029_add_session_list_indexes.rs
@@ -1,0 +1,65 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-sessions-updated_at-id")
+                    .table(Sessions::Table)
+                    .col(Sessions::UpdatedAt)
+                    .col(Sessions::Id)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-sessions-last_attention_at")
+                    .table(Sessions::Table)
+                    .col(Sessions::LastAttentionAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-sessions-last_attention_at")
+                    .table(Sessions::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-sessions-updated_at-id")
+                    .table(Sessions::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Sessions {
+    #[sea_orm(iden = "sessions")]
+    Table,
+    Id,
+    UpdatedAt,
+    LastAttentionAt,
+}

--- a/src-tauri/src/agent/lifecycle/queries.rs
+++ b/src-tauri/src/agent/lifecycle/queries.rs
@@ -1,5 +1,5 @@
 use crate::repositories::session_repository::SessionRepository;
-use crate::repositories::SessionMetadata;
+use crate::repositories::{SessionListCursor, SessionListPage, SessionMetadata};
 use std::sync::Arc;
 
 /// Get session metadata
@@ -21,4 +21,26 @@ pub async fn get_all_sessions(
         .get_all_sessions()
         .await
         .map_err(|e| format!("Failed to get all sessions: {}", e))
+}
+
+/// List sessions using cursor pagination.
+pub async fn list_sessions(
+    session_repo: &Arc<dyn SessionRepository>,
+    cursor: Option<SessionListCursor>,
+    limit: u64,
+) -> Result<SessionListPage, String> {
+    session_repo
+        .list_sessions(cursor, limit)
+        .await
+        .map_err(|e| format!("Failed to list sessions: {}", e))
+}
+
+/// List sessions with unread attention state.
+pub async fn list_attention_sessions(
+    session_repo: &Arc<dyn SessionRepository>,
+) -> Result<Vec<SessionMetadata>, String> {
+    session_repo
+        .list_attention_sessions()
+        .await
+        .map_err(|e| format!("Failed to list attention sessions: {}", e))
 }

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -8,8 +8,8 @@ use crate::mcp::types::ChannelNotification;
 use crate::mcp::MCPServiceProxyManager;
 use crate::models::chat::Message;
 use crate::repositories::{
-    CompactContextRecord, CompactContextRepository, SessionMetadata, SessionRepository,
-    SessionStatus,
+    CompactContextRecord, CompactContextRepository, SessionListCursor, SessionListPage,
+    SessionMetadata, SessionRepository, SessionStatus,
 };
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
@@ -308,6 +308,18 @@ impl AgentSessionManager {
     /// Get all sessions
     pub async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, String> {
         crate::agent::lifecycle::get_all_sessions(&self.session_repo).await
+    }
+
+    pub async fn list_sessions(
+        &self,
+        cursor: Option<SessionListCursor>,
+        limit: u64,
+    ) -> Result<SessionListPage, String> {
+        crate::agent::lifecycle::list_sessions(&self.session_repo, cursor, limit).await
+    }
+
+    pub async fn list_attention_sessions(&self) -> Result<Vec<SessionMetadata>, String> {
+        crate::agent::lifecycle::list_attention_sessions(&self.session_repo).await
     }
 
     /// Recover sessions stuck in BUSY state after app crash/restart

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -6,7 +6,9 @@ use crate::mcp::types::ServiceContext;
 use crate::models::chat::Message;
 use crate::models::chat::MessageSource;
 use crate::repositories::message_repository::MessageRepository;
-use crate::repositories::{CompactContextRecord, SessionMetadata, SessionRepository};
+use crate::repositories::{
+    CompactContextRecord, SessionListCursor, SessionListPage, SessionMetadata, SessionRepository,
+};
 use crate::services::AgentService;
 use crate::state::get_session_repository;
 use crate::{
@@ -16,6 +18,9 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tauri::{command, AppHandle, State};
+
+const DEFAULT_SESSION_LIST_LIMIT: u64 = 100;
+const MAX_SESSION_LIST_LIMIT: u64 = 200;
 
 /// Request to create a new agent session
 #[derive(Debug, Serialize, Deserialize)]
@@ -636,6 +641,83 @@ pub async fn agent_get_all_sessions(
     manager: State<'_, AgentSessionManager>,
 ) -> Result<Vec<SessionMetadata>, String> {
     manager.get_all_sessions().await
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAgentSessionsRequest {
+    pub cursor: Option<SessionListCursorDto>,
+    pub limit: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListCursorDto {
+    pub updated_at: i64,
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSessionListResponse {
+    pub items: Vec<SessionMetadata>,
+    pub next_cursor: Option<SessionListCursorDto>,
+}
+
+impl From<SessionListCursor> for SessionListCursorDto {
+    fn from(value: SessionListCursor) -> Self {
+        Self {
+            updated_at: value.updated_at,
+            id: value.id,
+        }
+    }
+}
+
+impl From<SessionListCursorDto> for SessionListCursor {
+    fn from(value: SessionListCursorDto) -> Self {
+        Self {
+            updated_at: value.updated_at,
+            id: value.id,
+        }
+    }
+}
+
+impl From<SessionListPage> for AgentSessionListResponse {
+    fn from(value: SessionListPage) -> Self {
+        Self {
+            items: value.items,
+            next_cursor: value.next_cursor.map(Into::into),
+        }
+    }
+}
+
+/// List sessions by latest activity using cursor pagination.
+#[command]
+pub async fn agent_list_sessions(
+    manager: State<'_, AgentSessionManager>,
+    request: Option<ListAgentSessionsRequest>,
+) -> Result<AgentSessionListResponse, String> {
+    let request = request.unwrap_or(ListAgentSessionsRequest {
+        cursor: None,
+        limit: None,
+    });
+    let limit = request
+        .limit
+        .unwrap_or(DEFAULT_SESSION_LIST_LIMIT)
+        .clamp(1, MAX_SESSION_LIST_LIMIT);
+
+    manager
+        .list_sessions(request.cursor.map(Into::into), limit)
+        .await
+        .map(Into::into)
+}
+
+/// List sessions with unread attention for the notifications UI.
+#[command]
+pub async fn agent_list_attention_sessions(
+    manager: State<'_, AgentSessionManager>,
+) -> Result<Vec<SessionMetadata>, String> {
+    manager.list_attention_sessions().await
 }
 
 /// Pause a running workflow

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,11 +37,11 @@ use commands::agent_commands::{
     agent_handle_compact_error, agent_handle_compact_response, agent_handle_llm_error,
     agent_handle_llm_response, agent_handle_tool_result, agent_init_session_with_messages,
     agent_inject_channel_message, agent_inject_channel_message_auto, agent_inject_messages,
-    agent_mark_session_viewed, agent_open_session, agent_pause_workflow,
-    agent_report_llm_streaming_issue, agent_respond_channel_permission,
-    agent_respond_tool_approval, agent_resume_session, agent_resume_workflow,
-    agent_save_compact_context, agent_send_message, agent_set_yolo_mode, agent_terminate_workflow,
-    agent_toggle_session_bookmark, agent_update_session_config,
+    agent_list_attention_sessions, agent_list_sessions, agent_mark_session_viewed,
+    agent_open_session, agent_pause_workflow, agent_report_llm_streaming_issue,
+    agent_respond_channel_permission, agent_respond_tool_approval, agent_resume_session,
+    agent_resume_workflow, agent_save_compact_context, agent_send_message, agent_set_yolo_mode,
+    agent_terminate_workflow, agent_toggle_session_bookmark, agent_update_session_config,
 };
 use commands::assistant_crud_commands::{
     batch_upsert_assistants, create_assistant, delete_assistant, get_assistant,
@@ -247,6 +247,8 @@ pub fn run() {
                 agent_get_session,
                 agent_get_tools,
                 agent_get_all_sessions,
+                agent_list_sessions,
+                agent_list_attention_sessions,
                 agent_delete_session,
                 agent_delete_session_only,
                 agent_get_available_tools,
@@ -362,8 +364,7 @@ pub fn run() {
             warn!("💡 Troubleshooting suggestions:");
             warn!("   1. Check WebKit/GTK installation: sudo apt install libwebkit2gtk-4.1-dev");
             warn!("   2. Update graphics drivers");
-            warn!("   3. Retry with LIBRAGENT_LINUX_COMPATIBILITY_MODE=1");
-            warn!("   4. Run in a desktop environment with proper display");
+            warn!("   3. Run in a desktop environment with proper display");
 
             std::process::exit(1);
         }

--- a/src-tauri/src/lifecycle/app_setup.rs
+++ b/src-tauri/src/lifecycle/app_setup.rs
@@ -809,20 +809,7 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     // Linux-specific checks
     #[cfg(target_os = "linux")]
     {
-        let compatibility_mode_enabled = matches!(
-            std::env::var("LIBRAGENT_LINUX_COMPATIBILITY_MODE"),
-            Ok(value)
-                if matches!(
-                    value.trim().to_ascii_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on"
-                )
-        );
-
-        if compatibility_mode_enabled {
-            info!("🐧 Linux compatibility mode is active (software rendering + X11 fallback)");
-        } else {
-            info!("🐧 Linux detected - running with default WebKit rendering path");
-        }
+        info!("🐧 Linux detected - running with default WebKit rendering path");
         if std::env::var("container").is_ok() || std::env::var("DISPLAY").is_err() {
             warn!("⚠️  Warning: Running in limited graphics environment");
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,46 +4,17 @@
 /// The main entry point for the LibrAgent application.
 ///
 /// This function is responsible for:
-/// 1. Optionally enabling Linux-specific WebKit compatibility mode (if on Linux)
-/// 2. Loading environment variables from .env file (development mode only)
-/// 3. Determining the path for the SQLite database. It prioritizes the `LIBRAGENT_DB_PATH`
+/// 1. Loading environment variables from .env file (development mode only)
+/// 2. Determining the path for the SQLite database. It prioritizes the `LIBRAGENT_DB_PATH`
 ///    environment variable, falling back to a default location within the user's data directory.
-/// 4. Ensuring the directory for the database exists.
-/// 5. Constructing the final SQLite connection URL.
-/// 6. Calling the main application runner (`run_with_sqlite_sync`) from the `tauri_mcp_agent_lib`
+/// 3. Ensuring the directory for the database exists.
+/// 4. Constructing the final SQLite connection URL.
+/// 5. Calling the main application runner (`run_with_sqlite_sync`) from the `tauri_mcp_agent_lib`
 ///    crate, passing it the database URL to initialize the application with database support.
-#[cfg(target_os = "linux")]
-fn linux_compatibility_mode_enabled() -> bool {
-    matches!(
-        std::env::var("LIBRAGENT_LINUX_COMPATIBILITY_MODE"),
-        Ok(value)
-            if matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-    )
-}
-
 fn main() {
-    // Set Linux-specific WebKit compatibility environment variables FIRST when explicitly enabled.
-    // This must happen before any WebView initialization.
     #[cfg(target_os = "linux")]
     {
-        if linux_compatibility_mode_enabled() {
-            println!("🐧 Linux compatibility mode enabled - applying WebKit fallback flags...");
-
-            // Disable WebKit compositing and force software rendering for problematic Linux setups.
-            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-            std::env::set_var("GDK_BACKEND", "x11");
-            std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
-
-            println!("✅ Linux compatibility mode active (software rendering + X11 fallback)");
-        } else {
-            println!("🐧 Linux detected - using default WebKit rendering path");
-            println!(
-                "ℹ️  Set LIBRAGENT_LINUX_COMPATIBILITY_MODE=1 only if you hit blank screens or driver issues"
-            );
-        }
+        println!("🐧 Linux detected - using default WebKit rendering path");
     }
 
     // Load environment variables from .env file

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -1,6 +1,7 @@
 use super::error::DbError;
 use super::session_repository::{
-    SessionAttentionReason, SessionMetadata, SessionRepository, SessionStatus,
+    SessionAttentionReason, SessionListCursor, SessionListPage, SessionMetadata, SessionRepository,
+    SessionStatus,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -156,6 +157,74 @@ impl SessionRepository for InMemorySessionRepository {
         let sessions = self.sessions.read().await;
         let result: Vec<SessionMetadata> = sessions.values().cloned().collect();
         log::debug!("InMemory: Get all sessions -> {} sessions", result.len());
+        Ok(result)
+    }
+
+    async fn list_sessions(
+        &self,
+        cursor: Option<SessionListCursor>,
+        limit: u64,
+    ) -> Result<SessionListPage, DbError> {
+        let sessions = self.sessions.read().await;
+        let normalized_limit = limit.clamp(1, 200) as usize;
+        let mut result: Vec<SessionMetadata> = sessions.values().cloned().collect();
+
+        result.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+
+        if let Some(cursor) = cursor {
+            result.retain(|session| {
+                session.updated_at < cursor.updated_at
+                    || (session.updated_at == cursor.updated_at && session.id < cursor.id)
+            });
+        }
+
+        let next_cursor = if result.len() > normalized_limit {
+            let cursor_source = result[normalized_limit - 1].clone();
+            result.truncate(normalized_limit);
+            Some(SessionListCursor {
+                updated_at: cursor_source.updated_at,
+                id: cursor_source.id,
+            })
+        } else {
+            None
+        };
+
+        Ok(SessionListPage {
+            items: result,
+            next_cursor,
+        })
+    }
+
+    async fn list_attention_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
+        let sessions = self.sessions.read().await;
+        let mut result: Vec<SessionMetadata> = sessions
+            .values()
+            .filter(|session| {
+                let Some(last_attention_at) = session.last_attention_at else {
+                    return false;
+                };
+
+                match session.last_viewed_at {
+                    Some(last_viewed_at) => last_attention_at > last_viewed_at,
+                    None => true,
+                }
+            })
+            .cloned()
+            .collect();
+
+        result.sort_by(|left, right| {
+            right
+                .last_attention_at
+                .cmp(&left.last_attention_at)
+                .then_with(|| right.updated_at.cmp(&left.updated_at))
+                .then_with(|| right.id.cmp(&left.id))
+        });
+
         Ok(result)
     }
 

--- a/src-tauri/src/repositories/mod.rs
+++ b/src-tauri/src/repositories/mod.rs
@@ -39,6 +39,7 @@ pub use scheduled_task_repository::{
 };
 pub use session_org_context::build_explicit_org_layer_context;
 pub use session_repository::{
-    SessionMetadata, SessionRepository, SessionStatus, SqliteSessionRepository,
+    SessionListCursor, SessionListPage, SessionMetadata, SessionRepository, SessionStatus,
+    SqliteSessionRepository,
 };
 pub use settings_repository::{SettingsRepository, SqliteSettingsRepository};

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -1,7 +1,10 @@
 use super::error::DbError;
 use async_trait::async_trait;
 use sea_orm::sea_query::Expr;
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
+};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -106,6 +109,20 @@ pub struct SessionMetadata {
     pub workspace_override: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListCursor {
+    pub updated_at: i64,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListPage {
+    pub items: Vec<SessionMetadata>,
+    pub next_cursor: Option<SessionListCursor>,
+}
+
 impl TryFrom<session::Model> for SessionMetadata {
     type Error = DbError;
 
@@ -165,6 +182,16 @@ pub trait SessionRepository: Send + Sync {
 
     /// Get all sessions
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError>;
+
+    /// List sessions ordered by most recent activity with cursor pagination.
+    async fn list_sessions(
+        &self,
+        cursor: Option<SessionListCursor>,
+        limit: u64,
+    ) -> Result<SessionListPage, DbError>;
+
+    /// List sessions that still have unread attention for notifications.
+    async fn list_attention_sessions(&self) -> Result<Vec<SessionMetadata>, DbError>;
 
     /// Get direct child session IDs for a parent session ID
     async fn get_child_session_ids(&self, parent_session_id: &str) -> Result<Vec<String>, DbError>;
@@ -350,8 +377,6 @@ impl SessionRepository for SqliteSessionRepository {
     }
 
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
-        use sea_orm::QueryOrder;
-
         let models = Session::find()
             .order_by_desc(session::Column::UpdatedAt)
             .all(&self.db)
@@ -361,6 +386,72 @@ impl SessionRepository for SqliteSessionRepository {
             models.into_iter().map(SessionMetadata::try_from).collect();
 
         sessions
+    }
+
+    async fn list_sessions(
+        &self,
+        cursor: Option<SessionListCursor>,
+        limit: u64,
+    ) -> Result<SessionListPage, DbError> {
+        let normalized_limit = limit.clamp(1, 200);
+        let mut condition = Condition::all();
+
+        if let Some(cursor) = cursor {
+            condition = condition.add(
+                Condition::any()
+                    .add(session::Column::UpdatedAt.lt(cursor.updated_at))
+                    .add(
+                        Condition::all()
+                            .add(session::Column::UpdatedAt.eq(cursor.updated_at))
+                            .add(session::Column::Id.lt(cursor.id)),
+                    ),
+            );
+        }
+
+        let mut models = Session::find()
+            .filter(condition)
+            .order_by_desc(session::Column::UpdatedAt)
+            .order_by_desc(session::Column::Id)
+            .limit(normalized_limit + 1)
+            .all(&self.db)
+            .await?;
+
+        let next_cursor = if models.len() > normalized_limit as usize {
+            models.truncate(normalized_limit as usize);
+            models.last().map(|model| SessionListCursor {
+                updated_at: model.updated_at,
+                id: model.id.clone(),
+            })
+        } else {
+            None
+        };
+
+        let items = models
+            .into_iter()
+            .map(SessionMetadata::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(SessionListPage { items, next_cursor })
+    }
+
+    async fn list_attention_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
+        let models = Session::find()
+            .filter(session::Column::LastAttentionAt.is_not_null())
+            .filter(
+                Condition::any()
+                    .add(session::Column::LastViewedAt.is_null())
+                    .add(
+                        Expr::col(session::Column::LastAttentionAt)
+                            .gt(Expr::col(session::Column::LastViewedAt)),
+                    ),
+            )
+            .order_by_desc(session::Column::LastAttentionAt)
+            .order_by_desc(session::Column::UpdatedAt)
+            .order_by_desc(session::Column::Id)
+            .all(&self.db)
+            .await?;
+
+        models.into_iter().map(SessionMetadata::try_from).collect()
     }
 
     async fn get_child_session_ids(&self, parent_session_id: &str) -> Result<Vec<String>, DbError> {

--- a/src-tauri/tests/session_pagination_repository_tests.rs
+++ b/src-tauri/tests/session_pagination_repository_tests.rs
@@ -1,0 +1,123 @@
+mod common;
+
+use tauri_mcp_agent_lib::repositories::session_repository::SessionAttentionReason;
+use tauri_mcp_agent_lib::repositories::{
+    SessionMetadata, SessionRepository, SessionStatus, SqliteSessionRepository,
+};
+
+async fn setup_repo() -> SqliteSessionRepository {
+    let db = common::setup_test_db_with_migrations().await;
+    SqliteSessionRepository::new(db)
+}
+
+fn build_session(id: &str, updated_at: i64) -> SessionMetadata {
+    SessionMetadata {
+        id: id.to_string(),
+        name: Some(format!("Session {id}")),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: updated_at,
+        updated_at,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[tokio::test]
+async fn list_sessions_returns_cursor_ordered_pages() {
+    let repo = setup_repo().await;
+    for (id, updated_at) in [
+        ("session-a", 1_000),
+        ("session-b", 3_000),
+        ("session-c", 2_000),
+    ] {
+        repo.upsert_session(&build_session(id, updated_at))
+            .await
+            .expect("session should insert");
+    }
+
+    let first_page = repo
+        .list_sessions(None, 2)
+        .await
+        .expect("first page should load");
+
+    assert_eq!(
+        first_page
+            .items
+            .iter()
+            .map(|session| session.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["session-b", "session-c"]
+    );
+
+    let second_page = repo
+        .list_sessions(first_page.next_cursor.clone(), 2)
+        .await
+        .expect("second page should load");
+
+    assert_eq!(
+        second_page
+            .items
+            .iter()
+            .map(|session| session.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["session-a"]
+    );
+    assert!(second_page.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn list_attention_sessions_only_returns_unread_attention() {
+    let repo = setup_repo().await;
+    let unread = build_session("unread", 3_000);
+    let read = build_session("read", 2_000);
+    let idle = build_session("idle", 1_000);
+
+    repo.upsert_session(&unread)
+        .await
+        .expect("unread session should insert");
+    repo.upsert_session(&read)
+        .await
+        .expect("read session should insert");
+    repo.upsert_session(&idle)
+        .await
+        .expect("idle session should insert");
+
+    repo.update_attention("unread", 4_000, SessionAttentionReason::PendingApproval)
+        .await
+        .expect("unread attention should persist");
+    repo.update_attention("read", 3_500, SessionAttentionReason::RecurringStop)
+        .await
+        .expect("read attention should persist");
+    repo.update_last_viewed_at("read", 3_500)
+        .await
+        .expect("read viewed state should persist");
+
+    let attention_sessions = repo
+        .list_attention_sessions()
+        .await
+        .expect("attention sessions should load");
+
+    assert_eq!(
+        attention_sessions
+            .iter()
+            .map(|session| session.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["unread"]
+    );
+}

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -318,14 +318,20 @@ export function AgentSessionListProvider({
     ) => {
       sessionListMutationVersionRef.current += 1;
       invalidateSessionListStartupCache();
-      setSessions(updater);
+      setSessions((previousSessions) => {
+        const nextSessions = updater(previousSessions);
+        sessionsRef.current = nextSessions;
+        return nextSessions;
+      });
       if (options?.notificationUpdater) {
-        setNotificationSessions((previousNotifications) =>
-          pruneNotificationSessions(
+        setNotificationSessions((previousNotifications) => {
+          const nextNotifications = pruneNotificationSessions(
             options.notificationUpdater?.(previousNotifications) ??
               previousNotifications,
-          ),
-        );
+          );
+          notificationSessionsRef.current = nextNotifications;
+          return nextNotifications;
+        });
       }
     },
     [pruneNotificationSessions],
@@ -333,27 +339,42 @@ export function AgentSessionListProvider({
 
   const applySessionUpdate = useCallback(
     (sessionId: string, updater: (session: AgentSession) => AgentSession) => {
-      const sourceSession =
-        sessionsRef.current.find((session) => session.id === sessionId) ??
-        notificationSessionsRef.current.find(
+      let updatedSessionFromSessions: AgentSession | undefined;
+
+      setSessions((previousSessions) => {
+        const nextSessions = updateSessionInList(
+          previousSessions,
+          sessionId,
+          (session) => {
+            const nextSession = updater(session);
+            updatedSessionFromSessions = nextSession;
+            return nextSession;
+          },
+        );
+        sessionsRef.current = nextSessions;
+        return nextSessions;
+      });
+      setNotificationSessions((previousNotifications) => {
+        const existingNotification = previousNotifications.find(
           (session) => session.id === sessionId,
         );
-      const updatedSession = sourceSession ? updater(sourceSession) : undefined;
-
-      setSessions((previousSessions) =>
-        updateSessionInList(previousSessions, sessionId, updater),
-      );
-      setNotificationSessions((previousNotifications) =>
-        pruneNotificationSessions(
-          updatedSession &&
-            !previousNotifications.some(
-              (session) => session.id === sessionId,
-            ) &&
-            hasUnreadAttention(updatedSession)
-            ? [...previousNotifications, updatedSession]
-            : updateSessionInList(previousNotifications, sessionId, updater),
-        ),
-      );
+        const nextNotificationSession =
+          updatedSessionFromSessions ??
+          (existingNotification ? updater(existingNotification) : undefined);
+        const nextNotifications = pruneNotificationSessions(
+          nextNotificationSession
+            ? existingNotification
+              ? previousNotifications.map((session) =>
+                  session.id === sessionId ? nextNotificationSession : session,
+                )
+              : hasUnreadAttention(nextNotificationSession)
+                ? [...previousNotifications, nextNotificationSession]
+                : previousNotifications
+            : previousNotifications,
+        );
+        notificationSessionsRef.current = nextNotifications;
+        return nextNotifications;
+      });
     },
     [hasUnreadAttention, pruneNotificationSessions, updateSessionInList],
   );

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -29,6 +29,8 @@ import {
 import { applyViewedAtToSession } from '@/lib/session-utils';
 import type {
   AgentSessionMetadata,
+  AgentSessionListCursor,
+  AgentSessionListResponse,
   CreateAgentSessionRequest,
   AgentResponse,
   AgentConfig,
@@ -37,66 +39,92 @@ import type {
 
 const logger = getLogger('AgentSessionListContext');
 const RESERVED_AGENT_SUBROUTES = new Set(['draft']);
+const SESSION_LIST_PAGE_SIZE = 100;
 
-let cachedSessionMetadataList: AgentSessionMetadata[] | null = null;
-let cachedSessionMetadataPromise: Promise<AgentSessionMetadata[]> | null = null;
-let sessionMetadataCacheGeneration = 0;
+interface InitialSessionListData {
+  page: AgentSessionListResponse;
+  attentionSessions: AgentSessionMetadata[];
+}
+
+let cachedInitialSessionListData: InitialSessionListData | null = null;
+let cachedInitialSessionListPromise: Promise<InitialSessionListData> | null =
+  null;
+let sessionListCacheGeneration = 0;
 
 type SessionMetadataLoadSource = 'cache' | 'inflight' | 'network';
 
 interface SessionMetadataLoadHandle {
   source: SessionMetadataLoadSource;
-  promise: Promise<AgentSessionMetadata[]>;
+  promise: Promise<InitialSessionListData>;
 }
 
 function invalidateSessionListStartupCache() {
-  sessionMetadataCacheGeneration += 1;
-  cachedSessionMetadataList = null;
-  cachedSessionMetadataPromise = null;
+  sessionListCacheGeneration += 1;
+  cachedInitialSessionListData = null;
+  cachedInitialSessionListPromise = null;
 }
 
-function loadSessionMetadataList(
+function loadInitialSessionList(
   forceRefresh = false,
 ): SessionMetadataLoadHandle {
   if (forceRefresh) {
     invalidateSessionListStartupCache();
   }
 
-  if (!forceRefresh && cachedSessionMetadataList !== null) {
+  if (!forceRefresh && cachedInitialSessionListData !== null) {
     return {
       source: 'cache',
-      promise: Promise.resolve(cachedSessionMetadataList),
+      promise: Promise.resolve(cachedInitialSessionListData),
     };
   }
 
-  if (!forceRefresh && cachedSessionMetadataPromise) {
+  if (!forceRefresh && cachedInitialSessionListPromise) {
     return {
       source: 'inflight',
-      promise: cachedSessionMetadataPromise,
+      promise: cachedInitialSessionListPromise,
     };
   }
 
-  const requestGeneration = sessionMetadataCacheGeneration;
-  const request = Promise.resolve(
-    safeInvoke<AgentSessionMetadata[]>('agent_get_all_sessions'),
-  )
-    .then((response) => {
-      const sessionMetadataList = Array.isArray(response) ? response : [];
+  const requestGeneration = sessionListCacheGeneration;
+  const request = Promise.all([
+    safeInvoke<AgentSessionListResponse>('agent_list_sessions', {
+      request: { limit: SESSION_LIST_PAGE_SIZE },
+    }),
+    safeInvoke<AgentSessionMetadata[]>('agent_list_attention_sessions'),
+  ])
+    .then(([page, attentionSessions]) => {
+      const normalizedPage = Array.isArray(page)
+        ? {
+            items: page,
+            nextCursor: undefined,
+          }
+        : page && Array.isArray(page.items)
+          ? page
+          : {
+              items: [],
+              nextCursor: undefined,
+            };
+      const initialData: InitialSessionListData = {
+        page: normalizedPage,
+        attentionSessions: Array.isArray(attentionSessions)
+          ? attentionSessions
+          : [],
+      };
       if (
-        requestGeneration === sessionMetadataCacheGeneration &&
-        cachedSessionMetadataPromise === request
+        requestGeneration === sessionListCacheGeneration &&
+        cachedInitialSessionListPromise === request
       ) {
-        cachedSessionMetadataList = sessionMetadataList;
+        cachedInitialSessionListData = initialData;
       }
-      return sessionMetadataList;
+      return initialData;
     })
     .finally(() => {
-      if (cachedSessionMetadataPromise === request) {
-        cachedSessionMetadataPromise = null;
+      if (cachedInitialSessionListPromise === request) {
+        cachedInitialSessionListPromise = null;
       }
     });
 
-  cachedSessionMetadataPromise = request;
+  cachedInitialSessionListPromise = request;
   return {
     source: 'network',
     promise: request,
@@ -107,12 +135,22 @@ export function __resetAgentSessionListStartupCacheForTests() {
   invalidateSessionListStartupCache();
 }
 
+function dedupeSessionsById(sessions: AgentSession[]): AgentSession[] {
+  const sessionById = new Map<string, AgentSession>();
+  sessions.forEach((session) => {
+    sessionById.set(session.id, session);
+  });
+  return Array.from(sessionById.values());
+}
+
 // --- STATE CONTEXT ---
 interface AgentSessionListStateContextValue {
   sessions: AgentSession[];
   notificationSessions: AgentSession[];
   unreadNotificationCount: number;
   isSessionsListLoading: boolean;
+  hasMoreSessions: boolean;
+  isLoadingMoreSessions: boolean;
 }
 
 const AgentSessionListStateContext = createContext<
@@ -127,9 +165,14 @@ interface AgentSessionListActionsContextValue {
   createSession: (params: CreateSessionParams) => Promise<AgentSession>;
 
   /**
-   * Load all agent sessions
+   * Load the first page of recent agent sessions.
    */
   loadSessions: (forceRefresh?: boolean) => Promise<void>;
+
+  /**
+   * Load the next page of session history.
+   */
+  loadMoreSessions: () => Promise<void>;
 
   /**
    * Delete an agent session
@@ -180,13 +223,20 @@ export function AgentSessionListProvider({
   } = useSettings();
   const { clearSessionState } = useLLMService();
   const [sessions, setSessions] = useState<AgentSession[]>([]);
+  const [notificationSessions, setNotificationSessions] = useState<
+    AgentSession[]
+  >([]);
   const [isSessionsListLoading, setIsSessionsListLoading] = useState(false);
+  const [isLoadingMoreSessions, setIsLoadingMoreSessions] = useState(false);
+  const [hasMoreSessions, setHasMoreSessions] = useState(false);
+  const sessionsRef = useRef<AgentSession[]>([]);
+  const notificationSessionsRef = useRef<AgentSession[]>([]);
   const pendingApprovalKeysRef = useRef(new Set<string>());
   const startupLoadRecordedRef = useRef(false);
   const sessionListMutationVersionRef = useRef(0);
-  const latestSessionListPromiseRef = useRef<Promise<
-    AgentSessionMetadata[]
-  > | null>(null);
+  const latestSessionListPromiseRef =
+    useRef<Promise<InitialSessionListData> | null>(null);
+  const nextCursorRef = useRef<AgentSessionListCursor | undefined>(undefined);
   const activeSessionId = useMemo(() => {
     const sessionId = matchPath('/agent/:sessionId', location.pathname)?.params
       .sessionId;
@@ -195,6 +245,8 @@ export function AgentSessionListProvider({
     }
     return sessionId;
   }, [location.pathname]);
+  sessionsRef.current = sessions;
+  notificationSessionsRef.current = notificationSessions;
 
   const hasUnreadAttention = useCallback((session: AgentSession): boolean => {
     if (!session.lastAttentionAt || !session.lastAttentionReason) {
@@ -208,83 +260,256 @@ export function AgentSessionListProvider({
     return session.lastAttentionAt.getTime() > session.lastViewedAt.getTime();
   }, []);
 
+  const sortNotificationSessions = useCallback(
+    (items: AgentSession[]) =>
+      items.slice().sort((left, right) => {
+        const leftPending = left.pendingApprovalCount ?? 0;
+        const rightPending = right.pendingApprovalCount ?? 0;
+        if (leftPending !== rightPending) {
+          return rightPending - leftPending;
+        }
+
+        const leftTime =
+          left.lastAttentionAt?.getTime() ??
+          left.lastMessageAt?.getTime() ??
+          left.updatedAt?.getTime() ??
+          left.createdAt.getTime();
+        const rightTime =
+          right.lastAttentionAt?.getTime() ??
+          right.lastMessageAt?.getTime() ??
+          right.updatedAt?.getTime() ??
+          right.createdAt.getTime();
+
+        return rightTime - leftTime;
+      }),
+    [],
+  );
+
+  const pruneNotificationSessions = useCallback(
+    (items: AgentSession[]) =>
+      sortNotificationSessions(
+        dedupeSessionsById(items).filter((session) =>
+          hasUnreadAttention(session),
+        ),
+      ),
+    [hasUnreadAttention, sortNotificationSessions],
+  );
+
+  const updateSessionInList = useCallback(
+    (
+      items: AgentSession[],
+      sessionId: string,
+      updater: (session: AgentSession) => AgentSession,
+    ): AgentSession[] =>
+      items.map((session) =>
+        session.id === sessionId ? updater(session) : session,
+      ),
+    [],
+  );
+
   const mutateSessions = useCallback(
-    (updater: (previousSessions: AgentSession[]) => AgentSession[]) => {
+    (
+      updater: (previousSessions: AgentSession[]) => AgentSession[],
+      options?: {
+        notificationUpdater?: (
+          previousNotifications: AgentSession[],
+        ) => AgentSession[];
+      },
+    ) => {
       sessionListMutationVersionRef.current += 1;
       invalidateSessionListStartupCache();
       setSessions(updater);
+      if (options?.notificationUpdater) {
+        setNotificationSessions((previousNotifications) =>
+          pruneNotificationSessions(
+            options.notificationUpdater?.(previousNotifications) ??
+              previousNotifications,
+          ),
+        );
+      }
     },
+    [pruneNotificationSessions],
+  );
+
+  const applySessionUpdate = useCallback(
+    (sessionId: string, updater: (session: AgentSession) => AgentSession) => {
+      const sourceSession =
+        sessionsRef.current.find((session) => session.id === sessionId) ??
+        notificationSessionsRef.current.find(
+          (session) => session.id === sessionId,
+        );
+      const updatedSession = sourceSession ? updater(sourceSession) : undefined;
+
+      setSessions((previousSessions) =>
+        updateSessionInList(previousSessions, sessionId, updater),
+      );
+      setNotificationSessions((previousNotifications) =>
+        pruneNotificationSessions(
+          updatedSession &&
+            !previousNotifications.some(
+              (session) => session.id === sessionId,
+            ) &&
+            hasUnreadAttention(updatedSession)
+            ? [...previousNotifications, updatedSession]
+            : updateSessionInList(previousNotifications, sessionId, updater),
+        ),
+      );
+    },
+    [hasUnreadAttention, pruneNotificationSessions, updateSessionInList],
+  );
+
+  const mapSessionMetadataList = useCallback(
+    (
+      sessionMetadataList: AgentSessionMetadata[],
+      pendingApprovalCounts: Map<string, number>,
+    ) =>
+      sortSessionsByLatestActivity(
+        sessionMetadataList.map((sessionMetadata) =>
+          mapSessionMetadataToAgentSession(
+            sessionMetadata,
+            pendingApprovalCounts.get(sessionMetadata.id) ?? 0,
+          ),
+        ),
+      ),
     [],
   );
 
   /**
-   * Load all agent sessions
+   * Load the first page of recent agent sessions plus notification sessions.
    */
-  const loadSessions = useCallback(async (forceRefresh = false) => {
-    const { source, promise } = loadSessionMetadataList(forceRefresh);
-    latestSessionListPromiseRef.current = promise;
-    const shouldLogLoad = forceRefresh || source === 'network';
+  const loadSessions = useCallback(
+    async (forceRefresh = false) => {
+      const { source, promise } = loadInitialSessionList(forceRefresh);
+      latestSessionListPromiseRef.current = promise;
+      const shouldLogLoad = forceRefresh || source === 'network';
 
-    if (shouldLogLoad) {
-      logger.info('Loading all agent sessions');
-    }
-
-    setIsSessionsListLoading(true);
-    const mutationVersion = sessionListMutationVersionRef.current;
-
-    try {
-      const sessionMetadataList = await promise;
-
-      if (
-        mutationVersion !== sessionListMutationVersionRef.current ||
-        promise !== latestSessionListPromiseRef.current
-      ) {
-        return;
+      if (shouldLogLoad) {
+        logger.info('Loading recent agent sessions');
       }
 
-      setSessions((prev) => {
+      setIsSessionsListLoading(true);
+      const mutationVersion = sessionListMutationVersionRef.current;
+
+      try {
+        const initialData = await promise;
+
+        if (
+          mutationVersion !== sessionListMutationVersionRef.current ||
+          promise !== latestSessionListPromiseRef.current
+        ) {
+          return;
+        }
+
+        const pendingApprovalCounts = new Map<string, number>();
+        [...sessionsRef.current, ...notificationSessionsRef.current].forEach(
+          (session) => {
+            pendingApprovalCounts.set(
+              session.id,
+              session.pendingApprovalCount ?? 0,
+            );
+          },
+        );
+
+        const recentSessions = mapSessionMetadataList(
+          initialData.page.items,
+          pendingApprovalCounts,
+        );
+        const unreadAttentionSessions = pruneNotificationSessions(
+          mapSessionMetadataList(
+            initialData.attentionSessions,
+            pendingApprovalCounts,
+          ),
+        );
+
+        setSessions(recentSessions);
+        setNotificationSessions(unreadAttentionSessions);
+        nextCursorRef.current = initialData.page.nextCursor;
+        setHasMoreSessions(Boolean(initialData.page.nextCursor));
+
+        if (shouldLogLoad) {
+          logger.info('Loaded recent sessions', {
+            count: recentSessions.length,
+            notificationCount: unreadAttentionSessions.length,
+            hasMore: Boolean(initialData.page.nextCursor),
+          });
+        }
+      } catch (err) {
+        if (shouldLogLoad) {
+          logger.error('Failed to load recent sessions', err);
+        }
+        if (
+          mutationVersion === sessionListMutationVersionRef.current &&
+          promise === latestSessionListPromiseRef.current
+        ) {
+          setSessions([]);
+          setNotificationSessions([]);
+          nextCursorRef.current = undefined;
+          setHasMoreSessions(false);
+        }
+      } finally {
+        if (promise === latestSessionListPromiseRef.current) {
+          setIsSessionsListLoading(false);
+        }
+        if (
+          promise === latestSessionListPromiseRef.current &&
+          !startupLoadRecordedRef.current
+        ) {
+          startupLoadRecordedRef.current = true;
+          markStartupMilestone('session-list-settled');
+        }
+      }
+    },
+    [mapSessionMetadataList, pruneNotificationSessions],
+  );
+
+  const loadMoreSessions = useCallback(async () => {
+    const cursor = nextCursorRef.current;
+    if (!cursor || isLoadingMoreSessions) {
+      return;
+    }
+
+    setIsLoadingMoreSessions(true);
+    try {
+      const response = await safeInvoke<AgentSessionListResponse>(
+        'agent_list_sessions',
+        {
+          request: {
+            cursor,
+            limit: SESSION_LIST_PAGE_SIZE,
+          },
+        },
+      );
+
+      const normalizedResponse =
+        response && Array.isArray(response.items)
+          ? response
+          : { items: [], nextCursor: undefined };
+
+      setSessions((previousSessions) => {
         const pendingApprovalCounts = new Map(
-          prev.map((session) => [
+          previousSessions.map((session) => [
             session.id,
             session.pendingApprovalCount ?? 0,
           ]),
         );
+        const incomingSessions = mapSessionMetadataList(
+          normalizedResponse.items,
+          pendingApprovalCounts,
+        );
 
         return sortSessionsByLatestActivity(
-          sessionMetadataList.map((sessionMetadata) =>
-            mapSessionMetadataToAgentSession(
-              sessionMetadata,
-              pendingApprovalCounts.get(sessionMetadata.id) ?? 0,
-            ),
-          ),
+          dedupeSessionsById([...previousSessions, ...incomingSessions]),
         );
       });
-      if (shouldLogLoad) {
-        logger.info('Loaded sessions', { count: sessionMetadataList.length });
-      }
+      nextCursorRef.current = normalizedResponse.nextCursor;
+      setHasMoreSessions(Boolean(normalizedResponse.nextCursor));
     } catch (err) {
-      if (shouldLogLoad) {
-        logger.error('Failed to load sessions', err);
-      }
-      if (
-        mutationVersion === sessionListMutationVersionRef.current &&
-        promise === latestSessionListPromiseRef.current
-      ) {
-        setSessions([]);
-      }
+      logger.error('Failed to load more sessions', err);
+      throw err;
     } finally {
-      if (promise === latestSessionListPromiseRef.current) {
-        setIsSessionsListLoading(false);
-      }
-      if (
-        promise === latestSessionListPromiseRef.current &&
-        !startupLoadRecordedRef.current
-      ) {
-        startupLoadRecordedRef.current = true;
-        markStartupMilestone('session-list-settled');
-      }
+      setIsLoadingMoreSessions(false);
     }
-  }, []);
+  }, [isLoadingMoreSessions, mapSessionMetadataList]);
 
   /**
    * Create a new agent session
@@ -448,7 +673,10 @@ export function AgentSessionListProvider({
         const idsToRemove = new Set(deletedIds);
 
         // Remove the session and ALL its descendants from the UI using the authoritative list from Rust
-        mutateSessions((prev) => prev.filter((s) => !idsToRemove.has(s.id)));
+        mutateSessions((prev) => prev.filter((s) => !idsToRemove.has(s.id)), {
+          notificationUpdater: (prev) =>
+            prev.filter((s) => !idsToRemove.has(s.id)),
+        });
 
         // Clean up LLM state outside the updater to avoid double-invocation in StrictMode
         idsToRemove.forEach((id) => clearSessionState(id));
@@ -482,12 +710,25 @@ export function AgentSessionListProvider({
         const orphanedIds = new Set(response?.data?.orphanedIds || []);
 
         // Remove the session; update explicitly orphaned children to have no parent
-        mutateSessions((prev) =>
-          prev
-            .filter((s) => s.id !== actualDeletedId)
-            .map((s) =>
-              orphanedIds.has(s.id) ? { ...s, parentSessionId: undefined } : s,
-            ),
+        mutateSessions(
+          (prev) =>
+            prev
+              .filter((s) => s.id !== actualDeletedId)
+              .map((s) =>
+                orphanedIds.has(s.id)
+                  ? { ...s, parentSessionId: undefined }
+                  : s,
+              ),
+          {
+            notificationUpdater: (prev) =>
+              prev
+                .filter((s) => s.id !== actualDeletedId)
+                .map((s) =>
+                  orphanedIds.has(s.id)
+                    ? { ...s, parentSessionId: undefined }
+                    : s,
+                ),
+          },
         );
 
         logger.info('Session deleted (children orphaned)', { sessionId });
@@ -509,10 +750,17 @@ export function AgentSessionListProvider({
       const newValue = !(session?.isBookmarked ?? false);
 
       // Optimistic: set locally with the known new value
-      mutateSessions((prev) =>
-        prev.map((s) =>
-          s.id === sessionId ? { ...s, isBookmarked: newValue } : s,
-        ),
+      mutateSessions(
+        (prev) =>
+          prev.map((s) =>
+            s.id === sessionId ? { ...s, isBookmarked: newValue } : s,
+          ),
+        {
+          notificationUpdater: (prev) =>
+            prev.map((s) =>
+              s.id === sessionId ? { ...s, isBookmarked: newValue } : s,
+            ),
+        },
       );
 
       try {
@@ -523,15 +771,14 @@ export function AgentSessionListProvider({
       } catch (err) {
         logger.error('Failed to toggle bookmark', err);
         // Revert optimistic update on failure using the inverse of what we set
-        setSessions((prev) =>
-          prev.map((s) =>
-            s.id === sessionId ? { ...s, isBookmarked: !newValue } : s,
-          ),
-        );
+        applySessionUpdate(sessionId, (session) => ({
+          ...session,
+          isBookmarked: !newValue,
+        }));
         throw err;
       }
     },
-    [mutateSessions, sessions],
+    [applySessionUpdate, mutateSessions, sessions],
   );
 
   const markSessionViewed = useCallback(
@@ -540,35 +787,25 @@ export function AgentSessionListProvider({
         sessionId,
         viewedAt: viewedAt.getTime(),
       });
-      setSessions((prev) =>
-        prev.map((session) =>
-          session.id === sessionId
-            ? applyViewedAtToSession(session, viewedAt)
-            : session,
-        ),
+      applySessionUpdate(sessionId, (session) =>
+        applyViewedAtToSession(session, viewedAt),
       );
     },
-    [],
+    [applySessionUpdate],
   );
 
   const clearPendingApproval = useCallback(
     (sessionId: string, toolCallId: string) => {
       pendingApprovalKeysRef.current.delete(`${sessionId}:${toolCallId}`);
-      setSessions((prev) =>
-        prev.map((session) =>
-          session.id === sessionId
-            ? {
-                ...session,
-                pendingApprovalCount: Math.max(
-                  0,
-                  (session.pendingApprovalCount ?? 0) - 1,
-                ),
-              }
-            : session,
+      applySessionUpdate(sessionId, (session) => ({
+        ...session,
+        pendingApprovalCount: Math.max(
+          0,
+          (session.pendingApprovalCount ?? 0) - 1,
         ),
-      );
+      }));
     },
-    [],
+    [applySessionUpdate],
   );
 
   // Initial load
@@ -616,13 +853,10 @@ export function AgentSessionListProvider({
           payload.sessionId &&
           payload.status
         ) {
-          setSessions((prev) =>
-            prev.map((s) =>
-              s.id === payload.sessionId
-                ? { ...s, status: payload.status as AgentSession['status'] }
-                : s,
-            ),
-          );
+          applySessionUpdate(payload.sessionId, (session) => ({
+            ...session,
+            status: payload.status as AgentSession['status'],
+          }));
           return;
         }
 
@@ -634,19 +868,11 @@ export function AgentSessionListProvider({
           const messageAt = new Date(payload.message.createdAt);
           const shouldMarkViewed = payload.sessionId === activeSessionId;
 
-          setSessions((prev) =>
-            prev.map((session) =>
-              session.id === payload.sessionId
-                ? {
-                    ...session,
-                    lastMessageAt: messageAt,
-                    lastViewedAt: shouldMarkViewed
-                      ? messageAt
-                      : session.lastViewedAt,
-                  }
-                : session,
-            ),
-          );
+          applySessionUpdate(payload.sessionId, (session) => ({
+            ...session,
+            lastMessageAt: messageAt,
+            lastViewedAt: shouldMarkViewed ? messageAt : session.lastViewedAt,
+          }));
           return;
         }
 
@@ -658,25 +884,21 @@ export function AgentSessionListProvider({
           const attentionAt = new Date();
           const shouldMarkViewed = payload.sessionId === activeSessionId;
 
-          setSessions((prev) =>
-            prev.map((session) =>
-              session.id === payload.sessionId
-                ? shouldMarkViewed
-                  ? applyViewedAtToSession(
-                      {
-                        ...session,
-                        lastAttentionAt: attentionAt,
-                        lastAttentionReason: 'recurringStop',
-                      },
-                      attentionAt,
-                    )
-                  : {
-                      ...session,
-                      lastAttentionAt: attentionAt,
-                      lastAttentionReason: 'recurringStop',
-                    }
-                : session,
-            ),
+          applySessionUpdate(payload.sessionId, (session) =>
+            shouldMarkViewed
+              ? applyViewedAtToSession(
+                  {
+                    ...session,
+                    lastAttentionAt: attentionAt,
+                    lastAttentionReason: 'recurringStop',
+                  },
+                  attentionAt,
+                )
+              : {
+                  ...session,
+                  lastAttentionAt: attentionAt,
+                  lastAttentionReason: 'recurringStop',
+                },
           );
 
           if (shouldMarkViewed) {
@@ -705,29 +927,24 @@ export function AgentSessionListProvider({
           const attentionAt = new Date();
           const shouldMarkViewed = payload.sessionId === activeSessionId;
           pendingApprovalKeysRef.current.add(pendingApprovalKey);
-          setSessions((prev) =>
-            prev.map((session) =>
-              session.id === payload.sessionId
-                ? shouldMarkViewed
-                  ? applyViewedAtToSession(
-                      {
-                        ...session,
-                        lastAttentionAt: attentionAt,
-                        lastAttentionReason: 'pendingApproval',
-                        pendingApprovalCount:
-                          (session.pendingApprovalCount ?? 0) + 1,
-                      },
-                      attentionAt,
-                    )
-                  : {
-                      ...session,
-                      lastAttentionAt: attentionAt,
-                      lastAttentionReason: 'pendingApproval',
-                      pendingApprovalCount:
-                        (session.pendingApprovalCount ?? 0) + 1,
-                    }
-                : session,
-            ),
+          applySessionUpdate(payload.sessionId, (session) =>
+            shouldMarkViewed
+              ? applyViewedAtToSession(
+                  {
+                    ...session,
+                    lastAttentionAt: attentionAt,
+                    lastAttentionReason: 'pendingApproval',
+                    pendingApprovalCount:
+                      (session.pendingApprovalCount ?? 0) + 1,
+                  },
+                  attentionAt,
+                )
+              : {
+                  ...session,
+                  lastAttentionAt: attentionAt,
+                  lastAttentionReason: 'pendingApproval',
+                  pendingApprovalCount: (session.pendingApprovalCount ?? 0) + 1,
+                },
           );
 
           if (shouldMarkViewed) {
@@ -757,35 +974,12 @@ export function AgentSessionListProvider({
     return () => {
       if (unlisten) unlisten();
     };
-  }, [activeSessionId, clearPendingApproval, markSessionViewed]);
-
-  const notificationSessions = useMemo(
-    () =>
-      sessions
-        .filter((session) => hasUnreadAttention(session))
-        .slice()
-        .sort((left, right) => {
-          const leftPending = left.pendingApprovalCount ?? 0;
-          const rightPending = right.pendingApprovalCount ?? 0;
-          if (leftPending !== rightPending) {
-            return rightPending - leftPending;
-          }
-
-          const leftTime =
-            left.lastAttentionAt?.getTime() ??
-            left.lastMessageAt?.getTime() ??
-            left.updatedAt?.getTime() ??
-            left.createdAt.getTime();
-          const rightTime =
-            right.lastAttentionAt?.getTime() ??
-            right.lastMessageAt?.getTime() ??
-            right.updatedAt?.getTime() ??
-            right.createdAt.getTime();
-
-          return rightTime - leftTime;
-        }),
-    [hasUnreadAttention, sessions],
-  );
+  }, [
+    activeSessionId,
+    applySessionUpdate,
+    clearPendingApproval,
+    markSessionViewed,
+  ]);
 
   const stateValue = useMemo(
     () => ({
@@ -793,14 +987,23 @@ export function AgentSessionListProvider({
       notificationSessions,
       unreadNotificationCount: notificationSessions.length,
       isSessionsListLoading,
+      hasMoreSessions,
+      isLoadingMoreSessions,
     }),
-    [sessions, notificationSessions, isSessionsListLoading],
+    [
+      hasMoreSessions,
+      isLoadingMoreSessions,
+      isSessionsListLoading,
+      notificationSessions,
+      sessions,
+    ],
   );
 
   const actionsValue = useMemo(
     () => ({
       createSession,
       loadSessions,
+      loadMoreSessions,
       deleteSession,
       deleteSessionOnly,
       toggleBookmark,
@@ -810,6 +1013,7 @@ export function AgentSessionListProvider({
     [
       createSession,
       loadSessions,
+      loadMoreSessions,
       deleteSession,
       deleteSessionOnly,
       toggleBookmark,

--- a/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
@@ -87,7 +87,10 @@ describe('AgentSessionListContext – toggleBookmark', () => {
 
     function setupWithSessions(sessions: ReturnType<typeof makeSession>[]) {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions') return Promise.resolve(sessions);
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({ items: sessions, nextCursor: undefined });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_toggle_session_bookmark') return Promise.resolve(undefined);
             return Promise.reject(new Error(`Unexpected cmd: ${cmd}`));
         });
@@ -137,7 +140,13 @@ describe('AgentSessionListContext – toggleBookmark', () => {
 
     it('reverts optimistic update when IPC call fails', async () => {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions') return Promise.resolve([makeSession('s1', false)]);
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({
+                    items: [makeSession('s1', false)],
+                    nextCursor: undefined,
+                });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_toggle_session_bookmark') return Promise.reject(new Error('network error'));
             return Promise.reject(new Error(`Unexpected cmd: ${cmd}`));
         });
@@ -163,7 +172,13 @@ describe('AgentSessionListContext – toggleBookmark', () => {
         const invokeArgs: unknown[] = [];
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd, args) => {
             invokeArgs.push({ cmd, args });
-            if (cmd === 'agent_get_all_sessions') return Promise.resolve([makeSession('s1', false)]);
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({
+                    items: [makeSession('s1', false)],
+                    nextCursor: undefined,
+                });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_toggle_session_bookmark') return Promise.resolve(undefined);
             return Promise.reject(new Error(`Unexpected cmd: ${cmd}`));
         });

--- a/src/context/__tests__/AgentSessionListContext-delete.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-delete.test.tsx
@@ -74,6 +74,10 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 describe('AgentSessionListContext – SP7 session delete options', () => {
     const mockUnlisten = vi.fn();
 
+    function createSessionPage(sessions: Array<Record<string, unknown>>) {
+        return { items: sessions, nextCursor: undefined };
+    }
+
     beforeEach(() => {
         vi.clearAllMocks();
         __resetAgentSessionListStartupCacheForTests();
@@ -84,11 +88,12 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
 
     it('deleteSession: BFS removes parent AND direct child from UI', async () => {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions')
-                return Promise.resolve([
+            if (cmd === 'agent_list_sessions')
+                return Promise.resolve(createSessionPage([
                     { id: 'parent', name: 'Parent', status: 'idle', createdAt: Date.now() },
                     { id: 'child', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'parent' },
-                ]);
+                ]));
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_delete_session') return Promise.resolve({ success: true, message: 'Deleted sessions', data: ['parent', 'child'] });
             return Promise.resolve();
         });
@@ -111,12 +116,13 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
 
     it('deleteSession: BFS removes entire 3-level tree (grandparent → parent → child)', async () => {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions')
-                return Promise.resolve([
+            if (cmd === 'agent_list_sessions')
+                return Promise.resolve(createSessionPage([
                     { id: 'gp', name: 'Grandparent', status: 'idle', createdAt: Date.now() },
                     { id: 'p', name: 'Parent', status: 'idle', createdAt: Date.now(), parentSessionId: 'gp' },
                     { id: 'c', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'p' },
-                ]);
+                ]));
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_delete_session') return Promise.resolve({ success: true, message: 'ok', data: ['gp', 'p', 'c'] });
             return Promise.resolve();
         });
@@ -140,11 +146,12 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
 
     it('deleteSessionOnly: removes parent, direct child becomes top-level (parentSessionId cleared)', async () => {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions')
-                return Promise.resolve([
+            if (cmd === 'agent_list_sessions')
+                return Promise.resolve(createSessionPage([
                     { id: 'parent', name: 'Parent', status: 'idle', createdAt: Date.now() },
                     { id: 'child', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'parent' },
-                ]);
+                ]));
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'parent', orphanedIds: ['child'] } });
             return Promise.resolve();
         });
@@ -171,12 +178,13 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
 
     it('deleteSessionOnly: uses deletedId from backend response when different from sessionId', async () => {
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions')
-                return Promise.resolve([
+            if (cmd === 'agent_list_sessions')
+                return Promise.resolve(createSessionPage([
                     { id: 'alias-id', name: 'Alias', status: 'idle', createdAt: Date.now() },
                     { id: 'canonical-id', name: 'Parent', status: 'idle', createdAt: Date.now() },
                     { id: 'child', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'canonical-id' },
-                ]);
+                ]));
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             // Mock backend resolving 'alias-id' to 'canonical-id'
             if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'canonical-id', orphanedIds: ['child'] } });
             return Promise.resolve();
@@ -207,12 +215,13 @@ describe('AgentSessionListContext – SP7 session delete options', () => {
     it('deleteSessionOnly: grandchild still linked to its own parent after orphan', async () => {
         // Tree: gp → p → c. Delete p with deleteSessionOnly.
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions')
-                return Promise.resolve([
+            if (cmd === 'agent_list_sessions')
+                return Promise.resolve(createSessionPage([
                     { id: 'gp', name: 'Grandparent', status: 'idle', createdAt: Date.now() },
                     { id: 'p', name: 'Parent', status: 'idle', createdAt: Date.now(), parentSessionId: 'gp' },
                     { id: 'c', name: 'Child', status: 'idle', createdAt: Date.now(), parentSessionId: 'p' },
-                ]);
+                ]));
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_delete_session_only') return Promise.resolve({ data: { deletedId: 'p', orphanedIds: ['c'] } });
             return Promise.resolve();
         });

--- a/src/context/__tests__/AgentSessionListContext-events.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-events.test.tsx
@@ -456,6 +456,39 @@ describe('AgentSessionListContext – statusChanged event (crash recovery)', () 
         });
     });
 
+    it('preserves the latest pending approval count when another attention event follows immediately', async () => {
+        const { result } = renderHook(() => useAgentSessionListState(), {
+            wrapper: TestWrapperWithEvent,
+        });
+
+        await waitFor(() => {
+            expect(agentEventHandler).toBeDefined();
+        });
+
+        act(() => {
+            agentEventHandler?.({
+                payload: {
+                    type: 'toolExecutionRequiresApproval',
+                    sessionId: 'session-child',
+                    toolCallId: 'call-1',
+                },
+            });
+            agentEventHandler?.({
+                payload: {
+                    type: 'workflowCompleted',
+                    sessionId: 'session-child',
+                    reason: 'recurringStop',
+                },
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.notificationSessions[0]?.id).toBe('session-child');
+            expect(result.current.notificationSessions[0]?.pendingApprovalCount).toBe(1);
+            expect(result.current.notificationSessions[0]?.lastAttentionReason).toBe('recurringStop');
+        });
+    });
+
     it('marks active-session approval requests as viewed immediately', async () => {
         const { result } = renderHook(() => useAgentSessionListState(), {
             wrapper: ActiveSessionWrapper,

--- a/src/context/__tests__/AgentSessionListContext.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext.test.tsx
@@ -150,7 +150,9 @@ describe('AgentSessionListContext', () => {
             expect(result.current.sessions[0].id).toBe('session-1');
         });
 
-        expect(safeInvoke).toHaveBeenCalledWith('agent_get_all_sessions');
+        expect(safeInvoke).toHaveBeenCalledWith('agent_list_sessions', {
+            request: { limit: 100 },
+        });
     });
 
     it('dedupes the initial session load across StrictMode remounts', async () => {
@@ -177,14 +179,27 @@ describe('AgentSessionListContext', () => {
         });
 
         await waitFor(() => {
-            expect(safeInvoke).toHaveBeenCalledTimes(1);
+            expect(
+                (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+                    ([cmd]) => cmd === 'agent_list_sessions',
+                ),
+            ).toHaveLength(1);
+            expect(
+                (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+                    ([cmd]) => cmd === 'agent_list_attention_sessions',
+                ),
+            ).toHaveLength(1);
         });
 
         expect(
-            loggerInfo.mock.calls.filter(([message]) => message === 'Loading all agent sessions')
+            loggerInfo.mock.calls.filter(
+                ([message]) => message === 'Loading recent agent sessions',
+            )
         ).toHaveLength(1);
         expect(
-            loggerInfo.mock.calls.filter(([message]) => message === 'Loaded sessions')
+            loggerInfo.mock.calls.filter(
+                ([message]) => message === 'Loaded recent sessions',
+            )
         ).toHaveLength(1);
     });
 
@@ -196,7 +211,9 @@ describe('AgentSessionListContext', () => {
         });
 
         await waitFor(() => {
-            expect(safeInvoke).toHaveBeenCalledWith('agent_get_all_sessions');
+            expect(safeInvoke).toHaveBeenCalledWith('agent_list_sessions', {
+                request: { limit: 100 },
+            });
         });
 
         expect(safeInvoke).not.toHaveBeenCalledWith(
@@ -226,11 +243,16 @@ describe('AgentSessionListContext', () => {
         >();
 
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd !== 'agent_get_all_sessions') {
+            if (cmd === 'agent_list_attention_sessions') {
+                return Promise.resolve([]);
+            }
+            if (cmd !== 'agent_list_sessions') {
                 return Promise.resolve();
             }
 
-            return (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.length === 1
+            return (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+                ([callCmd]) => callCmd === 'agent_list_sessions',
+            ).length === 1
                 ? staleSessions.promise
                 : refreshedSessions.promise;
         });
@@ -241,7 +263,11 @@ describe('AgentSessionListContext', () => {
         );
 
         await waitFor(() => {
-            expect((safeInvoke as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+            expect(
+                (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+                    ([cmd]) => cmd === 'agent_list_sessions',
+                ),
+            ).toHaveLength(1);
             expect(result.current.state.isSessionsListLoading).toBe(true);
         });
 
@@ -250,7 +276,11 @@ describe('AgentSessionListContext', () => {
         });
 
         await waitFor(() => {
-            expect((safeInvoke as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+            expect(
+                (safeInvoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+                    ([cmd]) => cmd === 'agent_list_sessions',
+                ),
+            ).toHaveLength(2);
         });
 
         staleSessions.resolve([
@@ -287,7 +317,10 @@ describe('AgentSessionListContext', () => {
     it('should create a new session', async () => {
         // Mock create response
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd, args) => {
-            if (cmd === 'agent_get_all_sessions') return Promise.resolve([]);
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({ items: [], nextCursor: undefined });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'get_assistant') {
                 return Promise.resolve({
                     id: args.id,
@@ -335,14 +368,20 @@ describe('AgentSessionListContext', () => {
     it('should delete a session', async () => {
         // Setup: Load one session
         (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
-            if (cmd === 'agent_get_all_sessions') return Promise.resolve([
-                {
-                    id: 'session-1',
-                    name: 'Test Session',
-                    status: 'idle',
-                    createdAt: Date.now(),
-                }
-            ]);
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({
+                    items: [
+                        {
+                            id: 'session-1',
+                            name: 'Test Session',
+                            status: 'idle',
+                            createdAt: Date.now(),
+                        },
+                    ],
+                    nextCursor: undefined,
+                });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
             if (cmd === 'agent_delete_session') return Promise.resolve({ success: true, message: 'Session deleted', data: ['session-1'] });
             return Promise.resolve();
         });

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -1,10 +1,17 @@
-import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { RefreshCw, Search, History, X, Bookmark } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Virtuoso } from 'react-virtuoso';
 import {
   buildChildrenMap,
   buildDescendantCounts,
@@ -19,6 +26,8 @@ import { SessionCard } from './SessionCard';
 interface SessionHistoryPanelProps {
   sessions: AgentSession[];
   isLoading: boolean;
+  hasMoreSessions: boolean;
+  isLoadingMoreSessions: boolean;
   activeTab: string;
   activeStatusFilter: 'all' | SessionStatus;
   searchQuery: string;
@@ -26,6 +35,7 @@ interface SessionHistoryPanelProps {
   onActiveStatusFilterChange: (value: 'all' | SessionStatus) => void;
   onSearchQueryChange: (value: string) => void;
   onRefresh: () => void;
+  onLoadMore: () => void;
   onResume: (sessionId: string) => void;
   onDelete: (sessionId: string) => void;
   onDeleteOnly?: (sessionId: string) => void;
@@ -47,6 +57,8 @@ const statusPriority: Record<string, number> = {
 export function SessionHistoryPanel({
   sessions,
   isLoading,
+  hasMoreSessions,
+  isLoadingMoreSessions,
   activeTab,
   activeStatusFilter,
   searchQuery,
@@ -54,6 +66,7 @@ export function SessionHistoryPanel({
   onActiveStatusFilterChange,
   onSearchQueryChange,
   onRefresh,
+  onLoadMore,
   onResume,
   onDelete,
   onDeleteOnly,
@@ -68,9 +81,11 @@ export function SessionHistoryPanel({
   const [selectedLineageId, setSelectedLineageId] = useState<string | null>(
     null,
   );
-  const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(
-    () => new Set(),
-  );
+  const [manuallyExpandedSessionIds, setManuallyExpandedSessionIds] = useState<
+    Set<string>
+  >(() => new Set());
+  const [collapsedAutoExpandedSessionIds, setCollapsedAutoExpandedSessionIds] =
+    useState<Set<string>>(() => new Set());
 
   const defaultHeading =
     heading ?? t('sessionHistory.defaultHeading', 'Recent Sessions');
@@ -95,42 +110,10 @@ export function SessionHistoryPanel({
   const isPending =
     searchQuery !== deferredSearchQuery || sessions !== deferredSessions;
 
-  const baseSessions = useMemo(() => {
-    if (!selectedLineageId) {
-      return deferredSessions;
-    }
-
-    return deferredSessions.filter(
-      (session) => session.lineageId === selectedLineageId,
-    );
-  }, [deferredSessions, selectedLineageId]);
-
-  const segmentedSessions = useMemo(() => {
-    if (activeTab === 'bookmarked') {
-      return baseSessions.filter((session) => session.isBookmarked === true);
-    }
-
-    return baseSessions;
-  }, [activeTab, baseSessions]);
-
-  const matchedSessions = useMemo(() => {
-    let filtered = segmentedSessions;
-
-    if (activeStatusFilter !== 'all') {
-      filtered = filtered.filter(
-        (session) => session.status === activeStatusFilter,
-      );
-    }
-
-    filtered = filterSessions(filtered, deferredSearchQuery);
-
-    return [...filtered].sort((a, b) => {
-      const statusDiff =
-        (statusPriority[a.status] ?? 999) - (statusPriority[b.status] ?? 999);
-      if (statusDiff !== 0) return statusDiff;
-      return b.createdAt.getTime() - a.createdAt.getTime();
-    });
-  }, [activeStatusFilter, deferredSearchQuery, segmentedSessions]);
+  const filtersActive =
+    activeTab === 'bookmarked' ||
+    activeStatusFilter !== 'all' ||
+    deferredSearchQuery.trim().length > 0;
 
   useEffect(() => {
     if (!selectedLineageId) {
@@ -145,6 +128,10 @@ export function SessionHistoryPanel({
     }
   }, [selectedLineageId, sessions]);
 
+  useEffect(() => {
+    setCollapsedAutoExpandedSessionIds(new Set());
+  }, [activeStatusFilter, activeTab, deferredSearchQuery, selectedLineageId]);
+
   const descendantCounts = useMemo(
     () => buildDescendantCounts(sessions),
     [sessions],
@@ -155,49 +142,14 @@ export function SessionHistoryPanel({
     [sessions],
   );
 
-  const filtersActive =
-    activeTab === 'bookmarked' ||
-    activeStatusFilter !== 'all' ||
-    deferredSearchQuery.trim().length > 0;
-
-  const autoExpandedAncestorIds = useMemo(() => {
-    if (!filtersActive) {
-      return new Set<string>();
-    }
-
-    const sessionById = new Map(
-      baseSessions.map((session) => [session.id, session]),
-    );
-    const expandedIds = new Set<string>();
-
-    matchedSessions.forEach((session) => {
-      let current = session.parentSessionId
-        ? sessionById.get(session.parentSessionId)
-        : undefined;
-      while (current) {
-        expandedIds.add(current.id);
-        current = current.parentSessionId
-          ? sessionById.get(current.parentSessionId)
-          : undefined;
-      }
-    });
-
-    return expandedIds;
-  }, [baseSessions, filtersActive, matchedSessions]);
-
-  useEffect(() => {
-    if (autoExpandedAncestorIds.size === 0) {
-      return;
-    }
-
-    setExpandedSessionIds((prev) => {
-      const next = new Set(prev);
-      autoExpandedAncestorIds.forEach((sessionId) => next.add(sessionId));
-      return next;
-    });
-  }, [autoExpandedAncestorIds]);
-
-  const displayRows = useMemo(() => {
+  const {
+    autoExpandedAncestorIds,
+    baseSessions,
+    bookmarkedCount,
+    displayRows,
+    matchedSessionCount,
+    statusCounts,
+  } = useMemo(() => {
     type SessionRow = {
       session: AgentSession;
       nestingLevel: number;
@@ -207,19 +159,76 @@ export function SessionHistoryPanel({
       descendantStatusCounts?: SessionStatusCounts;
     };
 
+    const lineageSessions = selectedLineageId
+      ? deferredSessions.filter(
+          (session) => session.lineageId === selectedLineageId,
+        )
+      : deferredSessions;
+    const nextStatusCounts = {
+      all: lineageSessions.length,
+      busy: 0,
+      idle: 0,
+      paused: 0,
+      error: 0,
+    };
+    let nextBookmarkedCount = 0;
+
+    lineageSessions.forEach((session) => {
+      if (
+        Object.prototype.hasOwnProperty.call(nextStatusCounts, session.status)
+      ) {
+        nextStatusCounts[session.status as keyof typeof nextStatusCounts]++;
+      }
+      if (session.isBookmarked) {
+        nextBookmarkedCount++;
+      }
+    });
+
+    let filteredSessions =
+      activeTab === 'bookmarked'
+        ? lineageSessions.filter((session) => session.isBookmarked === true)
+        : lineageSessions;
+
+    if (activeStatusFilter !== 'all') {
+      filteredSessions = filteredSessions.filter(
+        (session) => session.status === activeStatusFilter,
+      );
+    }
+
+    const matchedSessions = [
+      ...filterSessions(filteredSessions, deferredSearchQuery),
+    ].sort((a, b) => {
+      const statusDiff =
+        (statusPriority[a.status] ?? 999) - (statusPriority[b.status] ?? 999);
+      if (statusDiff !== 0) return statusDiff;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    });
+
     const sessionById = new Map(
-      baseSessions.map((session) => [session.id, session]),
+      lineageSessions.map((session) => [session.id, session]),
     );
-    const childrenByParent = buildChildrenMap(baseSessions);
+    const childrenByParent = buildChildrenMap(lineageSessions);
     const visibleIds = new Set<string>();
+    const nextAutoExpandedAncestorIds = new Set<string>();
 
     matchedSessions.forEach((session) => {
       let current: AgentSession | undefined = session;
       while (current) {
         visibleIds.add(current.id);
-        current = current.parentSessionId
+        const parent: AgentSession | undefined = current.parentSessionId
           ? sessionById.get(current.parentSessionId)
           : undefined;
+        if (parent && filtersActive) {
+          nextAutoExpandedAncestorIds.add(parent.id);
+        }
+        current = parent;
+      }
+    });
+
+    const effectiveExpandedSessionIds = new Set(manuallyExpandedSessionIds);
+    nextAutoExpandedAncestorIds.forEach((sessionId) => {
+      if (!collapsedAutoExpandedSessionIds.has(sessionId)) {
+        effectiveExpandedSessionIds.add(sessionId);
       }
     });
 
@@ -272,7 +281,7 @@ export function SessionHistoryPanel({
       children.sort(sortByCurrentOrder);
     }
 
-    const roots = baseSessions
+    const roots = lineageSessions
       .filter((session) => {
         if (!visibleIds.has(session.id)) {
           return false;
@@ -298,7 +307,7 @@ export function SessionHistoryPanel({
         : undefined;
       const hasExpandableChildren = visibleChildren.length > 0;
       const isExpanded = hasExpandableChildren
-        ? expandedSessionIds.has(session.id)
+        ? effectiveExpandedSessionIds.has(session.id)
         : false;
 
       rows.push({
@@ -327,43 +336,66 @@ export function SessionHistoryPanel({
       walk(root, 0);
     });
 
-    return rows;
+    return {
+      autoExpandedAncestorIds: nextAutoExpandedAncestorIds,
+      baseSessions: lineageSessions,
+      bookmarkedCount: nextBookmarkedCount,
+      displayRows: rows,
+      matchedSessionCount: matchedSessions.length,
+      statusCounts: nextStatusCounts,
+    };
   }, [
-    baseSessions,
+    activeStatusFilter,
+    activeTab,
+    collapsedAutoExpandedSessionIds,
     descendantStatusCounts,
-    expandedSessionIds,
-    matchedSessions,
+    deferredSearchQuery,
+    deferredSessions,
+    filtersActive,
+    manuallyExpandedSessionIds,
+    selectedLineageId,
     t,
   ]);
 
-  const bookmarkedCount = useMemo(() => {
-    return baseSessions.reduce(
-      (acc, session) => (session.isBookmarked ? acc + 1 : acc),
-      0,
-    );
-  }, [baseSessions]);
+  const handleToggleExpand = useCallback(
+    (sessionId: string) => {
+      const isAutoExpanded = autoExpandedAncestorIds.has(sessionId);
+      const isExpanded =
+        manuallyExpandedSessionIds.has(sessionId) ||
+        (isAutoExpanded && !collapsedAutoExpandedSessionIds.has(sessionId));
 
-  const statusCounts = useMemo(() => {
-    const counts = {
-      all: baseSessions.length,
-      busy: 0,
-      idle: 0,
-      paused: 0,
-      error: 0,
-    };
+      setManuallyExpandedSessionIds((prev) => {
+        const next = new Set(prev);
+        if (isExpanded) {
+          next.delete(sessionId);
+        } else if (!isAutoExpanded) {
+          next.add(sessionId);
+        }
+        return next;
+      });
 
-    segmentedSessions.forEach((session) => {
-      if (Object.prototype.hasOwnProperty.call(counts, session.status)) {
-        counts[session.status as keyof typeof counts]++;
+      if (isAutoExpanded) {
+        setCollapsedAutoExpandedSessionIds((prev) => {
+          const next = new Set(prev);
+          if (isExpanded) {
+            next.add(sessionId);
+          } else {
+            next.delete(sessionId);
+          }
+          return next;
+        });
       }
-    });
-
-    return counts;
-  }, [segmentedSessions]);
+    },
+    [
+      autoExpandedAncestorIds,
+      collapsedAutoExpandedSessionIds,
+      manuallyExpandedSessionIds,
+    ],
+  );
 
   return (
-    <div className="p-6 h-full flex flex-col bg-background">
-      <div className="max-w-5xl mx-auto w-full flex flex-col h-full">
+    <div className="flex h-full min-h-0 flex-col bg-background p-6">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl flex-col">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-4">
@@ -378,7 +410,22 @@ export function SessionHistoryPanel({
                 {defaultHeading}
               </h1>
               <p className="text-sm text-muted-foreground mt-0.5">
-                {defaultDescription} ({displayRows.length}/{baseSessions.length}
+                {defaultDescription} (
+                {t(
+                  'sessionHistory.loadedCountSummary',
+                  '{{count}} loaded sessions',
+                  { count: baseSessions.length },
+                )}
+                {hasMoreSessions
+                  ? `, ${t('sessionHistory.moreAvailable', 'more available')}`
+                  : ''}
+                {filtersActive
+                  ? `, ${t(
+                      'sessionHistory.matchCountSummary',
+                      '{{count}} matching filters',
+                      { count: matchedSessionCount },
+                    )}`
+                  : ''}
                 )
               </p>
             </div>
@@ -399,7 +446,7 @@ export function SessionHistoryPanel({
           defaultValue="all"
           value={activeTab}
           onValueChange={onActiveTabChange}
-          className="w-full mb-4"
+          className="mb-4 w-full shrink-0"
         >
           <TabsList className="w-full justify-start overflow-x-auto">
             <TabsTrigger value="all" className="flex-1">
@@ -413,7 +460,7 @@ export function SessionHistoryPanel({
           </TabsList>
         </Tabs>
 
-        <div className="mb-4 flex flex-wrap items-center gap-2">
+        <div className="mb-4 flex shrink-0 flex-wrap items-center gap-2">
           <span className="text-xs font-medium text-muted-foreground">
             {t('sessionHistory.statusFilter.label', 'Status')}
           </span>
@@ -459,7 +506,7 @@ export function SessionHistoryPanel({
           </Button>
         </div>
 
-        <div className="relative">
+        <div className="relative shrink-0">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
           <Input
             type="text"
@@ -501,7 +548,7 @@ export function SessionHistoryPanel({
         {/* Content */}
         <div
           className={cn(
-            'flex-1 min-h-0 overflow-y-auto pr-2 pb-4 mt-6 transition-opacity duration-200',
+            'mt-6 flex min-h-0 flex-1 flex-col transition-opacity duration-200',
             isPending ? 'opacity-50' : 'opacity-100',
           )}
           aria-busy={isPending}
@@ -571,54 +618,69 @@ export function SessionHistoryPanel({
               </div>
             </div>
           ) : (
-            <ul
-              className="grid grid-cols-1 gap-4 max-w-2xl list-none"
-              aria-labelledby="session-heading"
-            >
-              {displayRows.map(
-                ({
+            <Virtuoso
+              className="min-h-0 flex-1 max-w-2xl pr-2 pb-4"
+              style={{ height: '100%' }}
+              data={displayRows}
+              overscan={400}
+              computeItemKey={(_index, row) => row.session.id}
+              components={{
+                Footer: () =>
+                  hasMoreSessions ? (
+                    <div className="flex justify-center py-4">
+                      <Button
+                        variant="outline"
+                        onClick={onLoadMore}
+                        disabled={isLoadingMoreSessions}
+                      >
+                        <RefreshCw
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            isLoadingMoreSessions && 'animate-spin',
+                          )}
+                        />
+                        {isLoadingMoreSessions
+                          ? t('sessionHistory.loadingMore', 'Loading more...')
+                          : t('sessionHistory.loadMore', 'Load more')}
+                      </Button>
+                    </div>
+                  ) : null,
+              }}
+              itemContent={(
+                _index,
+                {
                   session,
                   nestingLevel,
                   lineageHint,
                   hasExpandableChildren,
                   isExpanded,
                   descendantStatusCounts: rowDescendantStatusCounts,
-                }) => (
-                  <li key={session.id}>
-                    <SessionCard
-                      session={session}
-                      onResume={onResume}
-                      onDelete={onDelete}
-                      onDeleteOnly={onDeleteOnly}
-                      onToggleBookmark={onToggleBookmark}
-                      nestingLevel={nestingLevel}
-                      lineageHint={lineageHint}
-                      selectedLineageId={selectedLineageId}
-                      descendantCount={descendantCounts.get(session.id) ?? 0}
-                      descendantStatusCounts={rowDescendantStatusCounts}
-                      hasExpandableChildren={hasExpandableChildren}
-                      isExpanded={isExpanded}
-                      onToggleExpand={(sessionId) =>
-                        setExpandedSessionIds((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(sessionId)) {
-                            next.delete(sessionId);
-                          } else {
-                            next.add(sessionId);
-                          }
-                          return next;
-                        })
-                      }
-                      onLineageSelect={(lineageId) =>
-                        setSelectedLineageId((prev) =>
-                          prev === lineageId ? null : lineageId,
-                        )
-                      }
-                    />
-                  </li>
-                ),
+                },
+              ) => (
+                <div key={session.id} className="pb-4">
+                  <SessionCard
+                    session={session}
+                    onResume={onResume}
+                    onDelete={onDelete}
+                    onDeleteOnly={onDeleteOnly}
+                    onToggleBookmark={onToggleBookmark}
+                    nestingLevel={nestingLevel}
+                    lineageHint={lineageHint}
+                    selectedLineageId={selectedLineageId}
+                    descendantCount={descendantCounts.get(session.id) ?? 0}
+                    descendantStatusCounts={rowDescendantStatusCounts}
+                    hasExpandableChildren={hasExpandableChildren}
+                    isExpanded={isExpanded}
+                    onToggleExpand={handleToggleExpand}
+                    onLineageSelect={(lineageId) =>
+                      setSelectedLineageId((prev) =>
+                        prev === lineageId ? null : lineageId,
+                      )
+                    }
+                  />
+                </div>
               )}
-            </ul>
+            />
           )}
         </div>
       </div>

--- a/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
+++ b/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
@@ -3,6 +3,7 @@ import { SessionHistoryPanel } from '../SessionHistoryPanel';
 import type { AgentSession } from '@/models/agent';
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
+import type { ReactNode } from 'react';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -48,6 +49,25 @@ vi.mock('../SessionCard', () => ({
   ),
 }));
 
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+    components,
+  }: {
+    data: unknown[];
+    itemContent: (index: number, item: unknown) => ReactNode;
+    components?: { Footer?: () => ReactNode };
+  }) => (
+    <div>
+      {data.map((item, index) => (
+        <div key={index}>{itemContent(index, item)}</div>
+      ))}
+      {components?.Footer ? <components.Footer /> : null}
+    </div>
+  ),
+}));
+
 global.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
@@ -72,6 +92,19 @@ function createSession(
   };
 }
 
+const defaultProps = {
+  hasMoreSessions: false,
+  isLoadingMoreSessions: false,
+  onActiveTabChange: () => {},
+  onActiveStatusFilterChange: () => {},
+  onSearchQueryChange: () => {},
+  onRefresh: () => {},
+  onLoadMore: () => {},
+  onResume: () => {},
+  onDelete: () => {},
+  onDeleteOnly: () => {},
+};
+
 describe('SessionHistoryPanel', () => {
   it('correctly calculates descendant counts for a session tree', () => {
     const sessions: AgentSession[] = [
@@ -87,16 +120,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -115,16 +142,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -147,16 +168,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -181,16 +196,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="all"
         activeStatusFilter="error"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -211,16 +220,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="bookmarked"
         activeStatusFilter="all"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -241,16 +244,10 @@ describe('SessionHistoryPanel', () => {
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
+        {...defaultProps}
         activeTab="bookmarked"
         activeStatusFilter="all"
         searchQuery=""
-        onActiveTabChange={() => {}}
-        onActiveStatusFilterChange={() => {}}
-        onSearchQueryChange={() => {}}
-        onRefresh={() => {}}
-        onResume={() => {}}
-        onDelete={() => {}}
-        onDeleteOnly={() => {}}
       />,
     );
 
@@ -258,5 +255,48 @@ describe('SessionHistoryPanel', () => {
 
     expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
     expect(screen.queryByTestId('session-card-child')).not.toBeInTheDocument();
+  });
+
+  it('resets collapsed auto-expanded lineage state when the filter context changes', () => {
+    const sessions: AgentSession[] = [
+      createSession('root', 'Root'),
+      createSession('child-alpha', 'Alpha child', {
+        parentSessionId: 'root',
+      }),
+      createSession('child-beta', 'Beta child', {
+        parentSessionId: 'root',
+      }),
+    ];
+
+    const { rerender } = render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeTab="all"
+        activeStatusFilter="all"
+        searchQuery="alpha"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
+
+    expect(
+      screen.queryByTestId('session-card-child-alpha'),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeTab="all"
+        activeStatusFilter="all"
+        searchQuery="beta"
+      />,
+    );
+
+    expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
+    expect(screen.getByTestId('session-card-child-beta')).toBeInTheDocument();
   });
 });

--- a/src/features/history/History.tsx
+++ b/src/features/history/History.tsx
@@ -15,9 +15,19 @@ const logger = getLogger('History');
 export default function History() {
   const navigate = useNavigate();
   const { t } = useTranslation('common');
-  const { sessions, isSessionsListLoading } = useAgentSessionListState();
-  const { loadSessions, deleteSession, deleteSessionOnly, toggleBookmark } =
-    useAgentSessionListActions();
+  const {
+    sessions,
+    isSessionsListLoading,
+    hasMoreSessions,
+    isLoadingMoreSessions,
+  } = useAgentSessionListState();
+  const {
+    loadSessions,
+    loadMoreSessions,
+    deleteSession,
+    deleteSessionOnly,
+    toggleBookmark,
+  } = useAgentSessionListActions();
   const [activeTab, setActiveTab] = useState('all');
   const [activeStatusFilter, setActiveStatusFilter] = useState<
     'all' | SessionStatus
@@ -62,14 +72,16 @@ export default function History() {
   );
 
   const handleRefreshSessions = useCallback(() => {
-    loadSessions();
+    loadSessions(true);
   }, [loadSessions]);
 
   return (
-    <div className="flex-1 flex flex-col text-foreground overflow-hidden">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden text-foreground">
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={isSessionsListLoading}
+        hasMoreSessions={hasMoreSessions}
+        isLoadingMoreSessions={isLoadingMoreSessions}
         activeTab={activeTab}
         activeStatusFilter={activeStatusFilter}
         searchQuery={searchQuery}
@@ -77,6 +89,7 @@ export default function History() {
         onActiveStatusFilterChange={setActiveStatusFilter}
         onSearchQueryChange={setSearchQuery}
         onRefresh={handleRefreshSessions}
+        onLoadMore={loadMoreSessions}
         onResume={handleResumeSession}
         onDelete={handleDeleteSession}
         onDeleteOnly={handleDeleteSessionOnly}

--- a/src/features/history/Org.tsx
+++ b/src/features/history/Org.tsx
@@ -1,14 +1,14 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Building2, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import {
-  useAgentSessionListActions,
-  useAgentSessionListState,
-} from '@/context/AgentSessionListContext';
+import { safeInvoke } from '@/lib/backend/core';
+import type { AgentSession } from '@/models/agent';
+import type { AgentSessionMetadata } from '@/models/agent-ipc';
+import { mapSessionMetadataToAgentSession } from '@/lib/session-metadata';
 import { selectOrgSummaries } from './org-sessions';
 import { OrgCard } from './OrgCard';
 
@@ -33,19 +33,38 @@ function OrgCardSkeleton() {
 
 export default function Org() {
   const { t } = useTranslation('common');
-  const { sessions, isSessionsListLoading } = useAgentSessionListState();
-  const { loadSessions } = useAgentSessionListActions();
+  const [sessions, setSessions] = useState<AgentSession[]>([]);
+  const [isSessionsListLoading, setIsSessionsListLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const orgs = useMemo(() => selectOrgSummaries(sessions), [sessions]);
 
-  async function handleRefresh() {
-    setIsRefreshing(true);
+  async function loadOrgSessions(forceRefreshing = false) {
+    if (forceRefreshing) {
+      setIsRefreshing(true);
+    } else {
+      setIsSessionsListLoading(true);
+    }
     try {
-      await loadSessions();
+      const response = await safeInvoke<AgentSessionMetadata[]>(
+        'agent_get_all_sessions',
+      );
+      const items = Array.isArray(response) ? response : [];
+      setSessions(
+        items.map((session) => mapSessionMetadataToAgentSession(session)),
+      );
     } finally {
       setIsRefreshing(false);
+      setIsSessionsListLoading(false);
     }
+  }
+
+  useEffect(() => {
+    void loadOrgSessions();
+  }, []);
+
+  async function handleRefresh() {
+    await loadOrgSessions(true);
   }
 
   if (isSessionsListLoading) {

--- a/src/features/history/__tests__/Org.test.tsx
+++ b/src/features/history/__tests__/Org.test.tsx
@@ -1,10 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentSession } from '@/models/agent';
 import Org from '../Org';
 
 const mockNavigate = vi.fn();
-const mockLoadSessions = vi.fn();
+const mockDeleteSession = vi.fn();
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
@@ -21,60 +20,65 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('@/lib/backend/core', () => ({
+  safeInvoke: vi.fn().mockResolvedValue([
+    {
+      id: 'solo',
+      name: 'Solo Session',
+      status: 'idle',
+      model: 'test-model',
+      provider: 'test-provider',
+      createdAt: new Date('2026-04-05T00:00:00Z').getTime(),
+      updatedAt: new Date('2026-04-05T00:00:00Z').getTime(),
+      lineageId: 'lineage-1',
+      yoloMode: false,
+    },
+    {
+      id: 'root',
+      name: 'Org Root',
+      status: 'idle',
+      model: 'test-model',
+      provider: 'test-provider',
+      createdAt: new Date('2026-04-05T00:00:00Z').getTime(),
+      updatedAt: new Date('2026-04-05T00:00:00Z').getTime(),
+      orgId: 'org-1',
+      orgName: 'Research Org',
+      orgRootSessionId: 'root',
+      yoloMode: false,
+    },
+    {
+      id: 'child',
+      name: 'Org Child',
+      status: 'busy',
+      model: 'test-model',
+      provider: 'test-provider',
+      createdAt: new Date('2026-04-05T00:01:00Z').getTime(),
+      updatedAt: new Date('2026-04-05T00:01:00Z').getTime(),
+      parentSessionId: 'root',
+      lineageId: 'lineage-2',
+      depth: 1,
+      orgId: 'org-1',
+      orgName: 'Research Org',
+      orgRootSessionId: 'root',
+      yoloMode: false,
+    },
+  ]),
+}));
+
 vi.mock('@/context/AgentSessionListContext', () => ({
-  useAgentSessionListState: () => ({
-    sessions: [
-      {
-        id: 'solo',
-        name: 'Solo Session',
-        status: 'idle',
-        model: 'test-model',
-        provider: 'test-provider',
-        createdAt: new Date('2026-04-05T00:00:00Z'),
-        lineageId: 'lineage-1',
-        yoloMode: false,
-      },
-      {
-        id: 'root',
-        name: 'Org Root',
-        status: 'idle',
-        model: 'test-model',
-        provider: 'test-provider',
-        createdAt: new Date('2026-04-05T00:00:00Z'),
-        orgId: 'org-1',
-        orgName: 'Research Org',
-        orgRootSessionId: 'root',
-        yoloMode: false,
-      },
-      {
-        id: 'child',
-        name: 'Org Child',
-        status: 'busy',
-        model: 'test-model',
-        provider: 'test-provider',
-        createdAt: new Date('2026-04-05T00:01:00Z'),
-        parentSessionId: 'root',
-        lineageId: 'lineage-2',
-        depth: 1,
-        orgId: 'org-1',
-        orgName: 'Research Org',
-        orgRootSessionId: 'root',
-        yoloMode: false,
-      },
-    ] satisfies AgentSession[],
-    isSessionsListLoading: false,
-  }),
   useAgentSessionListActions: () => ({
-    loadSessions: mockLoadSessions,
+    deleteSession: mockDeleteSession,
   }),
 }));
 
 describe('Org', () => {
-  it('renders explicit org cards only and resumes the root session', () => {
+  it('renders explicit org cards only and resumes the root session', async () => {
     render(<Org />);
 
-    expect(screen.getByText('Org View')).toBeInTheDocument();
-    expect(screen.getByText('Research Org')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Org View')).toBeInTheDocument();
+      expect(screen.getByText('Research Org')).toBeInTheDocument();
+    });
     expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.queryByText('Solo Session')).not.toBeInTheDocument();

--- a/src/features/knowledge/KnowledgePage.tsx
+++ b/src/features/knowledge/KnowledgePage.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Database, Loader2, RefreshCw, Search } from 'lucide-react';
 import {
@@ -14,17 +15,112 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  type GridComponents,
+  type GridItemProps,
+  type GridListProps,
+  type GridScrollSeekPlaceholderProps,
+  VirtuosoGrid,
+} from 'react-virtuoso';
+import { cn } from '@/lib/utils';
+import type { KnowledgeChunkListItem } from '@/lib/backend/knowledge';
 import { KnowledgeDetailDialog } from './components/KnowledgeDetailDialog';
 import { KnowledgeListItemCard } from './components/KnowledgeListItemCard';
 import { useKnowledgeBrowser } from './hooks/useKnowledgeBrowser';
+
+interface KnowledgeGridContext {
+  endOfResultsLabel: string;
+  excerptLabel: string;
+  hasMoreItems: boolean;
+  isLoadingMore: boolean;
+  loadMoreLabel: string;
+  onLoadMore: () => void;
+  onSelect: (id: number) => void;
+  selectedId: number | null;
+  untitledLabel: string;
+}
+
+const knowledgeGridComponents: GridComponents<KnowledgeGridContext> = {
+  List: forwardRef<HTMLDivElement, GridListProps>(function KnowledgeGridList(
+    { children, className, style, ...props },
+    ref,
+  ) {
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={cn('flex flex-wrap content-start px-1', className)}
+        style={style}
+      >
+        {children}
+      </div>
+    );
+  }),
+  Item: forwardRef<HTMLDivElement, GridItemProps>(function KnowledgeGridItem(
+    { children, className, style, ...props },
+    ref,
+  ) {
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={cn('flex w-full p-1.5 lg:w-1/2 2xl:w-1/3', className)}
+        style={style}
+      >
+        {children}
+      </div>
+    );
+  }),
+  Footer: function KnowledgeGridFooter({ context }) {
+    if (!context.hasMoreItems) {
+      return (
+        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+          {context.endOfResultsLabel}
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex justify-center px-3 py-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={context.onLoadMore}
+          disabled={context.isLoadingMore}
+          className="min-w-36 gap-2"
+        >
+          {context.isLoadingMore ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : null}
+          {context.loadMoreLabel}
+        </Button>
+      </div>
+    );
+  },
+  ScrollSeekPlaceholder: function KnowledgeGridScrollSeekPlaceholder({
+    height,
+  }: GridScrollSeekPlaceholderProps) {
+    return (
+      <div
+        className="w-full rounded-2xl border border-border/60 p-4"
+        style={{ height }}
+      >
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+      </div>
+    );
+  },
+};
 
 export default function KnowledgePage() {
   const { t } = useTranslation('common');
   const {
     assistantFilter,
-    assistants,
+    assistantOptions,
     cancelDelete,
     closeDetail,
     deleteSelectedItem,
@@ -34,8 +130,10 @@ export default function KnowledgePage() {
     isDeleting,
     isDetailLoading,
     isDetailOpen,
+    isInitialListLoading,
     isListLoading,
     isLoadingMore,
+    isRefreshingList,
     items,
     loadMore,
     query,
@@ -47,6 +145,63 @@ export default function KnowledgePage() {
     setAssistantFilter,
     setQuery,
   } = useKnowledgeBrowser();
+
+  const excerptLabel = t('knowledge.excerpt', 'Excerpt');
+  const untitledLabel = t(
+    'knowledge.untitledEntry',
+    'Untitled knowledge entry',
+  );
+  const loadMoreLabel = t('knowledge.loadMore', 'Load more');
+  const endOfResultsLabel = t(
+    'knowledge.endOfResults',
+    'You have reached the end of the current results.',
+  );
+
+  const handleLoadMore = useCallback(() => {
+    void loadMore();
+  }, [loadMore]);
+
+  const gridContext = useMemo<KnowledgeGridContext>(
+    () => ({
+      endOfResultsLabel,
+      excerptLabel,
+      hasMoreItems,
+      isLoadingMore,
+      loadMoreLabel,
+      onLoadMore: handleLoadMore,
+      onSelect: selectItem,
+      selectedId,
+      untitledLabel,
+    }),
+    [
+      endOfResultsLabel,
+      excerptLabel,
+      hasMoreItems,
+      isLoadingMore,
+      loadMoreLabel,
+      handleLoadMore,
+      selectItem,
+      selectedId,
+      untitledLabel,
+    ],
+  );
+
+  const renderKnowledgeCard = useCallback(
+    (
+      _index: number,
+      item: KnowledgeChunkListItem,
+      context: KnowledgeGridContext,
+    ) => (
+      <KnowledgeListItemCard
+        excerptLabel={context.excerptLabel}
+        item={item}
+        isActive={item.id === context.selectedId}
+        onSelect={context.onSelect}
+        untitledLabel={context.untitledLabel}
+      />
+    ),
+    [],
+  );
 
   return (
     <div className="h-full bg-background p-6">
@@ -75,13 +230,15 @@ export default function KnowledgePage() {
             onClick={refresh}
             className="gap-2"
           >
-            <RefreshCw className="h-4 w-4" />
+            <RefreshCw
+              className={cn('h-4 w-4', isListLoading && 'animate-spin')}
+            />
             {t('knowledge.refresh', 'Refresh')}
           </Button>
         </div>
 
         <div className="min-h-0 flex-1">
-          <Card className="min-h-0 gap-4 py-4">
+          <Card className="flex h-full min-h-0 flex-col gap-4 py-4">
             <CardHeader className="px-4">
               <CardTitle className="text-base">
                 {t('knowledge.browserTitle', 'Knowledge Browser')}
@@ -123,74 +280,59 @@ export default function KnowledgePage() {
                   <SelectItem value="all">
                     {t('knowledge.assistantFilterAll', 'All assistants')}
                   </SelectItem>
-                  {assistants.map((assistantId) => (
-                    <SelectItem key={assistantId} value={assistantId}>
-                      {assistantId}
+                  {assistantOptions.map((assistant) => (
+                    <SelectItem key={assistant.id} value={assistant.id}>
+                      {assistant.label}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
 
-              <ScrollArea className="min-h-0 flex-1">
-                <div className="space-y-4 pr-3">
-                  <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
-                    {isListLoading ? (
-                      Array.from({ length: 6 }).map((_, index) => (
-                        <div
-                          key={index}
-                          className="space-y-2 rounded-xl border p-3"
-                        >
-                          <Skeleton className="h-4 w-24" />
-                          <Skeleton className="h-3 w-full" />
-                          <Skeleton className="h-3 w-4/5" />
-                        </div>
-                      ))
-                    ) : items.length === 0 ? (
-                      <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
-                        {t(
-                          'knowledge.emptyState',
-                          'No knowledge entries match the current filters.',
-                        )}
-                      </div>
-                    ) : (
-                      items.map((item) => (
-                        <KnowledgeListItemCard
-                          key={item.id}
-                          item={item}
-                          isActive={item.id === selectedId}
-                          onSelect={selectItem}
-                        />
-                      ))
-                    )}
-                  </div>
-
-                  {!isListLoading && items.length > 0 ? (
-                    <div className="flex flex-col items-center gap-3 py-2">
-                      {hasMoreItems ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => void loadMore()}
-                          disabled={isLoadingMore}
-                          className="min-w-36 gap-2"
-                        >
-                          {isLoadingMore ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : null}
-                          {t('knowledge.loadMore', 'Load more')}
-                        </Button>
-                      ) : (
-                        <p className="text-xs text-muted-foreground">
-                          {t(
-                            'knowledge.endOfResults',
-                            'You have reached the end of the current results.',
-                          )}
-                        </p>
-                      )}
-                    </div>
-                  ) : null}
+              {isRefreshingList ? (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  {t('knowledge.refreshingResults', 'Updating results...')}
                 </div>
-              </ScrollArea>
+              ) : null}
+
+              {isInitialListLoading ? (
+                <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+                  {Array.from({ length: 6 }).map((_, index) => (
+                    <div
+                      key={index}
+                      className="space-y-2 rounded-xl border p-3"
+                    >
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-3 w-4/5" />
+                    </div>
+                  ))}
+                </div>
+              ) : items.length === 0 ? (
+                <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  {t(
+                    'knowledge.emptyState',
+                    'No knowledge entries match the current filters.',
+                  )}
+                </div>
+              ) : (
+                <div className="min-h-0 flex-1">
+                  <VirtuosoGrid
+                    className="h-full"
+                    style={{ height: '100%' }}
+                    data={items}
+                    components={knowledgeGridComponents}
+                    computeItemKey={(_index, item) => item.id}
+                    context={gridContext}
+                    increaseViewportBy={{ top: 160, bottom: 240 }}
+                    itemContent={renderKnowledgeCard}
+                    scrollSeekConfiguration={{
+                      enter: (velocity) => Math.abs(velocity) > 400,
+                      exit: (velocity) => Math.abs(velocity) < 80,
+                    }}
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/features/knowledge/components/KnowledgeListItemCard.tsx
+++ b/src/features/knowledge/components/KnowledgeListItemCard.tsx
@@ -1,22 +1,24 @@
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui';
 import type { KnowledgeChunkListItem } from '@/lib/backend/knowledge';
 import { formatTimestamp, getKnowledgeCardTitle } from '../knowledge-utils';
 
 interface KnowledgeListItemCardProps {
+  excerptLabel: string;
   item: KnowledgeChunkListItem;
   isActive: boolean;
   onSelect: (id: number) => void;
+  untitledLabel: string;
 }
 
 export const KnowledgeListItemCard = memo(function KnowledgeListItemCard({
+  excerptLabel,
   item,
   isActive,
   onSelect,
+  untitledLabel,
 }: KnowledgeListItemCardProps) {
-  const { t } = useTranslation('common');
-  const title = getKnowledgeCardTitle(item.preview, t);
+  const title = getKnowledgeCardTitle(item.preview, untitledLabel);
   const visibleTags = item.tags.slice(0, 2);
   const hiddenTagCount = Math.max(item.tags.length - visibleTags.length, 0);
 
@@ -24,12 +26,11 @@ export const KnowledgeListItemCard = memo(function KnowledgeListItemCard({
     <button
       type="button"
       onClick={() => onSelect(item.id)}
-      className={`w-full rounded-2xl border p-4 text-left shadow-sm transition-all [content-visibility:auto] ${
+      className={`min-h-[220px] w-full rounded-2xl border p-4 text-left shadow-sm transition-all ${
         isActive
           ? 'border-primary/70 bg-primary/5 shadow-primary/5'
           : 'border-border/60 bg-card/80 hover:border-border hover:bg-muted/30'
       }`}
-      style={{ containIntrinsicSize: '220px' }}
     >
       <div className="min-w-0 space-y-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -65,7 +66,7 @@ export const KnowledgeListItemCard = memo(function KnowledgeListItemCard({
 
       <div className="mt-4 rounded-xl border border-border/40 bg-muted/20 p-3">
         <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-          {t('knowledge.excerpt', 'Excerpt')}
+          {excerptLabel}
         </div>
         <p className="line-clamp-4 text-sm leading-6 text-foreground/90">
           {item.preview}

--- a/src/features/knowledge/components/knowledge-detail/KnowledgeDetailGraphTab.tsx
+++ b/src/features/knowledge/components/knowledge-detail/KnowledgeDetailGraphTab.tsx
@@ -19,17 +19,17 @@ export function KnowledgeDetailGraphTab({
   );
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+    <div className="grid h-full min-h-0 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
       <KnowledgeGraphPreview detail={detail} />
 
-      <Card className="py-4">
+      <Card className="flex min-h-0 flex-col py-4">
         <CardHeader className="px-4">
           <CardTitle className="text-sm">
             {t('knowledge.relationshipListTitle', 'Relationships')}
           </CardTitle>
         </CardHeader>
-        <CardContent className="px-4">
-          <ScrollArea className="h-[320px] pr-3">
+        <CardContent className="flex min-h-0 flex-1 px-4">
+          <ScrollArea className="min-h-0 flex-1 pr-3">
             <div className="space-y-2 text-sm">
               {detail.relationships.length === 0 ? (
                 <p className="text-muted-foreground">

--- a/src/features/knowledge/components/knowledge-detail/KnowledgeDetailOverviewTab.tsx
+++ b/src/features/knowledge/components/knowledge-detail/KnowledgeDetailOverviewTab.tsx
@@ -20,8 +20,8 @@ export function KnowledgeDetailOverviewTab({
   const { t } = useTranslation('common');
 
   return (
-    <div className="grid h-full gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
-      <Card className="min-h-0 py-4">
+    <div className="grid h-full min-h-0 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <Card className="flex min-h-0 flex-col py-4">
         <CardHeader className="px-4">
           <div className="flex flex-wrap gap-2">
             <Badge variant="secondary">{detail.assistantId}</Badge>
@@ -35,8 +35,8 @@ export function KnowledgeDetailOverviewTab({
             ))}
           </div>
         </CardHeader>
-        <CardContent className="min-h-0 px-4">
-          <ScrollArea className="h-[420px] pr-4">
+        <CardContent className="flex min-h-0 flex-1 px-4">
+          <ScrollArea className="min-h-0 flex-1 pr-4">
             <div className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
               {detail.content}
             </div>
@@ -73,14 +73,14 @@ export function KnowledgeDetailOverviewTab({
           </CardContent>
         </Card>
 
-        <Card className="min-h-0 flex-1 py-4">
+        <Card className="flex min-h-0 flex-1 flex-col py-4">
           <CardHeader className="px-4">
             <CardTitle className="text-sm">
               {t('knowledge.entitiesTitle', 'Entities')}
             </CardTitle>
           </CardHeader>
-          <CardContent className="min-h-0 px-4">
-            <ScrollArea className="h-[250px] pr-3">
+          <CardContent className="flex min-h-0 flex-1 px-4">
+            <ScrollArea className="min-h-0 flex-1 pr-3">
               <div className="space-y-2">
                 {detail.entities.length === 0 ? (
                   <p className="text-sm text-muted-foreground">

--- a/src/features/knowledge/hooks/useKnowledgeBrowser.ts
+++ b/src/features/knowledge/hooks/useKnowledgeBrowser.ts
@@ -1,18 +1,35 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listAssistantSummaries,
+  type AssistantSummary,
+} from '@/lib/backend/assistants';
+import { getLogger } from '@/lib/logger';
 import { useKnowledgeDelete } from './useKnowledgeDelete';
 import { useKnowledgeDetail } from './useKnowledgeDetail';
 import { useKnowledgeList } from './useKnowledgeList';
+
+const logger = getLogger('useKnowledgeBrowser');
+
+interface KnowledgeAssistantOption {
+  id: string;
+  label: string;
+}
 
 export function useKnowledgeBrowser() {
   const [query, setQuery] = useState('');
   const [assistantFilter, setAssistantFilter] = useState('all');
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [listRefreshToken, setListRefreshToken] = useState(0);
+  const [assistantSummaries, setAssistantSummaries] = useState<
+    AssistantSummary[]
+  >([]);
   const {
     assistants,
     hasMoreItems,
+    isInitialListLoading,
     isListLoading,
     isLoadingMore,
+    isRefreshingList,
     items,
     loadMore,
   } = useKnowledgeList({
@@ -22,10 +39,56 @@ export function useKnowledgeBrowser() {
   });
   const { detail, isDetailLoading } = useKnowledgeDetail(selectedId);
 
+  useEffect(() => {
+    let active = true;
+
+    const loadAssistantSummaries = async () => {
+      try {
+        const summaries = await listAssistantSummaries();
+        if (!active) {
+          return;
+        }
+        setAssistantSummaries(summaries);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        logger.warn(
+          'Failed to load assistant summaries for knowledge filter labels',
+          error,
+        );
+      }
+    };
+
+    void loadAssistantSummaries();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const selectedItem = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,
     [items, selectedId],
   );
+
+  const assistantOptions = useMemo<KnowledgeAssistantOption[]>(() => {
+    const labelById = new Map(
+      assistantSummaries.map((assistant) => [assistant.id, assistant.name]),
+    );
+    const optionIds = new Set(assistants);
+
+    if (assistantFilter !== 'all') {
+      optionIds.add(assistantFilter);
+    }
+
+    return [...optionIds]
+      .map((id) => ({
+        id,
+        label: labelById.get(id) ?? id,
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }, [assistantFilter, assistantSummaries, assistants]);
 
   const refresh = useCallback(() => {
     setListRefreshToken((current) => current + 1);
@@ -63,7 +126,7 @@ export function useKnowledgeBrowser() {
 
   return {
     assistantFilter,
-    assistants,
+    assistantOptions,
     cancelDelete,
     closeDetail,
     deleteSelectedItem,
@@ -73,8 +136,10 @@ export function useKnowledgeBrowser() {
     isDeleting,
     isDetailLoading,
     isDetailOpen: selectedItem !== null,
+    isInitialListLoading,
     isListLoading,
     isLoadingMore,
+    isRefreshingList,
     items,
     loadMore,
     query,

--- a/src/features/knowledge/hooks/useKnowledgeList.test.tsx
+++ b/src/features/knowledge/hooks/useKnowledgeList.test.tsx
@@ -123,4 +123,73 @@ describe('useKnowledgeList', () => {
       expect(result.current.isLoadingMore).toBe(false);
     });
   });
+
+  it('keeps prior results visible while a refetch is in flight', async () => {
+    let resolveRefresh: ((value: {
+      items: ReturnType<typeof createItem>[];
+      assistants: string[];
+      nextCursor: { createdAt: number; id: number } | null;
+    }) => void) | null = null;
+
+    vi.mocked(listGlobalKnowledge).mockImplementation(async () => {
+      if (resolveRefresh) {
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      }
+
+      resolveRefresh = null;
+      return {
+        items: [createItem(1)],
+        assistants: ['assistant-1'],
+        nextCursor: null,
+      };
+    });
+
+    const { result, rerender } = renderHook(
+      ({ refreshToken }) =>
+        useKnowledgeList({
+          assistantFilter: 'all',
+          query: '',
+          refreshToken,
+        }),
+      {
+        initialProps: {
+          refreshToken: 0,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(1)]);
+      expect(result.current.isInitialListLoading).toBe(false);
+    });
+
+    vi.mocked(listGlobalKnowledge).mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    rerender({ refreshToken: 1 });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(1)]);
+      expect(result.current.isInitialListLoading).toBe(false);
+      expect(result.current.isRefreshingList).toBe(true);
+    });
+
+    act(() => {
+      resolveRefresh?.({
+        items: [createItem(2)],
+        assistants: ['assistant-1'],
+        nextCursor: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([createItem(2)]);
+    });
+  });
 });

--- a/src/features/knowledge/hooks/useKnowledgeList.ts
+++ b/src/features/knowledge/hooks/useKnowledgeList.ts
@@ -34,6 +34,7 @@ export function useKnowledgeList({
   const { t } = useTranslation('common');
   const [items, setItems] = useState<KnowledgeChunkListItem[]>([]);
   const [assistants, setAssistants] = useState<string[]>([]);
+  const [hasResolvedFirstPage, setHasResolvedFirstPage] = useState(false);
   const [isListLoading, setIsListLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<KnowledgeListCursor | null>(
@@ -68,9 +69,11 @@ export function useKnowledgeList({
         setItems(response.items);
         setAssistants(response.assistants);
         setNextCursor(response.nextCursor ?? null);
+        setHasResolvedFirstPage(true);
       } catch (error) {
         logger.error('Failed to load global knowledge list', error);
         if (!cancelled) {
+          setHasResolvedFirstPage(true);
           toast.error(
             t(
               'knowledge.loadListFailed',
@@ -139,8 +142,10 @@ export function useKnowledgeList({
   return {
     assistants,
     hasMoreItems: nextCursor !== null,
+    isInitialListLoading: isListLoading && !hasResolvedFirstPage,
     isListLoading,
     isLoadingMore,
+    isRefreshingList: isListLoading && hasResolvedFirstPage,
     items,
     loadMore,
   };

--- a/src/features/knowledge/knowledge-utils.ts
+++ b/src/features/knowledge/knowledge-utils.ts
@@ -1,4 +1,3 @@
-import type { TFunction } from 'i18next';
 import type { KnowledgeGraphEntity } from '@/lib/backend/knowledge';
 
 const knowledgeDateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -10,10 +9,13 @@ export function formatTimestamp(timestamp: number): string {
   return knowledgeDateFormatter.format(new Date(timestamp));
 }
 
-export function getKnowledgeCardTitle(preview: string, t: TFunction): string {
+export function getKnowledgeCardTitle(
+  preview: string,
+  untitledLabel: string,
+): string {
   const normalizedPreview = preview.replace(/\s+/g, ' ').trim();
   if (!normalizedPreview) {
-    return t('knowledge.untitledEntry', 'Untitled knowledge entry');
+    return untitledLabel;
   }
 
   const sentenceMatch = normalizedPreview.match(/^(.{1,96}?[.!?])(?:\s|$)/);

--- a/src/models/agent-ipc.ts
+++ b/src/models/agent-ipc.ts
@@ -249,6 +249,16 @@ export interface AgentSessionMetadata {
   yoloMode: boolean;
 }
 
+export interface AgentSessionListCursor {
+  updatedAt: number;
+  id: string;
+}
+
+export interface AgentSessionListResponse {
+  items: AgentSessionMetadata[];
+  nextCursor?: AgentSessionListCursor;
+}
+
 export interface MessageCursor {
   createdAt: number;
   rowId: number;


### PR DESCRIPTION
## Summary
- remove the Linux software-rendering compatibility fallback and keep Linux on the default rendering path
- paginate session history loading, virtualize history/knowledge lists, and fix history layout/auto-expand behavior
- improve knowledge UX by avoiding refetch flicker, showing assistant names in the filter, stabilizing detail layouts, and reducing load-more scroll jump

## Validation
- pnpm refactor:validate