### PR TITLE
🕸️ Weaver: Refactor useAssistantSummaries using useSWR

### DIFF
--- a/src/features/agent/hooks/useAssistantSummaries.test.tsx
+++ b/src/features/agent/hooks/useAssistantSummaries.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SWRConfig } from 'swr';
+import type { ReactNode } from 'react';
+import { useAssistantSummaries } from './useAssistantSummaries';
+import { listAssistantSummaries } from '@/lib/backend/assistants';
+import type { AssistantSummary } from '@/lib/backend/assistants';
+
+const { mockWarn } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/assistants', () => ({
+  listAssistantSummaries: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    warn: mockWarn,
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SWRConfig
+    value={{
+      provider: () => new Map(),
+      dedupingInterval: 0,
+      errorRetryInterval: 1,
+    }}
+  >
+    {children}
+  </SWRConfig>
+);
+
+describe('useAssistantSummaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads assistant summaries and exposes loading state', async () => {
+    const summaries: AssistantSummary[] = [
+      {
+        id: 'assistant-1',
+        name: 'Alpha',
+        description: 'First assistant',
+        deletionProtected: false,
+      },
+    ];
+
+    vi.mocked(listAssistantSummaries).mockResolvedValueOnce(summaries);
+
+    const { result } = renderHook(() => useAssistantSummaries(), { wrapper });
+
+    expect(result.current.assistants).toEqual([]);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeUndefined();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.assistants).toEqual(summaries);
+    expect(result.current.error).toBeUndefined();
+    expect(listAssistantSummaries).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces fetch errors, logs once, and does not retry automatically', async () => {
+    const loadError = new Error('Failed to load assistant summaries');
+
+    vi.mocked(listAssistantSummaries).mockRejectedValueOnce(loadError);
+
+    const { result } = renderHook(() => useAssistantSummaries(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.assistants).toEqual([]);
+    expect(result.current.error).toBe(loadError);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'Failed to load assistant summaries',
+      loadError,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(listAssistantSummaries).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/agent/hooks/useAssistantSummaries.ts
+++ b/src/features/agent/hooks/useAssistantSummaries.ts
@@ -15,6 +15,7 @@ export function useAssistantSummaries() {
   } = useSWR<AssistantSummary[]>('assistantSummaries', listAssistantSummaries, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
+    shouldRetryOnError: false,
     onError: (err) => {
       logger.warn('Failed to load assistant summaries', err);
     },

--- a/src/features/agent/hooks/useAssistantSummaries.ts
+++ b/src/features/agent/hooks/useAssistantSummaries.ts
@@ -3,13 +3,22 @@ import {
   listAssistantSummaries,
   type AssistantSummary,
 } from '@/lib/backend/assistants';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('useAssistantSummaries');
 
 export function useAssistantSummaries() {
   const {
     data: assistants = [],
     isLoading: loading,
     error,
-  } = useSWR<AssistantSummary[]>('assistantSummaries', listAssistantSummaries);
+  } = useSWR<AssistantSummary[]>('assistantSummaries', listAssistantSummaries, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    onError: (err) => {
+      logger.warn('Failed to load assistant summaries', err);
+    },
+  });
 
   return { assistants, loading, error };
 }

--- a/src/features/agent/hooks/useAssistantSummaries.ts
+++ b/src/features/agent/hooks/useAssistantSummaries.ts
@@ -1,53 +1,15 @@
-import { useEffect, useState } from 'react';
+import useSWR from 'swr';
 import {
   listAssistantSummaries,
   type AssistantSummary,
 } from '@/lib/backend/assistants';
-import { getLogger } from '@/lib/logger';
-
-const logger = getLogger('useAssistantSummaries');
 
 export function useAssistantSummaries() {
-  const [assistants, setAssistants] = useState<AssistantSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let active = true;
-
-    const load = async () => {
-      try {
-        setLoading(true);
-        const summaries = await listAssistantSummaries();
-        if (!active) {
-          return;
-        }
-        setAssistants(summaries);
-        setError(null);
-      } catch (loadError) {
-        if (!active) {
-          return;
-        }
-        const nextError =
-          loadError instanceof Error
-            ? loadError
-            : new Error('Failed to load assistant summaries');
-        logger.error('Failed to load assistant summaries', loadError);
-        setAssistants([]);
-        setError(nextError);
-      } finally {
-        if (active) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void load();
-
-    return () => {
-      active = false;
-    };
-  }, []);
+  const {
+    data: assistants = [],
+    isLoading: loading,
+    error,
+  } = useSWR<AssistantSummary[]>('assistantSummaries', listAssistantSummaries);
 
   return { assistants, loading, error };
 }

--- a/src/features/knowledge/hooks/useKnowledgeBrowser.ts
+++ b/src/features/knowledge/hooks/useKnowledgeBrowser.ts
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  listAssistantSummaries,
-  type AssistantSummary,
-} from '@/lib/backend/assistants';
-import { getLogger } from '@/lib/logger';
 import { useKnowledgeDelete } from './useKnowledgeDelete';
 import { useKnowledgeDetail } from './useKnowledgeDetail';
 import { useKnowledgeList } from './useKnowledgeList';
-
-const logger = getLogger('useKnowledgeBrowser');
+import { useAssistantSummaries } from '@/features/agent/hooks/useAssistantSummaries';
 
 interface KnowledgeAssistantOption {
   id: string;
@@ -20,9 +14,8 @@ export function useKnowledgeBrowser() {
   const [assistantFilter, setAssistantFilter] = useState('all');
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [listRefreshToken, setListRefreshToken] = useState(0);
-  const [assistantSummaries, setAssistantSummaries] = useState<
-    AssistantSummary[]
-  >([]);
+
+  const { assistants: assistantSummaries } = useAssistantSummaries();
   const {
     assistants,
     hasMoreItems,
@@ -38,34 +31,6 @@ export function useKnowledgeBrowser() {
     refreshToken: listRefreshToken,
   });
   const { detail, isDetailLoading } = useKnowledgeDetail(selectedId);
-
-  useEffect(() => {
-    let active = true;
-
-    const loadAssistantSummaries = async () => {
-      try {
-        const summaries = await listAssistantSummaries();
-        if (!active) {
-          return;
-        }
-        setAssistantSummaries(summaries);
-      } catch (error) {
-        if (!active) {
-          return;
-        }
-        logger.warn(
-          'Failed to load assistant summaries for knowledge filter labels',
-          error,
-        );
-      }
-    };
-
-    void loadAssistantSummaries();
-
-    return () => {
-      active = false;
-    };
-  }, []);
 
   const selectedItem = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,


### PR DESCRIPTION
### 🚫 Eradicated
Removed imperative data fetching (`useState` + `useEffect` action-effect chains) in `useAssistantSummaries` and `useKnowledgeBrowser`.

### ✨ Woven
Implemented declarative data fetching using `useSWR`, enforcing separation of business logic and built-in caching, and centralized the `assistantSummaries` fetch by reusing the `useAssistantSummaries` custom hook within `useKnowledgeBrowser`.

### 📉 Impact
Prevents unnecessary re-renders by eliminating intermediate state updates and provides robust caching and loading state management seamlessly.

---
*PR created automatically by Jules for task [16582109165755406114](https://jules.google.com/task/16582109165755406114) started by @fritzprix*