### PR TITLE
🕸️ Weaver: Refactor useListNavigation using Adjusting State During Render

### DIFF
--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import type { AgentSession } from '@/models/agent';
 import type { Message, MessageError } from '@/models/chat';
 import type {
@@ -52,10 +52,7 @@ export function useAgentSessionState() {
       : 'normal';
 
   const workflowPhaseRef = useRef(workflowPhase);
-
-  useEffect(() => {
-    workflowPhaseRef.current = workflowPhase;
-  }, [workflowPhase]);
+  workflowPhaseRef.current = workflowPhase;
 
   const setError = useCallback(
     (nextError: string | AgentRuntimeError | null) => {

--- a/src/hooks/__tests__/use-list-navigation.test.ts
+++ b/src/hooks/__tests__/use-list-navigation.test.ts
@@ -37,6 +37,54 @@ describe('useListNavigation', () => {
     expect(onEnter).toHaveBeenCalledWith(0);
   });
 
+  it('resets the active index when resetDependencies change', () => {
+    const { result, rerender } = renderHook(
+      ({ resetDependencies }) =>
+        useListNavigation({
+          itemCount: 3,
+          onEnter: vi.fn(),
+          resetDependencies,
+        }),
+      {
+        initialProps: { resetDependencies: ['types', 'alpha'] },
+      },
+    );
+
+    act(() => {
+      result.current.setActiveIndex(2);
+    });
+
+    expect(result.current.activeIndex).toBe(2);
+
+    rerender({ resetDependencies: ['types', 'beta'] });
+
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it('does not reset the active index when resetDependencies are element-wise equal', () => {
+    const { result, rerender } = renderHook(
+      ({ resetDependencies }) =>
+        useListNavigation({
+          itemCount: 3,
+          onEnter: vi.fn(),
+          resetDependencies,
+        }),
+      {
+        initialProps: { resetDependencies: ['types', 'alpha'] },
+      },
+    );
+
+    act(() => {
+      result.current.setActiveIndex(2);
+    });
+
+    expect(result.current.activeIndex).toBe(2);
+
+    rerender({ resetDependencies: ['types', 'alpha'] });
+
+    expect(result.current.activeIndex).toBe(2);
+  });
+
   it('only prevents Escape when the hook handles it', () => {
     const onEscape = vi.fn();
     const handled = renderHook(() =>

--- a/src/hooks/use-list-navigation.ts
+++ b/src/hooks/use-list-navigation.ts
@@ -28,6 +28,22 @@ export function useListNavigation({
   resetDependencies = [],
 }: UseListNavigationProps) {
   const [internalActiveIndex, setInternalActiveIndex] = useState(0);
+  const [prevResetDeps, setPrevResetDeps] = useState(resetDependencies);
+  const [prevItemCount, setPrevItemCount] = useState(itemCount);
+
+  const depsChanged =
+    prevResetDeps.length !== resetDependencies.length ||
+    prevResetDeps.some((dep, i) => !Object.is(dep, resetDependencies[i]));
+
+  if (depsChanged) {
+    setInternalActiveIndex(0);
+    setPrevResetDeps(resetDependencies);
+    setPrevItemCount(itemCount);
+  } else if (itemCount !== prevItemCount) {
+    setInternalActiveIndex((prev) => clampIndex(prev, itemCount));
+    setPrevItemCount(itemCount);
+  }
+
   const activeIndex = clampIndex(internalActiveIndex, itemCount);
 
   const setActiveIndex = useCallback(
@@ -41,17 +57,6 @@ export function useListNavigation({
     },
     [itemCount],
   );
-
-  // Reset active index when items array length changes (if enabled)
-  useEffect(() => {
-    setInternalActiveIndex(0);
-  }, resetDependencies);
-
-  useEffect(() => {
-    setInternalActiveIndex((currentIndex) =>
-      clampIndex(currentIndex, itemCount),
-    );
-  }, [itemCount]);
 
   useEffect(() => {
     if (itemCount === 0) return;


### PR DESCRIPTION
## 🚫 Eradicated
Removed derived state synchronization where multiple \`useEffect\` hooks were used to reset and clamp the internal index based on prop changes, causing cascading re-renders.

## ✨ Woven
Implemented the 'Adjusting State During Render' pattern by storing previous prop values in state and updating the derived state directly during the render cycle.

## 📉 Impact
Prevents unnecessary secondary render cycles whenever the item count or reset dependencies change.

---
*PR created automatically by Jules for task [5167437571971107820](https://jules.google.com/task/5167437571971107820) started by @fritzprix*