### PR TITLE
Fix Ollama compaction tool disabling

### DIFF
--- a/src/lib/ai-service/__tests__/ollama.test.ts
+++ b/src/lib/ai-service/__tests__/ollama.test.ts
@@ -158,4 +158,31 @@ describe('OllamaService prompt layout', () => {
       'beta_tool',
     ]);
   });
+
+  it('omits tools from Ollama requests when tool use is disabled', async () => {
+    const { OllamaService } = await import('../ollama');
+    const service = new OllamaService('ollama-local');
+
+    const prepared = service.prepareContextInjection(
+      'Stable system prompt',
+      '# Current Context Information\nvolatile bits',
+      [createUserMessage('summarize this')],
+    );
+
+    await consumeStream(
+      service.streamChat(prepared.messages, {
+        modelName: 'llama3.1',
+        systemPrompt: prepared.systemPrompt,
+        sessionContext: prepared.sessionContext,
+        availableTools: [betaTool, alphaTool],
+        disableToolUse: true,
+      }),
+    );
+
+    const request = chatMock.mock.calls[0]?.[0] as {
+      tools?: Array<{ function?: { name?: string } }>;
+    };
+
+    expect(request.tools).toBeUndefined();
+  });
 });

--- a/src/lib/ai-service/ollama.ts
+++ b/src/lib/ai-service/ollama.ts
@@ -58,6 +58,8 @@ interface StreamChatOptions {
   sessionContext?: string;
   availableTools?: MCPTool[];
   config?: AIServiceConfig;
+  forceToolUse?: boolean;
+  disableToolUse?: boolean;
 }
 
 /**
@@ -265,6 +267,7 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
       hasSystemPrompt: !!options.systemPrompt,
       model: options.modelName || config.defaultModel || DEFAULT_MODEL,
       availableToolsCount: options.availableTools?.length ?? 0,
+      disableToolUse: options.disableToolUse ?? false,
     });
 
     try {
@@ -273,12 +276,14 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
         options.systemPrompt,
       );
       const model = options.modelName || config.defaultModel || DEFAULT_MODEL;
+      const shouldIncludeTools = !options.disableToolUse;
+      const requestTools = shouldIncludeTools ? ollamaTools : undefined;
 
       logger.info('📨 Converted messages for Ollama', {
         originalCount: sanitizedMessages.length,
         convertedCount: ollamaMessages.length,
         model,
-        toolCount: (ollamaTools ?? []).length,
+        toolCount: (requestTools ?? []).length,
         messageRoles: ollamaMessages.map((m) => m.role).join(','),
       });
 
@@ -314,7 +319,7 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
         messages: ollamaMessages as OllamaMessage[],
         stream: true,
         ...(thinkParam !== undefined && { think: thinkParam }), // Conditional inclusion
-        tools: ollamaTools,
+        ...(requestTools ? { tools: requestTools } : {}),
         keep_alive: '5m',
         options: {
           temperature: config.temperature || 0.7,


### PR DESCRIPTION
## Summary
- respect `disableToolUse` in the Ollama streaming request path
- omit tool definitions from compaction requests so Ollama stays in summary mode
- add a regression test covering tool-disabled Ollama requests

## Testing
- pnpm exec vitest run src/lib/ai-service/__tests__/ollama.test.ts