### PR TITLE
Fix workspace guidance and anchor responses

### DIFF
--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -387,12 +387,11 @@ impl SuccessHint {
             ("runShell" | "runPowerShell", ToolGroup::Workspace) => vec![
                 "Use listDirectory to verify created files".to_string(),
                 "Use readFile to verify file contents".to_string(),
-                "Use stopProcess if a long-running command needs to be terminated".to_string(),
             ],
             ("runInPersistentShell" | "runInPersistentPowerShell", ToolGroup::Workspace) => vec![
                 "Command state (CWD, env vars) is preserved for the next call".to_string(),
-                "Use listDirectory to verify file system changes".to_string(),
-                "Use readFile to check written output".to_string(),
+                "Use shell commands like `pwd` or `ls` in the next persistent-shell call to inspect the current shell directory".to_string(),
+                "readFile and listDirectory still use workspace root, not the shell CWD".to_string(),
             ],
             ("spawnProcess", ToolGroup::Workspace) => vec![
                 "Use listProcesses to see the status of the background task".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
@@ -289,15 +289,22 @@ impl WorkspaceServer {
                 "Background process started successfully
 
 • Process ID: {}
+{}\
 • Command: {}
 • Mode: Asynchronous (non-blocking)",
-                process_id, command
+                process_id,
+                process_name
+                    .as_ref()
+                    .map(|name| format!("• Name: {}\n", name))
+                    .unwrap_or_default(),
+                command
             ),
             vec![
                 format!(
                     "Use waitForProcess(\"{}\", 0) to check status and completion",
                     process_id
                 ),
+                "Use listProcesses to map optional names back to process IDs".to_string(),
                 "Use readProcessOutput with 'both' to inspect stdout and stderr".to_string(),
                 "Use listProcesses to see all running processes".to_string(),
             ],
@@ -305,6 +312,7 @@ impl WorkspaceServer {
 
         let response_data = serde_json::json!({
             "process_id": process_id,
+            "name": process_name,
             "command": command,
             "mode": "async",
             "note": "use waitForProcess or readProcessOutput to retrieve output"

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
@@ -9,6 +9,7 @@ use crate::session_isolation::{IsolatedProcessConfig, IsolationLevel};
 
 use super::super::super::{terminal_manager, WorkspaceServer, PERSISTENT_SHELL_TOOL};
 use super::super::{normalization, process, validation};
+use super::format_duration_ms;
 
 impl WorkspaceServer {
     /// Execute shell commands with isolation
@@ -247,7 +248,10 @@ impl WorkspaceServer {
                 }
 
                 // Enhanced text response with explicit status and output visibility
-                let header = format!("Command executed in {}ms (exit code: 0)", duration_ms);
+                let header = format!(
+                    "Command executed in {} (exit code: 0)",
+                    format_duration_ms(duration_ms)
+                );
 
                 // Include output in text message if available (CRITICAL FIX for sync visibility)
                 let text_message = if !stdout.is_empty() {

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/mod.rs
@@ -2,3 +2,11 @@ pub mod async_exec;
 pub mod handlers;
 pub mod isolated;
 pub mod persistent;
+
+pub(super) fn format_duration_ms(duration_ms: u64) -> String {
+    if duration_ms == 0 {
+        "< 1ms".to_string()
+    } else {
+        format!("{}ms", duration_ms)
+    }
+}

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
@@ -7,6 +7,7 @@ use crate::mcp::types::MCPResult;
 
 use super::super::super::{utils, WorkspaceServer, PERSISTENT_SHELL_TOOL};
 use super::super::normalization;
+use super::format_duration_ms;
 
 impl WorkspaceServer {
     /// Execute command using persistent shell
@@ -31,6 +32,7 @@ impl WorkspaceServer {
 
         // Track execution time
         let execution_start = std::time::Instant::now();
+        let previous_cwd = self.shell_manager.get_shell_cwd(&session_id).await;
 
         // Execute with timeout
         let timeout_duration = Duration::from_secs(timeout_secs);
@@ -95,7 +97,10 @@ impl WorkspaceServer {
                     self.invalidate_context_cache().await;
 
                     // Success - format with clear state reporting
-                    let header = format!("Command executed successfully in {}ms", duration_ms);
+                    let header = format!(
+                        "Command executed in {} (exit code: 0)",
+                        format_duration_ms(duration_ms)
+                    );
 
                     // Clear shell state section with persistence indicator
                     let shell_state = format!(
@@ -103,8 +108,32 @@ impl WorkspaceServer {
                         PERSISTENT_SHELL_TOOL, display_cwd, exit_code
                     );
 
-                    // Only show warning if shell CWD differs from workspace root for less noise
-                    let file_tools_warning = if display_cwd != "." {
+                    let previous_display_cwd = previous_cwd.as_deref().map(|previous| {
+                        let previous_path = std::path::Path::new(previous);
+                        let relative_previous = previous_path
+                            .strip_prefix(&workspace_path)
+                            .unwrap_or(previous_path)
+                            .to_string_lossy();
+
+                        if relative_previous.is_empty() {
+                            ".".to_string()
+                        } else if relative_previous.starts_with(".")
+                            || relative_previous.starts_with(std::path::MAIN_SEPARATOR)
+                            || relative_previous.contains(":")
+                        {
+                            relative_previous.to_string()
+                        } else {
+                            format!(".{}{}", std::path::MAIN_SEPARATOR, relative_previous)
+                        }
+                    });
+
+                    let cwd_changed = previous_display_cwd
+                        .as_deref()
+                        .map(|previous| previous != display_cwd)
+                        .unwrap_or(display_cwd != ".");
+
+                    // Only warn when this call moved the shell away from workspace root or to another directory.
+                    let file_tools_warning = if display_cwd != "." && cwd_changed {
                         "\n⚠️  File tools (readFile, listDirectory) always use workspace root (.)\n    To list files in shell's current directory, use shell commands: ls or find"
                     } else {
                         ""
@@ -119,10 +148,25 @@ impl WorkspaceServer {
                         format!("{}\n\n{}{}", header, shell_state, file_tools_warning)
                     };
 
-                    let hint = SuccessHint::new(
-                        text_message,
-                        SuccessHint::for_tool(tool_name, ToolGroup::Workspace),
-                    );
+                    let next_actions = if display_cwd == "." {
+                        vec![
+                            "Command state (CWD, env vars) is preserved for the next call"
+                                .to_string(),
+                            "Use listDirectory to inspect workspace-root file changes".to_string(),
+                            "Use readFile to inspect workspace-root file contents".to_string(),
+                        ]
+                    } else {
+                        vec![
+                            format!(
+                                "Use {} with shell commands like `pwd` or `ls` to inspect the current shell directory",
+                                tool_name
+                            ),
+                            "readFile and listDirectory still use workspace root, not the shell CWD"
+                                .to_string(),
+                        ]
+                    };
+
+                    let hint = SuccessHint::new(text_message, next_actions);
                     Ok(hint.to_mcp_result_with_data(Some(structured_data)))
                 } else {
                     // Failure - use ErrorGuidance format

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -150,8 +150,9 @@ impl WorkspaceServer {
                 &display_name,
                 "export",
                 &format!(
-                    "✓ File '{}' exported successfully\n\nDownload link available below",
-                    display_name
+                    "✓ File '{}' exported successfully\n\nSaved export: `{}`\nDownload link available below",
+                    display_name,
+                    relative_path.to_string_lossy().replace('\\', "/")
                 ),
             ));
         }
@@ -320,7 +321,12 @@ impl WorkspaceServer {
             &relative_path.to_string_lossy().replace('\\', "/"),
             &zip_filename,
             "export",
-            &format!("✓ ZIP package '{}' created successfully\n\nContains {} files\nDownload link available below", package_name, processed_files.len()),
+            &format!(
+                "✓ ZIP package '{}' created successfully\n\nContains {} files\nSaved export: `{}`\nDownload link available below",
+                package_name,
+                processed_files.len(),
+                relative_path.to_string_lossy().replace('\\', "/")
+            ),
         ))
     }
 
@@ -353,13 +359,19 @@ impl WorkspaceServer {
             html_content,
         );
 
+        let resource_uri = ui_resource["uri"].as_str().unwrap_or_default();
+        let full_text = format!(
+            "{text_response}\nUI resource: `{}`\nUse the UI resource to trigger the download workflow.",
+            resource_uri
+        );
+
         crate::mcp::builtin::utils::create_resource_response(
-            ui_resource["uri"].as_str().unwrap(),
+            resource_uri,
             "text/html",
             ui_resource["text"].as_str().unwrap(),
             "workspace",
             tool_name,
-            Some(text_response),
+            Some(&full_text),
         )
     }
 

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -359,7 +359,36 @@ impl WorkspaceServer {
             html_content,
         );
 
-        let resource_uri = ui_resource["uri"].as_str().unwrap_or_default();
+        let resource_uri = match ui_resource.get("uri").and_then(|value| value.as_str()) {
+            Some(uri) if !uri.is_empty() => uri,
+            _ => {
+                return guided_error(
+                    ErrorCategory::InternalError,
+                    "Export UI resource was created without a valid URI".to_string(),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Retry the export request".to_string(),
+                    "If this keeps happening, inspect the export UI resource builder".to_string(),
+                ])
+                .to_mcp_result();
+            }
+        };
+        let resource_text = match ui_resource.get("text").and_then(|value| value.as_str()) {
+            Some(text) => text,
+            None => {
+                return guided_error(
+                    ErrorCategory::InternalError,
+                    "Export UI resource was created without HTML content".to_string(),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Retry the export request".to_string(),
+                    "If this keeps happening, inspect the export UI resource builder".to_string(),
+                ])
+                .to_mcp_result();
+            }
+        };
         let full_text = format!(
             "{text_response}\nUI resource: `{}`\nUse the UI resource to trigger the download workflow.",
             resource_uri
@@ -368,7 +397,7 @@ impl WorkspaceServer {
         crate::mcp::builtin::utils::create_resource_response(
             resource_uri,
             "text/html",
-            ui_resource["text"].as_str().unwrap(),
+            resource_text,
             "workspace",
             tool_name,
             Some(&full_text),

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
@@ -106,7 +106,9 @@ fn build_new_hash_sections(edits: &[LineEdit], new_content: &str) -> Vec<String>
 
         let end_in_new = (start_in_new + replacement_line_count).min(new_content_lines.len());
         let section: Vec<String> = full_hashlines[start_in_new..end_in_new].to_vec();
-        new_hash_sections.push(section.join("\n"));
+        if !section.is_empty() {
+            new_hash_sections.push(section.join("\n"));
+        }
 
         let original_line_count = if edit.action == EditAction::InsertAfter {
             0
@@ -173,7 +175,7 @@ fn validate_edit_anchors(
             .guidance(vec![
                 "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
                     .to_string(),
-                "Copy only the 6-character anchor from the returned N:anchor|content line (the part between ':' and '|')"
+                "Copy only the 6-character anchor from the returned line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'."
                     .to_string(),
             ])
             .to_mcp_result());
@@ -234,7 +236,7 @@ fn validate_edit_anchors(
                 .guidance(vec![
                     "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
                         .to_string(),
-                    "Copy only the 6-character endAnchor from the returned N:anchor|content line (the part between ':' and '|')".to_string(),
+                    "Copy only the 6-character endAnchor from the returned line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'.".to_string(),
                 ])
                 .to_mcp_result());
             }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
@@ -421,6 +421,20 @@ pub(super) fn parse_line_edit(
         .map(|anchor| anchor.to_string());
 
     let requires_anchor = !(action == EditAction::InsertAfter && start_line == 0);
+    if !requires_anchor && (start_anchor.is_some() || end_anchor.is_some()) {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "{edit_label}: prepend edits with startLine 0 must omit 'startAnchor' and 'endAnchor'"
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "When startLine is 0, the edit inserts before the first line and does not target existing content".to_string(),
+            "Remove startAnchor/endAnchor and keep only startLine: 0 plus content".to_string(),
+        ])
+        .to_mcp_result());
+    }
     if requires_anchor && start_anchor.is_none() {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
@@ -430,7 +444,7 @@ pub(super) fn parse_line_edit(
         .guidance(vec![
             "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
                 .to_string(),
-            "Copy only the 6-character start-line anchor from the form N:anchor|content (the part between ':' and '|')".to_string(),
+            "Copy only the 6-character start-line anchor from the line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'.".to_string(),
             "If the edit also uses endLine for a range, copy only the 6-character endAnchor from the exact final line"
                 .to_string(),
             "Only insert_after with startLine: 0 may omit anchors".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -49,6 +49,64 @@ fn normalize_insert_after_edit(edit: &Value) -> Value {
     item
 }
 
+fn validate_edit_target_path(
+    server: &WorkspaceServer,
+    path_str: &str,
+    session_id: Option<String>,
+) -> Result<(), MCPResult> {
+    let safe_path = match server.validate_path_with_error_for_write(path_str, session_id) {
+        Ok(path) => path,
+        Err(error) => {
+            return Err(guided_error(
+                ErrorCategory::PermissionDenied,
+                format!("Path validation failed for '{}': {}", path_str, error),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Use workspace-relative paths only".to_string(),
+                "Use listDirectory('.') to inspect valid target paths".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    if !safe_path.exists() {
+        return Err(guided_error(
+            ErrorCategory::ResourceNotFound,
+            format!(
+                "File '{}' does not exist, so editFiles cannot modify it",
+                path_str
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            format!("Use writeFile(\"{}\") to create the file first", path_str),
+            "Use listDirectory('.') to verify the correct workspace-relative path".to_string(),
+            "Use search with filePattern if you need to find the existing file first".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    if safe_path.is_dir() {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!("'{}' is a directory, not a file", path_str),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Use listDirectory to inspect files inside that directory".to_string(),
+            format!(
+                "Select a file path inside '{}', not the directory itself",
+                path_str
+            ),
+            "editFiles only works on existing files".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
+    Ok(())
+}
+
 async fn write_prepared_batches(
     server: &WorkspaceServer,
     prepared_batches: &[PreparedFileEdit],
@@ -288,6 +346,10 @@ impl WorkspaceServer {
                     .to_mcp_result());
                 }
             };
+
+            if let Err(result) = validate_edit_target_path(self, &path, session_id.clone()) {
+                return Ok(result);
+            }
 
             let edit = match parse_line_edit(edit_obj, idx) {
                 Ok(edit) => edit,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
@@ -6,6 +6,9 @@ use serde_json::json;
 pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) -> MCPResult {
     let mut file_sections = Vec::new();
     let total_edits: usize = prepared_batches.iter().map(|batch| batch.edits.len()).sum();
+    let has_new_anchors = prepared_batches
+        .iter()
+        .any(|batch| !batch.new_hash_sections.is_empty());
 
     for batch in prepared_batches {
         let edit_summary = batch
@@ -34,17 +37,34 @@ pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) ->
             batch.original_line_count,
             batch.new_content.lines().count()
         );
-        let anchors = if batch.new_hash_sections.is_empty() {
-            "(No new lines were created by these edits)".to_string()
+        let anchors_section = if batch.new_hash_sections.is_empty() {
+            "\n\nAnchor refresh: no new anchors were generated because these edits only removed existing lines.".to_string()
         } else {
-            batch.new_hash_sections.join("\n...\n")
+            format!(
+                "\n\nNew anchors:\n```\n{}\n```",
+                batch.new_hash_sections.join("\n...\n")
+            )
         };
 
         file_sections.push(format!(
-            "File: '{}'\nChanges:\n{}\nSummary: {}\n\nNew anchors:\n```\n{}\n```",
-            batch.path, edit_summary, diff_summary, anchors
+            "File: '{}'\nChanges:\n{}\nSummary: {}{}",
+            batch.path, edit_summary, diff_summary, anchors_section
         ));
     }
+
+    let next_actions = if has_new_anchors {
+        vec![
+            "Anchors above are current for the edited ranges — reuse them directly with editFiles for follow-up edits in those same ranges".to_string(),
+            "Use readFile only when you need broader context, untouched lines, or fresh anchors outside the ranges shown above".to_string(),
+        ]
+    } else {
+        vec![
+            "No new anchors were generated because these edits only removed existing lines"
+                .to_string(),
+            "Use readFile when you need fresh anchors after the deletion or broader context"
+                .to_string(),
+        ]
+    };
 
     let hint = SuccessHint::new(
         format!(
@@ -53,10 +73,7 @@ pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) ->
             prepared_batches.len(),
             file_sections.join("\n\n")
         ),
-        vec![
-            "Anchors above are current for the edited ranges — reuse them directly with editFiles for follow-up edits in those same ranges".to_string(),
-            "Use readFile only when you need broader context, untouched lines, or fresh anchors outside the ranges shown above".to_string(),
-        ],
+        next_actions,
     );
 
     hint.to_mcp_result_with_data(Some(json!({

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
@@ -1,8 +1,6 @@
 use super::super::WorkspaceServer;
 use super::utils::{is_not_found_io_error, normalize_workspace_path_input};
-use crate::mcp::builtin::error_guidance::{
-    guided_error, not_found_error, ErrorCategory, SuccessHint, ToolGroup,
-};
+use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::builtin::workspace::utils::is_internal_workspace_artifact_path;
 use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};
@@ -209,24 +207,29 @@ impl WorkspaceServer {
                 let hint = if total_items == 0 {
                     SuccessHint::new(
                         format!(
-                            "Directory listing for '{}':\n\n(This directory is empty)\n\n💡 Next Steps:\n- Use writeFile('{}/filename.txt', content) to create a file\n- Use listDirectory('{}') to verify the directory exists\n- This is a valid empty directory",
-                            path_str, path_str, path_str
+                            "Directory listing for '{}':\n\n(This directory is empty)\n\nThis is a valid empty directory.",
+                            path_str
                         ),
                         vec![
-                            format!("Use writeFile('{}/filename.txt', content) to create a file", path_str),
-                            format!("Use listDirectory('{}') to verify the directory exists", path_str)
+                            format!(
+                                "Use writeFile with {{\"path\": \"{}/filename.txt\", \"content\": \"...\"}} to create a file",
+                                path_str
+                            )
                         ],
                     )
                 } else {
                     SuccessHint::new(
                         format!(
-                            "Directory listing for '{}':\n\n{}{}\n\n💡 Next Steps:\n- Use readFile('{}/filename') to read a file\n- Use listDirectory('{}/subdir') to explore subdirectories\n- Use search to search for content in files",
-                            path_str, listing_str, truncation_note, path_str, path_str
+                            "Directory listing for '{}':\n\n{}{}",
+                            path_str, listing_str, truncation_note
                         ),
                         vec![
                             format!("Use readFile('{}/filename') to read a file", path_str),
-                            format!("Use listDirectory('{}/subdir') to explore subdirectories", path_str),
-                            "Use search to search for content in files".to_string()
+                            format!(
+                                "Use listDirectory('{}/subdir') to explore subdirectories",
+                                path_str
+                            ),
+                            "Use search to search for content in files".to_string(),
                         ],
                     )
                 };
@@ -243,11 +246,18 @@ impl WorkspaceServer {
             Err(e) => {
                 error!("Failed to list directory {:?}: {}", safe_path, e);
                 if is_not_found_io_error(&e) {
-                    Ok(not_found_error(
-                        "Directory",
-                        &path_str,
+                    Ok(guided_error(
+                        ErrorCategory::ResourceNotFound,
+                        format!("Directory '{}' not found", path_str),
                         ToolGroup::Workspace,
-                    ))
+                    )
+                    .guidance(vec![
+                        "Use listDirectory('.') to inspect the workspace root".to_string(),
+                        "Verify the directory path is correct".to_string(),
+                        "Check whether the directory exists under the current workspace"
+                            .to_string(),
+                    ])
+                    .to_mcp_result())
                 } else {
                     Ok(guided_error(
                         ErrorCategory::OperationFailed,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -258,7 +258,7 @@ impl WorkspaceServer {
                 // Format response for clean markdown rendering
                 let text_message = if show_line_anchors {
                     format!(
-                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nAnchor format: `{{N}}:{{anchor}}|{{content}}` — for edit tools, pass only `{{anchor}}` (the 6 hex characters between `:` and `|`), not `{{N}}:` or `|{{content}}`",
+                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nLine format: `{{lineNumber}}:{{anchor}}|{{content}}`\n- `{{lineNumber}}`: 1-based line number\n- `{{anchor}}`: 6-character hex code (example: `792c6f`)\n- `{{content}}`: line content\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{{content}}`.",
                         path_str, size_str, chunk_summary, summary_suffix, chunk.content
                     )
                 } else {
@@ -272,7 +272,7 @@ impl WorkspaceServer {
                 let first_hint = if show_line_anchors {
                     "Use editFiles with path plus only the 6-character startAnchor; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
                 } else {
-                    "Rerun with showLineAnchors=true to get anchors for precise line editing with editFiles".to_string()
+                    "If you plan to use editFiles next, rerun with showLineAnchors=true to get anchors".to_string()
                 };
                 let mut next_actions = vec![
                     first_hint,
@@ -310,6 +310,27 @@ impl WorkspaceServer {
                 let is_not_found = e.contains("No such file") || e.contains("not found");
                 if is_not_found {
                     Ok(not_found_error("File", path_str, ToolGroup::Workspace))
+                } else if let Some((requested_line, total_lines)) =
+                    parse_start_line_exceeds_error(&e)
+                {
+                    Ok(
+                        guided_error(ErrorCategory::InvalidInput, &e, ToolGroup::Workspace)
+                            .guidance(vec![
+                                format!(
+                                    "Choose startLine between 1 and {} for this file",
+                                    total_lines
+                                ),
+                                format!(
+                                "Use startLine {} (or omit line bounds) to read from the file end",
+                                total_lines
+                            ),
+                                format!(
+                                    "Requested startLine {} is out of range for this file",
+                                    requested_line
+                                ),
+                            ])
+                            .to_mcp_result(),
+                    )
                 } else {
                     Ok(
                         guided_error(ErrorCategory::OperationFailed, &e, ToolGroup::Workspace)
@@ -327,6 +348,18 @@ impl WorkspaceServer {
 }
 
 // Helper functions
+
+fn parse_start_line_exceeds_error(message: &str) -> Option<(usize, usize)> {
+    let prefix = "Requested start line ";
+    let middle = " exceeds file length of ";
+    let suffix = " lines";
+
+    let after_prefix = message.strip_prefix(prefix)?;
+    let (requested_line, after_requested) = after_prefix.split_once(middle)?;
+    let total_lines = after_requested.strip_suffix(suffix)?;
+
+    Some((requested_line.parse().ok()?, total_lines.parse().ok()?))
+}
 
 async fn read_file_lines_range(
     path: &std::path::Path,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -160,7 +160,7 @@ pub(super) async fn search_content_in_file(
             s.push_str("Use the returned anchors with editFiles. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
         } else {
             s.push_str(
-                "Run with `showLineAnchors: true` to get anchors for targeted editing tools.\n",
+                "If you plan to use editFiles next, run again with `showLineAnchors: true` to get anchors.\n",
             );
         }
         s
@@ -383,9 +383,10 @@ pub(super) async fn search_content_in_dir(
     let paginated_files: Vec<_> = file_matches.into_iter().skip(offset).take(limit).collect();
     let has_more = offset + paginated_files.len() < total_files;
 
+    let per_file_preview_limit = 5usize;
     for fm in &paginated_files {
         text.push_str(&format!("### `{}`\n", fm.rel_path));
-        for hit in fm.hits.iter().take(5) {
+        for hit in fm.hits.iter().take(per_file_preview_limit) {
             let line_num = hit.get("line").and_then(|v| v.as_u64()).unwrap_or(0);
             let t = hit.get("text").and_then(|v| v.as_str()).unwrap_or("");
             if let Some(anchor) = hit.get("anchor").and_then(|v| v.as_str()) {
@@ -394,10 +395,11 @@ pub(super) async fn search_content_in_dir(
                 text.push_str(&format!("- L{}: `{}`\n", line_num, t.trim()));
             }
         }
-        if fm.hits.len() > 5 {
+        if fm.hits.len() > per_file_preview_limit {
             text.push_str(&format!(
-                "  ... and {} more matches in this file\n",
-                fm.hits.len() - 5
+                "  ... and {} more matches in this file (showing first {} per file)\n",
+                fm.hits.len() - per_file_preview_limit,
+                per_file_preview_limit
             ));
         }
         text.push('\n');

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
@@ -85,23 +85,6 @@ pub fn format_as_hashlines(content: &str) -> String {
         .join("\n")
 }
 
-pub fn format_tail_as_hashlines(content: &str, max_lines: usize) -> String {
-    let content_lines: Vec<&str> = content.lines().collect();
-    let start_idx = content_lines.len().saturating_sub(max_lines);
-    let mut prefix_state = initial_prefix_hash_state();
-
-    for line in &content_lines[..start_idx] {
-        prefix_state = update_prefix_hash_state(prefix_state, line);
-    }
-
-    content_lines[start_idx..]
-        .iter()
-        .enumerate()
-        .map(|(offset, line)| format_hashline(start_idx + offset + 1, line, &mut prefix_state))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// Format file size in bytes to human-readable format (B, KB, MB, GB)
 pub fn format_file_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
@@ -10,6 +10,7 @@ const FNV_PRIME: u32 = 16_777_619;
 const LINE_HASH_LEN: usize = 2;
 const PREFIX_HASH_LEN: usize = 4;
 const ANCHOR_LEN: usize = LINE_HASH_LEN + PREFIX_HASH_LEN;
+const MAX_LCS_CELLS: usize = 2_000_000;
 
 /// Compute a 2-char hex content hash for anchor generation.
 ///
@@ -80,6 +81,23 @@ pub fn format_as_hashlines(content: &str) -> String {
         .lines()
         .enumerate()
         .map(|(i, line)| format_hashline(i + 1, line, &mut prefix_state))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn format_tail_as_hashlines(content: &str, max_lines: usize) -> String {
+    let content_lines: Vec<&str> = content.lines().collect();
+    let start_idx = content_lines.len().saturating_sub(max_lines);
+    let mut prefix_state = initial_prefix_hash_state();
+
+    for line in &content_lines[..start_idx] {
+        prefix_state = update_prefix_hash_state(prefix_state, line);
+    }
+
+    content_lines[start_idx..]
+        .iter()
+        .enumerate()
+        .map(|(offset, line)| format_hashline(start_idx + offset + 1, line, &mut prefix_state))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -245,16 +263,132 @@ fn lcs_table(old_lines: &[&str], new_lines: &[&str]) -> Vec<Vec<usize>> {
     table
 }
 
+fn diff_change_window(old_lines: &[&str], new_lines: &[&str]) -> (usize, usize, usize, usize) {
+    let mut common_prefix = 0usize;
+    let max_prefix = old_lines.len().min(new_lines.len());
+    while common_prefix < max_prefix && old_lines[common_prefix] == new_lines[common_prefix] {
+        common_prefix += 1;
+    }
+
+    let mut common_suffix = 0usize;
+    while common_suffix < old_lines.len().saturating_sub(common_prefix)
+        && common_suffix < new_lines.len().saturating_sub(common_prefix)
+        && old_lines[old_lines.len() - 1 - common_suffix]
+            == new_lines[new_lines.len() - 1 - common_suffix]
+    {
+        common_suffix += 1;
+    }
+
+    let old_changed_end = old_lines.len().saturating_sub(common_suffix);
+    let new_changed_end = new_lines.len().saturating_sub(common_suffix);
+    (
+        common_prefix,
+        old_changed_end,
+        common_prefix,
+        new_changed_end,
+    )
+}
+
+fn emit_diff_preview(
+    diff_lines: &mut Vec<String>,
+    removed_lines: &[&str],
+    added_lines: &[&str],
+    max_diff_lines: usize,
+) {
+    let mut shown_lines = 0usize;
+    let mut omitted_change_lines = 0usize;
+
+    let emit_line = |line: String,
+                     shown_lines: &mut usize,
+                     omitted_change_lines: &mut usize,
+                     diff_lines: &mut Vec<String>| {
+        if *shown_lines < max_diff_lines {
+            diff_lines.push(line);
+            *shown_lines += 1;
+        } else {
+            *omitted_change_lines += 1;
+        }
+    };
+
+    for line in removed_lines {
+        emit_line(
+            format!("- {}", line),
+            &mut shown_lines,
+            &mut omitted_change_lines,
+            diff_lines,
+        );
+    }
+
+    for line in added_lines {
+        emit_line(
+            format!("+ {}", line),
+            &mut shown_lines,
+            &mut omitted_change_lines,
+            diff_lines,
+        );
+    }
+
+    if omitted_change_lines > 0 {
+        diff_lines.push(format!(
+            "... {} more changed line(s) omitted",
+            omitted_change_lines
+        ));
+    }
+}
+
 /// Format full file diff output (Git-style unified diff)
 pub fn format_file_diff(old_content: &str, new_content: &str, _file_path: &str) -> String {
     let old_lines: Vec<&str> = old_content.lines().collect();
     let new_lines: Vec<&str> = new_content.lines().collect();
-    let lcs = lcs_table(&old_lines, &new_lines);
-    let common_line_count = lcs[0][0];
-    let added = new_lines.len().saturating_sub(common_line_count);
-    let removed = old_lines.len().saturating_sub(common_line_count);
-
     let mut diff_lines = Vec::new();
+    let max_diff_lines = 50;
+    let max_cells = old_lines.len().saturating_mul(new_lines.len());
+
+    let (added, removed, removed_preview, added_preview) = if max_cells <= MAX_LCS_CELLS {
+        let lcs = lcs_table(&old_lines, &new_lines);
+        let common_line_count = lcs[0][0];
+        let added = new_lines.len().saturating_sub(common_line_count);
+        let removed = old_lines.len().saturating_sub(common_line_count);
+
+        let mut old_idx = 0usize;
+        let mut new_idx = 0usize;
+        let mut removed_preview = Vec::new();
+        let mut added_preview = Vec::new();
+
+        while old_idx < old_lines.len() || new_idx < new_lines.len() {
+            if old_idx < old_lines.len()
+                && new_idx < new_lines.len()
+                && old_lines[old_idx] == new_lines[new_idx]
+            {
+                old_idx += 1;
+                new_idx += 1;
+                continue;
+            }
+
+            if old_idx < old_lines.len()
+                && (new_idx == new_lines.len()
+                    || lcs[old_idx + 1][new_idx] >= lcs[old_idx][new_idx + 1])
+            {
+                removed_preview.push(old_lines[old_idx]);
+                old_idx += 1;
+            } else if new_idx < new_lines.len() {
+                added_preview.push(new_lines[new_idx]);
+                new_idx += 1;
+            }
+        }
+
+        (added, removed, removed_preview, added_preview)
+    } else {
+        let (old_start, old_end, new_start, new_end) = diff_change_window(&old_lines, &new_lines);
+        let removed_preview = old_lines[old_start..old_end].to_vec();
+        let added_preview = new_lines[new_start..new_end].to_vec();
+        (
+            added_preview.len(),
+            removed_preview.len(),
+            removed_preview,
+            added_preview,
+        )
+    };
 
     diff_lines.push(format!(
         "**Changes:** {} line(s) added, {} line(s) removed\n",
@@ -269,63 +403,12 @@ pub fn format_file_diff(old_content: &str, new_content: &str, _file_path: &str) 
         1,
         new_lines.len()
     ));
-
-    let max_diff_lines = 50;
-    let mut shown_lines = 0usize;
-    let mut omitted_change_lines = 0usize;
-    let mut old_idx = 0usize;
-    let mut new_idx = 0usize;
-
-    while old_idx < old_lines.len() || new_idx < new_lines.len() {
-        if old_idx < old_lines.len()
-            && new_idx < new_lines.len()
-            && old_lines[old_idx] == new_lines[new_idx]
-        {
-            old_idx += 1;
-            new_idx += 1;
-            continue;
-        }
-
-        let emit_line = |line: String,
-                         shown_lines: &mut usize,
-                         omitted_change_lines: &mut usize,
-                         diff_lines: &mut Vec<String>| {
-            if *shown_lines < max_diff_lines {
-                diff_lines.push(line);
-                *shown_lines += 1;
-            } else {
-                *omitted_change_lines += 1;
-            }
-        };
-
-        if old_idx < old_lines.len()
-            && (new_idx == new_lines.len()
-                || lcs[old_idx + 1][new_idx] >= lcs[old_idx][new_idx + 1])
-        {
-            emit_line(
-                format!("- {}", old_lines[old_idx]),
-                &mut shown_lines,
-                &mut omitted_change_lines,
-                &mut diff_lines,
-            );
-            old_idx += 1;
-        } else if new_idx < new_lines.len() {
-            emit_line(
-                format!("+ {}", new_lines[new_idx]),
-                &mut shown_lines,
-                &mut omitted_change_lines,
-                &mut diff_lines,
-            );
-            new_idx += 1;
-        }
-    }
-
-    if omitted_change_lines > 0 {
-        diff_lines.push(format!(
-            "... {} more changed line(s) omitted",
-            omitted_change_lines
-        ));
-    }
+    emit_diff_preview(
+        &mut diff_lines,
+        &removed_preview,
+        &added_preview,
+        max_diff_lines,
+    );
 
     diff_lines.push("```".to_string());
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
@@ -229,13 +229,30 @@ pub fn calculate_similarity(text1: &str, text2: &str) -> f32 {
     matching_chars as f32 / len1.max(len2) as f32
 }
 
+fn lcs_table(old_lines: &[&str], new_lines: &[&str]) -> Vec<Vec<usize>> {
+    let mut table = vec![vec![0usize; new_lines.len() + 1]; old_lines.len() + 1];
+
+    for old_idx in (0..old_lines.len()).rev() {
+        for new_idx in (0..new_lines.len()).rev() {
+            table[old_idx][new_idx] = if old_lines[old_idx] == new_lines[new_idx] {
+                table[old_idx + 1][new_idx + 1] + 1
+            } else {
+                table[old_idx + 1][new_idx].max(table[old_idx][new_idx + 1])
+            };
+        }
+    }
+
+    table
+}
+
 /// Format full file diff output (Git-style unified diff)
 pub fn format_file_diff(old_content: &str, new_content: &str, _file_path: &str) -> String {
     let old_lines: Vec<&str> = old_content.lines().collect();
     let new_lines: Vec<&str> = new_content.lines().collect();
-
-    let added = new_lines.len().saturating_sub(old_lines.len());
-    let removed = old_lines.len().saturating_sub(new_lines.len());
+    let lcs = lcs_table(&old_lines, &new_lines);
+    let common_line_count = lcs[0][0];
+    let added = new_lines.len().saturating_sub(common_line_count);
+    let removed = old_lines.len().saturating_sub(common_line_count);
 
     let mut diff_lines = Vec::new();
 
@@ -253,34 +270,61 @@ pub fn format_file_diff(old_content: &str, new_content: &str, _file_path: &str) 
         new_lines.len()
     ));
 
-    // Show removed lines (limited to first 50 for display)
     let max_diff_lines = 50;
-    let mut shown_lines = 0;
+    let mut shown_lines = 0usize;
+    let mut omitted_change_lines = 0usize;
+    let mut old_idx = 0usize;
+    let mut new_idx = 0usize;
 
-    for (idx, line) in old_lines.iter().enumerate() {
-        if shown_lines >= max_diff_lines {
-            diff_lines.push(format!(
-                "... {} more removed lines omitted",
-                old_lines.len() - idx
-            ));
-            break;
+    while old_idx < old_lines.len() || new_idx < new_lines.len() {
+        if old_idx < old_lines.len()
+            && new_idx < new_lines.len()
+            && old_lines[old_idx] == new_lines[new_idx]
+        {
+            old_idx += 1;
+            new_idx += 1;
+            continue;
         }
-        diff_lines.push(format!("- {}", line));
-        shown_lines += 1;
+
+        let emit_line = |line: String,
+                         shown_lines: &mut usize,
+                         omitted_change_lines: &mut usize,
+                         diff_lines: &mut Vec<String>| {
+            if *shown_lines < max_diff_lines {
+                diff_lines.push(line);
+                *shown_lines += 1;
+            } else {
+                *omitted_change_lines += 1;
+            }
+        };
+
+        if old_idx < old_lines.len()
+            && (new_idx == new_lines.len()
+                || lcs[old_idx + 1][new_idx] >= lcs[old_idx][new_idx + 1])
+        {
+            emit_line(
+                format!("- {}", old_lines[old_idx]),
+                &mut shown_lines,
+                &mut omitted_change_lines,
+                &mut diff_lines,
+            );
+            old_idx += 1;
+        } else if new_idx < new_lines.len() {
+            emit_line(
+                format!("+ {}", new_lines[new_idx]),
+                &mut shown_lines,
+                &mut omitted_change_lines,
+                &mut diff_lines,
+            );
+            new_idx += 1;
+        }
     }
 
-    shown_lines = 0;
-    // Show added lines (limited to first 50 for display)
-    for (idx, line) in new_lines.iter().enumerate() {
-        if shown_lines >= max_diff_lines {
-            diff_lines.push(format!(
-                "... {} more added lines omitted",
-                new_lines.len() - idx
-            ));
-            break;
-        }
-        diff_lines.push(format!("+ {}", line));
-        shown_lines += 1;
+    if omitted_change_lines > 0 {
+        diff_lines.push(format!(
+            "... {} more changed line(s) omitted",
+            omitted_change_lines
+        ));
     }
 
     diff_lines.push("```".to_string());

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -153,8 +153,34 @@ impl WorkspaceServer {
                 // Invalidate service context cache
                 self.invalidate_context_cache().await;
 
-                let lines = content.lines().count();
-                let size_str = format_file_size(content.len() as u64);
+                let current_content = if mode == "append" {
+                    match tokio::fs::read_to_string(&safe_path).await {
+                        Ok(updated) => updated,
+                        Err(e) => {
+                            return Ok(guided_error(
+                                ErrorCategory::OperationFailed,
+                                format!("File was updated but could not be read back: {}", e),
+                                ToolGroup::Workspace,
+                            )
+                            .guidance(vec![
+                                format!(
+                                    "Use readFile(\"{}\") to inspect the current file state",
+                                    path_str
+                                ),
+                                "Check file permissions if the follow-up read unexpectedly failed"
+                                    .to_string(),
+                            ])
+                            .to_mcp_result());
+                        }
+                    }
+                } else {
+                    content.to_string()
+                };
+
+                let total_lines = current_content.lines().count();
+                let total_size_str = format_file_size(current_content.len() as u64);
+                let appended_lines = content.lines().count();
+                let appended_size_str = format_file_size(content.len() as u64);
 
                 let message_header = match (file_exists, mode) {
                     (true, "append") => "**✅ Content Appended Successfully**",
@@ -162,73 +188,70 @@ impl WorkspaceServer {
                     _ => "**✅ New File Created Successfully**",
                 };
 
-                let mut message = format!("{}\n\n**File:** `{}`\n", message_header, path_str);
+                let mut message = format!(
+                    "{}\n\n**File:** `{}`\n**Total Size:** {}\n**Total Lines:** {}\n\n",
+                    message_header, path_str, total_size_str, total_lines
+                );
 
                 if mode == "append" {
                     message.push_str(&format!(
-                        "**Appended:** {} bytes, {} line(s)\n\n",
-                        size_str, lines
+                        "**Appended:** {}, {} line(s)\n\n",
+                        appended_size_str, appended_lines
                     ));
-                    message.push_str(
-                        "Use `readFile` to see the full content including the appended part.",
-                    );
-                } else {
+                }
+
+                if file_exists && mode == "overwrite" {
+                    // Show diff then anchored lines of new content for immediate editing
+                    use super::utils::format_file_diff;
+                    let diff_output = format_file_diff(&old_content, content, path_str);
+                    message.push_str(&diff_output);
                     message.push_str(&format!(
-                        "**Total Size:** {}\n**Total Lines:** {}\n\n",
-                        size_str, lines
+                        "\nCurrent anchors:\n```\n{}\n```\n",
+                        format_as_hashlines(content)
                     ));
+                } else {
+                    // New file / append — show anchors so agent can immediately use targeted editing tools
+                    let max_display_lines = 100;
+                    let max_display_bytes = 51200; // 50KB
+                    let content_lines: Vec<&str> = current_content.lines().collect();
+                    let is_truncated = content_lines.len() > max_display_lines
+                        || current_content.len() > max_display_bytes;
 
-                    if file_exists && mode == "overwrite" {
-                        // Show diff then anchored lines of new content for immediate editing
-                        use super::utils::format_file_diff;
-                        let diff_output = format_file_diff(&old_content, content, path_str);
-                        message.push_str(&diff_output);
-                        message.push_str(&format!(
-                            "\nCurrent anchors:\n```\n{}\n```\n",
-                            format_as_hashlines(content)
-                        ));
-                    } else {
-                        // New file — show anchors so agent can immediately use targeted editing tools
-                        let max_display_lines = 100;
-                        let max_display_bytes = 51200; // 50KB
-                        let content_lines: Vec<&str> = content.lines().collect();
-                        let is_truncated = content_lines.len() > max_display_lines
-                            || content.len() > max_display_bytes;
-
-                        let display_hashlines = if is_truncated {
-                            let truncated: Vec<&str> = if content.len() > max_display_bytes {
-                                let truncated_bytes =
-                                    &content[..max_display_bytes.min(content.len())];
-                                truncated_bytes.lines().take(max_display_lines).collect()
-                            } else {
-                                content_lines
-                                    .iter()
-                                    .take(max_display_lines)
-                                    .copied()
-                                    .collect()
-                            };
-                            let partial = truncated.join("\n");
-                            format!(
-                                "{}\n\n... (truncated: showing first {} of {} lines)",
-                                format_as_hashlines(&partial),
-                                truncated.len(),
-                                content_lines.len(),
-                            )
+                    let display_hashlines = if is_truncated {
+                        let truncated: Vec<&str> = if current_content.len() > max_display_bytes {
+                            let truncated_bytes =
+                                &current_content[..max_display_bytes.min(current_content.len())];
+                            truncated_bytes.lines().take(max_display_lines).collect()
                         } else {
-                            format_as_hashlines(content)
+                            content_lines
+                                .iter()
+                                .take(max_display_lines)
+                                .copied()
+                                .collect()
                         };
+                        let partial = truncated.join("\n");
+                        format!(
+                            "{}\n\n... (truncated: showing first {} of {} lines)",
+                            format_as_hashlines(&partial),
+                            truncated.len(),
+                            content_lines.len(),
+                        )
+                    } else {
+                        format_as_hashlines(&current_content)
+                    };
 
-                        message.push_str(&format!("```\n{}\n```\n", display_hashlines));
-                    }
+                    message.push_str(&format!("```\n{}\n```\n", display_hashlines));
                 }
 
                 // Context-aware next steps
                 let mut next_steps = Vec::new();
+                let preview_was_truncated = (mode == "create" || mode == "append")
+                    && (current_content.lines().count() > 100 || current_content.len() > 51200);
 
-                if mode == "overwrite" || mode == "append" {
-                    next_steps.push("Verify changes with readFile if unsure".to_string());
-                } else {
-                    next_steps.push("Use readFile to see full content (if truncated)".to_string());
+                if preview_was_truncated {
+                    next_steps.push(
+                        "Use readFile to inspect lines omitted from this preview".to_string(),
+                    );
                 }
 
                 // File type specific suggestions
@@ -249,7 +272,7 @@ impl WorkspaceServer {
                     "path": path_str,
                     "mode": mode,
                     "bytes_written": content.len(),
-                    "lines": lines,
+                    "lines": total_lines,
                     "file_exists_before": file_exists
                 }))))
             }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -1,12 +1,77 @@
 use super::super::WorkspaceServer;
-use super::utils::{format_as_hashlines, format_file_size, format_tail_as_hashlines};
+use super::utils::{
+    format_as_hashlines, format_file_size, format_hashline, initial_prefix_hash_state,
+};
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, permission_denied_error, ErrorCategory, SuccessHint,
     ToolGroup,
 };
 use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};
+use std::collections::VecDeque;
+use std::io::BufRead;
+use std::path::Path;
 use tracing::error;
+
+struct AppendPreview {
+    total_lines: usize,
+    total_size_bytes: u64,
+    shown_lines: usize,
+    preview_was_truncated: bool,
+    display_hashlines: String,
+}
+
+fn read_back_append_preview(
+    safe_path: &Path,
+    max_display_lines: usize,
+    max_display_bytes: usize,
+) -> Result<AppendPreview, String> {
+    let total_size_bytes = std::fs::metadata(safe_path)
+        .map_err(|e| format!("failed to stat updated file: {e}"))?
+        .len();
+    let file = std::fs::File::open(safe_path).map_err(|e| e.to_string())?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut prefix_state = initial_prefix_hash_state();
+    let mut total_lines = 0usize;
+    let mut preview_bytes = 0usize;
+    let mut tail_lines = VecDeque::new();
+
+    for line_result in reader.lines() {
+        let line = line_result.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::InvalidData {
+                "Content appears to be binary or contains invalid UTF-8 characters".to_string()
+            } else {
+                e.to_string()
+            }
+        })?;
+
+        total_lines += 1;
+        let anchored_line = format_hashline(total_lines, &line, &mut prefix_state);
+        preview_bytes += anchored_line.len() + 1;
+        tail_lines.push_back(anchored_line);
+
+        while tail_lines.len() > max_display_lines
+            || (preview_bytes > max_display_bytes && tail_lines.len() > 1)
+        {
+            if let Some(removed) = tail_lines.pop_front() {
+                preview_bytes = preview_bytes.saturating_sub(removed.len() + 1);
+            }
+        }
+    }
+
+    let shown_lines = tail_lines.len();
+    let preview_was_truncated =
+        total_lines > shown_lines || total_size_bytes > max_display_bytes as u64;
+
+    Ok(AppendPreview {
+        total_lines,
+        total_size_bytes,
+        shown_lines,
+        preview_was_truncated,
+        display_hashlines: tail_lines.into_iter().collect::<Vec<_>>().join("\n"),
+    })
+}
 
 impl WorkspaceServer {
     pub async fn handle_write_file(
@@ -153,13 +218,20 @@ impl WorkspaceServer {
                 // Invalidate service context cache
                 self.invalidate_context_cache().await;
 
-                let current_content = if mode == "append" {
-                    match tokio::fs::read_to_string(&safe_path).await {
-                        Ok(updated) => updated,
-                        Err(e) => {
+                let max_display_lines = 100;
+                let max_display_bytes = 51200; // 50KB
+                let append_preview = if mode == "append" {
+                    let safe_path = safe_path.clone();
+                    match tokio::task::spawn_blocking(move || {
+                        read_back_append_preview(&safe_path, max_display_lines, max_display_bytes)
+                    })
+                    .await
+                    {
+                        Ok(Ok(preview)) => Some(preview),
+                        Ok(Err(error)) => {
                             return Ok(guided_error(
                                 ErrorCategory::OperationFailed,
-                                format!("File was updated but could not be read back: {}", e),
+                                format!("File was updated but could not be read back: {}", error),
                                 ToolGroup::Workspace,
                             )
                             .guidance(vec![
@@ -172,13 +244,33 @@ impl WorkspaceServer {
                             ])
                             .to_mcp_result());
                         }
+                        Err(join_error) => return Err(join_error.to_string()),
                     }
                 } else {
-                    content.to_string()
+                    None
+                };
+                let current_content = if mode == "append" {
+                    None
+                } else {
+                    Some(content.to_string())
                 };
 
-                let total_lines = current_content.lines().count();
-                let total_size_str = format_file_size(current_content.len() as u64);
+                let total_lines = append_preview
+                    .as_ref()
+                    .map(|preview| preview.total_lines)
+                    .unwrap_or_else(|| {
+                        current_content
+                            .as_ref()
+                            .map_or(0, |text| text.lines().count())
+                    });
+                let total_size_str = format_file_size(
+                    append_preview
+                        .as_ref()
+                        .map(|preview| preview.total_size_bytes)
+                        .unwrap_or_else(|| {
+                            current_content.as_ref().map_or(0, |text| text.len() as u64)
+                        }),
+                );
                 let appended_lines = content.lines().count();
                 let appended_size_str = format_file_size(content.len() as u64);
 
@@ -211,22 +303,26 @@ impl WorkspaceServer {
                     ));
                 } else {
                     // New file / append — show anchors so agent can immediately use targeted editing tools
-                    let max_display_lines = 100;
-                    let max_display_bytes = 51200; // 50KB
-                    let content_lines: Vec<&str> = current_content.lines().collect();
-                    let is_truncated = content_lines.len() > max_display_lines
-                        || current_content.len() > max_display_bytes;
-
-                    let display_hashlines = if is_truncated {
-                        if mode == "append" {
-                            let shown_line_count = content_lines.len().min(max_display_lines);
+                    let display_hashlines = if let Some(preview) = append_preview.as_ref() {
+                        if preview.preview_was_truncated {
                             format!(
                                 "{}\n\n... (truncated: showing last {} of {} lines, including the appended tail)",
-                                format_tail_as_hashlines(&current_content, max_display_lines),
-                                shown_line_count,
-                                content_lines.len(),
+                                preview.display_hashlines,
+                                preview.shown_lines,
+                                preview.total_lines,
                             )
                         } else {
+                            preview.display_hashlines.clone()
+                        }
+                    } else {
+                        let current_content = current_content
+                            .as_ref()
+                            .expect("create/overwrite preview requires in-memory content");
+                        let content_lines: Vec<&str> = current_content.lines().collect();
+                        let is_truncated = content_lines.len() > max_display_lines
+                            || current_content.len() > max_display_bytes;
+
+                        if is_truncated {
                             let truncated: Vec<&str> = if current_content.len() > max_display_bytes
                             {
                                 let truncated_bytes = &current_content
@@ -246,9 +342,9 @@ impl WorkspaceServer {
                                 truncated.len(),
                                 content_lines.len(),
                             )
+                        } else {
+                            format_as_hashlines(current_content)
                         }
-                    } else {
-                        format_as_hashlines(&current_content)
                     };
 
                     message.push_str(&format!("```\n{}\n```\n", display_hashlines));
@@ -256,8 +352,15 @@ impl WorkspaceServer {
 
                 // Context-aware next steps
                 let mut next_steps = Vec::new();
-                let preview_was_truncated = (mode == "create" || mode == "append")
-                    && (current_content.lines().count() > 100 || current_content.len() > 51200);
+                let preview_was_truncated = append_preview
+                    .as_ref()
+                    .map(|preview| preview.preview_was_truncated)
+                    .unwrap_or_else(|| {
+                        current_content.as_ref().is_some_and(|text| {
+                            text.lines().count() > max_display_lines
+                                || text.len() > max_display_bytes
+                        })
+                    });
 
                 if preview_was_truncated {
                     next_steps.push(

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -1,5 +1,5 @@
 use super::super::WorkspaceServer;
-use super::utils::{format_as_hashlines, format_file_size};
+use super::utils::{format_as_hashlines, format_file_size, format_tail_as_hashlines};
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, permission_denied_error, ErrorCategory, SuccessHint,
     ToolGroup,
@@ -218,24 +218,35 @@ impl WorkspaceServer {
                         || current_content.len() > max_display_bytes;
 
                     let display_hashlines = if is_truncated {
-                        let truncated: Vec<&str> = if current_content.len() > max_display_bytes {
-                            let truncated_bytes =
-                                &current_content[..max_display_bytes.min(current_content.len())];
-                            truncated_bytes.lines().take(max_display_lines).collect()
+                        if mode == "append" {
+                            let shown_line_count = content_lines.len().min(max_display_lines);
+                            format!(
+                                "{}\n\n... (truncated: showing last {} of {} lines, including the appended tail)",
+                                format_tail_as_hashlines(&current_content, max_display_lines),
+                                shown_line_count,
+                                content_lines.len(),
+                            )
                         } else {
-                            content_lines
-                                .iter()
-                                .take(max_display_lines)
-                                .copied()
-                                .collect()
-                        };
-                        let partial = truncated.join("\n");
-                        format!(
-                            "{}\n\n... (truncated: showing first {} of {} lines)",
-                            format_as_hashlines(&partial),
-                            truncated.len(),
-                            content_lines.len(),
-                        )
+                            let truncated: Vec<&str> = if current_content.len() > max_display_bytes
+                            {
+                                let truncated_bytes = &current_content
+                                    [..max_display_bytes.min(current_content.len())];
+                                truncated_bytes.lines().take(max_display_lines).collect()
+                            } else {
+                                content_lines
+                                    .iter()
+                                    .take(max_display_lines)
+                                    .copied()
+                                    .collect()
+                            };
+                            let partial = truncated.join("\n");
+                            format!(
+                                "{}\n\n... (truncated: showing first {} of {} lines)",
+                                format_as_hashlines(&partial),
+                                truncated.len(),
+                                content_lines.len(),
+                            )
+                        }
                     } else {
                         format_as_hashlines(&current_content)
                     };

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
@@ -33,6 +33,7 @@ impl WorkspaceServer {
             .map(|e| {
                 serde_json::json!({
                     "process_id": e.id,
+                    "name": e.name,
                     "command": e.command,
                     "status": format!("{:?}", e.status).to_lowercase(),
                     "pid": e.pid,
@@ -93,6 +94,7 @@ impl WorkspaceServer {
                         .and_then(|v| v.as_str())
                         .unwrap_or("unknown");
                     let command = p.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                    let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
                     let pid = p
                         .get("pid")
                         .and_then(|v| v.as_u64())
@@ -105,10 +107,17 @@ impl WorkspaceServer {
                         .unwrap_or_default();
 
                     // Full command visible to agent (no truncation)
-                    format!(
-                        "• {} [{}]{}{}\n  Command: {}",
-                        id, status, pid, exit_code, command
-                    )
+                    if name.is_empty() {
+                        format!(
+                            "• {} [{}]{}{}\n  Command: {}",
+                            id, status, pid, exit_code, command
+                        )
+                    } else {
+                        format!(
+                            "• {} [{}]{}{}\n  Name: {}\n  Command: {}",
+                            id, status, pid, exit_code, name, command
+                        )
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join("\n\n")
@@ -126,26 +135,34 @@ impl WorkspaceServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
-            let mut actions = vec![format!(
-                "Use waitForProcess('{}', 0) to check status",
-                first_id
-            )];
+            let mut actions = Vec::new();
 
-            // Add appropriate readProcessOutput guidance based on status
             match first_status {
                 "failed" => {
                     actions.push(format!(
                         "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
+                    actions.push(
+                        "Use listProcesses() again if you need another processId from this session"
+                            .to_string(),
+                    );
                 }
                 "finished" => {
                     actions.push(format!(
                         "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
+                    actions.push(
+                        "Use listProcesses() again if you need another processId from this session"
+                            .to_string(),
+                    );
                 }
                 "running" => {
+                    actions.push(format!(
+                        "Use waitForProcess('{}', 0) to check status",
+                        first_id
+                    ));
                     actions.push(format!(
                         "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
@@ -156,6 +173,10 @@ impl WorkspaceServer {
                     ));
                 }
                 _ => {
+                    actions.push(format!(
+                        "Use waitForProcess('{}', 0) to check status",
+                        first_id
+                    ));
                     actions.push(format!(
                         "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
@@ -279,7 +279,7 @@ impl WorkspaceServer {
         }
 
         let text = format!(
-            "Read output from process {} (stream: {}, mode: {}, status: {})\n\nOutput paths:\n{}\n\n{}",
+            "Read output from process {} (stream: {}, mode: {}, status: {})\n\nInternal output files (absolute paths, not workspace-relative):\n{}\n\n{}",
             process_id,
             selection.as_str(),
             mode,
@@ -300,15 +300,30 @@ impl WorkspaceServer {
             (
                 "note".to_string(),
                 json!(
-                    "Text output only. Max 100 lines per request. Use output_paths with file tools for deeper inspection."
+                    "Text output only. Max 100 lines per request. output_paths are absolute internal diagnostics paths; do not pass them to readFile or listDirectory."
                 ),
             ),
         ]);
 
-        let hint = SuccessHint::new(
-            text,
-            SuccessHint::for_tool("readProcessOutput", ToolGroup::Workspace),
-        );
+        let next_actions = if is_process_running {
+            vec![
+                format!(
+                    "Use waitForProcess('{}', 0) to check whether it has finished",
+                    process_id
+                ),
+                format!(
+                    "Use stopProcess('{}') only if the running process is stuck",
+                    process_id
+                ),
+            ]
+        } else {
+            vec![
+                "Analyze the captured output to verify command success".to_string(),
+                "Use listProcesses() if you need another processId from this session".to_string(),
+            ]
+        };
+
+        let hint = SuccessHint::new(text, next_actions);
 
         Ok(hint.to_mcp_result_with_data(Some(Value::Object(response))))
     }

--- a/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
+++ b/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
@@ -141,7 +141,8 @@ mod tests {
                 println!("Poll Result text: {}", text);
                 assert!(text.contains("Tail line 1"));
                 assert!(text.contains("Tail line 2"));
-                assert!(text.contains("Output paths:"));
+                assert!(text
+                    .contains("Internal output files (absolute paths, not workspace-relative):"));
                 assert!(text.contains("[STDOUT]"));
             }
             _ => panic!("Expected text content"),

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -97,8 +97,9 @@ pub fn create_execute_shell_tool() -> MCPTool {
         name: "runInPersistentShell".to_string(),
         title: Some("Execute Shell Command (Persistent Session)".to_string()),
         description: "Run a shell command in a persistent session that preserves working directory and env vars across calls.\n\
-                      Use when you need 'cd' to stick, 'export' to carry forward, or interactive commands (sudo).\n\
-                      For simple stateless commands: runShell."
+                       Use when you need 'cd' to stick, 'export' to carry forward, or interactive commands (sudo).\n\
+                       File tools such as readFile and listDirectory still use workspace root paths and do not follow the shell's current directory.\n\
+                       For simple stateless commands: runShell."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -129,7 +130,7 @@ pub fn create_spawn_process_tool() -> MCPTool {
         string_prop(
             None,
             Some(100),
-            Some("Optional name for the process for easier identification"),
+            Some("Optional label shown in spawnProcess/listProcesses results. Control tools still require the returned processId."),
         ),
     );
 
@@ -137,8 +138,9 @@ pub fn create_spawn_process_tool() -> MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
         description: "Start a command as a non-blocking background process. Returns process_id immediately.\n\
-                      Stateless — starts from workspace root each call. No interactive input.\n\
-                      Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
+                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
+                       Stateless — starts from workspace root each call. No interactive input.\n\
+                       Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -239,8 +241,9 @@ pub fn create_execute_shell_tool() -> MCPTool {
         name: "runInPersistentPowerShell".to_string(),
         title: Some("Execute PowerShell Command (Persistent Session)".to_string()),
         description: "Run PowerShell in a persistent session that preserves location (Set-Location) and env vars across calls.\n\
-                      - Use ';' to chain commands.\n\
-                      - For simple stateless commands: runPowerShell."
+                       - Use ';' to chain commands.\n\
+                       - File tools such as readFile and listDirectory still use workspace root paths and do not follow the shell's current location.\n\
+                       - For simple stateless commands: runPowerShell."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -271,7 +274,7 @@ pub fn create_spawn_process_tool() -> MCPTool {
         string_prop(
             None,
             Some(100),
-            Some("Optional name for the process for easier identification"),
+            Some("Optional label shown in spawnProcess/listProcesses results. Control tools still require the returned processId."),
         ),
     );
 
@@ -279,8 +282,9 @@ pub fn create_spawn_process_tool() -> MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
         description: "Start a command as a non-blocking background process. Returns process_id immediately.\n\
-                      Stateless — starts from workspace root each call. No interactive input.\n\
-                      Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
+                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
+                       Stateless — starts from workspace root each call. No interactive input.\n\
+                       Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/export_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/export_tools.rs
@@ -23,8 +23,9 @@ pub fn create_export_tool() -> MCPTool {
         name: "export".to_string(),
         title: Some("Export Files".to_string()),
         description: "Export one or more workspace files/directories and return a downloadable HTML resource.\n\
-                      - A single file is exported as-is.\n\
-                      - Multiple paths or any directory are packaged as a ZIP."
+                       - A single file is exported as-is.\n\
+                       - Multiple paths or any directory are packaged as a ZIP.\n\
+                       - The text response includes the saved export path plus the UI resource URI used for download."
             .to_string(),
         input_schema: object_schema(props, vec!["paths".to_string()]),
         output_schema: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -34,14 +34,14 @@ pub fn create_read_file_tool() -> MCPTool {
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(
-            "Optional: include opaque edit anchors for each line (e.g. '42:a31f2c|...'). For edit tools, copy only the 6-character anchor between ':' and '|', not the line number or line content.",
+            "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. Here '42' is the line number and 'a31f2c' is the anchor. For edit tools, pass only the 6-character anchor (for example 'a31f2c'), not '42:a31f2c' or the trailing '|...'.",
         )),
     );
 
     MCPTool {
         name: "readFile".to_string(),
         title: Some("Read File".to_string()),
-        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true before calling editFiles to obtain anchor values."
+        description: "Read the contents of a file. Large responses are chunked automatically to stay inline; use the returned startLine/endLine guidance to continue reading. Use showLineAnchors=true when you need anchors for editFiles."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -79,7 +79,7 @@ pub fn create_write_file_tool() -> MCPTool {
     MCPTool {
         name: "writeFile".to_string(),
         title: Some("Write File".to_string()),
-        description: "Create, overwrite, or append content to a file. mode='overwrite' returns a diff of the changes."
+        description: "Create, overwrite, or append content to a file. Missing parent directories are created automatically. Responses include current line anchors so follow-up editFiles calls can usually reuse them directly. mode='overwrite' returns a diff of the changes."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string(), "content".to_string()]),
         output_schema: None,
@@ -188,7 +188,7 @@ pub fn create_search_tool() -> MCPTool {
         integer_prop(
             Some(1),
             Some(1000),
-            Some("Maximum number of results to return (default: 50)"),
+            Some("Maximum number of file entries to return (default: 50). For content search, this limits files with matches, not individual matching lines."),
         ),
     );
     props.insert(
@@ -222,7 +222,7 @@ pub fn create_search_tool() -> MCPTool {
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(
-            "Include edit anchors in results for use with editFiles (default: false). For edit tools, copy only the 6-character anchor between ':' and '|'.",
+            "Include edit anchors in results for use with editFiles (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c').",
         )),
     );
 
@@ -651,7 +651,7 @@ pub fn create_edit_files_tool() -> MCPTool {
         title: Some("Edit Files (Batch)".to_string()),
         description: "Apply multiple line edits across one or more files atomically in a single operation.
 
-PREREQUISITE: Call readFile(showLineAnchors=true) first to obtain anchor values. For anchors, pass only the 6 hex characters between ':' and '|'.
+PREREQUISITE: Obtain anchors from a prior readFile(showLineAnchors=true), writeFile response, or previous editFiles response. Anchored lines look like `42:a31f2c|...`; for anchors, pass only the 6-character code such as `a31f2c`, not `42:a31f2c`.
 
 Line numbering is 1-based for existing content. The only valid 0 value is startLine=0, which prepends at the file top.
 

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 pub fn create_read_process_output_tool() -> MCPTool {
     let mut props = HashMap::new();
 
-    props.insert("processId".to_string(), string_prop_required("Process ID"));
+    props.insert(
+        "processId".to_string(),
+        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
+    );
 
     props.insert(
         "stream".to_string(),
@@ -47,7 +50,7 @@ pub fn create_wait_for_process_tool() -> MCPTool {
 
     props.insert(
         "processId".to_string(),
-        string_prop_required("Process ID to wait for"),
+        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
     );
     props.insert(
         "timeout".to_string(),
@@ -101,7 +104,7 @@ pub fn create_stop_process_tool() -> MCPTool {
 
     props.insert(
         "processId".to_string(),
-        string_prop_required("Process ID to stop"),
+        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
     );
 
     MCPTool {

--- a/src-tauri/tests/read_file_chunking_tests.rs
+++ b/src-tauri/tests/read_file_chunking_tests.rs
@@ -73,6 +73,12 @@ async fn read_file_truncates_large_output_and_guides_next_chunk() {
         "response should tell the agent how to continue reading: {text}"
     );
     assert!(
+        text.contains(
+            "If you plan to use editFiles next, rerun with showLineAnchors=true to get anchors"
+        ),
+        "plain readFile should keep anchor guidance optional instead of sounding mandatory: {text}"
+    );
+    assert!(
         !text.contains("line truncated to fit inline limit"),
         "readFile should only emit complete lines: {text}"
     );
@@ -177,8 +183,12 @@ async fn read_file_with_anchors_uses_more_conservative_line_budget() {
         text.len()
     );
     assert!(
-        text.contains("Anchor format:"),
+        text.contains("Line format:"),
         "anchored response should keep anchor guidance: {text}"
+    );
+    assert!(
+        text.contains("Do not pass `1:792c6f`"),
+        "anchored response should clarify that only the 6-character anchor is valid: {text}"
     );
     assert!(
         !text.contains("line truncated to fit inline limit"),

--- a/src-tauri/tests/read_process_output_tests.rs
+++ b/src-tauri/tests/read_process_output_tests.rs
@@ -138,8 +138,12 @@ async fn read_process_output_both_returns_both_sections_and_structured_outputs()
         "stderr content missing: {text}"
     );
     assert!(
-        text.contains("Output paths:"),
-        "output paths section missing: {text}"
+        text.contains("Internal output files (absolute paths, not workspace-relative):"),
+        "output paths section should clearly explain path scope: {text}"
+    );
+    assert!(
+        text.contains("not workspace-relative"),
+        "readProcessOutput should warn that these paths cannot be fed back into workspace file tools: {text}"
     );
 
     let structured = read_result
@@ -250,4 +254,163 @@ async fn read_process_output_stdout_returns_single_output_path() {
     assert!(structured["output_paths"].get("stderr").is_none());
     assert!(structured["outputs"]["stdout"].is_object());
     assert!(structured["outputs"].get("stderr").is_none());
+}
+
+#[tokio::test]
+async fn spawn_and_list_processes_surface_optional_name_labels() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "process-name-labels";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(
+            json!({
+                "command": dual_stream_command(),
+                "name": "demo-process"
+            }),
+            session_id,
+        )
+        .await
+        .expect("spawnProcess should succeed");
+
+    let spawn_text = extract_text_content(&spawn_result);
+    assert!(
+        spawn_text.contains("• Name: demo-process"),
+        "spawn response should expose process name label: {spawn_text}"
+    );
+
+    let structured = spawn_result
+        .structured_content
+        .as_ref()
+        .expect("spawn structured content expected");
+    let process_id = structured["process_id"]
+        .as_str()
+        .expect("spawnProcess should return process_id")
+        .to_string();
+    assert_eq!(structured["name"], json!("demo-process"));
+
+    let list_result = server
+        .handle_list_processes(json!({}), session_id)
+        .await
+        .expect("listProcesses should succeed");
+
+    let list_text = extract_text_content(&list_result);
+    assert!(
+        list_text.contains("Name: demo-process"),
+        "listProcesses should show the optional process name: {list_text}"
+    );
+
+    let processes = list_result
+        .structured_content
+        .as_ref()
+        .and_then(|value| value.get("processes"))
+        .and_then(|value| value.as_array())
+        .expect("process list expected");
+    assert!(
+        processes.iter().any(|item| {
+            item["process_id"] == json!(process_id) && item["name"] == json!("demo-process")
+        }),
+        "structured process list should include process name"
+    );
+}
+
+#[tokio::test]
+async fn list_processes_prefers_read_output_for_finished_processes() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "list-processes-finished-hints";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(json!({ "command": dual_stream_command() }), session_id)
+        .await
+        .expect("spawnProcess should succeed");
+    let process_id = spawn_result
+        .structured_content
+        .as_ref()
+        .and_then(|data| data.get("process_id"))
+        .and_then(|value| value.as_str())
+        .expect("spawnProcess should return process_id")
+        .to_string();
+
+    wait_for_terminal_state(&server, &process_id, session_id).await;
+
+    let list_result = server
+        .handle_list_processes(json!({}), session_id)
+        .await
+        .expect("listProcesses should succeed");
+
+    let text = extract_text_content(&list_result);
+    assert!(
+        text.contains(&format!(
+            "Use readProcessOutput('{}', 'both') to inspect stdout and stderr",
+            process_id
+        )),
+        "finished processes should point to readProcessOutput first: {text}"
+    );
+    assert!(
+        !text.contains(&format!(
+            "Use waitForProcess('{}', 0) to check status",
+            process_id
+        )),
+        "finished processes should not suggest polling again as the primary next step: {text}"
+    );
+    assert!(
+        !text.contains("Use stopProcess"),
+        "finished processes should not suggest stopProcess: {text}"
+    );
+}
+
+#[tokio::test]
+async fn read_process_output_avoids_stop_hint_after_process_has_finished() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-process-output-finished-hints";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(json!({ "command": dual_stream_command() }), session_id)
+        .await
+        .expect("spawnProcess should succeed");
+    let process_id = spawn_result
+        .structured_content
+        .as_ref()
+        .and_then(|data| data.get("process_id"))
+        .and_then(|value| value.as_str())
+        .expect("spawnProcess should return process_id")
+        .to_string();
+
+    wait_for_terminal_state(&server, &process_id, session_id).await;
+
+    let result = server
+        .call_tool(
+            "readProcessOutput",
+            json!({
+                "processId": process_id,
+                "stream": "both",
+                "mode": "tail",
+                "lines": 10
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readProcessOutput should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Analyze the captured output to verify command success"),
+        "finished processes should suggest analyzing the finished output: {text}"
+    );
+    assert!(
+        !text.contains("Use stopProcess"),
+        "finished processes should not suggest stopProcess: {text}"
+    );
+    assert!(
+        !text.contains("waitForProcess"),
+        "finished processes should not suggest waiting again: {text}"
+    );
 }

--- a/src-tauri/tests/workspace_file_operation_utils_tests.rs
+++ b/src-tauri/tests/workspace_file_operation_utils_tests.rs
@@ -59,3 +59,23 @@ fn format_file_diff_counts_replacements_as_removed_and_added_lines() {
         "unchanged lines should not be mislabeled as removals: {diff}"
     );
 }
+
+#[test]
+fn format_file_diff_uses_linear_fallback_for_large_replacement_windows() {
+    let repeated = std::iter::repeat_n("same", 1_100)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let old_content = format!("{repeated}\nold_marker\n{repeated}\n");
+    let new_content = format!("{repeated}\nnew_marker\n{repeated}\n");
+
+    let diff = format_file_diff(&old_content, &new_content, "demo.txt");
+
+    assert!(
+        diff.contains("**Changes:** 1 line(s) added, 1 line(s) removed"),
+        "large replacement-only diffs should keep accurate add/remove counts without quadratic diff cost: {diff}"
+    );
+    assert!(
+        diff.contains("- old_marker") && diff.contains("+ new_marker"),
+        "fallback diff preview should still show the changed middle lines: {diff}"
+    );
+}

--- a/src-tauri/tests/workspace_file_operation_utils_tests.rs
+++ b/src-tauri/tests/workspace_file_operation_utils_tests.rs
@@ -1,5 +1,5 @@
 use tauri_mcp_agent_lib::mcp::builtin::workspace::file_operations::utils::{
-    is_not_found_io_error, normalize_workspace_path_input,
+    format_file_diff, is_not_found_io_error, normalize_workspace_path_input,
 };
 
 #[test]
@@ -32,4 +32,30 @@ fn windows_localized_not_found_error_is_classified_as_missing_path_root_cause() 
 
     assert!(is_not_found_io_error(&localized_not_found));
     assert!(!is_not_found_io_error(&permission_denied));
+}
+
+#[test]
+fn format_file_diff_counts_replacements_as_removed_and_added_lines() {
+    let diff = format_file_diff(
+        "line1\nline2\nline3\n",
+        "line1\nline2_changed\nline3\n",
+        "demo.txt",
+    );
+
+    assert!(
+        diff.contains("**Changes:** 1 line(s) added, 1 line(s) removed"),
+        "replacement-only diffs must still count as one add plus one remove: {diff}"
+    );
+    assert!(
+        diff.contains("- line2"),
+        "removed line should remain visible in the diff body: {diff}"
+    );
+    assert!(
+        diff.contains("+ line2_changed"),
+        "added line should remain visible in the diff body: {diff}"
+    );
+    assert!(
+        !diff.contains("- line1"),
+        "unchanged lines should not be mislabeled as removals: {diff}"
+    );
 }

--- a/src-tauri/tests/workspace_guidance_tests.rs
+++ b/src-tauri/tests/workspace_guidance_tests.rs
@@ -1,0 +1,189 @@
+mod common;
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::agent::concurrency::{
+    ConcurrencyGate, DEFAULT_MAX_ACTIVE_AGENTS, DEFAULT_MAX_ACTIVE_PROCESSES,
+    DEFAULT_MAX_SUSPENDED_AGENTS, DEFAULT_MAX_SUSPENDED_PROCESSES,
+};
+use tauri_mcp_agent_lib::agent::session_bus::SessionBus;
+use tauri_mcp_agent_lib::lifecycle::repositories::init_repositories;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tauri_mcp_agent_lib::{init_concurrency_gate, init_session_bus};
+use tempfile::tempdir;
+use tokio::sync::OnceCell;
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+async fn ensure_settings_repository() {
+    static REPOSITORIES: OnceCell<()> = OnceCell::const_new();
+
+    REPOSITORIES
+        .get_or_init(|| async {
+            let db = common::setup_test_db_with_migrations().await;
+            init_repositories(&db).await;
+            init_session_bus(SessionBus::new());
+            init_concurrency_gate(ConcurrencyGate::new(
+                DEFAULT_MAX_ACTIVE_AGENTS,
+                DEFAULT_MAX_SUSPENDED_AGENTS,
+                DEFAULT_MAX_ACTIVE_PROCESSES,
+                DEFAULT_MAX_SUSPENDED_PROCESSES,
+            ));
+        })
+        .await;
+}
+
+#[cfg(unix)]
+fn simple_shell_command() -> &'static str {
+    "printf 'hello\\n'"
+}
+
+#[cfg(windows)]
+fn simple_shell_command() -> &'static str {
+    "Write-Output 'hello'"
+}
+
+#[cfg(unix)]
+fn move_into_subdir_command() -> &'static str {
+    "mkdir -p sandbox && cd sandbox && pwd"
+}
+
+#[cfg(windows)]
+fn move_into_subdir_command() -> &'static str {
+    "New-Item -ItemType Directory -Path sandbox -Force | Out-Null; Set-Location sandbox; Get-Location"
+}
+
+#[tokio::test]
+async fn read_file_out_of_range_guidance_points_to_line_bounds() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-file-out-of-range-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "a\nb\nc\nd\ne\n").expect("write file");
+
+    let result = server
+        .handle_read_file(
+            json!({
+                "path": "sample.txt",
+                "startLine": 100
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readFile should return MCPResult");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Choose startLine between 1 and 5 for this file"),
+        "out-of-range guidance should point at valid line bounds: {text}"
+    );
+    assert!(
+        !text.contains("Check file permissions"),
+        "out-of-range guidance should not send the agent down a permission rabbit hole: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_directory_empty_response_does_not_suggest_rerunning_same_call() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "list-directory-empty-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("empty")).expect("create empty dir");
+
+    let result = server
+        .handle_list_directory(
+            json!({
+                "path": "empty"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("listDirectory should return MCPResult");
+
+    let text = extract_text_content(&result);
+    assert!(
+        !text.contains("Use listDirectory with {\"path\": \"empty\"}"),
+        "empty directory guidance should not recommend rerunning the same listDirectory call: {text}"
+    );
+    assert!(
+        !text.contains("💡 Next Steps:"),
+        "listDirectory should not duplicate next-step rendering in the message body: {text}"
+    );
+}
+
+#[tokio::test]
+async fn run_shell_success_hint_no_longer_mentions_stop_process() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "run-shell-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_run_shell(
+            json!({
+                "command": simple_shell_command()
+            }),
+            session_id,
+        )
+        .await
+        .expect("runShell should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        !text.contains("stopProcess"),
+        "completed runShell responses should not mention stopProcess: {text}"
+    );
+}
+
+#[tokio::test]
+async fn persistent_shell_uses_shell_specific_guidance_after_changing_cwd() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "persistent-shell-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_execute_shell(
+            json!({
+                "command": move_into_subdir_command()
+            }),
+            session_id,
+        )
+        .await
+        .expect("runInPersistentShell should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("readFile and listDirectory still use workspace root, not the shell CWD"),
+        "persistent shell guidance should explicitly warn about workspace-root file tools: {text}"
+    );
+    assert!(
+        !text.contains("Use listDirectory to verify file system changes"),
+        "persistent shell guidance should not recommend listDirectory for shell-local CWD changes: {text}"
+    );
+}

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -159,6 +159,114 @@ async fn edit_file_allows_hashless_insert_at_top() {
 }
 
 #[tokio::test]
+async fn edit_file_missing_target_reports_file_not_found_before_anchor_guidance() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-missing-target";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "missing.txt",
+                "edits": [
+                    {
+                        "op": "replace",
+                        "startLine": 1,
+                        "content": "hello"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit should return MCPResult");
+
+    let text = extract_text_content(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("does not exist"),
+        "expected missing-file guidance, got: {text}"
+    );
+    assert!(
+        !text.contains("requires 'startAnchor'"),
+        "path errors should be reported before anchor guidance: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_file_directory_target_reports_directory_error_before_anchor_guidance() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-directory-target";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("sample-dir")).expect("create sample dir");
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample-dir",
+                "edits": [
+                    {
+                        "op": "replace",
+                        "startLine": 1,
+                        "content": "hello"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit should return MCPResult");
+
+    let text = extract_text_content(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("is a directory, not a file"),
+        "expected directory-specific guidance, got: {text}"
+    );
+    assert!(
+        text.contains("Use listDirectory"),
+        "directory guidance should point at listDirectory: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_file_rejects_anchors_for_top_insert() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-top-insert-anchor";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "edits": [
+                    {
+                        "op": "insert_after",
+                        "startLine": 0,
+                        "startAnchor": "abcdef",
+                        "content": "header"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit should return MCPResult");
+
+    let text = extract_text_content(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("must omit 'startAnchor' and 'endAnchor'"),
+        "prepend edits should reject ignored anchors: {text}"
+    );
+}
+
+#[tokio::test]
 async fn edit_file_rejects_start_line_zero_for_replace_and_delete() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "edit-file-rejects-zero-start-line";
@@ -291,6 +399,58 @@ async fn edit_files_allows_replace_without_explicit_op() {
     );
     let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
     assert_eq!(updated, "ALPHA\nbeta\n");
+}
+
+#[tokio::test]
+async fn edit_files_delete_only_response_does_not_claim_new_anchors_exist() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-delete-only-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\ngamma\n")
+        .expect("write sample file");
+
+    let anchors = format_as_hashlines("alpha\nbeta\ngamma\n");
+    let second_anchor = anchors
+        .lines()
+        .nth(1)
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("second anchor");
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "sample.txt",
+                        "op": "delete",
+                        "startLine": 2,
+                        "startAnchor": second_anchor
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit batch should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains(
+            "no new anchors were generated because these edits only removed existing lines"
+        ),
+        "delete-only success should explain why there are no fresh anchors: {text}"
+    );
+    assert!(
+        !text.contains("New anchors:\n```\n\n```"),
+        "delete-only success should not render an empty new-anchors block: {text}"
+    );
+    assert!(
+        !text.contains("Anchors above are current for the edited ranges"),
+        "delete-only success must not claim that new anchors are available: {text}"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/workspace_internal_artifacts_tests.rs
+++ b/src-tauri/tests/workspace_internal_artifacts_tests.rs
@@ -27,6 +27,20 @@ fn extract_resource_html(result: &MCPResult) -> String {
         .expect("resource html expected")
 }
 
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[tokio::test]
 async fn list_directory_hides_internal_tmp_and_exports_inside_libragent() {
     let temp_dir = tempdir().expect("temp dir");
@@ -143,9 +157,18 @@ async fn export_response_uses_libragent_download_path() {
         .expect("export should succeed");
 
     let html = extract_resource_html(&result);
+    let text = extract_text_content(&result);
     assert!(
         html.contains(".libragent/exports/files/"),
         "download path should point at .libragent exports: {html}"
+    );
+    assert!(
+        text.contains("Saved export: `.libragent/exports/files/"),
+        "text response should expose the saved export path: {text}"
+    );
+    assert!(
+        text.contains("UI resource: `ui://export/"),
+        "text response should expose the UI resource URI: {text}"
     );
 
     let exports_dir = workspace_dir.join(".libragent/exports/files");

--- a/src-tauri/tests/workspace_list_directory_regression_tests.rs
+++ b/src-tauri/tests/workspace_list_directory_regression_tests.rs
@@ -51,8 +51,12 @@ async fn list_directory_returns_not_found_contract_for_missing_workspace_subdire
         "missing directory should use the not-found contract: {text}"
     );
     assert!(
-        text.contains("Use listDirectory to see available files"),
-        "resource-not-found guidance should stay visible: {text}"
+        text.contains("Use listDirectory('.') to inspect the workspace root"),
+        "resource-not-found guidance should still point at the workspace root: {text}"
+    );
+    assert!(
+        text.contains("Verify the directory path is correct"),
+        "missing-directory guidance should stay directory-specific: {text}"
     );
     assert!(
         !text.contains("Verify the directory exists"),

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -486,6 +486,51 @@ async fn write_file_duplicate_resource_guidance_keeps_numbered_steps_clean() {
 }
 
 #[tokio::test]
+async fn write_file_append_returns_updated_anchors_without_forcing_followup_read() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "write-file-append-anchors";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    server
+        .handle_write_file(
+            json!({
+                "path": "notes.txt",
+                "content": "alpha\n",
+                "mode": "create",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("initial write should succeed");
+
+    let append_result = server
+        .handle_write_file(
+            json!({
+                "path": "notes.txt",
+                "content": "beta\n",
+                "mode": "append",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("append write should succeed");
+
+    let text = extract_text_content(&append_result);
+    assert!(
+        text.contains("**✅ Content Appended Successfully**"),
+        "append response should keep the append-specific success header: {text}"
+    );
+    assert!(
+        text.contains("1:") && text.contains("2:"),
+        "append response should include current anchored lines for immediate follow-up edits: {text}"
+    );
+    assert!(
+        !text.contains("Use `readFile` to see the full content including the appended part."),
+        "append response should not force a follow-up read just to inspect the result: {text}"
+    );
+}
+
+#[tokio::test]
 async fn search_skips_binary_looking_files_even_without_binary_extension() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "search-binary-skip";

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -531,6 +531,47 @@ async fn write_file_append_returns_updated_anchors_without_forcing_followup_read
 }
 
 #[tokio::test]
+async fn write_file_append_truncation_keeps_appended_tail_visible() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "write-file-append-tail-preview";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    let original = (1..=140)
+        .map(|index| format!("line-{index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(workspace_dir.join("notes.txt"), format!("{original}\n"))
+        .expect("seed large file");
+
+    let append_result = server
+        .handle_write_file(
+            json!({
+                "path": "notes.txt",
+                "content": "fresh-tail-line\n",
+                "mode": "append",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("append write should succeed");
+
+    let text = extract_text_content(&append_result);
+    assert!(
+        text.contains("showing last"),
+        "truncated append response should explain that it is showing the tail: {text}"
+    );
+    assert!(
+        text.contains("fresh-tail-line"),
+        "truncated append response should include the appended line in the preview: {text}"
+    );
+    assert!(
+        text.contains("\n42:") && !text.contains("\n1:"),
+        "truncated append response should keep the tail window instead of restarting from line 1: {text}"
+    );
+}
+
+#[tokio::test]
 async fn search_skips_binary_looking_files_even_without_binary_extension() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "search-binary-skip";


### PR DESCRIPTION
## Summary
- tighten workspace tool guidance so next steps match actual behavior
- fix editFiles delete-only anchor responses and stale empty-anchor output
- add regression coverage for guidance, process output, diff counts, and anchor flows

## Validation
- pnpm refactor:validate