### PR TITLE
🎨 Palette: Add tooltips to image content renderer buttons

### DIFF
--- a/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Check, Copy, Download } from 'lucide-react';
 import { toast } from 'sonner';
 import { useRustBackend } from '@/hooks/use-rust-backend';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui';
 import { getLogger } from '@/lib/logger';
 import { useResolvedMediaSource } from '../hooks/useResolvedMediaSource';
 
@@ -193,33 +194,46 @@ export function ImageContentRenderer({
   return (
     <div className="group relative inline-block max-w-full">
       <div className="absolute top-2 right-2 z-10 flex items-center gap-1 rounded-md border border-border bg-background/80 p-1 opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-        <button
-          type="button"
-          onClick={handleCopy}
-          disabled={!canCopyImage}
-          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          title={
-            canCopyImage
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0} className="flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <button
+                type="button"
+                onClick={handleCopy}
+                disabled={!canCopyImage}
+                className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 w-full h-full"
+                aria-label="Copy image to clipboard"
+              >
+                {copied ? (
+                  <Check size={16} className="text-emerald-500" />
+                ) : (
+                  <Copy size={16} />
+                )}
+              </button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {canCopyImage
               ? 'Copy Image'
-              : 'Image clipboard is not supported in this environment'
-          }
-          aria-label="Copy image to clipboard"
-        >
-          {copied ? (
-            <Check size={16} className="text-emerald-500" />
-          ) : (
-            <Copy size={16} />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={handleDownload}
-          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          title="Download Image"
-          aria-label="Download image"
-        >
-          <Download size={16} />
-        </button>
+              : 'Image clipboard is not supported in this environment'}
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Download image"
+            >
+              <Download size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Download Image
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       <img

--- a/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
@@ -127,6 +127,8 @@ export function ImageContentRenderer({
   );
   const [copied, setCopied] = useState(false);
   const canCopyImage = canWriteImagesToClipboard();
+  const copyButtonClassName =
+    'flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
   if (!imageSrc) {
     return loadError ? (
@@ -191,27 +193,41 @@ export function ImageContentRenderer({
     }
   };
 
+  const copyButton = (
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={!canCopyImage}
+      className={copyButtonClassName}
+      aria-label="Copy image to clipboard"
+    >
+      {copied ? (
+        <Check size={16} className="text-emerald-500" />
+      ) : (
+        <Copy size={16} />
+      )}
+    </button>
+  );
+
   return (
     <div className="group relative inline-block max-w-full">
       <div className="absolute top-2 right-2 z-10 flex items-center gap-1 rounded-md border border-border bg-background/80 p-1 opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span tabIndex={0} className="flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-              <button
-                type="button"
-                onClick={handleCopy}
-                disabled={!canCopyImage}
-                className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 w-full h-full"
+          {canCopyImage ? (
+            <TooltipTrigger asChild>{copyButton}</TooltipTrigger>
+          ) : (
+            <TooltipTrigger asChild>
+              <span
+                tabIndex={0}
+                role="button"
                 aria-label="Copy image to clipboard"
+                aria-disabled="true"
+                className="flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                {copied ? (
-                  <Check size={16} className="text-emerald-500" />
-                ) : (
-                  <Copy size={16} />
-                )}
-              </button>
-            </span>
-          </TooltipTrigger>
+                {copyButton}
+              </span>
+            </TooltipTrigger>
+          )}
           <TooltipContent>
             {canCopyImage
               ? 'Copy Image'
@@ -230,9 +246,7 @@ export function ImageContentRenderer({
               <Download size={16} />
             </button>
           </TooltipTrigger>
-          <TooltipContent>
-            Download Image
-          </TooltipContent>
+          <TooltipContent>Download Image</TooltipContent>
         </Tooltip>
       </div>
 


### PR DESCRIPTION
💡 **What**: Wrapped the icon-only Copy and Download buttons in the image content renderer with Radix UI Tooltip components.
🎯 **Why**: Enhances UX by providing explicit text context for the buttons instead of relying on the native title attribute, improving accessibility and consistency across the app.
📸 **Before/After**: N/A
♿ **Accessibility**: The tooltips make the purpose of the buttons explicit for keyboard focus events, as the native title attribute often fails on focus.

---
*PR created automatically by Jules for task [15810172928522348375](https://jules.google.com/task/15810172928522348375) started by @fritzprix*