### PR TITLE
fix: optimize settings dirty tracking

### DIFF
--- a/src/features/settings/hooks/__tests__/useSettingsForm.test.tsx
+++ b/src/features/settings/hooks/__tests__/useSettingsForm.test.tsx
@@ -29,6 +29,14 @@ describe('useSettingsForm', () => {
     const { result } = renderHook(() => useSettingsForm());
     expect(result.current.formState).toEqual(DEFAULT_SETTING);
     expect(result.current.isDirty).toBe(false);
+    expect(result.current.dirtyState).toEqual({
+      general: false,
+      'ai-models': false,
+      'chat-interface': false,
+      system: false,
+      advanced: false,
+      dev: false,
+    });
   });
 
   it('should update top-level settings', () => {
@@ -40,6 +48,8 @@ describe('useSettingsForm', () => {
 
     expect(result.current.formState.windowSize).toBe(50);
     expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtyState['chat-interface']).toBe(true);
+    expect(result.current.dirtyState.general).toBe(false);
   });
 
   it('should update service config', () => {
@@ -63,6 +73,8 @@ describe('useSettingsForm', () => {
 
     expect(result.current.formState.advanced.maxRetries).toBe(5);
     expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtyState['ai-models']).toBe(true);
+    expect(result.current.dirtyState.advanced).toBe(false);
   });
 
   it('should reset changes', () => {
@@ -163,5 +175,6 @@ describe('useSettingsForm', () => {
 
     expect(result.current.formState.windowSize).toBe(50);
     expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtyState['chat-interface']).toBe(true);
   });
 });

--- a/src/features/settings/hooks/useSettingsForm.ts
+++ b/src/features/settings/hooks/useSettingsForm.ts
@@ -13,13 +13,137 @@ import equal from 'fast-deep-equal';
 // Define the form state shape, identical to Settings for now
 export type SettingsFormState = Settings;
 
+export type SettingsDirtyState = {
+  general: boolean;
+  'ai-models': boolean;
+  'chat-interface': boolean;
+  system: boolean;
+  advanced: boolean;
+  dev: boolean;
+};
+
+type SettingsFormStore = {
+  formState: SettingsFormState;
+  dirtyState: SettingsDirtyState;
+};
+
+function getEmptyDirtyState(): SettingsDirtyState {
+  return {
+    general: false,
+    'ai-models': false,
+    'chat-interface': false,
+    system: false,
+    advanced: false,
+    dev: false,
+  };
+}
+
+function getAiModelsComparableState(settings: SettingsFormState) {
+  return {
+    serviceConfigs: settings.serviceConfigs,
+    preferredModel: settings.preferredModel,
+    fallbackModel: settings.fallbackModel,
+    agentHubUrl: settings.agentHubUrl,
+    maxRetries: settings.advanced.maxRetries,
+    retryDelay: settings.advanced.retryDelay,
+    defaultMaxOutputTokens: settings.advanced.defaultMaxOutputTokens,
+  };
+}
+
+function getChatInterfaceComparableState(settings: SettingsFormState) {
+  return {
+    contextStrategy: settings.contextStrategy,
+    windowSize: settings.windowSize,
+    maxInputContext: settings.maxInputContext,
+    toolCallGroupVisibleCount: settings.toolCallGroupVisibleCount,
+    diffContextLines: settings.advanced.diffContextLines,
+  };
+}
+
+function getSystemComparableState(settings: SettingsFormState) {
+  return {
+    skillsDirectory: settings.system.skillsDirectory,
+    maxFileUploadSizeMB: settings.system.maxFileUploadSizeMB,
+    searchIndexFrequencyMinutes: settings.system.searchIndexFrequencyMinutes,
+    webActionTimeoutSeconds: settings.system.webActionTimeoutSeconds,
+    mcpServerStartupTimeoutSeconds:
+      settings.system.mcpServerStartupTimeoutSeconds,
+    mcpToolTimeoutSeconds: settings.system.mcpToolTimeoutSeconds,
+    scheduledTaskMinimumIntervalMinutes:
+      settings.system.scheduledTaskMinimumIntervalMinutes,
+    maxScheduledTaskGroups: settings.system.maxScheduledTaskGroups,
+    httpServerPort: settings.system.httpServerPort,
+    httpServerExpose: settings.system.httpServerExpose,
+  };
+}
+
+function getAdvancedComparableState(settings: SettingsFormState) {
+  const { diffContextLines, ...advancedWithoutChatFields } = settings.advanced;
+  void diffContextLines;
+
+  return {
+    ...advancedWithoutChatFields,
+    maxRetries: undefined,
+    retryDelay: undefined,
+    defaultMaxOutputTokens: undefined,
+    shellIsolationLevel: settings.system.shellIsolationLevel,
+  };
+}
+
+export function getSettingsDirtyState(
+  formState: SettingsFormState,
+  globalSettings: SettingsFormState,
+): SettingsDirtyState {
+  return {
+    general:
+      formState.uiLanguage !== globalSettings.uiLanguage ||
+      !equal(formState.display, globalSettings.display),
+    'ai-models': !equal(
+      getAiModelsComparableState(formState),
+      getAiModelsComparableState(globalSettings),
+    ),
+    'chat-interface': !equal(
+      getChatInterfaceComparableState(formState),
+      getChatInterfaceComparableState(globalSettings),
+    ),
+    system: !equal(
+      getSystemComparableState(formState),
+      getSystemComparableState(globalSettings),
+    ),
+    advanced: !equal(
+      getAdvancedComparableState(formState),
+      getAdvancedComparableState(globalSettings),
+    ),
+    dev: false,
+  };
+}
+
 export function useSettingsForm() {
   const { value: globalSettings, update: updateGlobal } = useSettings();
 
-  // Initialize form state from global settings
-  const [formState, setFormState] = useState<SettingsFormState>(globalSettings);
+  const [state, setState] = useState<SettingsFormStore>(() => ({
+    formState: globalSettings,
+    dirtyState: getEmptyDirtyState(),
+  }));
   const previousGlobalSettingsRef = useRef(globalSettings);
   const shouldAcceptNextGlobalSyncRef = useRef(false);
+  const globalSettingsRef = useRef(globalSettings);
+
+  const updateFormStore = useCallback(
+    (updater: (previous: SettingsFormState) => SettingsFormState) => {
+      setState((previous) => {
+        const nextFormState = updater(previous.formState);
+        return {
+          formState: nextFormState,
+          dirtyState: getSettingsDirtyState(
+            nextFormState,
+            globalSettingsRef.current,
+          ),
+        };
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     const previousGlobalSettings = previousGlobalSettingsRef.current;
@@ -30,15 +154,25 @@ export function useSettingsForm() {
 
     const shouldSyncFormState =
       shouldAcceptNextGlobalSyncRef.current ||
-      equal(formState, previousGlobalSettings);
+      equal(state.formState, previousGlobalSettings);
 
     previousGlobalSettingsRef.current = globalSettings;
+    globalSettingsRef.current = globalSettings;
     shouldAcceptNextGlobalSyncRef.current = false;
 
     if (shouldSyncFormState) {
-      setFormState(globalSettings);
+      setState({
+        formState: globalSettings,
+        dirtyState: getEmptyDirtyState(),
+      });
+      return;
     }
-  }, [formState, globalSettings]);
+
+    setState((previous) => ({
+      formState: previous.formState,
+      dirtyState: getSettingsDirtyState(previous.formState, globalSettings),
+    }));
+  }, [globalSettings, state.formState]);
 
   // Generic update for top-level keys
   const update = useCallback(
@@ -46,18 +180,18 @@ export function useSettingsForm() {
       key: K,
       value: SettingsFormState[K],
     ) => {
-      setFormState((prev) => ({
+      updateFormStore((prev) => ({
         ...prev,
         [key]: value,
       }));
     },
-    [],
+    [updateFormStore],
   );
 
   // Specialized updaters for nested objects to keep usage clean
   const updateServiceConfig = useCallback(
     (provider: AIServiceProvider, patch: Partial<ServiceConfig>) => {
-      setFormState((prev) => {
+      updateFormStore((prev) => {
         const currentConfig = prev.serviceConfigs[provider] || {};
         const newConfig = { ...currentConfig, ...patch };
         return {
@@ -69,12 +203,12 @@ export function useSettingsForm() {
         };
       });
     },
-    [],
+    [updateFormStore],
   );
 
   const updateAdvanced = useCallback(
     <K extends keyof AdvancedSettings>(key: K, value: AdvancedSettings[K]) => {
-      setFormState((prev) => ({
+      updateFormStore((prev) => ({
         ...prev,
         advanced: {
           ...prev.advanced,
@@ -82,12 +216,12 @@ export function useSettingsForm() {
         },
       }));
     },
-    [],
+    [updateFormStore],
   );
 
   const updateDisplay = useCallback(
     <K extends keyof DisplaySettings>(key: K, value: DisplaySettings[K]) => {
-      setFormState((prev) => ({
+      updateFormStore((prev) => ({
         ...prev,
         display: {
           ...prev.display,
@@ -95,12 +229,12 @@ export function useSettingsForm() {
         },
       }));
     },
-    [],
+    [updateFormStore],
   );
 
   const updateSystem = useCallback(
     <K extends keyof SystemSettings>(key: K, value: SystemSettings[K]) => {
-      setFormState((prev) => ({
+      updateFormStore((prev) => ({
         ...prev,
         system: {
           ...prev.system,
@@ -108,30 +242,34 @@ export function useSettingsForm() {
         },
       }));
     },
-    [],
+    [updateFormStore],
   );
 
   const reset = useCallback(() => {
-    setFormState(globalSettings);
-  }, [globalSettings]);
+    setState({
+      formState: globalSettingsRef.current,
+      dirtyState: getEmptyDirtyState(),
+    });
+  }, []);
 
   const save = useCallback(async () => {
     shouldAcceptNextGlobalSyncRef.current = true;
 
     try {
-      await updateGlobal(formState);
+      await updateGlobal(state.formState);
     } catch (error) {
       shouldAcceptNextGlobalSyncRef.current = false;
       throw error;
     }
-  }, [formState, updateGlobal]);
+  }, [state.formState, updateGlobal]);
 
   const isDirty = useMemo(() => {
-    return !equal(formState, globalSettings);
-  }, [formState, globalSettings]);
+    return Object.values(state.dirtyState).some(Boolean);
+  }, [state.dirtyState]);
 
   return {
-    formState,
+    formState: state.formState,
+    dirtyState: state.dirtyState,
     update,
     updateServiceConfig,
     updateAdvanced,

--- a/src/features/settings/hooks/useSettingsPageController.ts
+++ b/src/features/settings/hooks/useSettingsPageController.ts
@@ -1,4 +1,3 @@
-import equal from 'fast-deep-equal';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { mutate } from 'swr';
@@ -52,6 +51,7 @@ export function useSettingsPageController() {
   const { t } = useTranslation('common');
   const {
     formState,
+    dirtyState,
     update,
     updateServiceConfig,
     updateAdvanced,
@@ -95,117 +95,13 @@ export function useSettingsPageController() {
     ],
   );
 
-  const tabDirtyState = useMemo(() => {
-    const {
-      diffContextLines: formDiffContextLines,
-      ...formAdvancedWithoutDiff
-    } = formState.advanced;
-    const {
-      diffContextLines: globalDiffContextLines,
-      ...globalAdvancedWithoutDiff
-    } = globalSettings.advanced;
-
-    return {
-      general:
-        formState.uiLanguage !== globalSettings.uiLanguage ||
-        !equal(formState.display, globalSettings.display),
-      'ai-models': !equal(
-        {
-          serviceConfigs: formState.serviceConfigs,
-          preferredModel: formState.preferredModel,
-          fallbackModel: formState.fallbackModel,
-          agentHubUrl: formState.agentHubUrl,
-          maxRetries: formState.advanced.maxRetries,
-          retryDelay: formState.advanced.retryDelay,
-          defaultMaxOutputTokens: formState.advanced.defaultMaxOutputTokens,
-        },
-        {
-          serviceConfigs: globalSettings.serviceConfigs,
-          preferredModel: globalSettings.preferredModel,
-          fallbackModel: globalSettings.fallbackModel,
-          agentHubUrl: globalSettings.agentHubUrl,
-          maxRetries: globalSettings.advanced.maxRetries,
-          retryDelay: globalSettings.advanced.retryDelay,
-          defaultMaxOutputTokens:
-            globalSettings.advanced.defaultMaxOutputTokens,
-        },
-      ),
-      'chat-interface': !equal(
-        {
-          contextStrategy: formState.contextStrategy,
-          windowSize: formState.windowSize,
-          maxInputContext: formState.maxInputContext,
-          toolCallGroupVisibleCount: formState.toolCallGroupVisibleCount,
-          diffContextLines: formDiffContextLines,
-        },
-        {
-          contextStrategy: globalSettings.contextStrategy,
-          windowSize: globalSettings.windowSize,
-          maxInputContext: globalSettings.maxInputContext,
-          toolCallGroupVisibleCount: globalSettings.toolCallGroupVisibleCount,
-          diffContextLines: globalDiffContextLines,
-        },
-      ),
-      system: !equal(
-        {
-          skillsDirectory: formState.system.skillsDirectory,
-          maxFileUploadSizeMB: formState.system.maxFileUploadSizeMB,
-          searchIndexFrequencyMinutes:
-            formState.system.searchIndexFrequencyMinutes,
-          webActionTimeoutSeconds: formState.system.webActionTimeoutSeconds,
-          mcpServerStartupTimeoutSeconds:
-            formState.system.mcpServerStartupTimeoutSeconds,
-          mcpToolTimeoutSeconds: formState.system.mcpToolTimeoutSeconds,
-          scheduledTaskMinimumIntervalMinutes:
-            formState.system.scheduledTaskMinimumIntervalMinutes,
-          maxScheduledTaskGroups: formState.system.maxScheduledTaskGroups,
-          httpServerPort: formState.system.httpServerPort,
-          httpServerExpose: formState.system.httpServerExpose,
-        },
-        {
-          skillsDirectory: globalSettings.system.skillsDirectory,
-          maxFileUploadSizeMB: globalSettings.system.maxFileUploadSizeMB,
-          searchIndexFrequencyMinutes:
-            globalSettings.system.searchIndexFrequencyMinutes,
-          webActionTimeoutSeconds:
-            globalSettings.system.webActionTimeoutSeconds,
-          mcpServerStartupTimeoutSeconds:
-            globalSettings.system.mcpServerStartupTimeoutSeconds,
-          mcpToolTimeoutSeconds: globalSettings.system.mcpToolTimeoutSeconds,
-          scheduledTaskMinimumIntervalMinutes:
-            globalSettings.system.scheduledTaskMinimumIntervalMinutes,
-          maxScheduledTaskGroups: globalSettings.system.maxScheduledTaskGroups,
-          httpServerPort: globalSettings.system.httpServerPort,
-          httpServerExpose: globalSettings.system.httpServerExpose,
-        },
-      ),
-      advanced: !equal(
-        {
-          ...formAdvancedWithoutDiff,
-          maxRetries: undefined,
-          retryDelay: undefined,
-          defaultMaxOutputTokens: undefined,
-          shellIsolationLevel: formState.system.shellIsolationLevel,
-        },
-        {
-          ...globalAdvancedWithoutDiff,
-          maxRetries: undefined,
-          retryDelay: undefined,
-          defaultMaxOutputTokens: undefined,
-          shellIsolationLevel: globalSettings.system.shellIsolationLevel,
-        },
-      ),
-      dev: false,
-    } satisfies Record<SettingsTabValue, boolean>;
-  }, [formState, globalSettings]);
-
   const changedSectionCount = useMemo(
     () =>
-      Object.entries(tabDirtyState).filter(
+      Object.entries(dirtyState).filter(
         ([tab, isChanged]) =>
           isChanged && (import.meta.env.DEV || tab !== 'dev'),
       ).length,
-    [tabDirtyState],
+    [dirtyState],
   );
 
   const triggerAppRestart = useCallback(() => {
@@ -493,27 +389,27 @@ export function useSettingsPageController() {
       {
         value: 'general',
         label: t('settings.tabs.general', 'General'),
-        isDirty: tabDirtyState.general,
+        isDirty: dirtyState.general,
       },
       {
         value: 'ai-models',
         label: t('settings.tabs.aiModels', 'AI & Models'),
-        isDirty: tabDirtyState['ai-models'],
+        isDirty: dirtyState['ai-models'],
       },
       {
         value: 'chat-interface',
         label: t('settings.tabs.chatInterface', 'Chat Interface'),
-        isDirty: tabDirtyState['chat-interface'],
+        isDirty: dirtyState['chat-interface'],
       },
       {
         value: 'system',
         label: t('settings.tabs.system', 'System'),
-        isDirty: tabDirtyState.system,
+        isDirty: dirtyState.system,
       },
       {
         value: 'advanced',
         label: t('settings.tabs.advanced', 'Advanced'),
-        isDirty: tabDirtyState.advanced,
+        isDirty: dirtyState.advanced,
       },
     ];
 
@@ -527,7 +423,7 @@ export function useSettingsPageController() {
     }
 
     return items;
-  }, [t, tabDirtyState]);
+  }, [dirtyState, t]);
 
   return {
     activeTab,

--- a/src/features/settings/tabs/AIModelsTab.tsx
+++ b/src/features/settings/tabs/AIModelsTab.tsx
@@ -11,6 +11,45 @@ const OUTPUT_TOKEN_PRESETS = [
 ] as const;
 const RETRY_DELAY_PRESETS = [1000, 3000, 5000, 10000] as const;
 
+const PROVIDER_META: Record<
+  AIServiceProvider,
+  { name: string; description: string }
+> = {
+  [AIServiceProvider.OpenAI]: {
+    name: 'OpenAI',
+    description: 'GPT-4o, o3, o4-mini and more',
+  },
+  [AIServiceProvider.Anthropic]: {
+    name: 'Anthropic',
+    description: 'Claude 3.5 Sonnet, Haiku and more',
+  },
+  [AIServiceProvider.Gemini]: {
+    name: 'Google Gemini',
+    description: 'Gemini 2.5 Pro, Flash and more',
+  },
+  [AIServiceProvider.Ollama]: {
+    name: 'Ollama',
+    description: 'Run open models locally on your machine',
+  },
+  [AIServiceProvider.Groq]: {
+    name: 'Groq',
+    description: 'Ultra-fast inference via Groq LPU chips',
+  },
+  [AIServiceProvider.Fireworks]: {
+    name: 'Fireworks AI',
+    description: 'Fast hosting for open-source models',
+  },
+  [AIServiceProvider.Cerebras]: {
+    name: 'Cerebras',
+    description: "World's fastest AI inference chips",
+  },
+  [AIServiceProvider.OpenRouter]: {
+    name: 'OpenRouter',
+    description: 'Access 200+ models through one API key',
+  },
+  [AIServiceProvider.Empty]: { name: 'None', description: '' },
+};
+
 function findNearestPresetIndex(value: number): number {
   return OUTPUT_TOKEN_PRESETS.reduce((bestIndex, preset, index) => {
     const bestDistance = Math.abs(OUTPUT_TOKEN_PRESETS[bestIndex] - value);
@@ -61,46 +100,6 @@ function AIModelsTabComponent({
   const selectedOutputTokenIndex = findNearestPresetIndex(
     localDefaultMaxOutputTokens,
   );
-
-  // Static metadata for each provider — user-friendly name + short description
-  const PROVIDER_META: Record<
-    AIServiceProvider,
-    { name: string; description: string }
-  > = {
-    [AIServiceProvider.OpenAI]: {
-      name: 'OpenAI',
-      description: 'GPT-4o, o3, o4-mini and more',
-    },
-    [AIServiceProvider.Anthropic]: {
-      name: 'Anthropic',
-      description: 'Claude 3.5 Sonnet, Haiku and more',
-    },
-    [AIServiceProvider.Gemini]: {
-      name: 'Google Gemini',
-      description: 'Gemini 2.5 Pro, Flash and more',
-    },
-    [AIServiceProvider.Ollama]: {
-      name: 'Ollama',
-      description: 'Run open models locally on your machine',
-    },
-    [AIServiceProvider.Groq]: {
-      name: 'Groq',
-      description: 'Ultra-fast inference via Groq LPU chips',
-    },
-    [AIServiceProvider.Fireworks]: {
-      name: 'Fireworks AI',
-      description: 'Fast hosting for open-source models',
-    },
-    [AIServiceProvider.Cerebras]: {
-      name: 'Cerebras',
-      description: "World's fastest AI inference chips",
-    },
-    [AIServiceProvider.OpenRouter]: {
-      name: 'OpenRouter',
-      description: 'Access 200+ models through one API key',
-    },
-    [AIServiceProvider.Empty]: { name: 'None', description: '' },
-  };
 
   return (
     <div className="space-y-8">

--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DisplaySettings } from '@/context/SettingsContext';
 import {
+  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -59,6 +60,12 @@ const PREFILL_DISPLAY_FORMAT_OPTIONS = [
   },
 ] as const;
 
+const LANGUAGE_SELECT_ID = 'settings-language';
+const FONT_FAMILY_SELECT_ID = 'settings-font-family';
+const TOOL_DETAIL_LEVEL_SELECT_ID = 'settings-tool-detail-level';
+const METRIC_DISPLAY_MODE_SELECT_ID = 'settings-metric-display-mode';
+const PREFILL_DISPLAY_FORMAT_SELECT_ID = 'settings-prefill-display-format';
+
 function isToolDetailLevel(
   value: string,
 ): value is DisplaySettings['toolDetailLevel'] {
@@ -100,11 +107,17 @@ function GeneralTabComponent({
   return (
     <div className="space-y-6">
       <div className="min-w-0">
-        <label className="block text-muted-foreground mb-2 font-medium">
+        <Label
+          htmlFor={LANGUAGE_SELECT_ID}
+          className="mb-2 block text-muted-foreground"
+        >
           {t('settings.language.label', 'Language')}
-        </label>
+        </Label>
         <Select value={localLanguage} onValueChange={onChange}>
-          <SelectTrigger className="w-full max-w-xs bg-background">
+          <SelectTrigger
+            id={LANGUAGE_SELECT_ID}
+            className="w-full max-w-xs bg-background"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -123,16 +136,22 @@ function GeneralTabComponent({
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="min-w-0">
-            <label className="block text-muted-foreground mb-2 font-medium">
+            <Label
+              htmlFor={FONT_FAMILY_SELECT_ID}
+              className="mb-2 block text-muted-foreground"
+            >
               {t('settings.display.fontFamily', 'Font Family')}
-            </label>
+            </Label>
             <Select
               value={localDisplay.fontFamily ?? 'Pretendard'}
               onValueChange={(value) =>
                 onDisplaySettingsChange('fontFamily', value)
               }
             >
-              <SelectTrigger className="w-full max-w-xs bg-background">
+              <SelectTrigger
+                id={FONT_FAMILY_SELECT_ID}
+                className="w-full max-w-xs bg-background"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -171,9 +190,12 @@ function GeneralTabComponent({
           </div>
 
           <div className="min-w-0">
-            <label className="block text-muted-foreground mb-2 font-medium">
+            <Label
+              htmlFor={TOOL_DETAIL_LEVEL_SELECT_ID}
+              className="mb-2 block text-muted-foreground"
+            >
               {t('settings.display.toolDetailLevel', 'Tool Detail Level')}
-            </label>
+            </Label>
             <Select
               value={localDisplay.toolDetailLevel ?? 'simple'}
               onValueChange={(value) => {
@@ -182,7 +204,10 @@ function GeneralTabComponent({
                 }
               }}
             >
-              <SelectTrigger className="w-full max-w-xs bg-background">
+              <SelectTrigger
+                id={TOOL_DETAIL_LEVEL_SELECT_ID}
+                className="w-full max-w-xs bg-background"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -210,9 +235,12 @@ function GeneralTabComponent({
         <div className="space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="min-w-0">
-              <label className="block text-muted-foreground mb-2 font-medium">
+              <Label
+                htmlFor={METRIC_DISPLAY_MODE_SELECT_ID}
+                className="mb-2 block text-muted-foreground"
+              >
                 {t('settings.display.metricDisplayMode', 'Metric Display Mode')}
-              </label>
+              </Label>
               <Select
                 value={localDisplay.metricDisplayMode}
                 onValueChange={(value) => {
@@ -221,7 +249,10 @@ function GeneralTabComponent({
                   }
                 }}
               >
-                <SelectTrigger className="w-full max-w-xs bg-background">
+                <SelectTrigger
+                  id={METRIC_DISPLAY_MODE_SELECT_ID}
+                  className="w-full max-w-xs bg-background"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -241,12 +272,15 @@ function GeneralTabComponent({
             </div>
 
             <div className="min-w-0">
-              <label className="block text-muted-foreground mb-2 font-medium">
+              <Label
+                htmlFor={PREFILL_DISPLAY_FORMAT_SELECT_ID}
+                className="mb-2 block text-muted-foreground"
+              >
                 {t(
                   'settings.display.prefillDisplayFormat',
                   'Prefill Performance Format',
                 )}
-              </label>
+              </Label>
               <Select
                 value={localDisplay.prefillDisplayFormat}
                 onValueChange={(value) => {
@@ -255,7 +289,10 @@ function GeneralTabComponent({
                   }
                 }}
               >
-                <SelectTrigger className="w-full max-w-xs bg-background">
+                <SelectTrigger
+                  id={PREFILL_DISPLAY_FORMAT_SELECT_ID}
+                  className="w-full max-w-xs bg-background"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -1,6 +1,83 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DisplaySettings } from '@/context/SettingsContext';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui';
+
+const LANGUAGE_OPTIONS = [
+  { value: 'en', labelKey: 'settings.language.en', fallback: 'English' },
+  { value: 'ko', labelKey: 'settings.language.ko', fallback: '한국어' },
+  { value: 'zh', labelKey: 'settings.language.zh', fallback: '简体中文' },
+  { value: 'ja', labelKey: 'settings.language.ja', fallback: '日本語' },
+  { value: 'fr', labelKey: 'settings.language.fr', fallback: 'Français' },
+  { value: 'es', labelKey: 'settings.language.es', fallback: 'Español' },
+  { value: 'de', labelKey: 'settings.language.de', fallback: 'Deutsch' },
+  { value: 'pt', labelKey: 'settings.language.pt', fallback: 'Português' },
+] as const;
+
+const TOOL_DETAIL_LEVEL_OPTIONS = [
+  {
+    value: 'simple',
+    labelKey: 'settings.display.toolDetailSimple',
+    fallback: 'Simple (tool name only)',
+  },
+  {
+    value: 'developer',
+    labelKey: 'settings.display.toolDetailDeveloper',
+    fallback: 'Developer (params, errors, timing)',
+  },
+] as const;
+
+const METRIC_DISPLAY_MODE_OPTIONS = [
+  {
+    value: 'inline',
+    labelKey: 'settings.display.inline',
+    fallback: 'Inline (show in message)',
+  },
+  {
+    value: 'tooltip',
+    labelKey: 'settings.display.tooltip',
+    fallback: 'Tooltip (hover to see)',
+  },
+] as const;
+
+const PREFILL_DISPLAY_FORMAT_OPTIONS = [
+  {
+    value: 'time',
+    labelKey: 'settings.display.time',
+    fallback: 'Time to First Token (e.g., 245ms)',
+  },
+  {
+    value: 'tokensPerSecond',
+    labelKey: 'settings.display.tokensPerSecond',
+    fallback: 'Tokens Per Second (e.g., 520 tok/s)',
+  },
+] as const;
+
+function isToolDetailLevel(
+  value: string,
+): value is DisplaySettings['toolDetailLevel'] {
+  return TOOL_DETAIL_LEVEL_OPTIONS.some((option) => option.value === value);
+}
+
+function isMetricDisplayMode(
+  value: string,
+): value is DisplaySettings['metricDisplayMode'] {
+  return METRIC_DISPLAY_MODE_OPTIONS.some((option) => option.value === value);
+}
+
+function isPrefillDisplayFormat(
+  value: string,
+): value is DisplaySettings['prefillDisplayFormat'] {
+  return PREFILL_DISPLAY_FORMAT_OPTIONS.some(
+    (option) => option.value === value,
+  );
+}
 
 interface GeneralTabProps {
   localLanguage: string;
@@ -26,20 +103,18 @@ function GeneralTabComponent({
         <label className="block text-muted-foreground mb-2 font-medium">
           {t('settings.language.label', 'Language')}
         </label>
-        <select
-          className="bg-background border text-foreground rounded px-3 py-2 w-full max-w-xs"
-          value={localLanguage}
-          onChange={(e) => onChange(e.target.value)}
-        >
-          <option value="en">{t('settings.language.en', 'English')}</option>
-          <option value="ko">{t('settings.language.ko', '한국어')}</option>
-          <option value="zh">{t('settings.language.zh', '简体中文')}</option>
-          <option value="ja">{t('settings.language.ja', '日本語')}</option>
-          <option value="fr">{t('settings.language.fr', 'Français')}</option>
-          <option value="es">{t('settings.language.es', 'Español')}</option>
-          <option value="de">{t('settings.language.de', 'Deutsch')}</option>
-          <option value="pt">{t('settings.language.pt', 'Português')}</option>
-        </select>
+        <Select value={localLanguage} onValueChange={onChange}>
+          <SelectTrigger className="w-full max-w-xs bg-background">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LANGUAGE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {t(option.labelKey, option.fallback)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="border-t pt-6">
@@ -51,38 +126,42 @@ function GeneralTabComponent({
             <label className="block text-muted-foreground mb-2 font-medium">
               {t('settings.display.fontFamily', 'Font Family')}
             </label>
-            <select
-              className="bg-background border text-foreground rounded px-3 py-2 w-full max-w-xs"
+            <Select
               value={localDisplay.fontFamily ?? 'Pretendard'}
-              onChange={(e) =>
-                onDisplaySettingsChange('fontFamily', e.target.value)
+              onValueChange={(value) =>
+                onDisplaySettingsChange('fontFamily', value)
               }
             >
-              <option value="Pretendard">
-                {t(
-                  'settings.display.fontFamilyOptions.pretendard',
-                  'Pretendard (Standard Sans)',
-                )}
-              </option>
-              <option value="Inter">
-                {t(
-                  'settings.display.fontFamilyOptions.inter',
-                  'Inter (Clean UI Sans)',
-                )}
-              </option>
-              <option value="NanumSquare Neo">
-                {t(
-                  'settings.display.fontFamilyOptions.nanumSquareNeo',
-                  'NanumSquare Neo (Modern Geometric)',
-                )}
-              </option>
-              <option value="D2Coding">
-                {t(
-                  'settings.display.fontFamilyOptions.d2coding',
-                  'D2Coding (Developer Mono)',
-                )}
-              </option>
-            </select>
+              <SelectTrigger className="w-full max-w-xs bg-background">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Pretendard">
+                  {t(
+                    'settings.display.fontFamilyOptions.pretendard',
+                    'Pretendard (Standard Sans)',
+                  )}
+                </SelectItem>
+                <SelectItem value="Inter">
+                  {t(
+                    'settings.display.fontFamilyOptions.inter',
+                    'Inter (Clean UI Sans)',
+                  )}
+                </SelectItem>
+                <SelectItem value="NanumSquare Neo">
+                  {t(
+                    'settings.display.fontFamilyOptions.nanumSquareNeo',
+                    'NanumSquare Neo (Modern Geometric)',
+                  )}
+                </SelectItem>
+                <SelectItem value="D2Coding">
+                  {t(
+                    'settings.display.fontFamilyOptions.d2coding',
+                    'D2Coding (Developer Mono)',
+                  )}
+                </SelectItem>
+              </SelectContent>
+            </Select>
             <p className="text-xs text-muted-foreground mt-1">
               {t(
                 'settings.display.fontFamilyDescription',
@@ -95,29 +174,25 @@ function GeneralTabComponent({
             <label className="block text-muted-foreground mb-2 font-medium">
               {t('settings.display.toolDetailLevel', 'Tool Detail Level')}
             </label>
-            <select
-              className="bg-background border text-foreground rounded px-3 py-2 w-full max-w-xs"
+            <Select
               value={localDisplay.toolDetailLevel ?? 'simple'}
-              onChange={(e) =>
-                onDisplaySettingsChange(
-                  'toolDetailLevel',
-                  e.target.value as 'simple' | 'developer',
-                )
-              }
+              onValueChange={(value) => {
+                if (isToolDetailLevel(value)) {
+                  onDisplaySettingsChange('toolDetailLevel', value);
+                }
+              }}
             >
-              <option value="simple">
-                {t(
-                  'settings.display.toolDetailSimple',
-                  'Simple (tool name only)',
-                )}
-              </option>
-              <option value="developer">
-                {t(
-                  'settings.display.toolDetailDeveloper',
-                  'Developer (params, errors, timing)',
-                )}
-              </option>
-            </select>
+              <SelectTrigger className="w-full max-w-xs bg-background">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TOOL_DETAIL_LEVEL_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {t(option.labelKey, option.fallback)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <p className="text-xs text-muted-foreground mt-1">
               {t(
                 'settings.display.toolDetailLevelDescription',
@@ -138,23 +213,25 @@ function GeneralTabComponent({
               <label className="block text-muted-foreground mb-2 font-medium">
                 {t('settings.display.metricDisplayMode', 'Metric Display Mode')}
               </label>
-              <select
-                className="bg-background border text-foreground rounded px-3 py-2 w-full max-w-xs"
+              <Select
                 value={localDisplay.metricDisplayMode}
-                onChange={(e) =>
-                  onDisplaySettingsChange(
-                    'metricDisplayMode',
-                    e.target.value as 'tooltip' | 'inline',
-                  )
-                }
+                onValueChange={(value) => {
+                  if (isMetricDisplayMode(value)) {
+                    onDisplaySettingsChange('metricDisplayMode', value);
+                  }
+                }}
               >
-                <option value="inline">
-                  {t('settings.display.inline', 'Inline (show in message)')}
-                </option>
-                <option value="tooltip">
-                  {t('settings.display.tooltip', 'Tooltip (hover to see)')}
-                </option>
-              </select>
+                <SelectTrigger className="w-full max-w-xs bg-background">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {METRIC_DISPLAY_MODE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {t(option.labelKey, option.fallback)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <p className="text-xs text-muted-foreground mt-1">
                 {t(
                   'settings.display.metricDisplayModeDescription',
@@ -170,29 +247,25 @@ function GeneralTabComponent({
                   'Prefill Performance Format',
                 )}
               </label>
-              <select
-                className="bg-background border text-foreground rounded px-3 py-2 w-full max-w-xs"
+              <Select
                 value={localDisplay.prefillDisplayFormat}
-                onChange={(e) =>
-                  onDisplaySettingsChange(
-                    'prefillDisplayFormat',
-                    e.target.value as 'time' | 'tokensPerSecond',
-                  )
-                }
+                onValueChange={(value) => {
+                  if (isPrefillDisplayFormat(value)) {
+                    onDisplaySettingsChange('prefillDisplayFormat', value);
+                  }
+                }}
               >
-                <option value="time">
-                  {t(
-                    'settings.display.time',
-                    'Time to First Token (e.g., 245ms)',
-                  )}
-                </option>
-                <option value="tokensPerSecond">
-                  {t(
-                    'settings.display.tokensPerSecond',
-                    'Tokens Per Second (e.g., 520 tok/s)',
-                  )}
-                </option>
-              </select>
+                <SelectTrigger className="w-full max-w-xs bg-background">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PREFILL_DISPLAY_FORMAT_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {t(option.labelKey, option.fallback)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <p className="text-xs text-muted-foreground mt-1">
                 {t(
                   'settings.display.prefillDisplayFormatDescription',

--- a/src/features/settings/tabs/__tests__/GeneralTab.test.tsx
+++ b/src/features/settings/tabs/__tests__/GeneralTab.test.tsx
@@ -25,7 +25,9 @@ describe('GeneralTab', () => {
       />,
     );
 
-    expect(screen.getByText('Simple (tool name only)')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Tool Detail Level'),
+    ).toHaveTextContent('Simple (tool name only)');
 
     rerender(
       <GeneralTab
@@ -40,7 +42,7 @@ describe('GeneralTab', () => {
     );
 
     expect(
-      screen.getByText('Developer (params, errors, timing)'),
-    ).toBeInTheDocument();
+      screen.getByLabelText('Tool Detail Level'),
+    ).toHaveTextContent('Developer (params, errors, timing)');
   });
 });

--- a/src/features/settings/tabs/__tests__/GeneralTab.test.tsx
+++ b/src/features/settings/tabs/__tests__/GeneralTab.test.tsx
@@ -25,9 +25,7 @@ describe('GeneralTab', () => {
       />,
     );
 
-    expect(
-      screen.getByDisplayValue('Simple (tool name only)'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Simple (tool name only)')).toBeInTheDocument();
 
     rerender(
       <GeneralTab
@@ -42,7 +40,7 @@ describe('GeneralTab', () => {
     );
 
     expect(
-      screen.getByDisplayValue('Developer (params, errors, timing)'),
+      screen.getByText('Developer (params, errors, timing)'),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- centralize Settings dirty-state calculation in useSettingsForm
- reuse section dirty state in the page controller instead of re-running broad deep comparisons
- migrate GeneralTab selects to shadcn Select and hoist static AI provider metadata

## Testing
- pnpm refactor:validate