### PR TITLE
Implement preset categories and LLM execution cleanup

### DIFF
--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,24 +1,28 @@
 {
   "mcpServers": {
     "hn": {
+      "category": "search",
       "description": "Read Hacker News — top, new, best, Ask HN, Show HN, and job stories.",
       "logo": "https://news.ycombinator.com/favicon.ico",
       "command": "npx",
       "args": ["-y", "@fre4x/hn"]
     },
     "yahoo-finance": {
+      "category": "data",
       "description": "Get real-time stock prices, financials, options chains, and insider data. No API key required.",
       "logo": "https://s.yimg.com/rz/p/yahoo_finance_en-US_h_p_finance_2.png",
       "command": "npx",
       "args": ["-y", "@fre4x/yahoo-finance"]
     },
     "ddg-search": {
+      "category": "search",
       "description": "Search the web privately using DuckDuckGo.",
       "logo": "https://duckduckgo.com/favicon.ico",
       "command": "uvx",
       "args": ["duckduckgo-mcp-server"]
     },
     "context7": {
+      "category": "devtools",
       "description": "Access up-to-date documentation for any library via Context7.",
       "logo": "https://context7.com/favicon.ico",
       "url": "https://mcp.context7.com/mcp",
@@ -36,6 +40,7 @@
       }
     },
     "serena": {
+      "category": "devtools",
       "description": "Semantic coding agent with symbol-level code understanding and editing.",
       "logo": "https://oraios.github.io/serena/_static/serena-icon-32.png",
       "command": "uvx",
@@ -47,6 +52,7 @@
       ]
     },
     "github": {
+      "category": "devtools",
       "description": "Interact with GitHub repositories, issues, PRs, and code search.",
       "logo": "https://github.com/favicon.ico",
       "url": "https://api.githubcopilot.com/mcp/",
@@ -64,6 +70,7 @@
       }
     },
     "jules": {
+      "category": "devtools",
       "description": "Google Jules — autonomous coding agent for GitHub tasks.",
       "logo": "https://jules.google.com/favicon.ico",
       "command": "npx",
@@ -81,6 +88,7 @@
       }
     },
     "brave-search": {
+      "category": "search",
       "description": "Search the web with Brave Search API.",
       "logo": "https://brave.com/favicon.ico",
       "command": "docker",
@@ -105,6 +113,7 @@
       }
     },
     "exa": {
+      "category": "search",
       "description": "AI-powered web search and content retrieval via Exa.",
       "logo": "https://exa.ai/favicon.ico",
       "url": "https://mcp.exa.ai/mcp",
@@ -119,6 +128,7 @@
       }
     },
     "fred": {
+      "category": "data",
       "description": "Access Federal Reserve economic data — GDP, inflation, unemployment, interest rates, and 800K+ series.",
       "logo": "https://fred.stlouisfed.org/favicon.ico",
       "command": "npx",
@@ -136,12 +146,14 @@
       }
     },
     "arxiv": {
+      "category": "search",
       "description": "Search and retrieve academic papers from arXiv — millions of papers across all categories.",
       "logo": "https://arxiv.org/favicon.ico",
       "command": "npx",
       "args": ["-y", "@fre4x/arxiv"]
     },
     "gemini": {
+      "category": "ai",
       "description": "Google Gemini — multimodal text generation, image/video analysis, and image synthesis via Imagen.",
       "logo": "https://www.gstatic.com/lamda/images/gemini_favicon_f069958c85030456e93de685481c559f160ea06.svg",
       "command": "npx",
@@ -159,6 +171,7 @@
       }
     },
     "grok": {
+      "category": "ai",
       "description": "Grok API access for text generation and analysis.",
       "logo": "https://grok.ai/favicon.ico",
       "command": "npx",
@@ -176,18 +189,21 @@
       }
     },
     "docx": {
+      "category": "documents",
       "description": "Work with Word documents programmatically through MCP APIs.",
       "logo": "https://www.docx.com/favicon.ico",
       "command": "npx",
       "args": ["-y", "@fre4x/docx"]
     },
     "jupyter": {
+      "category": "documents",
       "description": "Execute and manage Jupyter notebooks via MCP.",
       "logo": "https://jupyter.org/favicon.ico",
       "command": "npx",
       "args": ["-y", "@fre4x/jupyter"]
     },
     "comfyui": {
+      "category": "creative",
       "description": "Interact with ComfyUI to generate and manage AI images.",
       "command": "npx",
       "args": ["-y", "@fre4x/comfyui"],
@@ -204,6 +220,7 @@
       }
     },
     "openai": {
+      "category": "ai",
       "description": "OpenAI MCP server for text generation and analysis.",
       "command": "npx",
       "args": ["-y", "@fre4x/openai"],
@@ -220,6 +237,7 @@
       }
     },
     "huggingface": {
+      "category": "ai",
       "description": "Interact with Hugging Face models and datasets.",
       "logo": "https://huggingface.co/front/assets/huggingface_logo-noborder.svg",
       "command": "npx",
@@ -253,6 +271,23 @@
           "required": false,
           "label": "Allow Remote Models",
           "description": "Set to 'true' to allow downloading remote models",
+          "type": "text"
+        }
+      }
+    },
+    "benchmark": {
+      "category": "devtools",
+      "description": "Run GAIA benchmark challenges to evaluate AI agent capabilities.",
+      "command": "npx",
+      "args": ["-y", "@fre4x/benchmark"],
+      "env": {
+        "BENCHMARK_GAIA_DATA_FILE": ""
+      },
+      "variableDefinitions": {
+        "BENCHMARK_GAIA_DATA_FILE": {
+          "required": true,
+          "label": "GAIA Data File Path",
+          "description": "Absolute path to the GAIA benchmark challenges JSON file",
           "type": "text"
         }
       }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3862,7 +3862,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/mcp/presets.rs
+++ b/src-tauri/src/mcp/presets.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 #[serde(rename_all = "camelCase")]
 pub struct MCPServerPreset {
     pub name: String,
+    pub category: Option<String>,
     pub description: Option<String>,
     pub logo: Option<String>,
     pub transport_type: String, // "stdio" or "sse"
@@ -18,6 +19,7 @@ pub struct MCPServerPreset {
 
 #[derive(Deserialize)]
 struct RawPresetConfig {
+    category: Option<String>,
     // stdio fields
     command: Option<String>,
     #[serde(default)]
@@ -71,6 +73,7 @@ pub fn get_recommended_servers() -> Vec<MCPServerPreset> {
 
         presets.push(MCPServerPreset {
             name: key,
+            category: config.category,
             description: config.description,
             logo: config.logo,
             transport_type,
@@ -103,6 +106,7 @@ mod tests {
         assert_eq!(exa.transport_type, "sse");
         assert!(exa.url.is_some(), "exa must have a url");
         assert!(exa.command.is_none(), "exa must not have a command");
+        assert_eq!(exa.category.as_deref(), Some("search"));
     }
 
     /// Regression: stdlib stdio presets must still parse correctly after making command Optional.
@@ -115,6 +119,7 @@ mod tests {
         assert_eq!(ddg.transport_type, "stdio");
         assert!(ddg.command.is_some(), "ddg-search must have a command");
         assert!(ddg.url.is_none());
+        assert_eq!(ddg.category.as_deref(), Some("search"));
     }
 
     /// All presets in mcp-server.json must parse without panicking.
@@ -128,6 +133,11 @@ mod tests {
                 p.transport_type == "stdio" || p.transport_type == "sse",
                 "transport_type must be stdio or sse, got: {}",
                 p.transport_type
+            );
+            assert!(
+                p.category.as_deref().is_some(),
+                "preset {} must declare a category",
+                p.name
             );
         }
     }

--- a/src-tauri/tests/mcp_preset_category_tests.rs
+++ b/src-tauri/tests/mcp_preset_category_tests.rs
@@ -1,0 +1,37 @@
+use tauri_mcp_agent_lib::mcp::presets::get_recommended_servers;
+
+#[test]
+fn all_embedded_presets_declare_a_category() {
+    let presets = get_recommended_servers();
+
+    assert!(!presets.is_empty(), "expected embedded presets to exist");
+    assert!(
+        presets
+            .iter()
+            .all(|preset| preset.category.as_deref().is_some()),
+        "every preset should declare a category"
+    );
+}
+
+#[test]
+fn category_assignments_match_expected_presets() {
+    let presets = get_recommended_servers();
+
+    let github = presets
+        .iter()
+        .find(|preset| preset.name == "github")
+        .expect("github preset should exist");
+    assert_eq!(github.category.as_deref(), Some("devtools"));
+
+    let openai = presets
+        .iter()
+        .find(|preset| preset.name == "openai")
+        .expect("openai preset should exist");
+    assert_eq!(openai.category.as_deref(), Some("ai"));
+
+    let yahoo_finance = presets
+        .iter()
+        .find(|preset| preset.name == "yahoo-finance")
+        .expect("yahoo-finance preset should exist");
+    assert_eq!(yahoo_finance.category.as_deref(), Some("data"));
+}

--- a/src/context/__tests__/LLMServiceContext.test.tsx
+++ b/src/context/__tests__/LLMServiceContext.test.tsx
@@ -768,6 +768,7 @@ describe('LLMServiceContext – Core', () => {
       ];
 
       let requestPromise!: Promise<Message>;
+      let requestSettled!: Promise<unknown>;
       await act(async () => {
         requestPromise = result.current.executeCompletionRequest(
           'test-session',
@@ -777,6 +778,7 @@ describe('LLMServiceContext – Core', () => {
           'openai',
           'test-key',
         );
+        requestSettled = requestPromise.catch((error: unknown) => error);
       });
 
       await waitFor(() => {
@@ -794,10 +796,113 @@ describe('LLMServiceContext – Core', () => {
         expect(result.current.streamingMessages.has('test-session')).toBe(false);
       });
 
+      await expect(requestPromise).rejects.toThrow('Request aborted');
       await act(async () => {
-        await requestPromise;
+        await requestSettled;
       });
 
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+
+    it('treats a silent pre-first-chunk abort as cancellation instead of empty response', async () => {
+      const { result } = renderHook(() => useLLMServiceHarness(), {
+        wrapper: TestWrapper,
+      });
+
+      mockStreamChat.mockImplementation(async function* (
+        _messages: Message[],
+        options?: { signal?: AbortSignal },
+      ) {
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        if (options?.signal?.aborted) {
+          return;
+        }
+        yield JSON.stringify({ content: 'late reply' });
+      });
+
+      const messages: Message[] = [
+        {
+          id: 'msg1',
+          sessionId: 'test-session',
+          threadId: 'test-session',
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          createdAt: new Date(),
+        },
+      ];
+
+      let requestPromise!: Promise<Message>;
+      await act(async () => {
+        requestPromise = result.current.executeCompletionRequest(
+          'test-session',
+          'response-msg-silent-cancel',
+          messages,
+          'gpt-4',
+          'openai',
+          'test-key',
+        );
+      });
+
+      act(() => {
+        result.current.cancelCompletionRequest(
+          'test-session',
+          'response-msg-silent-cancel',
+        );
+      });
+
+      await expect(requestPromise).rejects.toThrow('Request aborted');
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+
+    it('treats a silent pre-first-chunk supersede as superseded instead of empty response', async () => {
+      const { result } = renderHook(() => useLLMServiceHarness(), {
+        wrapper: TestWrapper,
+      });
+
+      mockStreamChat.mockImplementation(async function* (
+        _messages: Message[],
+        options?: { signal?: AbortSignal },
+      ) {
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        if (options?.signal?.aborted) {
+          return;
+        }
+        yield JSON.stringify({ content: 'fresh reply' });
+      });
+
+      const messages: Message[] = [
+        {
+          id: 'msg1',
+          sessionId: 'test-session',
+          threadId: 'test-session',
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          createdAt: new Date(),
+        },
+      ];
+
+      const firstPromise = result.current.executeCompletionRequest(
+        'test-session',
+        'response-msg-old-silent',
+        messages,
+        'gpt-4',
+        'openai',
+        'test-key',
+      );
+
+      const secondPromise = result.current.executeCompletionRequest(
+        'test-session',
+        'response-msg-new-silent',
+        messages,
+        'gpt-4',
+        'openai',
+        'test-key',
+      );
+
+      await expect(firstPromise).rejects.toThrow('Request superseded');
+      await expect(secondPromise).resolves.toMatchObject({
+        content: [{ type: 'text', text: 'fresh reply' }],
+      });
       expect(mockDispose).not.toHaveBeenCalled();
     });
 

--- a/src/context/__tests__/LLMServiceContext.test.tsx
+++ b/src/context/__tests__/LLMServiceContext.test.tsx
@@ -82,6 +82,7 @@ describe('LLMServiceContext – Core', () => {
   const mockListModels = vi.fn();
   const mockCancel = vi.fn();
   const mockDispose = vi.fn();
+  const mockSetDefaultConfig = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -96,6 +97,7 @@ describe('LLMServiceContext – Core', () => {
       listModels: mockListModels,
       cancel: mockCancel,
       dispose: mockDispose,
+      setDefaultConfig: mockSetDefaultConfig,
       sanitizeMessages: vi.fn((messages: Message[]) => messages),
       // Default implementation: pass-through (mirrors BaseAIService default)
       prepareContextInjection: vi.fn((systemPrompt, _sessionContext, messages) => ({
@@ -235,6 +237,8 @@ describe('LLMServiceContext – Core', () => {
       await waitFor(() => {
         expect(mockUnlisten).toHaveBeenCalled();
       });
+
+      expect(mockDispose).not.toHaveBeenCalled();
     });
   });
 
@@ -350,6 +354,7 @@ describe('LLMServiceContext – Core', () => {
         'test-key',
         expect.any(Object), // Settings config object
       );
+      expect(mockSetDefaultConfig).not.toHaveBeenCalled();
     });
 
     it('should handle tool calls in response', async () => {
@@ -740,14 +745,13 @@ describe('LLMServiceContext – Core', () => {
         wrapper: TestWrapper,
       });
 
-      let cancelled = false;
-      mockCancel.mockImplementation(() => {
-        cancelled = true;
-      });
-      mockStreamChat.mockImplementation(async function* () {
+      mockStreamChat.mockImplementation(async function* (
+        _messages: Message[],
+        options?: { signal?: AbortSignal },
+      ) {
         yield JSON.stringify({ thinking: 'looping...' });
 
-        while (!cancelled) {
+        while (!options?.signal?.aborted) {
           await new Promise((resolve) => window.setTimeout(resolve, 0));
         }
       });
@@ -793,6 +797,75 @@ describe('LLMServiceContext – Core', () => {
       await act(async () => {
         await requestPromise;
       });
+
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+
+    it('does not dispose a shared cached service when a new request supersedes the old one', async () => {
+      const { result } = renderHook(() => useLLMServiceHarness(), {
+        wrapper: TestWrapper,
+      });
+
+      let streamCallCount = 0;
+      mockStreamChat.mockImplementation(async function* (
+        _messages: Message[],
+        options?: { signal?: AbortSignal },
+      ) {
+        streamCallCount += 1;
+        if (streamCallCount === 1) {
+          while (!options?.signal?.aborted) {
+            await new Promise((resolve) => window.setTimeout(resolve, 0));
+          }
+          return;
+        }
+
+        yield JSON.stringify({ content: 'fresh reply' });
+      });
+
+      const messages: Message[] = [
+        {
+          id: 'msg1',
+          sessionId: 'test-session',
+          threadId: 'test-session',
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          createdAt: new Date(),
+        },
+      ];
+
+      let firstPromise!: Promise<Message>;
+      let secondPromise!: Promise<Message>;
+      let firstSettled!: Promise<unknown>;
+      let secondSettled!: Promise<unknown>;
+      await act(async () => {
+        firstPromise = result.current.executeCompletionRequest(
+          'test-session',
+          'response-msg-old',
+          messages,
+          'gpt-4',
+          'openai',
+          'test-key',
+        );
+        firstSettled = firstPromise.catch((error: unknown) => error);
+      });
+
+      await act(async () => {
+        secondPromise = result.current.executeCompletionRequest(
+          'test-session',
+          'response-msg-new',
+          messages,
+          'gpt-4',
+          'openai',
+          'test-key',
+        );
+        secondSettled = secondPromise.catch((error: unknown) => error);
+      });
+
+      await act(async () => {
+        await Promise.all([firstSettled, secondSettled]);
+      });
+
+      expect(mockDispose).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/context/llm/__tests__/cancel.test.ts
+++ b/src/context/llm/__tests__/cancel.test.ts
@@ -300,8 +300,6 @@ describe('cancelCompletionRequest coordinates provider and local aborts', () => 
       const activeService = services.get(targetSessionId);
       if (activeService) {
         services.delete(targetSessionId);
-        activeService.cancel();
-        activeService.dispose();
       }
       const activeController = controllers.get(targetSessionId);
       if (activeController) {
@@ -312,8 +310,8 @@ describe('cancelCompletionRequest coordinates provider and local aborts', () => 
 
     cancelCompletionRequest(sessionId);
 
-    expect(service.cancel).toHaveBeenCalledTimes(1);
-    expect(service.dispose).toHaveBeenCalledTimes(1);
+    expect(service.cancel).not.toHaveBeenCalled();
+    expect(service.dispose).not.toHaveBeenCalled();
     expect(controller.signal.aborted).toBe(true);
     expect(requestIds.has(sessionId)).toBe(false);
     expect(timeouts.has(sessionId)).toBe(false);
@@ -369,8 +367,6 @@ describe('cancelCompletionRequest coordinates provider and local aborts', () => 
       const activeService = services.get(targetSessionId);
       if (activeService) {
         services.delete(targetSessionId);
-        activeService.cancel();
-        activeService.dispose();
       }
       const activeController = controllers.get(targetSessionId);
       if (activeController) {

--- a/src/context/llm/__tests__/compact-toast.test.ts
+++ b/src/context/llm/__tests__/compact-toast.test.ts
@@ -446,7 +446,11 @@ describe('compact request handler', () => {
 
   it('forwards summary to handleCompactResponse on success', async () => {
     const compactService = vi.fn().mockResolvedValue('A concise summary.');
-    const getService = vi.fn().mockReturnValue({ compact: compactService });
+    const setDefaultConfig = vi.fn();
+    const getService = vi.fn().mockReturnValue({
+      compact: compactService,
+      setDefaultConfig,
+    });
     const handleCompactResponse = vi.fn().mockResolvedValue(undefined);
     const setCompactedRangeForSession = vi.fn();
 
@@ -466,6 +470,7 @@ describe('compact request handler', () => {
       TO_ID,
       'A concise summary.',
     );
+    expect(setDefaultConfig).not.toHaveBeenCalled();
     expect(setCompactedRangeForSession).toHaveBeenCalledWith(SESSION_ID, {
       fromId: FROM_ID,
       toId: TO_ID,

--- a/src/context/llm/service-runtime-config.ts
+++ b/src/context/llm/service-runtime-config.ts
@@ -1,10 +1,6 @@
 import type { AIServiceConfig } from '@/lib/ai-service/types';
 import type { Settings } from '@/lib/services/settings-service';
 
-type ConfigurableAIService = {
-  setDefaultConfig?: (config: AIServiceConfig) => void;
-};
-
 export function buildServiceRuntimeConfig(
   settings: Settings,
   baseConfig: AIServiceConfig = {},
@@ -16,18 +12,4 @@ export function buildServiceRuntimeConfig(
     retryDelay: settings.advanced.retryDelay,
     ...overrides,
   };
-}
-
-export function applyServiceRuntimeConfig(
-  service: unknown,
-  config: AIServiceConfig,
-): void {
-  if (
-    typeof service === 'object' &&
-    service !== null &&
-    'setDefaultConfig' in service &&
-    typeof (service as ConfigurableAIService).setDefaultConfig === 'function'
-  ) {
-    (service as ConfigurableAIService).setDefaultConfig?.(config);
-  }
 }

--- a/src/context/llm/useExecuteCompletion.ts
+++ b/src/context/llm/useExecuteCompletion.ts
@@ -28,10 +28,7 @@ import type {
   MCPToolCallContent,
 } from '@/lib/mcp';
 import type { Settings } from '@/lib/services/settings-service';
-import {
-  applyServiceRuntimeConfig,
-  buildServiceRuntimeConfig,
-} from './service-runtime-config';
+import { buildServiceRuntimeConfig } from './service-runtime-config';
 import { isSupersededRequestError } from './types';
 import {
   buildStreamingMessage,
@@ -77,7 +74,7 @@ export function useExecuteCompletion({
   setStreamingMessages,
   updateSessionStatus,
 }: UseExecuteCompletionProps) {
-  // Track active service instances for cleanup
+  // Track which shared service instance is currently bound to each session
   const activeServicesRef = useRef<Map<string, AICompletionExecutionService>>(
     new Map(),
   );
@@ -103,7 +100,6 @@ export function useExecuteCompletion({
       );
       timeoutsRef.current.clear();
 
-      activeServicesRef.current.forEach((svc) => svc.dispose());
       activeServicesRef.current.clear();
       activeRequestIdsRef.current.clear();
     };
@@ -141,15 +137,13 @@ export function useExecuteCompletion({
         lastMessageId: messages[messages.length - 1]?.id ?? 'none',
       });
 
-      // Cancel and dispose any previously active request for this session
+      // Cancel any previously active request for this session.
+      // Shared service instances are factory-owned and must not be disposed here.
       const previousController = abortControllersRef.current.get(sessionId);
       if (previousController) {
         previousController.abort();
       }
-      const previousService = activeServicesRef.current.get(sessionId);
-      if (previousService) {
-        previousService.dispose();
-      }
+      activeServicesRef.current.delete(sessionId);
       const previousTimeoutId = timeoutsRef.current.get(sessionId);
       if (previousTimeoutId) {
         clearTimeout(previousTimeoutId);
@@ -174,7 +168,6 @@ export function useExecuteCompletion({
         settingsRef.current,
         providerConfig,
       );
-      applyServiceRuntimeConfig(service, runtimeConfig);
       activeServicesRef.current.set(sessionId, service);
 
       // Get existing streaming message (already set by event listener)
@@ -271,6 +264,7 @@ export function useExecuteCompletion({
           availableTools: availableTools || [],
           config,
           forceToolUse: false,
+          signal: abortController.signal,
         });
 
         for await (const rawChunk of streamGenerator) {
@@ -801,15 +795,13 @@ export function useExecuteCompletion({
         timeoutsRef.current.delete(sessionId);
       }
       const service = activeServicesRef.current.get(sessionId);
-      if (service) {
-        activeServicesRef.current.delete(sessionId);
-        service.cancel();
-        service.dispose();
-      }
       const abortController = abortControllersRef.current.get(sessionId);
       if (abortController) {
         abortControllersRef.current.delete(sessionId);
         abortController.abort();
+      }
+      if (service) {
+        activeServicesRef.current.delete(sessionId);
       }
     },
     [setStreamingMessages],

--- a/src/context/llm/useExecuteCompletion.ts
+++ b/src/context/llm/useExecuteCompletion.ts
@@ -578,6 +578,27 @@ export function useExecuteCompletion({
           return next;
         });
 
+        const activeRequestId = activeRequestIdsRef.current.get(sessionId);
+
+        if (
+          activeRequestId !== undefined &&
+          activeRequestId !== responseMessageId
+        ) {
+          logger.info('Dropping completed stream for superseded request', {
+            sessionId,
+            responseMessageId,
+            activeRequestId,
+          });
+          throw new Error('Request superseded');
+        }
+
+        if (abortController.signal.aborted) {
+          logger.warn('Completion request aborted before first chunk', {
+            sessionId,
+          });
+          throw new Error('Request aborted');
+        }
+
         const endTime = performance.now();
         const totalDurationMs = endTime - startTime;
 

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -31,10 +31,7 @@ import {
   isSupersededRequestError,
   isWorkflowCancelledError,
 } from './types';
-import {
-  applyServiceRuntimeConfig,
-  buildServiceRuntimeConfig,
-} from './service-runtime-config';
+import { buildServiceRuntimeConfig } from './service-runtime-config';
 import {
   extractCompactionPressure,
   shouldBypassRetryAndFallback,
@@ -467,7 +464,6 @@ export function useLLMListener({
             );
             const service: AIContextCompactionService =
               AIServiceFactory.getService(provider, apiKey, providerConfig);
-            applyServiceRuntimeConfig(service, runtimeConfig);
             const summary = await service.compact(messages, {
               modelName: model,
               systemPrompt: parentRequest?.systemPrompt,

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -69,10 +69,6 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
     [presets],
   );
 
-  if (normalizedPresets.length === 0) {
-    return null;
-  }
-
   const categoryCounts = useMemo(() => {
     return normalizedPresets.reduce<Record<PresetCategory, number>>(
       (counts, preset) => {
@@ -139,6 +135,10 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   const shouldGroupByCategory =
     activeCategory === 'all' && trimmedSearchQuery.length === 0;
 
+  if (normalizedPresets.length === 0) {
+    return null;
+  }
+
   const renderPresetCard = (preset: CategorizedPreset) => {
     const isInstalled = installedServerNames.has(preset.name);
     const canInstall = !isInstalled && registryLoaded;
@@ -146,6 +146,10 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
       !isInstalled && !registryLoaded && !!registryError;
     const categoryMeta = PRESET_CATEGORY_META[preset.category];
     const CategoryIcon = categoryMeta.icon;
+    const transportLabel = t(
+      `assistant.mcp.transport.${preset.transportType}`,
+      preset.transportType,
+    );
     const presetCommandPreview = preset.command
       ? `${preset.command} ${preset.args?.[0] ?? ''}`.trim()
       : (preset.url ?? t('assistant.mcp.transport.sse', 'sse'));
@@ -215,7 +219,7 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
               </span>
             ) : canInstall ? (
               <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
-                {t('assistant.mcp.transport.stdio', 'stdio')}
+                {transportLabel}
               </span>
             ) : canRetryRegistryLoad ? (
               <span className="text-[10px] bg-destructive/10 px-1.5 py-0.5 rounded text-destructive uppercase">

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -1,15 +1,22 @@
-import React, { useMemo } from 'react';
-import { Download, Server } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Download, Search, Server } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { MCPServerPreset } from '@/lib/backend/mcp-server-config';
 import { MCPServerEntity } from '@/models/chat';
-import { Button, buttonVariants } from '@/components/ui/button';
+import { Button, Input } from '@/components/ui';
+import { buttonVariants } from '@/components/ui/button';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import {
+  PRESET_CATEGORY_META,
+  PRESET_CATEGORY_ORDER,
+  type PresetCategory,
+  normalizePresetCategory,
+} from '../utils/preset-categories';
 
 interface RecommendedPresetsProps {
   presets: MCPServerPreset[] | undefined;
@@ -21,6 +28,10 @@ interface RecommendedPresetsProps {
   onRetryRegistryLoad: () => Promise<void>;
 }
 
+type CategorizedPreset = MCPServerPreset & {
+  category: PresetCategory;
+};
+
 export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   presets,
   servers,
@@ -31,6 +42,10 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
   onRetryRegistryLoad,
 }) => {
   const { t } = useTranslation('common');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState<'all' | PresetCategory>(
+    'all',
+  );
   const installedServerNames = useMemo(() => {
     const names = new Set<string>();
 
@@ -45,9 +60,231 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
     return names;
   }, [allServers, servers]);
 
-  if (!presets || presets.length === 0) {
+  const normalizedPresets = useMemo(
+    () =>
+      (presets ?? []).map((preset) => ({
+        ...preset,
+        category: normalizePresetCategory(preset.category),
+      })),
+    [presets],
+  );
+
+  if (normalizedPresets.length === 0) {
     return null;
   }
+
+  const categoryCounts = useMemo(() => {
+    return normalizedPresets.reduce<Record<PresetCategory, number>>(
+      (counts, preset) => {
+        counts[preset.category] += 1;
+        return counts;
+      },
+      {
+        search: 0,
+        ai: 0,
+        devtools: 0,
+        data: 0,
+        documents: 0,
+        creative: 0,
+        other: 0,
+      },
+    );
+  }, [normalizedPresets]);
+
+  const trimmedSearchQuery = searchQuery.trim().toLowerCase();
+
+  const filteredPresets = useMemo(() => {
+    return normalizedPresets.filter((preset) => {
+      const matchesCategory =
+        activeCategory === 'all' || preset.category === activeCategory;
+      if (!matchesCategory) {
+        return false;
+      }
+
+      if (!trimmedSearchQuery) {
+        return true;
+      }
+
+      const categoryMeta = PRESET_CATEGORY_META[preset.category];
+      const searchText = [
+        preset.name,
+        preset.description ?? '',
+        categoryMeta.defaultLabel,
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return searchText.includes(trimmedSearchQuery);
+    });
+  }, [activeCategory, normalizedPresets, trimmedSearchQuery]);
+
+  const groupedFilteredPresets = useMemo(() => {
+    return filteredPresets.reduce<Record<PresetCategory, CategorizedPreset[]>>(
+      (groups, preset) => {
+        groups[preset.category].push(preset);
+        return groups;
+      },
+      {
+        search: [],
+        ai: [],
+        devtools: [],
+        data: [],
+        documents: [],
+        creative: [],
+        other: [],
+      },
+    );
+  }, [filteredPresets]);
+
+  const shouldGroupByCategory =
+    activeCategory === 'all' && trimmedSearchQuery.length === 0;
+
+  const renderPresetCard = (preset: CategorizedPreset) => {
+    const isInstalled = installedServerNames.has(preset.name);
+    const canInstall = !isInstalled && registryLoaded;
+    const canRetryRegistryLoad =
+      !isInstalled && !registryLoaded && !!registryError;
+    const categoryMeta = PRESET_CATEGORY_META[preset.category];
+    const CategoryIcon = categoryMeta.icon;
+    const presetCommandPreview = preset.command
+      ? `${preset.command} ${preset.args?.[0] ?? ''}`.trim()
+      : (preset.url ?? t('assistant.mcp.transport.sse', 'sse'));
+
+    return (
+      <div
+        key={preset.name}
+        className={cn(
+          'group relative flex flex-col justify-between rounded-[1.5rem] border bg-background/50 backdrop-blur-sm p-5 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-primary/20 outline-none',
+          isInstalled
+            ? 'opacity-60 cursor-default bg-muted/20 border-border/50'
+            : canInstall
+              ? 'hover:shadow-2xl hover:bg-background hover:-translate-y-1 cursor-pointer border-border/50 hover:border-primary/40'
+              : 'opacity-60 cursor-wait border-border/50',
+        )}
+        role={canInstall ? 'button' : undefined}
+        tabIndex={canInstall ? 0 : -1}
+        aria-disabled={!canInstall}
+        aria-label={
+          canInstall
+            ? t('mcpServer.installExtension', {
+                name: preset.name,
+                defaultValue: 'Install {{name}} extension',
+              })
+            : undefined
+        }
+        onClick={() => canInstall && onSetupPreset(preset)}
+        onKeyDown={(event) => {
+          if (!canInstall) return;
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onSetupPreset(preset);
+          }
+        }}
+      >
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <div className="w-6 h-6 rounded overflow-hidden flex-shrink-0 border border-border/50">
+                {preset.logo ? (
+                  <img
+                    src={preset.logo}
+                    alt={preset.name}
+                    className="w-full h-full object-contain"
+                    onError={(e) => {
+                      (e.currentTarget as HTMLImageElement).style.display =
+                        'none';
+                      (
+                        e.currentTarget.nextElementSibling as HTMLElement | null
+                      )?.classList.remove('hidden');
+                    }}
+                  />
+                ) : null}
+                <div
+                  className={`w-full h-full bg-muted flex items-center justify-center ${preset.logo ? 'hidden' : ''}`}
+                >
+                  <Server className="w-3 h-3 text-muted-foreground" />
+                </div>
+              </div>
+              <h4 className="font-semibold tracking-tight truncate">
+                {preset.name}
+              </h4>
+            </div>
+            {isInstalled ? (
+              <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium flex items-center gap-1">
+                {t('mcpServer.installed', 'Installed')}
+              </span>
+            ) : canInstall ? (
+              <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
+                {t('assistant.mcp.transport.stdio', 'stdio')}
+              </span>
+            ) : canRetryRegistryLoad ? (
+              <span className="text-[10px] bg-destructive/10 px-1.5 py-0.5 rounded text-destructive uppercase">
+                {t('common.retry', 'Retry')}
+              </span>
+            ) : (
+              <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
+                {t('common.loading', 'Loading')}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+            <CategoryIcon className="w-3 h-3" />
+            <span>{t(categoryMeta.labelKey, categoryMeta.defaultLabel)}</span>
+          </div>
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {preset.description ||
+              t('mcpServer.noDescription', 'No description available')}
+          </p>
+        </div>
+        {canInstall ? (
+          <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 group-focus-visible:opacity-100 group-focus-within:opacity-100 transition-opacity gap-3">
+            <code className="text-[10px] bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground truncate">
+              {presetCommandPreview}
+            </code>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  className={cn(
+                    buttonVariants({ variant: 'ghost', size: 'icon' }),
+                    'h-6 w-6 rounded-full group-hover:bg-primary/10 group-hover:text-primary transition-colors',
+                  )}
+                  aria-hidden="true"
+                >
+                  <Download className="w-3.5 h-3.5" />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t('mcpServer.installExtension', {
+                  name: preset.name,
+                  defaultValue: 'Install {{name}} extension',
+                })}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        ) : canRetryRegistryLoad ? (
+          <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between gap-3">
+            <p className="text-[11px] text-muted-foreground">
+              {t(
+                'mcpServer.registryLoadFailed',
+                'Could not verify installed extensions yet.',
+              )}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={(event) => {
+                event.stopPropagation();
+                void onRetryRegistryLoad();
+              }}
+            >
+              {t('common.retry', 'Retry')}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-6">
@@ -58,146 +295,120 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
         </h3>
         <div className="h-px bg-border/50 flex-1 ml-2" />
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {presets.map((preset) => {
-          const isInstalled = installedServerNames.has(preset.name);
-          const canInstall = !isInstalled && registryLoaded;
-          const canRetryRegistryLoad =
-            !isInstalled && !registryLoaded && !!registryError;
-          return (
-            <div
-              key={preset.name}
-              className={cn(
-                'group relative flex flex-col justify-between rounded-[1.5rem] border bg-background/50 backdrop-blur-sm p-5 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-primary/20 outline-none',
-                isInstalled
-                  ? 'opacity-60 cursor-default bg-muted/20 border-border/50'
-                  : canInstall
-                    ? 'hover:shadow-2xl hover:bg-background hover:-translate-y-1 cursor-pointer border-border/50 hover:border-primary/40'
-                    : 'opacity-60 cursor-wait border-border/50',
-              )}
-              role={canInstall ? 'button' : undefined}
-              tabIndex={canInstall ? 0 : -1}
-              aria-disabled={!canInstall}
-              aria-label={
-                canInstall
-                  ? t('mcpServer.installExtension', {
-                      name: preset.name,
-                      defaultValue: 'Install {{name}} extension',
-                    })
-                  : undefined
-              }
-              onClick={() => canInstall && onSetupPreset(preset)}
-              onKeyDown={(event) => {
-                if (!canInstall) return;
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault();
-                  onSetupPreset(preset);
-                }
+      <div className="rounded-[1.5rem] border border-border/60 bg-muted/10 p-4 space-y-4">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 w-4 h-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={t(
+              'mcpServer.searchRecommended',
+              'Search recommended extensions...',
+            )}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant={activeCategory === 'all' ? 'default' : 'outline'}
+            onClick={() => setActiveCategory('all')}
+          >
+            {t('mcpServer.categories.all', 'All')}
+            <span className="ml-2 rounded-full bg-background/20 px-1.5 py-0.5 text-[10px]">
+              {normalizedPresets.length}
+            </span>
+          </Button>
+
+          {PRESET_CATEGORY_ORDER.filter(
+            (category) => categoryCounts[category] > 0,
+          ).map((category) => {
+            const categoryMeta = PRESET_CATEGORY_META[category];
+            const CategoryIcon = categoryMeta.icon;
+
+            return (
+              <Button
+                key={category}
+                type="button"
+                size="sm"
+                variant={activeCategory === category ? 'default' : 'outline'}
+                onClick={() => setActiveCategory(category)}
+              >
+                <CategoryIcon className="w-3.5 h-3.5 mr-1.5" />
+                {t(categoryMeta.labelKey, categoryMeta.defaultLabel)}
+                <span className="ml-2 rounded-full bg-background/20 px-1.5 py-0.5 text-[10px]">
+                  {categoryCounts[category]}
+                </span>
+              </Button>
+            );
+          })}
+
+          {(searchQuery || activeCategory !== 'all') && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setSearchQuery('');
+                setActiveCategory('all');
               }}
             >
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-6 h-6 rounded overflow-hidden flex-shrink-0 border border-border/50">
-                      {preset.logo ? (
-                        <img
-                          src={preset.logo}
-                          alt={preset.name}
-                          className="w-full h-full object-contain"
-                          onError={(e) => {
-                            (
-                              e.currentTarget as HTMLImageElement
-                            ).style.display = 'none';
-                            (
-                              e.currentTarget
-                                .nextElementSibling as HTMLElement | null
-                            )?.classList.remove('hidden');
-                          }}
-                        />
-                      ) : null}
-                      <div
-                        className={`w-full h-full bg-muted flex items-center justify-center ${preset.logo ? 'hidden' : ''}`}
-                      >
-                        <Server className="w-3 h-3 text-muted-foreground" />
-                      </div>
-                    </div>
-                    <h4 className="font-semibold tracking-tight">
-                      {preset.name}
-                    </h4>
-                  </div>
-                  {isInstalled ? (
-                    <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium flex items-center gap-1">
-                      {t('mcpServer.installed', 'Installed')}
-                    </span>
-                  ) : canInstall ? (
-                    <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
-                      {t('assistant.mcp.transport.stdio', 'stdio')}
-                    </span>
-                  ) : canRetryRegistryLoad ? (
-                    <span className="text-[10px] bg-destructive/10 px-1.5 py-0.5 rounded text-destructive uppercase">
-                      {t('common.retry', 'Retry')}
-                    </span>
-                  ) : (
-                    <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground uppercase">
-                      {t('common.loading', 'Loading')}
-                    </span>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground line-clamp-2">
-                  {preset.description ||
-                    t('mcpServer.noDescription', 'No description available')}
-                </p>
-              </div>
-              {canInstall ? (
-                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between opacity-60 group-hover:opacity-100 group-focus-visible:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                  <code className="text-[10px] bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">
-                    {preset.command} {preset.args?.[0]}
-                  </code>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        className={cn(
-                          buttonVariants({ variant: 'ghost', size: 'icon' }),
-                          'h-6 w-6 rounded-full group-hover:bg-primary/10 group-hover:text-primary transition-colors',
-                        )}
-                        aria-hidden="true"
-                      >
-                        <Download className="w-3.5 h-3.5" />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {t('mcpServer.installExtension', {
-                        name: preset.name,
-                        defaultValue: 'Install {{name}} extension',
-                      })}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              ) : canRetryRegistryLoad ? (
-                <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between gap-3">
-                  <p className="text-[11px] text-muted-foreground">
-                    {t(
-                      'mcpServer.registryLoadFailed',
-                      'Could not verify installed extensions yet.',
-                    )}
-                  </p>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      void onRetryRegistryLoad();
-                    }}
-                  >
-                    {t('common.retry', 'Retry')}
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+              {t('common.clear', 'Clear')}
+            </Button>
+          )}
+        </div>
       </div>
+
+      {filteredPresets.length === 0 ? (
+        <div className="border border-dashed rounded-[1.5rem] bg-muted/5 py-10 px-6 text-center text-sm text-muted-foreground">
+          {t(
+            'mcpServer.noMatchingRecommended',
+            'No recommended extensions match the current filters.',
+          )}
+        </div>
+      ) : shouldGroupByCategory ? (
+        <div className="space-y-8">
+          {PRESET_CATEGORY_ORDER.map((category) => {
+            const categoryPresets = groupedFilteredPresets[category];
+            if (categoryPresets.length === 0) {
+              return null;
+            }
+
+            const categoryMeta = PRESET_CATEGORY_META[category];
+            const CategoryIcon = categoryMeta.icon;
+
+            return (
+              <section key={category} className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center rounded-lg bg-primary/10 text-primary p-2">
+                    <CategoryIcon className="w-4 h-4" />
+                  </div>
+                  <div>
+                    <h4 className="font-semibold tracking-tight">
+                      {t(categoryMeta.labelKey, categoryMeta.defaultLabel)}
+                    </h4>
+                    <p className="text-xs text-muted-foreground">
+                      {t(
+                        categoryMeta.descriptionKey,
+                        categoryMeta.defaultDescription,
+                      )}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {categoryPresets.map(renderPresetCard)}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredPresets.map(renderPresetCard)}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
+++ b/src/features/mcp-servers/components/__tests__/RecommendedPresets.test.tsx
@@ -67,6 +67,36 @@ describe('RecommendedPresets', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('keeps hook ordering stable when presets load after an empty render', () => {
+    const { rerender } = render(
+      <RecommendedPresets
+        presets={[]}
+        servers={[]}
+        allServers={[]}
+        registryLoaded={true}
+        registryError={undefined}
+        onSetupPreset={vi.fn()}
+        onRetryRegistryLoad={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    rerender(
+      <RecommendedPresets
+        presets={[basePreset]}
+        servers={[]}
+        allServers={[]}
+        registryLoaded={true}
+        registryError={undefined}
+        onSetupPreset={vi.fn()}
+        onRetryRegistryLoad={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Install filesystem extension' }),
+    ).toBeInTheDocument();
+  });
+
   it('uses the visible installed grid as a temporary installed source before the full registry finishes loading', () => {
     render(
       <RecommendedPresets
@@ -108,6 +138,32 @@ describe('RecommendedPresets', () => {
 
     fireEvent.click(presetCard);
     expect(onSetupPreset).not.toHaveBeenCalled();
+  });
+
+  it('shows the actual preset transport badge for installable presets', () => {
+    render(
+      <RecommendedPresets
+        presets={[
+          {
+            ...basePreset,
+            name: 'exa',
+            transportType: 'sse',
+            command: undefined,
+            args: undefined,
+            url: 'https://example.com/sse',
+          },
+        ]}
+        servers={[]}
+        allServers={[]}
+        registryLoaded={true}
+        registryError={undefined}
+        onSetupPreset={vi.fn()}
+        onRetryRegistryLoad={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByText('sse')).toBeInTheDocument();
+    expect(screen.queryByText('stdio')).not.toBeInTheDocument();
   });
 
   it('offers a retry action when the full registry load failed', () => {

--- a/src/features/mcp-servers/utils/preset-categories.ts
+++ b/src/features/mcp-servers/utils/preset-categories.ts
@@ -1,0 +1,88 @@
+import {
+  BarChart3,
+  FileText,
+  Image,
+  type LucideIcon,
+  Search,
+  Sparkles,
+  Wrench,
+} from 'lucide-react';
+
+export const PRESET_CATEGORY_ORDER = [
+  'search',
+  'ai',
+  'devtools',
+  'data',
+  'documents',
+  'creative',
+  'other',
+] as const;
+
+export type PresetCategory = (typeof PRESET_CATEGORY_ORDER)[number];
+
+export interface PresetCategoryMeta {
+  labelKey: string;
+  defaultLabel: string;
+  descriptionKey: string;
+  defaultDescription: string;
+  icon: LucideIcon;
+}
+
+export const PRESET_CATEGORY_META: Record<PresetCategory, PresetCategoryMeta> =
+  {
+    search: {
+      labelKey: 'mcpServer.categories.search',
+      defaultLabel: 'Search',
+      descriptionKey: 'mcpServer.categoryDescriptions.search',
+      defaultDescription: 'Web search, research, and information retrieval.',
+      icon: Search,
+    },
+    ai: {
+      labelKey: 'mcpServer.categories.ai',
+      defaultLabel: 'AI / LLM',
+      descriptionKey: 'mcpServer.categoryDescriptions.ai',
+      defaultDescription: 'Foundation models, generation, and inference tools.',
+      icon: Sparkles,
+    },
+    devtools: {
+      labelKey: 'mcpServer.categories.devtools',
+      defaultLabel: 'Developer Tools',
+      descriptionKey: 'mcpServer.categoryDescriptions.devtools',
+      defaultDescription: 'Code, GitHub, docs, and agent workflow helpers.',
+      icon: Wrench,
+    },
+    data: {
+      labelKey: 'mcpServer.categories.data',
+      defaultLabel: 'Data',
+      descriptionKey: 'mcpServer.categoryDescriptions.data',
+      defaultDescription: 'Financial, economic, and structured data sources.',
+      icon: BarChart3,
+    },
+    documents: {
+      labelKey: 'mcpServer.categories.documents',
+      defaultLabel: 'Documents',
+      descriptionKey: 'mcpServer.categoryDescriptions.documents',
+      defaultDescription: 'Document and notebook tooling.',
+      icon: FileText,
+    },
+    creative: {
+      labelKey: 'mcpServer.categories.creative',
+      defaultLabel: 'Creative',
+      descriptionKey: 'mcpServer.categoryDescriptions.creative',
+      defaultDescription: 'Image generation and creative media workflows.',
+      icon: Image,
+    },
+    other: {
+      labelKey: 'mcpServer.categories.other',
+      defaultLabel: 'Other',
+      descriptionKey: 'mcpServer.categoryDescriptions.other',
+      defaultDescription: 'Presets without a recognized category.',
+      icon: Wrench,
+    },
+  };
+
+export function normalizePresetCategory(category?: string): PresetCategory {
+  return PRESET_CATEGORY_ORDER.includes(category as PresetCategory)
+    ? (category as PresetCategory)
+    : 'other';
+}

--- a/src/features/mcp-servers/utils/preset-utils.ts
+++ b/src/features/mcp-servers/utils/preset-utils.ts
@@ -23,6 +23,7 @@ export function buildPresetMetadata(
   preset: MCPServerPreset,
 ): MCPServerEntity['metadata'] {
   return {
+    category: preset.category,
     description: preset.description,
     logo: preset.logo,
     variableDefinitions: preset.variableDefinitions,

--- a/src/lib/ai-service/__tests__/anthropic.test.ts
+++ b/src/lib/ai-service/__tests__/anthropic.test.ts
@@ -284,6 +284,62 @@ describe('AnthropicService', () => {
   });
 
   describe('streamChat()', () => {
+    it('preserves tools but disables tool use when disableToolUse is true', async () => {
+      const mockStreamFn = vi.fn().mockReturnValue(
+        (async function* () {
+          yield {
+            type: 'content_block_delta',
+            delta: {
+              type: 'text_delta',
+              text: 'summary',
+            },
+          };
+        })(),
+      );
+
+      (
+        mockAnthropicClient as { messages: { stream: typeof mockStreamFn } }
+      ).messages.stream = mockStreamFn;
+
+      const stream = service.streamChat(
+        [
+          {
+            id: 'user-1',
+            sessionId: 'session-1',
+            threadId: 'thread-1',
+            role: 'user',
+            content: [{ type: 'text', text: 'Summarize this thread' }],
+          },
+        ],
+        {
+          availableTools: [
+            {
+              name: 'workspace__writeFile',
+              description: 'Write a file',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+              },
+            },
+          ],
+          disableToolUse: true,
+        },
+      );
+
+      await stream.next();
+
+      const request = mockStreamFn.mock.calls[0]?.[0] as
+        | {
+            tools?: unknown;
+            tool_choice?: { type: string };
+          }
+        | undefined;
+
+      expect(request?.tools).toBeDefined();
+      expect(Array.isArray(request?.tools)).toBe(true);
+      expect(request?.tool_choice).toEqual({ type: 'none' });
+    });
+
     it('emits a provisional indexed tool call as soon as tool_use starts', async () => {
       const mockStreamFn = vi.fn().mockReturnValue(
         (async function* () {

--- a/src/lib/ai-service/__tests__/empty.test.ts
+++ b/src/lib/ai-service/__tests__/empty.test.ts
@@ -23,7 +23,7 @@ describe('EmptyAIService', () => {
     expect(() => service.convertTools(mockTools)).toThrow('Tool conversion not supported');
   });
 
-  it('should throw an error and yield empty string when streaming chat', async () => {
+  it('should throw an error without yielding any stream chunks', async () => {
     const service = new EmptyAIService();
     const mockMessages: Message[] = [];
 
@@ -42,7 +42,7 @@ describe('EmptyAIService', () => {
 
     expect(caughtError).toBeInstanceOf(AIServiceError);
     expect(caughtError?.message).toContain('EmptyAIService does not support streaming chat');
-    expect(output).toEqual(['']); // Yields empty string before throwing
+    expect(output).toEqual([]);
   });
 
   it('should return empty array when converting messages', () => {

--- a/src/lib/ai-service/__tests__/gemini.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/gemini.cancel.test.ts
@@ -84,7 +84,31 @@ describe('GeminiService cancellation wiring', () => {
     generateContentStreamMock.mockResolvedValue(createEmptyStream());
   });
 
-  it('passes an AbortSignal through stream config and aborts it on cancel', async () => {
+  it('passes through the provided AbortSignal in stream config', async () => {
+    const { GeminiService } = await import('../gemini');
+    const service = new GeminiService('test-key');
+    const controller = new AbortController();
+
+    await consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'gemini-2.5-flash',
+        signal: controller.signal,
+      }),
+    );
+
+    const request = generateContentStreamMock.mock.calls[0]?.[0] as
+      | { config?: { abortSignal?: AbortSignal } }
+      | undefined;
+
+    expect(request?.config?.abortSignal).toBe(controller.signal);
+    expect(request?.config?.abortSignal?.aborted).toBe(false);
+
+    controller.abort();
+
+    expect(request?.config?.abortSignal?.aborted).toBe(true);
+  });
+
+  it('does not inject a synthetic AbortSignal when none is provided', async () => {
     const { GeminiService } = await import('../gemini');
     const service = new GeminiService('test-key');
 
@@ -98,15 +122,10 @@ describe('GeminiService cancellation wiring', () => {
       | { config?: { abortSignal?: AbortSignal } }
       | undefined;
 
-    expect(request?.config?.abortSignal).toBeInstanceOf(AbortSignal);
-    expect(request?.config?.abortSignal?.aborted).toBe(false);
-
-    service.cancel();
-
-    expect(request?.config?.abortSignal?.aborted).toBe(true);
+    expect(request?.config?.abortSignal).toBeUndefined();
   });
 
-  it('passes an AbortSignal through non-stream config', async () => {
+  it('passes through the provided AbortSignal in non-stream config', async () => {
     generateContentMock.mockResolvedValueOnce({
       candidates: [
         {
@@ -123,15 +142,54 @@ describe('GeminiService cancellation wiring', () => {
 
     const { GeminiService } = await import('../gemini');
     const service = new GeminiService('test-key');
+    const controller = new AbortController();
 
     await service.sampleText('hello', {
       modelName: 'gemini-2.5-flash',
+      signal: controller.signal,
     });
 
     const request = generateContentMock.mock.calls[0]?.[0] as
       | { config?: { abortSignal?: AbortSignal } }
       | undefined;
 
-    expect(request?.config?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(request?.config?.abortSignal).toBe(controller.signal);
+  });
+
+  it('retries malformed function call failures once without tools', async () => {
+    generateContentStreamMock
+      .mockRejectedValueOnce(new Error('MALFORMED_FUNCTION_CALL'))
+      .mockResolvedValueOnce(createEmptyStream());
+
+    const { GeminiService } = await import('../gemini');
+    const service = new GeminiService('test-key');
+
+    await consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'gemini-2.5-flash',
+        availableTools: [
+          {
+            name: 'workspace__writeFile',
+            description: 'Write a file',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(generateContentStreamMock).toHaveBeenCalledTimes(2);
+
+    const firstRequest = generateContentStreamMock.mock.calls[0]?.[0] as
+      | { config?: { tools?: unknown[] } }
+      | undefined;
+    const secondRequest = generateContentStreamMock.mock.calls[1]?.[0] as
+      | { config?: { tools?: unknown[] } }
+      | undefined;
+
+    expect(firstRequest?.config?.tools).toBeDefined();
+    expect(secondRequest?.config?.tools).toBeUndefined();
   });
 });

--- a/src/lib/ai-service/__tests__/groq.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/groq.cancel.test.ts
@@ -59,15 +59,17 @@ describe('GroqService cancellation wiring', () => {
     vi.clearAllMocks();
   });
 
-  it('passes an AbortSignal to streaming requests and aborts it on cancel', async () => {
+  it('passes through the provided AbortSignal to streaming requests', async () => {
     createMock.mockResolvedValueOnce(createEmptyStream());
 
     const { GroqService } = await import('../groq');
     const service = new GroqService('test-key');
+    const controller = new AbortController();
 
     await consumeStream(
       service.streamChat([createUserMessage('hello')], {
         modelName: 'llama-3.1-8b-instant',
+        signal: controller.signal,
       }),
     );
 
@@ -75,15 +77,15 @@ describe('GroqService cancellation wiring', () => {
       | { signal?: AbortSignal }
       | undefined;
 
-    expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(requestOptions?.signal).toBe(controller.signal);
     expect(requestOptions?.signal?.aborted).toBe(false);
 
-    service.cancel();
+    controller.abort();
 
     expect(requestOptions?.signal?.aborted).toBe(true);
   });
 
-  it('passes an AbortSignal to non-streaming requests', async () => {
+  it('passes through the provided AbortSignal to non-streaming requests', async () => {
     createMock.mockResolvedValueOnce({
       choices: [
         {
@@ -101,15 +103,17 @@ describe('GroqService cancellation wiring', () => {
 
     const { GroqService } = await import('../groq');
     const service = new GroqService('test-key');
+    const controller = new AbortController();
 
     await service.sampleText('hello', {
       modelName: 'llama-3.1-8b-instant',
+      signal: controller.signal,
     });
 
     const requestOptions = createMock.mock.calls[0]?.[1] as
       | { signal?: AbortSignal }
       | undefined;
 
-    expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(requestOptions?.signal).toBe(controller.signal);
   });
 });

--- a/src/lib/ai-service/__tests__/ollama.test.ts
+++ b/src/lib/ai-service/__tests__/ollama.test.ts
@@ -185,4 +185,43 @@ describe('OllamaService prompt layout', () => {
 
     expect(request.tools).toBeUndefined();
   });
+
+  it('removes the abort listener after stream cleanup', async () => {
+    const { OllamaService } = await import('../ollama');
+    const service = new OllamaService('ollama-local');
+    const controller = new AbortController();
+    const addEventListenerSpy = vi.spyOn(controller.signal, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(
+      controller.signal,
+      'removeEventListener',
+    );
+
+    const abortSpy = vi.fn();
+    chatMock.mockResolvedValue({
+      abort: abortSpy,
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => ({ done: true, value: undefined as never }),
+        };
+      },
+    });
+
+    await consumeStream(
+      service.streamChat([createUserMessage('hello')], {
+        modelName: 'llama3.1',
+        signal: controller.signal,
+      }),
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+      { once: true },
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+    expect(abortSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/ai-service/__tests__/openai.cancel.test.ts
+++ b/src/lib/ai-service/__tests__/openai.cancel.test.ts
@@ -75,6 +75,7 @@ async function consumeStream(
 describe('OpenAIService cancellation wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    createMock.mockReset();
     vi.useFakeTimers();
   });
 
@@ -82,39 +83,40 @@ describe('OpenAIService cancellation wiring', () => {
     vi.useRealTimers();
   });
 
-  it('reuses the original AbortSignal for stream retries after cancel', async () => {
+  it('keeps the provided AbortSignal across stream retry scheduling and aborts before retrying', async () => {
     createMock
       .mockRejectedValueOnce({ status: 500 })
       .mockResolvedValueOnce(createEmptyStream());
 
     const { OpenAIService } = await import('../openai');
-    const service = new OpenAIService('sk-test', { retryDelay: 0 });
+    const service = new OpenAIService('sk-test', { retryDelay: 1000 });
+    const controller = new AbortController();
 
     const streamPromise = consumeStream(
       service.streamChat([createUserMessage('hello')], {
         modelName: 'gpt-4o-mini',
+        signal: controller.signal,
       }),
     );
+    const streamExpectation = expect(streamPromise).rejects.toMatchObject({
+      name: 'AbortError',
+    });
 
+    await Promise.resolve();
+    controller.abort();
     await vi.runAllTimersAsync();
-    service.cancel();
-    await vi.runAllTimersAsync();
-    await streamPromise;
+    await streamExpectation;
 
     const firstOptions = createMock.mock.calls[0]?.[1] as
       | { signal?: AbortSignal }
       | undefined;
-    const secondOptions = createMock.mock.calls[1]?.[1] as
-      | { signal?: AbortSignal }
-      | undefined;
 
-    expect(createMock).toHaveBeenCalledTimes(2);
-    expect(firstOptions?.signal).toBeInstanceOf(AbortSignal);
-    expect(secondOptions?.signal).toBe(firstOptions?.signal);
-    expect(secondOptions?.signal?.aborted).toBe(true);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(firstOptions?.signal).toBe(controller.signal);
+    expect(firstOptions?.signal?.aborted).toBe(true);
   });
 
-  it('reuses the original AbortSignal for non-stream retries after cancel', async () => {
+  it('keeps the provided AbortSignal across non-stream retry scheduling and aborts before retrying', async () => {
     createMock
       .mockRejectedValueOnce({ status: 500 })
       .mockResolvedValueOnce({
@@ -133,27 +135,28 @@ describe('OpenAIService cancellation wiring', () => {
       });
 
     const { OpenAIService } = await import('../openai');
-    const service = new OpenAIService('sk-test', { retryDelay: 0 });
+    const service = new OpenAIService('sk-test', { retryDelay: 1000 });
+    const controller = new AbortController();
 
     const samplePromise = service.sampleText('hello', {
       modelName: 'gpt-4o-mini',
+      signal: controller.signal,
+    });
+    const sampleExpectation = expect(samplePromise).rejects.toMatchObject({
+      name: 'AbortError',
     });
 
+    await Promise.resolve();
+    controller.abort();
     await vi.runAllTimersAsync();
-    service.cancel();
-    await vi.runAllTimersAsync();
-    await samplePromise;
+    await sampleExpectation;
 
     const firstOptions = createMock.mock.calls[0]?.[1] as
       | { signal?: AbortSignal }
       | undefined;
-    const secondOptions = createMock.mock.calls[1]?.[1] as
-      | { signal?: AbortSignal }
-      | undefined;
 
-    expect(createMock).toHaveBeenCalledTimes(2);
-    expect(firstOptions?.signal).toBeInstanceOf(AbortSignal);
-    expect(secondOptions?.signal).toBe(firstOptions?.signal);
-    expect(secondOptions?.signal?.aborted).toBe(true);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(firstOptions?.signal).toBe(controller.signal);
+    expect(firstOptions?.signal?.aborted).toBe(true);
   });
 });

--- a/src/lib/ai-service/anthropic.ts
+++ b/src/lib/ai-service/anthropic.ts
@@ -259,6 +259,7 @@ export class AnthropicService extends BaseAIService<
       config?: AIServiceConfig;
       forceToolUse?: boolean;
       disableToolUse?: boolean;
+      signal?: AbortSignal;
     } = {},
   ): AsyncGenerator<string, void, void> {
     const { config, tools, sanitizedMessages } = this.prepareStreamChat(
@@ -289,6 +290,12 @@ export class AnthropicService extends BaseAIService<
         options.systemPrompt,
         options.sessionContext,
       );
+      const requestTools = tools;
+      const toolChoice = options.disableToolUse
+        ? { type: 'none' as const }
+        : options.forceToolUse && requestTools?.length
+          ? { type: 'any' as const }
+          : undefined;
 
       const stream = this.anthropic.messages.stream(
         {
@@ -297,11 +304,10 @@ export class AnthropicService extends BaseAIService<
           messages: anthropicMessages,
           ...(systemBlocks && { system: systemBlocks }),
           ...(extendedThinking && { extended_thinking: extendedThinking }),
-          tools: tools,
-          ...(options.forceToolUse &&
-            options.availableTools?.length && { tool_choice: { type: 'any' } }),
+          ...(requestTools && { tools: requestTools }),
+          ...(toolChoice && { tool_choice: toolChoice }),
         },
-        { signal: this.getAbortSignal() },
+        { signal: options.signal },
       );
 
       // Tool call accumulator for partial JSON streaming
@@ -323,13 +329,13 @@ export class AnthropicService extends BaseAIService<
       // Track current usage metrics (updated from message_start and message_delta)
       let currentUsage: TokenUsage = createEmptyAnthropicUsage();
 
-      if (this.getAbortSignal().aborted) {
+      if (options.signal?.aborted) {
         this.logger.debug('Stream aborted before iteration');
         return;
       }
 
       for await (const chunk of stream) {
-        if (this.getAbortSignal().aborted) {
+        if (options.signal?.aborted) {
           this.logger.debug('Stream aborted during iteration');
           break;
         }
@@ -605,29 +611,32 @@ export class AnthropicService extends BaseAIService<
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     const config = this.mergeConfig(options);
     const model =
       options?.modelName || config.defaultModel || this.getDefaultModel();
     const s = options?.samplingOptions;
-    const abortSignal = this.getAbortSignal();
+    const abortSignal = options?.signal;
 
-    const response = await this.withRetry(() =>
-      this.anthropic.messages.create(
-        {
-          model,
-          max_tokens: s?.maxTokens ?? config.maxTokens ?? 4096,
-          temperature: s?.temperature ?? config.temperature,
-          top_p: s?.topP,
-          top_k: s?.topK,
-          stop_sequences: s?.stopSequences,
-          messages: [{ role: 'user', content: prompt }],
-        },
-        {
-          signal: abortSignal,
-        },
-      ),
+    const response = await this.withRetry(
+      () =>
+        this.anthropic.messages.create(
+          {
+            model,
+            max_tokens: s?.maxTokens ?? config.maxTokens ?? 4096,
+            temperature: s?.temperature ?? config.temperature,
+            top_p: s?.topP,
+            top_k: s?.topK,
+            stop_sequences: s?.stopSequences,
+            messages: [{ role: 'user', content: prompt }],
+          },
+          {
+            signal: abortSignal,
+          },
+        ),
+      abortSignal,
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');

--- a/src/lib/ai-service/base-service-compaction.ts
+++ b/src/lib/ai-service/base-service-compaction.ts
@@ -24,6 +24,7 @@ interface CompactionContext {
       config?: CompactOptions['config'];
       forceToolUse: false;
       disableToolUse: true;
+      signal?: AbortSignal;
     },
   ) => AsyncGenerator<string, void, void>;
   isAborted: () => boolean;
@@ -57,6 +58,7 @@ export async function compactMessages(
     config: context.options?.config,
     forceToolUse: false,
     disableToolUse: true,
+    signal: context.options?.signal,
   });
 
   let summaryText = '';

--- a/src/lib/ai-service/base-service-shared.ts
+++ b/src/lib/ai-service/base-service-shared.ts
@@ -10,6 +10,7 @@ export interface StreamChatOptions {
   config?: AIServiceConfig;
   forceToolUse?: boolean;
   disableToolUse?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface PrepareStreamChatOptions {
@@ -19,6 +20,7 @@ export interface PrepareStreamChatOptions {
   availableTools?: MCPTool[];
   config?: AIServiceConfig;
   disableToolUse?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface PrepareStreamChatResult<TProviderTool> {
@@ -39,12 +41,14 @@ export interface CompactOptions {
   systemPrompt?: string;
   sessionContext?: string;
   availableTools?: MCPTool[];
+  signal?: AbortSignal;
 }
 
 export interface SampleTextOptions {
   modelName?: string;
   samplingOptions?: SamplingOptions;
   config?: AIServiceConfig;
+  signal?: AbortSignal;
 }
 
 export interface SyntheticSessionContextMessageOptions {

--- a/src/lib/ai-service/base-service-strategies.ts
+++ b/src/lib/ai-service/base-service-strategies.ts
@@ -15,6 +15,12 @@ interface StreamingErrorLogger {
   error: (message: string, ...args: unknown[]) => unknown;
 }
 
+export function createAbortError(): Error {
+  const abortError = new Error('Request aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
 export function shouldRetryRequest(error: unknown): boolean {
   const status = (error as { status?: number })?.status;
   if (status === undefined) {
@@ -31,7 +37,7 @@ export function shouldRetryRequest(error: unknown): boolean {
 export async function withRetryPolicy<T>(args: {
   fn: () => Promise<T>;
   config: AIServiceConfig;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   logger: RetryLogger;
   provider: AIServiceProvider;
   shouldRetry: (error: unknown) => boolean;
@@ -45,7 +51,7 @@ export async function withRetryPolicy<T>(args: {
     } catch (error: unknown) {
       lastError = error;
 
-      if (args.abortSignal.aborted) {
+      if (args.abortSignal?.aborted) {
         throw error;
       }
 
@@ -54,7 +60,25 @@ export async function withRetryPolicy<T>(args: {
         args.logger.warn(
           `Retrying request (${i + 1}/${maxRetries}) after ${delay}ms...`,
         );
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve, reject) => {
+          if (args.abortSignal?.aborted) {
+            reject(createAbortError());
+            return;
+          }
+
+          const timeoutId = setTimeout(() => {
+            args.abortSignal?.removeEventListener('abort', onAbort);
+            resolve();
+          }, delay);
+
+          const onAbort = () => {
+            clearTimeout(timeoutId);
+            args.abortSignal?.removeEventListener('abort', onAbort);
+            reject(createAbortError());
+          };
+
+          args.abortSignal?.addEventListener('abort', onAbort, { once: true });
+        });
         continue;
       }
 
@@ -77,7 +101,7 @@ export async function withRetryPolicy<T>(args: {
 export function throwStreamingError(args: {
   error: unknown;
   context: StreamingErrorContext;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
   logger: StreamingErrorLogger;
   provider: AIServiceProvider;
 }): never {
@@ -86,7 +110,7 @@ export function throwStreamingError(args: {
   const errorStack = args.error instanceof Error ? args.error.stack : undefined;
 
   const isCancellation =
-    args.abortSignal.aborted ||
+    args.abortSignal?.aborted ||
     (args.error instanceof Error &&
       (args.error.name === 'AbortError' ||
         args.error.message.includes('abort') ||
@@ -94,12 +118,7 @@ export function throwStreamingError(args: {
 
   if (isCancellation) {
     args.logger.info(`${args.provider} stream cancelled by user`);
-    throw new AIServiceError(
-      `${args.provider} stream cancelled`,
-      args.provider,
-      undefined,
-      args.error instanceof Error ? args.error : undefined,
-    );
+    throw createAbortError();
   }
 
   args.logger.error(`${args.provider} streaming failed`, {

--- a/src/lib/ai-service/base-service.ts
+++ b/src/lib/ai-service/base-service.ts
@@ -72,9 +72,6 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
    */
   protected logger = getLogger(this.getProvider());
 
-  // Instance-level AbortController for stream cancellation
-  protected abortController: AbortController = new AbortController();
-
   /**
    * Initializes a new instance of the `BaseAIService`.
    * @param apiKey The API key for the service.
@@ -89,32 +86,12 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
   }
 
   /**
-   * Sets the default configuration for the service.
-   * @param config The new default configuration.
-   */
-  setDefaultConfig(config: AIServiceConfig): void {
-    this.defaultConfig = { ...this.defaultConfig, ...config };
-  }
-
-  /**
    * Cancels any ongoing streaming request.
    */
   cancel(): void {
-    if (!this.abortController.signal.aborted) {
-      this.logger.info('Cancelling active stream');
-      this.abortController.abort();
-    }
-    // Re-create the AbortController for the next request
-    this.abortController = new AbortController();
-  }
-
-  /**
-   * Returns the `AbortSignal` for the current request.
-   * @returns The `AbortSignal`.
-   * @protected
-   */
-  protected getAbortSignal(): AbortSignal {
-    return this.abortController.signal;
+    this.logger.debug(
+      'Ignoring service-level cancel; request-scoped signal owns cancellation',
+    );
   }
 
   /**
@@ -154,11 +131,14 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
    * @returns A promise that resolves to the result of the function.
    * @protected
    */
-  protected async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  protected async withRetry<T>(
+    fn: () => Promise<T>,
+    abortSignal?: AbortSignal,
+  ): Promise<T> {
     return withRetryPolicy({
       fn,
       config: this.defaultConfig,
-      abortSignal: this.abortController.signal,
+      abortSignal,
       logger: this.logger,
       provider: this.getProvider(),
       shouldRetry: (error) => this.shouldRetry(error),
@@ -227,7 +207,7 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
     throwStreamingError({
       error,
       context,
-      abortSignal: this.abortController.signal,
+      abortSignal: context.options.signal,
       logger: this.logger,
       provider: this.getProvider(),
     });
@@ -264,9 +244,6 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
     options: PrepareStreamChatOptions = {},
   ): PrepareStreamChatResult<TProviderTool> {
     this.validateMessages(messages);
-
-    // Re-initialize AbortController for this call
-    this.abortController = new AbortController();
 
     return prepareStreamChatRequest({
       messages,
@@ -539,7 +516,7 @@ export abstract class BaseAIService<TProviderMessage, TProviderTool>
         ),
       streamChat: (compactInput, compactOptions) =>
         this.streamChat(compactInput, compactOptions),
-      isAborted: () => this.getAbortSignal().aborted,
+      isAborted: () => options?.signal?.aborted ?? false,
       getProvider: () => this.getProvider(),
     });
   }

--- a/src/lib/ai-service/cerebras.ts
+++ b/src/lib/ai-service/cerebras.ts
@@ -21,6 +21,7 @@ interface StreamChatOptions {
   sessionContext?: string;
   availableTools?: MCPTool[];
   config?: AIServiceConfig;
+  signal?: AbortSignal;
 }
 /** @internal */
 interface ChunkChoice {
@@ -160,6 +161,7 @@ export class CerebrasService extends BaseAIService<
         options.systemPrompt,
       );
       const model = options.modelName || config.defaultModel || DEFAULT_MODEL;
+      const abortSignal = options.signal;
 
       const stream = await this.withRetry(
         async (): Promise<AsyncIterable<unknown>> => {
@@ -175,64 +177,53 @@ export class CerebrasService extends BaseAIService<
               tools: tools,
               tool_choice: tools ? 'auto' : undefined,
             },
-            { signal: this.getAbortSignal() },
+            { signal: abortSignal },
           );
         },
+        abortSignal,
       );
 
-      if (this.getAbortSignal().aborted) {
+      if (abortSignal?.aborted) {
         this.logger.info('Stream aborted before iteration');
         return;
       }
 
-      // Measure TTFT (Cerebras doesn't provide native prefill timing)
-      const startTime = performance.now();
-      let firstChunkReceived = false;
+      yield* this.streamChatWithTTFT(
+        (async function* (
+          service: CerebrasService,
+        ): AsyncGenerator<string, void, void> {
+          for await (const chunk of stream) {
+            if (abortSignal?.aborted) {
+              service.logger.info('Stream aborted during iteration');
+              break;
+            }
 
-      for await (const chunk of stream) {
-        if (this.getAbortSignal().aborted) {
-          this.logger.info('Stream aborted during iteration');
-          break;
-        }
+            // Handle usage metrics usually found in the final chunk
+            const chunkObj = chunk as unknown as Record<string, unknown>;
+            if (chunkObj?.usage) {
+              const u = chunkObj.usage as unknown as {
+                prompt_tokens?: number;
+                completion_tokens?: number;
+                total_tokens?: number;
+                prompt_tokens_details?: { cached_tokens?: number };
+              };
+              yield JSON.stringify({
+                usage: {
+                  promptTokens: u.prompt_tokens || 0,
+                  completionTokens: u.completion_tokens || 0,
+                  totalTokens: u.total_tokens || 0,
+                  cachedPromptTokens: u.prompt_tokens_details?.cached_tokens,
+                },
+              });
+            }
 
-        // Inject TTFT metric on first chunk
-        if (!firstChunkReceived) {
-          const ttft = performance.now() - startTime;
-          firstChunkReceived = true;
-          yield JSON.stringify({
-            usage: {
-              promptTokens: 0,
-              completionTokens: 0,
-              totalTokens: 0,
-              details: { timeToFirstToken: ttft },
-            },
-          });
-        }
-
-        // Handle usage metrics usually found in the final chunk
-        const chunkObj = chunk as unknown as Record<string, unknown>;
-        if (chunkObj?.usage) {
-          const u = chunkObj.usage as unknown as {
-            prompt_tokens?: number;
-            completion_tokens?: number;
-            total_tokens?: number;
-            prompt_tokens_details?: { cached_tokens?: number };
-          };
-          yield JSON.stringify({
-            usage: {
-              promptTokens: u.prompt_tokens || 0,
-              completionTokens: u.completion_tokens || 0,
-              totalTokens: u.total_tokens || 0,
-              cachedPromptTokens: u.prompt_tokens_details?.cached_tokens,
-            },
-          });
-        }
-
-        const processedChunk = this.processChunk(chunk);
-        if (processedChunk) {
-          yield processedChunk;
-        }
-      }
+            const processedChunk = service.processChunk(chunk);
+            if (processedChunk) {
+              yield processedChunk;
+            }
+          }
+        })(this),
+      );
     } catch (error: unknown) {
       this.handleStreamingError(error, { messages, options, config });
     }
@@ -475,6 +466,7 @@ export class CerebrasService extends BaseAIService<
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     if (!this.cerebras) {
@@ -484,18 +476,20 @@ export class CerebrasService extends BaseAIService<
     const model = options?.modelName || config.defaultModel || '';
     const s = options?.samplingOptions;
 
-    const response = await this.withRetry(() =>
-      this.cerebras!.chat.completions.create({
-        model,
-        stream: false,
-        messages: [{ role: 'user', content: prompt }],
-        max_tokens: s?.maxTokens ?? config.maxTokens,
-        temperature: s?.temperature ?? config.temperature,
-        top_p: s?.topP,
-        presence_penalty: s?.presencePenalty,
-        frequency_penalty: s?.frequencyPenalty,
-        stop: s?.stopSequences,
-      }),
+    const response = await this.withRetry(
+      () =>
+        this.cerebras!.chat.completions.create({
+          model,
+          stream: false,
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: s?.maxTokens ?? config.maxTokens,
+          temperature: s?.temperature ?? config.temperature,
+          top_p: s?.topP,
+          presence_penalty: s?.presencePenalty,
+          frequency_penalty: s?.frequencyPenalty,
+          stop: s?.stopSequences,
+        }),
+      options?.signal,
     );
 
     // The Cerebras SDK's ChatCompletion union includes streaming chunks; narrow to the response type

--- a/src/lib/ai-service/empty.ts
+++ b/src/lib/ai-service/empty.ts
@@ -42,20 +42,18 @@ export class EmptyAIService extends BaseAIService<unknown, never> {
    */
   protected async *doStreamChat(
     messages: Message[],
-    options?: unknown,
+    options?: { signal?: AbortSignal },
   ): AsyncGenerator<string, void, void> {
     void messages;
-    void options;
-    if (this.getAbortSignal().aborted) {
+    if (options?.signal?.aborted) {
       this.logger.info('EmptyAIService stream cancelled before starting.');
       return;
     }
-    yield '';
+    yield* [];
     throw new AIServiceError(
       `EmptyAIService does not support streaming chat`,
       AIServiceProvider.Empty,
     );
-    // Yield nothing, this is an empty service
   }
 
   protected convertMessages(

--- a/src/lib/ai-service/gemini/service.ts
+++ b/src/lib/ai-service/gemini/service.ts
@@ -248,80 +248,85 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
       config?: AIServiceConfig;
       forceToolUse?: boolean;
       disableToolUse?: boolean;
+      signal?: AbortSignal;
     } = {},
   ): AsyncGenerator<string, void, void> {
-    const { config, tools, sanitizedMessages } = this.prepareStreamChat(
-      messages,
-      options,
-    );
-    try {
-      const abortSignal = this.getAbortSignal();
-      const normalizedContextInjection = this.prepareContextInjection(
-        options.systemPrompt,
-        options.sessionContext,
-        sanitizedMessages,
+    const abortSignal = options.signal;
+    let currentOptions = options;
+    let allowMalformedFunctionRetry = Boolean(options.availableTools?.length);
+
+    while (true) {
+      const { config, tools, sanitizedMessages } = this.prepareStreamChat(
+        messages,
+        currentOptions,
       );
-      const geminiMessages = this.convertMessages(
-        normalizedContextInjection.messages,
-        normalizedContextInjection.systemPrompt,
-      );
-      if (geminiMessages.length === 0) {
-        throw new Error(
-          'No valid messages to send to Gemini (must start with user/tool role)',
+
+      try {
+        const normalizedContextInjection = this.prepareContextInjection(
+          currentOptions.systemPrompt,
+          currentOptions.sessionContext,
+          sanitizedMessages,
         );
-      }
-      const geminiTools = tools
-        ? [
-            {
-              functionDeclarations: tools as FunctionDeclaration[],
-            },
-          ]
-        : undefined;
-
-      const model =
-        options.modelName || config.defaultModel || getDefaultModel();
-      const stablePrefix = normalizedContextInjection.systemPrompt ?? '';
-      const encoder = new TextEncoder();
-      const toolDeclarationCount =
-        geminiTools?.[0]?.functionDeclarations.length ?? 0;
-
-      const requestMessageSummary = summarizeLibrAgentMessages(
-        normalizedContextInjection.messages,
-      );
-      const geminiContentSummary = summarizeGeminiContents(geminiMessages);
-
-      this.logger.info('Gemini request assembly breakdown', {
-        model,
-        implicitCachingEligible: model.startsWith('gemini-2.5-'),
-        disableToolUse: options.disableToolUse ?? false,
-        forceToolUse: options.forceToolUse ?? false,
-        librAgentMessages: requestMessageSummary,
-        geminiContents: geminiContentSummary,
-        stablePrefixLength: stablePrefix.length,
-        stablePrefixBytes: encoder.encode(stablePrefix).length,
-        toolDeclarationCount,
-      });
-
-      let thinkingConfig: GeminiServiceConfig['thinkingConfig'];
-      if (config.enableReasoning) {
-        const modelSupportsThinking = await checkThinkingSupport(
-          model,
-          this.modelCache,
+        const geminiMessages = this.convertMessages(
+          normalizedContextInjection.messages,
+          normalizedContextInjection.systemPrompt,
         );
-        if (modelSupportsThinking) {
-          const thinkingBudget = mapReasoningEffortToBudget(
-            config.reasoningEffort,
+        if (geminiMessages.length === 0) {
+          throw new Error(
+            'No valid messages to send to Gemini (must start with user/tool role)',
           );
-          thinkingConfig = {
-            thinkingBudget,
-            includeThoughts: true,
-          };
         }
-      }
+        const geminiTools =
+          (tools?.length ?? 0) > 0
+            ? [
+                {
+                  functionDeclarations: tools as FunctionDeclaration[],
+                },
+              ]
+            : undefined;
 
-      const safetySettings = prepareSafetySettings(config);
+        const model =
+          currentOptions.modelName || config.defaultModel || getDefaultModel();
+        const stablePrefix = normalizedContextInjection.systemPrompt ?? '';
+        const encoder = new TextEncoder();
+        const toolDeclarationCount =
+          geminiTools?.[0]?.functionDeclarations.length ?? 0;
 
-      const createGeminiConfig = (): GeminiServiceConfig => {
+        const requestMessageSummary = summarizeLibrAgentMessages(
+          normalizedContextInjection.messages,
+        );
+        const geminiContentSummary = summarizeGeminiContents(geminiMessages);
+
+        this.logger.info('Gemini request assembly breakdown', {
+          model,
+          implicitCachingEligible: model.startsWith('gemini-2.5-'),
+          disableToolUse: currentOptions.disableToolUse ?? false,
+          forceToolUse: currentOptions.forceToolUse ?? false,
+          librAgentMessages: requestMessageSummary,
+          geminiContents: geminiContentSummary,
+          stablePrefixLength: stablePrefix.length,
+          stablePrefixBytes: encoder.encode(stablePrefix).length,
+          toolDeclarationCount,
+        });
+
+        let thinkingConfig: GeminiServiceConfig['thinkingConfig'];
+        if (config.enableReasoning) {
+          const modelSupportsThinking = await checkThinkingSupport(
+            model,
+            this.modelCache,
+          );
+          if (modelSupportsThinking) {
+            const thinkingBudget = mapReasoningEffortToBudget(
+              config.reasoningEffort,
+            );
+            thinkingConfig = {
+              thinkingBudget,
+              includeThoughts: true,
+            };
+          }
+        }
+
+        const safetySettings = prepareSafetySettings(config);
         const geminiConfig: GeminiServiceConfig = {
           responseMimeType: 'text/plain',
           abortSignal,
@@ -335,13 +340,13 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
         }
 
         if (geminiTools) {
-          if (options.disableToolUse) {
+          if (currentOptions.disableToolUse) {
             geminiConfig.toolConfig = {
               functionCallingConfig: {
                 mode: FunctionCallingConfigMode.NONE,
               },
             };
-          } else if (options.forceToolUse) {
+          } else if (currentOptions.forceToolUse) {
             geminiConfig.toolConfig = {
               functionCallingConfig: {
                 mode: FunctionCallingConfigMode.ANY,
@@ -364,62 +369,60 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
 
         geminiConfig.safetySettings = safetySettings;
 
-        return geminiConfig;
-      };
-
-      const geminiConfig = createGeminiConfig();
-
-      // 🔍 Detailed Logging before API Call
-      const sysPromptText = geminiConfig.systemInstruction?.[0]?.text || '';
-      this.logger.debug('🚀 Calling Gemini API - System Prompt Verification', {
-        model,
-        systemPromptLength: sysPromptText.length,
-        includesSkills: sysPromptText.includes('<available_skills>'),
-        first500Chars: sysPromptText.substring(0, 500),
-        last500Chars: sysPromptText.substring(sysPromptText.length - 500),
-      });
-
-      const createStream = async (requestConfig: GeminiServiceConfig) => {
-        return this.genAI.models.generateContentStream({
-          model: model,
-          config: requestConfig,
-          contents: geminiMessages,
-        });
-      };
-
-      const result = await this.withRetry(async () => {
-        return createStream(geminiConfig);
-      });
-
-      if (abortSignal.aborted) {
-        this.logger.debug('Stream aborted before iteration');
-        return;
-      }
-
-      // Use the stream processing logic from stream.ts
-      yield* processGeminiStream(result, abortSignal, this.logger);
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        (error.message.includes('malformed_function_call') ||
-          error.message.includes('MALFORMED_FUNCTION_CALL'))
-      ) {
-        this.logger.warn(
-          'MALFORMED_FUNCTION_CALL detected. Retrying request without tools.',
-          { originalError: error },
+        // 🔍 Detailed Logging before API Call
+        const sysPromptText = geminiConfig.systemInstruction?.[0]?.text || '';
+        this.logger.debug(
+          '🚀 Calling Gemini API - System Prompt Verification',
+          {
+            model,
+            systemPromptLength: sysPromptText.length,
+            includesSkills: sysPromptText.includes('<available_skills>'),
+            first500Chars: sysPromptText.substring(0, 500),
+            last500Chars: sysPromptText.substring(sysPromptText.length - 500),
+          },
         );
-        if (options.availableTools && options.availableTools.length > 0) {
-          const retryOptions = { ...options, availableTools: [] };
-          yield* this.streamChat(messages, retryOptions);
+
+        const result = await this.withRetry(async () => {
+          return this.genAI.models.generateContentStream({
+            model: model,
+            config: geminiConfig,
+            contents: geminiMessages,
+          });
+        }, abortSignal);
+
+        if (abortSignal?.aborted) {
+          this.logger.debug('Stream aborted before iteration');
           return;
         }
-      }
 
-      this.handleStreamingError(error, {
-        messages,
-        options,
-        config,
-      });
+        yield* processGeminiStream(result, abortSignal, this.logger);
+        return;
+      } catch (error) {
+        const malformedFunctionCall =
+          error instanceof Error &&
+          (error.message.includes('malformed_function_call') ||
+            error.message.includes('MALFORMED_FUNCTION_CALL'));
+
+        if (malformedFunctionCall && allowMalformedFunctionRetry) {
+          this.logger.warn(
+            'MALFORMED_FUNCTION_CALL detected. Retrying request without tools.',
+            { originalError: error },
+          );
+          allowMalformedFunctionRetry = false;
+          currentOptions = {
+            ...currentOptions,
+            availableTools: [],
+            forceToolUse: false,
+          };
+          continue;
+        }
+
+        this.handleStreamingError(error, {
+          messages,
+          options: currentOptions,
+          config,
+        });
+      }
     }
   }
 
@@ -539,6 +542,7 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     const rawConfig = this.mergeConfig(options) as AIServiceConfig &
@@ -546,21 +550,23 @@ export class GeminiService extends BaseAIService<Content, FunctionDeclaration> {
     const model =
       options?.modelName || rawConfig.defaultModel || getDefaultModel();
     const s = options?.samplingOptions;
-    const abortSignal = this.getAbortSignal();
+    const abortSignal = options?.signal;
 
-    const response = await this.withRetry(() =>
-      this.genAI.models.generateContent({
-        model,
-        config: {
-          abortSignal,
-          maxOutputTokens: s?.maxTokens ?? rawConfig.maxTokens,
-          temperature: s?.temperature ?? rawConfig.temperature,
-          topP: s?.topP,
-          topK: s?.topK,
-          stopSequences: s?.stopSequences,
-        },
-        contents: [{ role: 'user', parts: [{ text: prompt }] }],
-      }),
+    const response = await this.withRetry(
+      () =>
+        this.genAI.models.generateContent({
+          model,
+          config: {
+            abortSignal,
+            maxOutputTokens: s?.maxTokens ?? rawConfig.maxTokens,
+            temperature: s?.temperature ?? rawConfig.temperature,
+            topP: s?.topP,
+            topK: s?.topK,
+            stopSequences: s?.stopSequences,
+          },
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        }),
+      abortSignal,
     );
 
     const candidate = response.candidates?.[0];

--- a/src/lib/ai-service/gemini/stream.ts
+++ b/src/lib/ai-service/gemini/stream.ts
@@ -81,10 +81,10 @@ function isFunctionCallPart(part: GeminiChunkPart): part is GeminiChunkPart & {
  */
 export async function* processGeminiStream(
   result: AsyncIterable<GeminiStreamChunk>,
-  signal: AbortSignal,
+  signal: AbortSignal | undefined,
   logger: ReturnType<typeof getLogger>,
 ): AsyncGenerator<string, void, void> {
-  if (signal.aborted) {
+  if (signal?.aborted) {
     logger.debug('Stream aborted before iteration');
     return;
   }
@@ -105,7 +105,7 @@ export async function* processGeminiStream(
   let usageUpdateCount = 0;
 
   for await (const chunk of result) {
-    if (signal.aborted) {
+    if (signal?.aborted) {
       logger.info('Stream aborted during iteration');
       break;
     }

--- a/src/lib/ai-service/groq.ts
+++ b/src/lib/ai-service/groq.ts
@@ -91,13 +91,14 @@ export class GroqService extends BaseAIService<
       sessionContext?: string;
       availableTools?: MCPTool[];
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     } = {},
   ): AsyncGenerator<string, void, void> {
     const { config, tools, sanitizedMessages } = this.prepareStreamChat(
       messages,
       options,
     );
-    const abortSignal = this.getAbortSignal();
+    const abortSignal = options.signal;
 
     try {
       const groqMessages = this.convertMessages(
@@ -110,107 +111,104 @@ export class GroqService extends BaseAIService<
         options.modelName || config.defaultModel || 'llama-3.1-8b-instant',
       );
 
-      const chatCompletion = await this.withRetry(() =>
-        this.groq.chat.completions.create(
-          {
-            messages: groqMessages,
-            model:
-              options.modelName ||
-              config.defaultModel ||
-              'llama-3.1-8b-instant',
-            temperature: config.temperature,
-            max_tokens: config.maxTokens,
-            reasoning_format: model?.supportReasoning ? 'parsed' : undefined,
-            stream: true,
-            tools: tools,
-            tool_choice: options.availableTools ? 'auto' : undefined,
-          },
-          {
-            signal: abortSignal,
-          },
-        ),
+      const chatCompletion = await this.withRetry(
+        () =>
+          this.groq.chat.completions.create(
+            {
+              messages: groqMessages,
+              model:
+                options.modelName ||
+                config.defaultModel ||
+                'llama-3.1-8b-instant',
+              temperature: config.temperature,
+              max_tokens: config.maxTokens,
+              reasoning_format: model?.supportReasoning ? 'parsed' : undefined,
+              stream: true,
+              tools: tools,
+              tool_choice: options.availableTools ? 'auto' : undefined,
+            },
+            {
+              signal: abortSignal,
+            },
+          ),
+        abortSignal,
       );
 
-      if (abortSignal.aborted) {
+      if (abortSignal?.aborted) {
         this.logger.info('Stream aborted before iteration');
         return;
       }
 
-      // Measure TTFT (Groq doesn't provide native prefill timing)
-      const startTime = performance.now();
-      let firstChunkReceived = false;
+      yield* this.streamChatWithTTFT(
+        (async function* (
+          service: GroqService,
+        ): AsyncGenerator<string, void, void> {
+          for await (const chunk of chatCompletion) {
+            if (abortSignal?.aborted) {
+              service.logger.info('Stream aborted during iteration');
+              break;
+            }
 
-      for await (const chunk of chatCompletion) {
-        if (abortSignal.aborted) {
-          this.logger.info('Stream aborted during iteration');
-          break;
-        }
+            // Extract usage from the last chunk if available
+            const chunkObj = chunk as unknown as Record<string, unknown>;
+            const xGroq = chunkObj?.x_groq as
+              | Record<string, unknown>
+              | undefined;
+            if (xGroq?.usage) {
+              const u = xGroq.usage as unknown as {
+                prompt_tokens?: number;
+                completion_tokens?: number;
+                total_tokens?: number;
+                prompt_cache_hit_tokens?: number;
+              };
+              const usage: TokenUsage = {
+                promptTokens: u.prompt_tokens || 0,
+                completionTokens: u.completion_tokens || 0,
+                totalTokens: u.total_tokens || 0,
+                cachedPromptTokens: u.prompt_cache_hit_tokens,
+              };
+              yield JSON.stringify({ usage });
+            }
 
-        // Inject TTFT metric on first chunk.
-        // Only yield details here — yielding zero token counts would briefly reset the
-        // gauge to 0% before the real usage chunk arrives at the end of the stream.
-        if (!firstChunkReceived) {
-          const ttft = performance.now() - startTime;
-          firstChunkReceived = true;
-          yield JSON.stringify({
-            usage: { details: { timeToFirstToken: ttft } },
-          });
-        }
+            if (chunk.choices[0]?.delta?.reasoning) {
+              yield JSON.stringify({
+                thinking: chunk.choices[0].delta.reasoning,
+              });
+            } else if (chunk.choices[0]?.delta?.tool_calls) {
+              const toolCalls = chunk.choices[0].delta.tool_calls
+                .map((toolCall) => {
+                  if (typeof toolCall.index !== 'number') {
+                    return null;
+                  }
 
-        // Extract usage from the last chunk if available
-        const chunkObj = chunk as unknown as Record<string, unknown>;
-        const xGroq = chunkObj?.x_groq as Record<string, unknown> | undefined;
-        if (xGroq?.usage) {
-          const u = xGroq.usage as unknown as {
-            prompt_tokens?: number;
-            completion_tokens?: number;
-            total_tokens?: number;
-            prompt_cache_hit_tokens?: number;
-          };
-          const usage: TokenUsage = {
-            promptTokens: u.prompt_tokens || 0,
-            completionTokens: u.completion_tokens || 0,
-            totalTokens: u.total_tokens || 0,
-            cachedPromptTokens: u.prompt_cache_hit_tokens,
-          };
-          yield JSON.stringify({ usage });
-        }
+                  return createSerializableToolCallArgumentDelta(
+                    toolCall.index,
+                    toolCall.function?.arguments || '',
+                    {
+                      id: toolCall.id,
+                      name: toolCall.function?.name,
+                    },
+                  );
+                })
+                .filter(
+                  (
+                    toolCall,
+                  ): toolCall is ReturnType<
+                    typeof createSerializableToolCallArgumentDelta
+                  > => toolCall !== null,
+                );
 
-        if (chunk.choices[0]?.delta?.reasoning) {
-          yield JSON.stringify({ thinking: chunk.choices[0].delta.reasoning });
-        } else if (chunk.choices[0]?.delta?.tool_calls) {
-          const toolCalls = chunk.choices[0].delta.tool_calls
-            .map((toolCall) => {
-              if (typeof toolCall.index !== 'number') {
-                return null;
+              if (toolCalls.length > 0) {
+                yield serializeToolCallArgumentDeltas(toolCalls);
               }
-
-              return createSerializableToolCallArgumentDelta(
-                toolCall.index,
-                toolCall.function?.arguments || '',
-                {
-                  id: toolCall.id,
-                  name: toolCall.function?.name,
-                },
-              );
-            })
-            .filter(
-              (
-                toolCall,
-              ): toolCall is ReturnType<
-                typeof createSerializableToolCallArgumentDelta
-              > => toolCall !== null,
-            );
-
-          if (toolCalls.length > 0) {
-            yield serializeToolCallArgumentDeltas(toolCalls);
+            } else if (chunk.choices[0]?.delta?.content) {
+              yield JSON.stringify({
+                content: chunk.choices[0]?.delta?.content || '',
+              });
+            }
           }
-        } else if (chunk.choices[0]?.delta?.content) {
-          yield JSON.stringify({
-            content: chunk.choices[0]?.delta?.content || '',
-          });
-        }
-      }
+        })(this),
+      );
     } catch (error) {
       this.handleStreamingError(error, { messages, options, config });
     }
@@ -389,30 +387,33 @@ export class GroqService extends BaseAIService<
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     const config = this.mergeConfig(options);
     const model = options?.modelName || config.defaultModel || '';
     const s = options?.samplingOptions;
-    const abortSignal = this.getAbortSignal();
+    const abortSignal = options?.signal;
 
-    const response = await this.withRetry(() =>
-      this.groq.chat.completions.create(
-        {
-          model,
-          stream: false,
-          messages: [{ role: 'user', content: prompt }],
-          max_tokens: s?.maxTokens ?? config.maxTokens,
-          temperature: s?.temperature ?? config.temperature,
-          top_p: s?.topP,
-          presence_penalty: s?.presencePenalty,
-          frequency_penalty: s?.frequencyPenalty,
-          stop: s?.stopSequences,
-        },
-        {
-          signal: abortSignal,
-        },
-      ),
+    const response = await this.withRetry(
+      () =>
+        this.groq.chat.completions.create(
+          {
+            model,
+            stream: false,
+            messages: [{ role: 'user', content: prompt }],
+            max_tokens: s?.maxTokens ?? config.maxTokens,
+            temperature: s?.temperature ?? config.temperature,
+            top_p: s?.topP,
+            presence_penalty: s?.presencePenalty,
+            frequency_penalty: s?.frequencyPenalty,
+            stop: s?.stopSequences,
+          },
+          {
+            signal: abortSignal,
+          },
+        ),
+      abortSignal,
     );
 
     const choice = response.choices[0];

--- a/src/lib/ai-service/ollama.ts
+++ b/src/lib/ai-service/ollama.ts
@@ -60,6 +60,39 @@ interface StreamChatOptions {
   config?: AIServiceConfig;
   forceToolUse?: boolean;
   disableToolUse?: boolean;
+  signal?: AbortSignal;
+}
+
+interface OllamaAbortableStream extends AsyncIterable<unknown> {
+  abort?: () => void;
+}
+
+interface OllamaChatResponsePayload {
+  model: string;
+  done: boolean;
+  message: {
+    content: string;
+  };
+  eval_count?: number;
+  prompt_eval_count?: number;
+}
+
+function isOllamaChatResponsePayload(
+  value: unknown,
+): value is OllamaChatResponsePayload {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'model' in value &&
+    typeof value.model === 'string' &&
+    'done' in value &&
+    typeof value.done === 'boolean' &&
+    'message' in value &&
+    typeof value.message === 'object' &&
+    value.message !== null &&
+    'content' in value.message &&
+    typeof value.message.content === 'string'
+  );
 }
 
 /**
@@ -153,16 +186,6 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
    */
   convertTools(mcpTools: MCPTool[]): Tool[] {
     return convertMCPToolsToOllamaTools(mcpTools, coreLogger);
-  }
-
-  /**
-   * Cancels any ongoing streams by calling the Ollama client's abort method.
-   * This will abort all running requests on the client instance.
-   */
-  public cancel(): void {
-    super.cancel(); // Call base implementation to set the abort signal
-    this.logger.info('Calling Ollama client abort()');
-    this.ollamaClient.abort();
   }
 
   /**
@@ -278,6 +301,7 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
       const model = options.modelName || config.defaultModel || DEFAULT_MODEL;
       const shouldIncludeTools = !options.disableToolUse;
       const requestTools = shouldIncludeTools ? ollamaTools : undefined;
+      const abortSignal = options.signal;
 
       logger.info('📨 Converted messages for Ollama', {
         originalCount: sanitizedMessages.length,
@@ -347,12 +371,10 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
           }
           throw error;
         }
-      });
+      }, abortSignal);
 
-      if (this.getAbortSignal().aborted) {
-        this.logger.debug('Stream aborted before iteration');
-        return;
-      }
+      const abortableStream: OllamaAbortableStream = stream;
+      const abortStream = () => abortableStream.abort?.();
 
       // Tool call accumulator for partial JSON handling
       const toolCallAccumulators = new Map<
@@ -360,52 +382,63 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
         import('./ollama-core').OllamaToolCallAccumulator
       >();
 
-      for await (const chunk of stream) {
-        if (this.getAbortSignal().aborted) {
-          this.logger.debug('Stream aborted during iteration');
-          break;
+      try {
+        abortSignal?.addEventListener('abort', abortStream, { once: true });
+        if (abortSignal?.aborted) {
+          abortStream();
+          this.logger.debug('Stream aborted before iteration');
+          return;
         }
 
-        // DIAGNOSTIC LOGGING: Log raw chunk from generator
-        // This is high volume, so keep it at debug level
-        if (typeof chunk === 'object') {
-          // It's already an object from ollama library
-          // logger.debug('Raw Ollama Chunk', { chunk });
+        for await (const chunk of stream) {
+          if (abortSignal?.aborted) {
+            this.logger.debug('Stream aborted during iteration');
+            break;
+          }
+
+          // DIAGNOSTIC LOGGING: Log raw chunk from generator
+          // This is high volume, so keep it at debug level
+          if (typeof chunk === 'object') {
+            // It's already an object from ollama library
+            // logger.debug('Raw Ollama Chunk', { chunk });
+          }
+
+          const processedChunk = processChunk(
+            chunk,
+            coreLogger,
+            toolCallAccumulators,
+          );
+          if (processedChunk) {
+            if (processedChunk.content) {
+              yield JSON.stringify({ content: processedChunk.content });
+            }
+
+            if (processedChunk.thinking) {
+              yield JSON.stringify({ thinking: processedChunk.thinking });
+            }
+
+            if (processedChunk.tool_calls) {
+              const toolCalls = processedChunk.tool_calls.map((toolCall) =>
+                createSerializableDirectToolCall(
+                  toolCall.id,
+                  toolCall.function.name,
+                  toolCall.function.arguments,
+                ),
+              );
+              yield serializeDirectToolCalls(toolCalls);
+            }
+
+            if (processedChunk.usage) {
+              yield JSON.stringify({ usage: processedChunk.usage });
+            }
+
+            if (processedChunk.error) {
+              logger.error('Error processing chunk', processedChunk.error);
+            }
+          }
         }
-
-        const processedChunk = processChunk(
-          chunk,
-          coreLogger,
-          toolCallAccumulators,
-        );
-        if (processedChunk) {
-          if (processedChunk.content) {
-            yield JSON.stringify({ content: processedChunk.content });
-          }
-
-          if (processedChunk.thinking) {
-            yield JSON.stringify({ thinking: processedChunk.thinking });
-          }
-
-          if (processedChunk.tool_calls) {
-            const toolCalls = processedChunk.tool_calls.map((toolCall) =>
-              createSerializableDirectToolCall(
-                toolCall.id,
-                toolCall.function.name,
-                toolCall.function.arguments,
-              ),
-            );
-            yield serializeDirectToolCalls(toolCalls);
-          }
-
-          if (processedChunk.usage) {
-            yield JSON.stringify({ usage: processedChunk.usage });
-          }
-
-          if (processedChunk.error) {
-            logger.error('Error processing chunk', processedChunk.error);
-          }
-        }
+      } finally {
+        abortSignal?.removeEventListener('abort', abortStream);
       }
 
       // Cleanup: Check for incomplete tool calls
@@ -470,23 +503,46 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     const config = this.mergeConfig(options);
     const model = options?.modelName || config.defaultModel || '';
     const s = options?.samplingOptions;
+    const response = await this.withRetry(async () => {
+      const ollamaResponse = await fetch(new URL('/api/chat', this.host), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          stream: false,
+          messages: [{ role: 'user', content: prompt }],
+          options: {
+            num_predict: s?.maxTokens ?? config.maxTokens,
+            temperature: s?.temperature ?? config.temperature,
+            top_p: s?.topP,
+            stop: s?.stopSequences,
+          },
+        }),
+        signal: options?.signal,
+      });
 
-    const response = await this.ollamaClient.chat({
-      model,
-      stream: false,
-      messages: [{ role: 'user', content: prompt }],
-      options: {
-        num_predict: s?.maxTokens ?? config.maxTokens,
-        temperature: s?.temperature ?? config.temperature,
-        top_p: s?.topP,
-        stop: s?.stopSequences,
-      },
-    });
+      if (!ollamaResponse.ok) {
+        const errorText = await ollamaResponse.text();
+        throw new Error(
+          `Ollama request failed (${ollamaResponse.status}): ${errorText || ollamaResponse.statusText}`,
+        );
+      }
+
+      const payload: unknown = await ollamaResponse.json();
+      if (!isOllamaChatResponsePayload(payload)) {
+        throw new Error('Invalid Ollama chat response payload');
+      }
+
+      return payload;
+    }, options?.signal);
 
     const text = response.message.content;
 

--- a/src/lib/ai-service/openai.ts
+++ b/src/lib/ai-service/openai.ts
@@ -213,6 +213,7 @@ export class OpenAIService extends BaseAIService<
       config?: AIServiceConfig;
       forceToolUse?: boolean;
       disableToolUse?: boolean;
+      signal?: AbortSignal;
     } = {},
   ): AsyncGenerator<string, void, void> {
     const { config, tools, sanitizedMessages } = this.prepareStreamChat(
@@ -300,108 +301,104 @@ export class OpenAIService extends BaseAIService<
         request,
       });
 
-      const abortSignal = this.getAbortSignal();
-      const completion = await this.withRetry(() =>
-        this.openai.chat.completions.create(request, {
-          signal: abortSignal,
-          headers: {
-            'x-libragent-request-id': requestId,
-          },
-        }),
+      const abortSignal = options.signal;
+      const completion = await this.withRetry(
+        () =>
+          this.openai.chat.completions.create(request, {
+            signal: abortSignal,
+            headers: {
+              'x-libragent-request-id': requestId,
+            },
+          }),
+        abortSignal,
       );
 
-      if (abortSignal.aborted) {
+      if (abortSignal?.aborted) {
         this.logger.debug('Stream aborted before iteration');
         return;
       }
 
-      // Wrap with TTFT measurement (OpenAI doesn't provide native prefill timing)
-      const startTime = performance.now();
-      let firstChunkReceived = false;
-      for await (const chunk of completion) {
-        if (abortSignal.aborted) {
-          this.logger.info('Stream aborted during iteration');
-          break;
-        }
+      yield* this.streamChatWithTTFT(
+        (async function* (
+          service: OpenAIService,
+        ): AsyncGenerator<string, void, void> {
+          for await (const chunk of completion) {
+            if (abortSignal?.aborted) {
+              service.logger.info('Stream aborted during iteration');
+              break;
+            }
 
-        // Measure TTFT on first chunk (OpenAI doesn't provide native prefill timing).
-        // Only yield details here — yielding zero token counts would briefly reset the
-        // gauge to 0% before the real usage chunk arrives at the end of the stream.
-        if (!firstChunkReceived) {
-          const ttft = performance.now() - startTime;
-          firstChunkReceived = true;
-          yield JSON.stringify({
-            usage: { details: { timeToFirstToken: ttft } },
-          });
-        }
+            const rawUsage = chunk.usage;
+            if (rawUsage && isOpenAIStreamUsage(rawUsage)) {
+              const u = rawUsage as OpenAIStreamUsage;
+              service.promptDiagnostics.logPromptCacheMetadata({
+                mode: 'stream',
+                model: modelName,
+                request,
+                usage: u,
+              });
+              const cachedPromptTokens =
+                u.prompt_tokens_details?.cached_tokens ??
+                u.prompt_cache_hit_tokens;
 
-        const rawUsage = chunk.usage;
-        if (rawUsage && isOpenAIStreamUsage(rawUsage)) {
-          const u = rawUsage as OpenAIStreamUsage;
-          this.promptDiagnostics.logPromptCacheMetadata({
-            mode: 'stream',
-            model: modelName,
-            request,
-            usage: u,
-          });
-          const cachedPromptTokens =
-            u.prompt_tokens_details?.cached_tokens ?? u.prompt_cache_hit_tokens;
-
-          const usage: TokenUsage = {
-            promptTokens: u.prompt_tokens || 0,
-            completionTokens: u.completion_tokens || 0,
-            totalTokens: u.total_tokens || 0,
-            cachedPromptTokens,
-            details: {
-              reasoningTokens: u.completion_tokens_details?.reasoning_tokens,
-            },
-          };
-          yield JSON.stringify({ usage });
-        }
-
-        const delta = chunk.choices[0]
-          ?.delta as OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
-          reasoning_content?: string;
-        };
-        if (delta?.reasoning_content) {
-          yield JSON.stringify({
-            thinking: delta.reasoning_content || '',
-          });
-        }
-
-        if (delta?.tool_calls) {
-          const toolCalls = delta.tool_calls
-            .map((toolCall) => {
-              if (typeof toolCall.index !== 'number') {
-                return null;
-              }
-
-              return createSerializableToolCallArgumentDelta(
-                toolCall.index,
-                toolCall.function?.arguments || '',
-                {
-                  id: toolCall.id,
-                  name: toolCall.function?.name,
+              const usage: TokenUsage = {
+                promptTokens: u.prompt_tokens || 0,
+                completionTokens: u.completion_tokens || 0,
+                totalTokens: u.total_tokens || 0,
+                cachedPromptTokens,
+                details: {
+                  reasoningTokens:
+                    u.completion_tokens_details?.reasoning_tokens,
                 },
-              );
-            })
-            .filter(
-              (
-                toolCall,
-              ): toolCall is ReturnType<
-                typeof createSerializableToolCallArgumentDelta
-              > => toolCall !== null,
-            );
+              };
+              yield JSON.stringify({ usage });
+            }
 
-          if (toolCalls.length > 0) {
-            yield serializeToolCallArgumentDeltas(toolCalls);
+            const delta = chunk.choices[0]
+              ?.delta as OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
+              reasoning_content?: string;
+            };
+            if (delta?.reasoning_content) {
+              yield JSON.stringify({
+                thinking: delta.reasoning_content || '',
+              });
+            }
+
+            if (delta?.tool_calls) {
+              const toolCalls = delta.tool_calls
+                .map((toolCall) => {
+                  if (typeof toolCall.index !== 'number') {
+                    return null;
+                  }
+
+                  return createSerializableToolCallArgumentDelta(
+                    toolCall.index,
+                    toolCall.function?.arguments || '',
+                    {
+                      id: toolCall.id,
+                      name: toolCall.function?.name,
+                    },
+                  );
+                })
+                .filter(
+                  (
+                    toolCall,
+                  ): toolCall is ReturnType<
+                    typeof createSerializableToolCallArgumentDelta
+                  > => toolCall !== null,
+                );
+
+              if (toolCalls.length > 0) {
+                yield serializeToolCallArgumentDeltas(toolCalls);
+              }
+            } else if (delta?.content) {
+              yield JSON.stringify({
+                content: delta.content || '',
+              });
+            }
           }
-        } else if (delta?.content) {
-          yield JSON.stringify({
-            content: delta.content || '',
-          });
-        }
-      }
+        })(this),
+      );
     } catch (error) {
       this.handleStreamingError(error, { messages, options, config });
     }
@@ -527,6 +524,7 @@ export class OpenAIService extends BaseAIService<
       modelName?: string;
       samplingOptions?: SamplingOptions;
       config?: AIServiceConfig;
+      signal?: AbortSignal;
     },
   ): Promise<SamplingResponse> {
     const config = this.mergeConfig(options);
@@ -565,14 +563,16 @@ export class OpenAIService extends BaseAIService<
       request,
     });
 
-    const abortSignal = this.getAbortSignal();
-    const response = await this.withRetry(() =>
-      this.openai.chat.completions.create(request, {
-        signal: abortSignal,
-        headers: {
-          'x-libragent-request-id': requestId,
-        },
-      }),
+    const abortSignal = options?.signal;
+    const response = await this.withRetry(
+      () =>
+        this.openai.chat.completions.create(request, {
+          signal: abortSignal,
+          headers: {
+            'x-libragent-request-id': requestId,
+          },
+        }),
+      abortSignal,
     );
 
     if (response.usage) {

--- a/src/lib/ai-service/service-contracts.ts
+++ b/src/lib/ai-service/service-contracts.ts
@@ -14,12 +14,14 @@ export interface AIStreamChatOptions {
   config?: AIServiceConfig;
   forceToolUse?: boolean;
   disableToolUse?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface AISampleTextOptions {
   modelName?: string;
   samplingOptions?: SamplingOptions;
   config?: AIServiceConfig;
+  signal?: AbortSignal;
 }
 
 export interface AICompactOptions {
@@ -28,6 +30,7 @@ export interface AICompactOptions {
   systemPrompt?: string;
   sessionContext?: string;
   availableTools?: MCPTool[];
+  signal?: AbortSignal;
 }
 
 export interface AIStreamingService {

--- a/src/lib/backend/mcp-server-config.ts
+++ b/src/lib/backend/mcp-server-config.ts
@@ -176,6 +176,7 @@ export async function getMCPServer(
 
 export interface MCPServerPreset {
   name: string;
+  category?: string;
   description?: string;
   logo?: string;
   transportType: 'stdio' | 'sse';

--- a/src/lib/mcp/config/server-config.ts
+++ b/src/lib/mcp/config/server-config.ts
@@ -9,6 +9,7 @@ import type { TransportConfig, OAuthConfig } from './transport';
  * Server metadata (optional descriptive information)
  */
 export interface ServerMetadata {
+  category?: string;
   description?: string;
   logo?: string;
   vendor?: string;


### PR DESCRIPTION
## Summary
- add MCP preset category metadata and a category-aware recommended preset browser
- refactor LLM execution to use request-scoped cancellation without mutating or disposing shared cached services
- preserve Anthropic prompt cache while disabling tool use, and clean up Gemini/TTFT/Ollama follow-up issues

## Scope
- preset categories end-to-end (data, backend DTOs, persisted metadata, frontend grouping/filtering)
- request-scoped cancel plumbing across providers and LLM execution contexts
- provider follow-ups for Anthropic, Gemini, EmptyAIService, TTFT reuse, and Ollama abort listener cleanup