### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file read operations

### DIFF
--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -214,23 +214,13 @@ impl SecurityValidator {
         self.validate_path(user_path)
     }
 
-    /// Validate a path for read-only operations. Absolute paths outside the base directory are
-    /// permitted, while relative paths continue to be constrained to the base directory.
+    /// Validate a path for read-only operations.
+    ///
+    /// Like all file operations, read paths must be strictly constrained to the base directory
+    /// to prevent path traversal vulnerabilities. Absolute paths are only permitted if they
+    /// resolve to a location inside the base directory.
     pub fn validate_path_for_read(&self, user_path: &str) -> Result<PathBuf, SecurityError> {
-        let normalized = user_path.replace(['\\', '/'], "/");
-
-        // Detect Windows drive-letter absolute paths like C:\foo
-        let is_windows_absolute = normalized.len() >= 2 && normalized.as_bytes()[1] == b':';
-
-        // Also treat Unix-style absolute paths (starting with '/') as absolute
-        let is_unix_style_absolute = normalized.starts_with('/');
-
-        if Path::new(&normalized).is_absolute() || is_windows_absolute || is_unix_style_absolute {
-            let cleaned = PathBuf::from(&normalized).clean();
-            return Ok(cleaned);
-        }
-
-        self.validate_path(&normalized)
+        self.validate_path(user_path)
     }
 
     /// Check if file size is within limits

--- a/src-tauri/tests/builtin_security_validator_tests.rs
+++ b/src-tauri/tests/builtin_security_validator_tests.rs
@@ -14,6 +14,11 @@ fn test_path_validation() {
         .validate_path("attachments/docker_조사....md")
         .is_ok());
 
+    // Absolute paths for read operations are now strictly rejected
+    assert!(validator
+        .validate_path_for_read("/tmp/some-file.txt")
+        .is_err());
+
     // Invalid paths (directory traversal)
     assert!(validator.validate_path("../test.txt").is_err());
     assert!(validator.validate_path("../../etc/passwd").is_err());

--- a/src-tauri/tests/builtin_security_validator_tests.rs
+++ b/src-tauri/tests/builtin_security_validator_tests.rs
@@ -14,11 +14,6 @@ fn test_path_validation() {
         .validate_path("attachments/docker_조사....md")
         .is_ok());
 
-    // Absolute paths for read operations should be allowed
-    assert!(validator
-        .validate_path_for_read("/tmp/some-file.txt")
-        .is_ok());
-
     // Invalid paths (directory traversal)
     assert!(validator.validate_path("../test.txt").is_err());
     assert!(validator.validate_path("../../etc/passwd").is_err());


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `validate_path_for_read` function in `src-tauri/src/mcp/builtin/utils.rs` contained an unsafe exception that allowed any absolute path to bypass the base directory restriction. An attacker or rogue agent could supply a path like `/etc/passwd` or `C:\Windows\System32\config\SAM` to read arbitrary system files.
🎯 **Impact:** Allowed arbitrary file read capabilities beyond the intended file system sandbox, exposing the system to severe data leakage, including secrets, system configurations, and user data.
🔧 **Fix:** Removed the unsafe absolute path exception in `validate_path_for_read` and delegated validation entirely to the robust `validate_path` method. All paths, whether relative or absolute, must now resolve inside the base directory bounds.
✅ **Verification:** Ran `pnpm test`, `cargo check`, and specific backend tests. Code review validated the mitigation.

---
*PR created automatically by Jules for task [16690460971812772915](https://jules.google.com/task/16690460971812772915) started by @fritzprix*