### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Windows reserved filename bypass in SecureFileManager

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3862,7 +3862,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -197,11 +197,13 @@ impl SecurityValidator {
         let path_for_check = PathBuf::from(user_path.replace(['\\', '/'], "/"));
         for component in path_for_check.components() {
             if let Component::Normal(name) = component {
-                // Strip the extension (CON.txt -> CON) before checking.
+                // Windows strips trailing spaces and dots from path components before resolving
+                // device names, so normalize those away before checking reserved names.
                 let stem = Path::new(name)
                     .file_stem()
                     .and_then(|s| s.to_str())
-                    .unwrap_or("");
+                    .unwrap_or("")
+                    .trim_end_matches([' ', '.']);
                 let upper = stem.to_uppercase();
                 if RESERVED.contains(&upper.as_str()) {
                     return Err(SecurityError::InvalidPath(format!(

--- a/src-tauri/src/services/secure_file_manager.rs
+++ b/src-tauri/src/services/secure_file_manager.rs
@@ -88,7 +88,7 @@ impl SecureFileManager {
     pub async fn write_file(&self, path: &str, content: &[u8]) -> Result<(), String> {
         let safe_path = self
             .security
-            .validate_path(path)
+            .validate_path_for_write(path)
             .map_err(|e| format!("Security error: {e}"))?;
 
         // Check content size
@@ -199,7 +199,7 @@ impl SecureFileManager {
     pub async fn append_file_string(&self, path: &str, content: &str) -> Result<(), String> {
         let safe_path = self
             .security
-            .validate_path(path)
+            .validate_path_for_write(path)
             .map_err(|e| format!("Security error: {e}"))?;
 
         // If the file does not exist, create it by writing the content.
@@ -257,7 +257,7 @@ impl SecureFileManager {
         // Validate destination path using security validator
         let dest_path = self
             .security
-            .validate_path(dest_rel_path)
+            .validate_path_for_write(dest_rel_path)
             .map_err(|e| format!("Security error for destination: {e}"))?;
 
         // Check source file exists and is a file

--- a/src-tauri/tests/secure_file_manager_tests.rs
+++ b/src-tauri/tests/secure_file_manager_tests.rs
@@ -108,3 +108,66 @@ async fn test_append_file_string_within_limit() {
         "Append should succeed when within the configured limit"
     );
 }
+
+fn assert_windows_reserved_filename_error(result: Result<(), String>, path: &str) {
+    let error = result.expect_err("Operation should reject Windows reserved filenames");
+    assert!(
+        error.contains("Windows reserved filename"),
+        "Expected reserved filename error for '{path}', got: {error}"
+    );
+}
+
+fn windows_reserved_filename_bypass_cases() -> [&'static str; 3] {
+    ["CON ", "NUL.", "COM1..."]
+}
+
+#[tokio::test]
+async fn test_write_operations_reject_windows_reserved_filenames() {
+    let dir = tempdir().unwrap();
+    let manager = SecureFileManager::new_with_base_dir(dir.path().to_path_buf());
+
+    assert_windows_reserved_filename_error(manager.write_file("CON", b"blocked").await, "CON");
+    assert_windows_reserved_filename_error(
+        manager.write_file_string("NUL.txt", "blocked").await,
+        "NUL.txt",
+    );
+    assert_windows_reserved_filename_error(
+        manager.append_file_string("COM1.txt", "blocked").await,
+        "COM1.txt",
+    );
+
+    for path in windows_reserved_filename_bypass_cases() {
+        assert_windows_reserved_filename_error(manager.write_file(path, b"blocked").await, path);
+    }
+}
+
+#[tokio::test]
+async fn test_copy_file_from_external_rejects_windows_reserved_filenames() {
+    let dir = tempdir().unwrap();
+    let manager = SecureFileManager::new_with_base_dir(dir.path().to_path_buf());
+
+    let external_source = dir.path().join("source.txt");
+    std::fs::write(&external_source, "blocked").unwrap();
+
+    let error = manager
+        .copy_file_from_external(&external_source, "LPT1.txt")
+        .await
+        .expect_err("Copy should reject Windows reserved filenames");
+
+    assert!(
+        error.contains("Windows reserved filename"),
+        "Expected reserved filename error for copy destination, got: {error}"
+    );
+
+    for path in windows_reserved_filename_bypass_cases() {
+        let error = manager
+            .copy_file_from_external(&external_source, path)
+            .await
+            .expect_err("Copy should reject Windows reserved filename bypass variants");
+
+        assert!(
+            error.contains("Windows reserved filename"),
+            "Expected reserved filename error for copy destination '{path}', got: {error}"
+        );
+    }
+}


### PR DESCRIPTION
## 🛡️ Sentinel Security Fix

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Write operations in `SecureFileManager` were using the basic `validate_path` method instead of `validate_path_for_write`. This allowed bypassing the block on Windows reserved filenames (e.g., `CON`, `NUL`) during file creation, which become undeletable on Windows once written.
🎯 **Impact:** An attacker could cause a Denial of Service or filesystem issues on Windows by creating files with reserved names that cannot be removed through standard means.
🔧 **Fix:** Updated `write_file`, `append_file_string`, and `copy_file_from_external` methods in `SecureFileManager` to use `validate_path_for_write`.
✅ **Verification:** Run `cargo test -p libragent -- services::secure_file_manager` and verify the changes via code review.

---
*PR created automatically by Jules for task [15345423909803338909](https://jules.google.com/task/15345423909803338909) started by @fritzprix*