### PR TITLE
⚡ Bolt: Optimize summarizeIpcCalls by removing redundant O(N) reductions

### DIFF
--- a/src/lib/performance/startup-metrics.ts
+++ b/src/lib/performance/startup-metrics.ts
@@ -117,8 +117,15 @@ function summarizeIpcCalls(
   ipcCalls: readonly StartupIpcCallEntry[],
 ): StartupIpcSummary {
   const byCommand = new Map<string, StartupIpcCommandSummary>();
+  let globalFailedCount = 0;
+  let globalTotalDurationMs = 0;
+  let globalMaxDurationMs = 0;
 
   for (const ipcCall of ipcCalls) {
+    globalFailedCount += ipcCall.ok ? 0 : 1;
+    globalTotalDurationMs += ipcCall.durationMs;
+    globalMaxDurationMs = Math.max(globalMaxDurationMs, ipcCall.durationMs);
+
     const existing = byCommand.get(ipcCall.cmd);
     if (existing) {
       existing.count += 1;
@@ -140,22 +147,11 @@ function summarizeIpcCalls(
     });
   }
 
-  const failedCount = ipcCalls.reduce(
-    (count, ipcCall) => count + (ipcCall.ok ? 0 : 1),
-    0,
-  );
-
   return {
     count: ipcCalls.length,
-    failedCount,
-    totalDurationMs: ipcCalls.reduce(
-      (total, ipcCall) => total + ipcCall.durationMs,
-      0,
-    ),
-    maxDurationMs: ipcCalls.reduce(
-      (maxDuration, ipcCall) => Math.max(maxDuration, ipcCall.durationMs),
-      0,
-    ),
+    failedCount: globalFailedCount,
+    totalDurationMs: globalTotalDurationMs,
+    maxDurationMs: globalMaxDurationMs,
     commands: Array.from(byCommand.values()).sort(
       (left, right) => right.totalDurationMs - left.totalDurationMs,
     ),


### PR DESCRIPTION
💡 What: Consolidated three redundant O(N) `.reduce()` passes into a single pass loop during `startup-metrics` computation.
🎯 Why: Avoid unnecessary iteration overhead when iterating over `ipcCalls`. Aggregates can be computed while constructing the `byCommand` map.
📊 Impact: Reduces iteration cycles over `ipcCalls` array from 4 to 1, providing a micro-optimization in metric summarization times.
🔬 Measurement: Verify tests still pass and startup metrics operate exactly as they did before.

---
*PR created automatically by Jules for task [8347684452965786337](https://jules.google.com/task/8347684452965786337) started by @fritzprix*