### PR TITLE
🗜️ Distill: Optimize MCP response for readMessage

### DIFF
--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -2,5 +2,5 @@
 **Learning:** Initializing distill journal to document any critical learnings about LLM parsing and pagination.
 **Action:** Use this file only for highly specific, critical insights that change our approach.
 ## 2024-05-24 - Prevent Pagination Bypass
-**Learning:** Returning a full unpaginated entity (e.g., `rawMessage`) alongside its chunked or paginated representation defeats `offset` and `limit` parameters, causing massive context window bloat.
+**Learning:** Returning a full unpaginated entity (e.g., `rawMessage`) alongside its chunked or paginated representation defeats pagination parameters (such as `offsetChars`/`maxChars` for `readMessage` or `page`/`pageSize` for `readSession`/`search`), causing massive context window bloat.
 **Action:** When implementing chunked read or pagination tools, ensure the JSON response strictly mirrors the distilled DTO and never includes the raw database record.

--- a/.jules/distill.md
+++ b/.jules/distill.md
@@ -1,0 +1,6 @@
+## 2024-05-24 - Initial Setup
+**Learning:** Initializing distill journal to document any critical learnings about LLM parsing and pagination.
+**Action:** Use this file only for highly specific, critical insights that change our approach.
+## 2024-05-24 - Prevent Pagination Bypass
+**Learning:** Returning a full unpaginated entity (e.g., `rawMessage`) alongside its chunked or paginated representation defeats `offset` and `limit` parameters, causing massive context window bloat.
+**Action:** When implementing chunked read or pagination tools, ensure the JSON response strictly mirrors the distilled DTO and never includes the raw database record.

--- a/src-tauri/src/mcp/builtin/history/handlers.rs
+++ b/src-tauri/src/mcp/builtin/history/handlers.rs
@@ -223,10 +223,7 @@ pub async fn read_message(_server: &HistoryServer, args: Value) -> Result<MCPRes
             })
             .unwrap_or_default(),
     )
-    .to_mcp_result_with_data(Some(json!({
-        "message": response,
-        "rawMessage": message
-    }))))
+    .to_mcp_result_with_data(Some(json!(response))))
 }
 
 pub async fn search_history(

--- a/src-tauri/tests/history_builtin_tests.rs
+++ b/src-tauri/tests/history_builtin_tests.rs
@@ -439,11 +439,11 @@ async fn history_read_session_and_message_are_paginated() {
     let structured = read_message
         .structured_content
         .expect("structured content expected");
-    assert_eq!(structured["message"]["chunkLength"], 3000);
-    assert_eq!(structured["message"]["hasMore"], true);
-    assert_eq!(structured["message"]["nextOffset"], 3000);
+    assert_eq!(structured["chunkLength"], 3000);
+    assert_eq!(structured["hasMore"], true);
+    assert_eq!(structured["nextOffset"], 3000);
     assert_eq!(
-        structured["message"]["contentChunk"]
+        structured["contentChunk"]
             .as_str()
             .expect("chunk text"),
         "L".repeat(3000)

--- a/src-tauri/tests/history_builtin_tests.rs
+++ b/src-tauri/tests/history_builtin_tests.rs
@@ -443,9 +443,7 @@ async fn history_read_session_and_message_are_paginated() {
     assert_eq!(structured["hasMore"], true);
     assert_eq!(structured["nextOffset"], 3000);
     assert_eq!(
-        structured["contentChunk"]
-            .as_str()
-            .expect("chunk text"),
+        structured["contentChunk"].as_str().expect("chunk text"),
         "L".repeat(3000)
     );
 }

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
💡 What: Removed the unpaginated `rawMessage` entity from the `readMessage` JSON payload, retaining only the paginated `HistoryMessageReadResponse` DTO.
🎯 Why: The inclusion of the full `Message` entity alongside the chunked version defeated the purpose of `offsetChars` and `maxChars` pagination. Removing it reduces IPC/UI payload size and overhead since `rawMessage` was passed along unnecessarily.
📉 Performance Impact: Primarily reduces IPC/UI payload size (rather than LLM tokens directly, as LLM-facing text was already derived from the `content` text via `formatToolResultForLlm`).
🛠️ Error Recovery: No changes to error handling were required, as the existing handler correctly issues `offsetChars` retry suggestions when content exceeds the max size.

---
*PR created automatically by Jules for task [17996785523107671726](https://jules.google.com/task/17996785523107671726) started by @fritzprix*
