### PR TITLE
Fix initial agent chat bottom scroll

### DIFF
--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -27,7 +27,12 @@ import { PendingApprovalWidget } from './PendingApprovalWidget';
 import { getLogger } from '@/lib/logger';
 import type { Message } from '@/models/chat';
 import { useTranslation } from 'react-i18next';
-import { Virtuoso, type Components, type ListProps } from 'react-virtuoso';
+import {
+  Virtuoso,
+  type Components,
+  type ListProps,
+  type VirtuosoHandle,
+} from 'react-virtuoso';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
@@ -97,6 +102,23 @@ function scrollFooterSentinelIntoView(sentinel: HTMLDivElement | null) {
     inline: 'nearest',
     behavior: 'auto',
   });
+}
+
+function scrollVirtuosoToBottom(
+  virtuoso: VirtuosoHandle | null,
+  itemCount: number,
+): boolean {
+  if (!virtuoso || itemCount === 0) {
+    return false;
+  }
+
+  virtuoso.scrollToIndex({
+    index: 'LAST',
+    align: 'end',
+    behavior: 'auto',
+  });
+
+  return true;
 }
 
 function renderVirtualPlaceholder() {
@@ -366,8 +388,16 @@ export function AgentChatMessages() {
   const assistantName = session?.assistant?.name || 'Agent';
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const scrollerElementRef = useRef<HTMLDivElement | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
   const isPinnedToBottomRef = useRef(true);
   const autoScrollFrameRef = useRef<number | null>(null);
+  const hasHydratedMessagesRef = useRef<{
+    sessionId: string | undefined;
+    hasMessages: boolean;
+  }>({
+    sessionId: undefined,
+    hasMessages: false,
+  });
   const [firstItemIndex, setFirstItemIndex] = useState(
     INITIAL_FIRST_ITEM_INDEX,
   );
@@ -420,6 +450,17 @@ export function AgentChatMessages() {
   const agentError = useMemo(() => error, [error]);
   const agentLlmError = useMemo(() => llmError, [llmError]);
 
+  const scrollToBottomNow = useCallback(() => {
+    const scrolledWithVirtuoso = scrollVirtuosoToBottom(
+      virtuosoRef.current,
+      groupedMessages.length,
+    );
+
+    if (scrolledWithVirtuoso || groupedMessages.length === 0) {
+      scrollFooterSentinelIntoView(footerEndRef.current);
+    }
+  }, [groupedMessages.length]);
+
   useEffect(() => {
     const previous = previousListStateRef.current;
     const firstId = groupedMessages[0]?.message.id;
@@ -453,9 +494,9 @@ export function AgentChatMessages() {
 
     autoScrollFrameRef.current = requestAnimationFrame(() => {
       autoScrollFrameRef.current = null;
-      scrollFooterSentinelIntoView(footerEndRef.current);
+      scrollToBottomNow();
     });
-  }, []);
+  }, [scrollToBottomNow]);
 
   useEffect(() => {
     isPinnedToBottomRef.current = true;
@@ -502,6 +543,30 @@ export function AgentChatMessages() {
     };
   }, [bottomThreshold, session?.id]);
 
+  useEffect(() => {
+    const trackedSessionId = hasHydratedMessagesRef.current.sessionId;
+
+    if (trackedSessionId !== session?.id) {
+      hasHydratedMessagesRef.current = {
+        sessionId: session?.id,
+        hasMessages: groupedMessages.length > 0,
+      };
+      return;
+    }
+
+    if (
+      !hasHydratedMessagesRef.current.hasMessages &&
+      groupedMessages.length > 0 &&
+      isPinnedToBottomRef.current
+    ) {
+      scheduleScrollToBottom();
+    }
+
+    if (groupedMessages.length > 0) {
+      hasHydratedMessagesRef.current.hasMessages = true;
+    }
+  }, [groupedMessages.length, scheduleScrollToBottom, session?.id]);
+
   const scrollToBottom = useCallback(() => {
     isPinnedToBottomRef.current = true;
     setIsPinned(true);
@@ -525,6 +590,28 @@ export function AgentChatMessages() {
     });
 
     observer.observe(content);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [scheduleScrollToBottom, session?.id]);
+
+  useEffect(() => {
+    const scroller = scrollerElementRef.current;
+
+    if (!scroller || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (!isPinnedToBottomRef.current) {
+        return;
+      }
+
+      scheduleScrollToBottom();
+    });
+
+    observer.observe(scroller);
 
     return () => {
       observer.disconnect();
@@ -721,6 +808,7 @@ export function AgentChatMessages() {
     <div className="relative flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
       <Virtuoso
         key={session?.id ?? 'agent-chat'}
+        ref={virtuosoRef}
         className="flex-1"
         style={{ height: '100%' }}
         data={groupedMessages}

--- a/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { act, render, screen } from '@testing-library/react';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentChatMessages,
@@ -62,8 +62,10 @@ const groupedMessagesMock: GroupedMessage[] = [
   },
 ];
 
-const { virtuosoMock, sessionState, chatState } = vi.hoisted(() => ({
+const { virtuosoMock, scrollToIndexMock, sessionState, chatState } = vi.hoisted(
+  () => ({
   virtuosoMock: vi.fn(),
+  scrollToIndexMock: vi.fn(),
   sessionState: {
     session: { id: 'session-1', assistant: { name: 'Agent' } },
   },
@@ -71,13 +73,14 @@ const { virtuosoMock, sessionState, chatState } = vi.hoisted(() => ({
     messages: [] as Message[],
     workflowStatus: 'idle' as 'idle' | 'busy',
   },
-}));
+}),
+);
 
-let resizeObserverCallback: ResizeObserverCallback | null = null;
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
 
 class MockResizeObserver implements ResizeObserver {
   constructor(callback: ResizeObserverCallback) {
-    resizeObserverCallback = callback;
+    resizeObserverCallbacks.push(callback);
   }
 
   observe(): void {}
@@ -170,7 +173,9 @@ vi.mock('@/components/ui/tooltip', () => ({
 
 vi.mock('react-virtuoso', () => ({
   Virtuoso: forwardRef(function MockVirtuoso(props, ref) {
-    void ref;
+    useImperativeHandle(ref, () => ({
+      scrollToIndex: scrollToIndexMock,
+    }));
     return virtuosoMock(props);
   }),
 }));
@@ -178,7 +183,8 @@ vi.mock('react-virtuoso', () => ({
 describe('AgentChatMessages compaction rendering', () => {
   beforeEach(() => {
     virtuosoMock.mockClear();
-    resizeObserverCallback = null;
+    scrollToIndexMock.mockClear();
+    resizeObserverCallbacks = [];
     sessionState.session = { id: 'session-1', assistant: { name: 'Agent' } };
     chatState.messages = groupedToolMessages.slice(1);
     chatState.workflowStatus = 'idle';
@@ -372,9 +378,16 @@ describe('AgentChatMessages compaction rendering', () => {
       render(<AgentChatMessages />);
 
       act(() => {
-        resizeObserverCallback?.([], {} as ResizeObserver);
+        resizeObserverCallbacks.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
       });
 
+      expect(scrollToIndexMock).toHaveBeenCalledWith({
+        index: 'LAST',
+        align: 'end',
+        behavior: 'auto',
+      });
       expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
@@ -398,11 +411,17 @@ describe('AgentChatMessages compaction rendering', () => {
 
     try {
       const { rerender } = render(<AgentChatMessages />);
+      scrollToIndexMock.mockClear();
       scrollIntoView.mockClear();
 
       sessionState.session = { id: 'session-2', assistant: { name: 'Agent' } };
       rerender(<AgentChatMessages />);
 
+      expect(scrollToIndexMock).toHaveBeenCalledWith({
+        index: 'LAST',
+        align: 'end',
+        behavior: 'auto',
+      });
       expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
@@ -436,6 +455,7 @@ describe('AgentChatMessages compaction rendering', () => {
 
     try {
       render(<AgentChatMessages />);
+      scrollToIndexMock.mockClear();
       scrollIntoView.mockClear();
 
       const nextFrame = frameQueue.shift();
@@ -445,6 +465,11 @@ describe('AgentChatMessages compaction rendering', () => {
         nextFrame?.(0);
       });
 
+      expect(scrollToIndexMock).toHaveBeenCalledWith({
+        index: 'LAST',
+        align: 'end',
+        behavior: 'auto',
+      });
       expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
@@ -495,6 +520,7 @@ describe('AgentChatMessages compaction rendering', () => {
 
     try {
       render(<AgentChatMessages />);
+      scrollToIndexMock.mockClear();
       scrollIntoView.mockClear();
 
       const nextFrame = frameQueue.shift();
@@ -504,6 +530,71 @@ describe('AgentChatMessages compaction rendering', () => {
         nextFrame?.(0);
       });
 
+      expect(scrollToIndexMock).toHaveBeenCalledWith({
+        index: 'LAST',
+        align: 'end',
+        behavior: 'auto',
+      });
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('re-aligns to the bottom when a session hydrates messages after mounting empty', () => {
+    const scrollIntoView = vi.fn();
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+    chatState.messages = [];
+    groupedMessagesMock.splice(0, groupedMessagesMock.length);
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      const { rerender } = render(<AgentChatMessages />);
+      scrollToIndexMock.mockClear();
+      scrollIntoView.mockClear();
+
+      chatState.messages = groupedToolMessages.slice(1);
+      groupedMessagesMock.splice(
+        0,
+        groupedMessagesMock.length,
+        {
+          type: 'tool_group',
+          message: baseMessage,
+          messages: [baseMessage],
+          coveredMessageIds: ['assistant-1', 'tool-1'],
+          toolGroup: {
+            calls: [
+              {
+                id: 'call-1',
+                type: 'function',
+                function: {
+                  name: 'agent__compactSessionContext',
+                  arguments: '{}',
+                },
+              },
+            ],
+            results: [],
+          },
+        },
+      );
+
+      rerender(<AgentChatMessages />);
+
+      expect(scrollToIndexMock).toHaveBeenCalledWith({
+        index: 'LAST',
+        align: 'end',
+        behavior: 'auto',
+      });
       expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;


### PR DESCRIPTION
## Summary
- switch initial and follow-up bottom alignment to Virtuoso's imperative scroll API
- re-align pinned sessions when messages hydrate after an empty initial mount
- cover session changes, resize behavior, and delayed hydration with focused tests