### PR TITLE
Fix agent tool contract gaps

### DIFF
--- a/src-tauri/src/agent/llm/prompt.rs
+++ b/src-tauri/src/agent/llm/prompt.rs
@@ -226,6 +226,17 @@ fn build_stable_prefix(
         parts.push(agent_config.system_prompt.clone());
     }
 
+    if agent_config.id.is_some() || !agent_config.name.trim().is_empty() {
+        let agent_id = agent_config.id.as_deref().unwrap_or("(unknown)");
+        parts.push(format!(
+            "\n\n## Agent Runtime Identity\n\
+            - Agent Name: {}\n\
+            - Agent ID: {}",
+            agent_config.name.trim(),
+            agent_id
+        ));
+    }
+
     // 2. Persona / Voice Template — injected from SOUL.md and kept distinct from
     //    workspace instructions because it defines character, not task guidance.
     if let Some((filename, content)) = &soul_instruction {

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -58,6 +58,44 @@ pub fn runtime_allowed_builtin_service_aliases(
         .collect()
 }
 
+/// Derive the runtime-enabled builtin aliases directly from a stored config JSON value.
+///
+/// This preserves the runtime contract even when legacy or partially invalid config payloads
+/// fail full `AgentConfig` deserialization. Explicit builtin lists remain explicit; they do not
+/// silently fall back to "all optional builtins enabled".
+pub fn runtime_allowed_builtin_service_aliases_from_value(config: &Value) -> Vec<String> {
+    if let Ok(agent_config) = serde_json::from_value::<crate::agent::AgentConfig>(config.clone()) {
+        return runtime_allowed_builtin_service_aliases(&agent_config);
+    }
+
+    let mut allowed: HashSet<String> = CORE_BUILTIN_SERVICE_ALIASES
+        .iter()
+        .map(|alias| alias.to_string())
+        .collect();
+
+    match config.get("allowedBuiltInServiceAliases") {
+        Some(Value::Array(configured_aliases)) => {
+            for alias in configured_aliases.iter().filter_map(Value::as_str) {
+                if let Some(canonical_alias) = canonicalize_builtin_service_alias(alias) {
+                    allowed.insert(canonical_alias.to_string());
+                }
+            }
+        }
+        Some(_) => {}
+        None => {
+            for entry in BUILTIN_SERVICE_REGISTRY.iter().filter(|e| e.optional) {
+                allowed.insert(entry.canonical.to_string());
+            }
+        }
+    }
+
+    BUILTIN_SERVICE_REGISTRY
+        .iter()
+        .filter(|entry| allowed.contains(entry.canonical))
+        .map(|entry| entry.canonical.to_string())
+        .collect()
+}
+
 pub fn is_builtin_service_alias_enabled(
     agent_config: &crate::agent::AgentConfig,
     alias: &str,

--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -1,11 +1,11 @@
 use serde_json::{json, Value};
 use std::sync::Arc;
 
+use crate::agent::tools::runtime_allowed_builtin_service_aliases_from_value;
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::builtin::session_api::utils::build_agent_tool_data;
 use crate::mcp::types::MCPResult;
 use crate::repositories::mcp_server_repository::MCPServerRepository;
-use crate::{agent::tools::runtime_allowed_builtin_service_aliases, agent::AgentConfig};
 
 use super::super::formatting::{
     build_server_name_lookup, extract_string_list, format_capability_list,
@@ -155,14 +155,12 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
 
     for agent in paged_agents {
         let config: Value = serde_json::from_str(&agent.config).unwrap_or_default();
-        let parsed_agent_config = serde_json::from_value::<AgentConfig>(config.clone())
-            .unwrap_or_else(|_| AgentConfig::default());
         let desc = config
             .get("description")
             .and_then(|v| v.as_str())
             .unwrap_or("No description");
         let builtins = extract_string_list(config.get("allowedBuiltInServiceAliases"));
-        let effective_builtins = runtime_allowed_builtin_service_aliases(&parsed_agent_config);
+        let effective_builtins = runtime_allowed_builtin_service_aliases_from_value(&config);
         let external_ids = extract_string_list(config.get("mcpServerIds"));
         let external_labels = resolve_external_server_labels(&external_ids, &server_name_lookup);
 

--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -5,6 +5,7 @@ use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHi
 use crate::mcp::builtin::session_api::utils::build_agent_tool_data;
 use crate::mcp::types::MCPResult;
 use crate::repositories::mcp_server_repository::MCPServerRepository;
+use crate::{agent::tools::runtime_allowed_builtin_service_aliases, agent::AgentConfig};
 
 use super::super::formatting::{
     build_server_name_lookup, extract_string_list, format_capability_list,
@@ -128,6 +129,10 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
 
     let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
     let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let verbose = args
+        .get("verbose")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
 
     let total = agents.len();
     let paged_agents: Vec<_> = agents.into_iter().skip(offset).take(limit).collect();
@@ -137,6 +142,7 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
 
     let mut results = Vec::new();
     let mut text_summary = format!("Found {} agent configurations.\n\n", total);
+    let mut any_truncated = false;
     if !paged_agents.is_empty() {
         text_summary.push_str("| Name | ID | Capabilities | Servers | Description |\n");
         text_summary.push_str("|---|---|---|---|---|\n");
@@ -149,22 +155,26 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
 
     for agent in paged_agents {
         let config: Value = serde_json::from_str(&agent.config).unwrap_or_default();
+        let parsed_agent_config = serde_json::from_value::<AgentConfig>(config.clone())
+            .unwrap_or_else(|_| AgentConfig::default());
         let desc = config
             .get("description")
             .and_then(|v| v.as_str())
             .unwrap_or("No description");
         let builtins = extract_string_list(config.get("allowedBuiltInServiceAliases"));
+        let effective_builtins = runtime_allowed_builtin_service_aliases(&parsed_agent_config);
         let external_ids = extract_string_list(config.get("mcpServerIds"));
         let external_labels = resolve_external_server_labels(&external_ids, &server_name_lookup);
 
         let desc_clean = desc.replace('|', "\\|").replace('\n', " ");
-        let desc_trunc = if desc_clean.chars().count() > 100 {
+        let desc_trunc = if !verbose && desc_clean.chars().count() > 100 {
+            any_truncated = true;
             format!("{}...", desc_clean.chars().take(97).collect::<String>())
         } else {
             desc_clean
         };
         let name_clean = agent.name.replace('|', "\\|").replace('\n', " ");
-        let capabilities = format_capability_list(&builtins)
+        let capabilities = format_capability_list(&effective_builtins)
             .replace('|', "\\|")
             .replace('\n', " ");
         let servers = format_external_server_refs(&external_ids, &server_name_lookup)
@@ -180,16 +190,21 @@ async fn list_agent_configs(server: &AgentServer, args: &Value) -> Result<MCPRes
             "id": agent.id,
             "name": agent.name,
             "description": desc,
-            "builtinCapabilities": builtins,
+            "configuredBuiltinCapabilities": builtins,
+            "builtinCapabilities": effective_builtins.clone(),
+            "effectiveBuiltinCapabilities": effective_builtins,
             "externalMcpServers": external_ids,
             "externalMcpServerLabels": external_labels
         }));
     }
 
-    let hint = SuccessHint::new(
-        text_summary,
-        vec!["Use startSession(agentId=\"...\") to delegate work".to_string()],
-    );
+    let mut hint_lines = vec!["Use startSession(agentId=\"...\") to delegate work".to_string()];
+    if any_truncated {
+        hint_lines.push(
+            "Use list(type=\"configs\", verbose=true) to show full descriptions.".to_string(),
+        );
+    }
+    let hint = SuccessHint::new(text_summary, hint_lines);
     let response_message = hint.message.clone();
     let mut response_data = build_agent_tool_data(
         "list",

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -220,6 +220,14 @@ pub async fn message_to_session(
         .ok_or("AgentSessionManager not available")?;
     let session_id = read_required_string(&args, "sessionId")?;
     let message_text = read_required_string(&args, "message")?;
+    let wait_for_response = args
+        .get("waitForResponse")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let timeout_seconds = args
+        .get("timeout")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(3600);
     if let Err(result) = load_accessible_delegated_session(
         manager,
         caller_session_id,
@@ -244,6 +252,19 @@ pub async fn message_to_session(
         }
         Err(err) => return Err(err),
     };
+
+    if wait_for_response {
+        return check_session(
+            server,
+            json!({
+                "sessionId": session_id,
+                "wait": true,
+                "timeout": timeout_seconds
+            }),
+            caller_session_id,
+        )
+        .await;
+    }
 
     let hint = SuccessHint::new(
         format!("Message {} for session {}.", response.status, session_id),
@@ -290,11 +311,38 @@ pub async fn stop_session(
         ));
     }
 
-    if let Err(result) =
-        load_accessible_delegated_session(manager, caller_session_id, &session_id, "stopSession")
-            .await
+    let target_session = match load_accessible_delegated_session(
+        manager,
+        caller_session_id,
+        &session_id,
+        "stopSession",
+    )
+    .await
     {
-        return Ok(result);
+        Ok(session) => session,
+        Err(result) => return Ok(result),
+    };
+
+    if target_session.status != SessionStatus::Busy {
+        let current_status = target_session.status.as_str().to_string();
+        let message = format!(
+            "Session {} was already {}. No action taken.",
+            session_id, current_status
+        );
+        let mut response_data = build_agent_tool_data(
+            "stopSession",
+            "session",
+            Some(&session_id),
+            &message,
+            "noop",
+            vec![],
+        );
+        response_data.insert("sessionId".to_string(), Value::String(session_id));
+        response_data.insert("stopped".to_string(), Value::Bool(false));
+        response_data.insert("status".to_string(), Value::String(current_status));
+
+        return Ok(SuccessHint::new(message, vec![])
+            .to_mcp_result_with_data(Some(Value::Object(response_data))));
     }
 
     if let Err(error) = manager.terminate_session(session_id.clone()).await {

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -224,10 +224,24 @@ pub async fn message_to_session(
         .get("waitForResponse")
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
-    let timeout_seconds = args
-        .get("timeout")
-        .and_then(|value| value.as_u64())
-        .unwrap_or(3600);
+    let timeout_seconds = match args.get("timeout") {
+        None => 3600,
+        Some(value) => match value.as_u64() {
+            Some(timeout) if (1..=3600).contains(&timeout) => timeout,
+            _ => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    "timeout must be an integer between 1 and 3600 seconds".to_string(),
+                    ToolGroup::Agent,
+                )
+                .with_guidance(vec![
+                    "Omit timeout to use the default 3600-second wait window".to_string(),
+                    "Use a value between 1 and 3600 when waitForResponse=true".to_string(),
+                ])
+                .to_mcp_result());
+            }
+        },
+    };
     if let Err(result) = load_accessible_delegated_session(
         manager,
         caller_session_id,

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -30,7 +30,7 @@ fn create_tool() -> MCPTool {
                 ("description".to_string(), string_prop(None, None, Some("Short description of what this agent does. If omitted, the configuration is created without a description."))),
                 ("systemPrompt".to_string(), string_prop(None, None, Some("The core personality and instructions for the agent. If omitted, no custom system prompt is stored."))),
                 ("temperature".to_string(), number_prop(Some(0.0), Some(2.0), Some("Sampling temperature (0.0 to 2.0). If omitted, the configuration leaves temperature unset and the runtime/model default applies."))),
-                ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("List of builtin service aliases to allow (e.g. ['workspace', 'browser', 'planning']). If omitted, the configuration leaves builtin capability overrides unset."))),
+                ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("List of optional builtin service aliases to add beyond the always-on core services (e.g. ['browser', 'knowledge']). Core services remain enabled even when you pass a restricted list. If omitted, all optional builtin services stay enabled."))),
                 ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("List of external MCP server IDs to allow (e.g. ['github', 'google-search']). If omitted, the configuration leaves external MCP server overrides unset."))),
             ],
             vec!["name".to_string()],
@@ -57,6 +57,11 @@ fn list_tool() -> MCPTool {
                     ),
                 ),
                 ("query".to_string(), string_prop(None, None, Some("Search term to filter agent configurations by name or description. If omitted, no text filtering is applied."))),
+                ("verbose".to_string(), {
+                    let mut schema = boolean_prop(Some("If true, show full descriptions instead of truncating them in the text table."));
+                    schema.default = Some(json!(false));
+                    schema
+                }),
                 (
                     "limit".to_string(),
                     integer_prop_with_default(
@@ -111,7 +116,7 @@ fn update_tool() -> MCPTool {
                     "temperature".to_string(),
                     number_prop(Some(0.0), Some(2.0), Some("Change temperature. If omitted, keep the current temperature unchanged.")),
                 ),
-                ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("Replace the allowed builtin service aliases. If omitted, keep the current builtin capability list unchanged."))),
+                ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("Replace the optional builtin service aliases that are added on top of the always-on core services. If omitted, keep the current optional builtin capability list unchanged."))),
                 ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("Replace the allowed external MCP server IDs. If omitted, keep the current external MCP server list unchanged."))),
             ],
             vec!["id".to_string()],
@@ -203,7 +208,7 @@ fn message_to_session_tool() -> MCPTool {
         name: "messageToSession".to_string(),
         title: Some("Message Agent Session".to_string()),
         description:
-            "Send a follow-up message or additional instructions to an existing sub-agent session to continue the conversation. This can also be used to explicitly wake paused or error sessions and retry the delegated workflow from the latest stable state."
+            "Send a follow-up message or additional instructions to an existing sub-agent session to continue the conversation. This can also be used to explicitly wake paused or error sessions and retry the delegated workflow from the latest stable state. Returns immediately unless waitForResponse=true."
                 .to_string(),
         input_schema: object_prop(
             vec![
@@ -214,6 +219,23 @@ fn message_to_session_tool() -> MCPTool {
                 (
                     "message".to_string(),
                     string_prop_required("The message or instruction to send."),
+                ),
+                (
+                    "waitForResponse".to_string(),
+                    {
+                        let mut schema = boolean_prop(Some("If true, block until the child reaches a terminal response after receiving this message."));
+                        schema.default = Some(json!(false));
+                        schema
+                    },
+                ),
+                (
+                    "timeout".to_string(),
+                    integer_prop_with_default(
+                        Some(1),
+                        Some(3600),
+                        3600,
+                        Some("Maximum seconds to wait when waitForResponse is true. Ignored otherwise."),
+                    ),
                 ),
             ],
             vec!["sessionId".to_string(), "message".to_string()],
@@ -259,7 +281,7 @@ fn stop_session_tool() -> MCPTool {
     MCPTool {
         name: "stopSession".to_string(),
         title: Some("Stop Agent Session".to_string()),
-        description: "Forcefully terminate an active sub-agent session. Use this when a delegated task is no longer needed or if the sub-agent appears stuck. This immediately halts execution.".to_string(),
+        description: "Forcefully terminate an active sub-agent session. Use this when a delegated task is no longer needed or if the sub-agent appears stuck. If the session is already non-running, the tool reports that no action was needed.".to_string(),
         input_schema: object_prop(
             vec![
                 ("sessionId".to_string(), string_prop_required("ID of the session to stop.")),

--- a/src-tauri/src/mcp/builtin/assistant/operations.rs
+++ b/src-tauri/src/mcp/builtin/assistant/operations.rs
@@ -11,6 +11,82 @@ use serde_json::{json, Value};
 
 use super::AssistantServer;
 
+fn extract_string_array(config: &Value, key: &str) -> Vec<String> {
+    config
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn format_summary_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn build_agent_config_response_data(id: &str, name: &str, config: &Value) -> Value {
+    let parsed_config = serde_json::from_value::<crate::agent::AgentConfig>(config.clone())
+        .unwrap_or_else(|_| crate::agent::AgentConfig::default());
+    let configured_builtin_capabilities =
+        extract_string_array(config, "allowedBuiltInServiceAliases");
+    let effective_builtin_capabilities =
+        crate::agent::tools::runtime_allowed_builtin_service_aliases(&parsed_config);
+    let external_mcp_servers = extract_string_array(config, "mcpServerIds");
+
+    json!({
+        "success": true,
+        "id": id,
+        "name": name,
+        "description": config.get("description").and_then(Value::as_str),
+        "systemPrompt": config.get("systemPrompt").and_then(Value::as_str),
+        "temperature": config.get("temperature").and_then(Value::as_f64),
+        "builtinCapabilities": effective_builtin_capabilities.clone(),
+        "configuredBuiltinCapabilities": configured_builtin_capabilities.clone(),
+        "effectiveBuiltinCapabilities": effective_builtin_capabilities,
+        "externalMcpServers": external_mcp_servers.clone(),
+        "mcpServerIds": external_mcp_servers,
+    })
+}
+
+fn build_agent_config_echo_message(action: &str, name: &str, id: &str, config: &Value) -> String {
+    let configured_builtin_capabilities =
+        extract_string_array(config, "allowedBuiltInServiceAliases");
+    let parsed_config = serde_json::from_value::<crate::agent::AgentConfig>(config.clone())
+        .unwrap_or_else(|_| crate::agent::AgentConfig::default());
+    let effective_builtin_capabilities =
+        crate::agent::tools::runtime_allowed_builtin_service_aliases(&parsed_config);
+    let external_mcp_servers = extract_string_array(config, "mcpServerIds");
+    let description = config
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("none");
+    let temperature = config
+        .get("temperature")
+        .and_then(Value::as_f64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "provider default".to_string());
+
+    format!(
+        "Agent configuration '{}' {} (ID: {})\n\nDescription: {}\nTemperature: {}\nConfigured builtin capabilities: {}\nEffective builtin capabilities: {}\nExternal MCP servers: {}",
+        name,
+        action,
+        id,
+        description,
+        temperature,
+        format_summary_list(&configured_builtin_capabilities),
+        format_summary_list(&effective_builtin_capabilities),
+        format_summary_list(&external_mcp_servers),
+    )
+}
+
 /// Request structure for creating an assistant
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -179,7 +255,7 @@ pub async fn create_assistant(server: &AssistantServer, args: Value) -> Result<M
         };
 
     // Always auto-generate ID
-    let id = cuid2::create_id();
+    let id = uuid::Uuid::new_v4().to_string();
 
     // Use repository from server's db connection instead of global state
     let repo = crate::repositories::SqliteAssistantRepository::new(server.get_db().clone());
@@ -245,10 +321,7 @@ pub async fn create_assistant(server: &AssistantServer, args: Value) -> Result<M
     {
         Ok(_) => {
             let hint = SuccessHint::new(
-                format!(
-                    "Agent configuration '{}' created successfully (ID: {})",
-                    normalized_name, id
-                ),
+                build_agent_config_echo_message("created successfully", &normalized_name, &id, &config),
                 vec![
                     "List agent configurations to review the new configuration".to_string(),
                     "Update the configuration if you want to refine its prompt, temperature, or capabilities"
@@ -265,11 +338,13 @@ pub async fn create_assistant(server: &AssistantServer, args: Value) -> Result<M
                 Some(id.clone()),
             );
 
-            Ok(hint.to_mcp_result_with_data(Some(json!({
-                "success": true,
-                "id": id,
-                "name": normalized_name
-            }))))
+            Ok(
+                hint.to_mcp_result_with_data(Some(build_agent_config_response_data(
+                    &id,
+                    &normalized_name,
+                    &config,
+                ))),
+            )
         }
         Err(e) => Ok(guided_error(
             ErrorCategory::DatabaseError,
@@ -408,7 +483,12 @@ pub async fn update_assistant(
     match result {
         Ok(_) => {
             let hint = SuccessHint::new(
-                format!("Agent configuration '{}' updated successfully", request.id),
+                build_agent_config_echo_message(
+                    "updated successfully",
+                    &name,
+                    &request.id,
+                    &config,
+                ),
                 vec![
                     "Inspect the configuration details to verify the changes".to_string(),
                     "Start a new delegated session to apply the updated configuration".to_string(),
@@ -424,12 +504,13 @@ pub async fn update_assistant(
                 Some(request.id.clone()),
             );
 
-            Ok(hint.to_mcp_result_with_data(Some(json!({
-                "success": true,
-                "id": request.id,
-                "name": name,
-                "config": config
-            }))))
+            Ok(
+                hint.to_mcp_result_with_data(Some(build_agent_config_response_data(
+                    &request.id,
+                    &name,
+                    &config,
+                ))),
+            )
         }
         Err(e) => Ok(guided_error(
             ErrorCategory::DatabaseError,

--- a/src-tauri/src/mcp/builtin/assistant/operations.rs
+++ b/src-tauri/src/mcp/builtin/assistant/operations.rs
@@ -33,12 +33,10 @@ fn format_summary_list(values: &[String]) -> String {
 }
 
 fn build_agent_config_response_data(id: &str, name: &str, config: &Value) -> Value {
-    let parsed_config = serde_json::from_value::<crate::agent::AgentConfig>(config.clone())
-        .unwrap_or_else(|_| crate::agent::AgentConfig::default());
     let configured_builtin_capabilities =
         extract_string_array(config, "allowedBuiltInServiceAliases");
     let effective_builtin_capabilities =
-        crate::agent::tools::runtime_allowed_builtin_service_aliases(&parsed_config);
+        crate::agent::tools::runtime_allowed_builtin_service_aliases_from_value(config);
     let external_mcp_servers = extract_string_array(config, "mcpServerIds");
 
     json!({
@@ -59,10 +57,8 @@ fn build_agent_config_response_data(id: &str, name: &str, config: &Value) -> Val
 fn build_agent_config_echo_message(action: &str, name: &str, id: &str, config: &Value) -> String {
     let configured_builtin_capabilities =
         extract_string_array(config, "allowedBuiltInServiceAliases");
-    let parsed_config = serde_json::from_value::<crate::agent::AgentConfig>(config.clone())
-        .unwrap_or_else(|_| crate::agent::AgentConfig::default());
     let effective_builtin_capabilities =
-        crate::agent::tools::runtime_allowed_builtin_service_aliases(&parsed_config);
+        crate::agent::tools::runtime_allowed_builtin_service_aliases_from_value(config);
     let external_mcp_servers = extract_string_array(config, "mcpServerIds");
     let description = config
         .get("description")

--- a/src-tauri/src/services/assistant_service.rs
+++ b/src-tauri/src/services/assistant_service.rs
@@ -157,7 +157,7 @@ impl AssistantService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::assistant::Model as AssistantModel;
+    use crate::entity::assistant::Model as AssistantModel;
     use crate::repositories::{AssistantRepository, DbError};
     use async_trait::async_trait;
 
@@ -191,6 +191,19 @@ mod tests {
         }
         async fn list_assistants(&self) -> Result<Vec<AssistantModel>, DbError> {
             unimplemented!()
+        }
+        async fn list_assistants_paginated(
+            &self,
+            limit: u64,
+            offset: u64,
+        ) -> Result<Vec<AssistantModel>, DbError> {
+            Ok(self
+                .assistants
+                .iter()
+                .skip(offset as usize)
+                .take(limit as usize)
+                .cloned()
+                .collect())
         }
         async fn search_assistants(&self, _query: &str) -> Result<Vec<AssistantModel>, DbError> {
             Ok(self.assistants.clone())

--- a/src-tauri/tests/agent_capability_contract_tests.rs
+++ b/src-tauri/tests/agent_capability_contract_tests.rs
@@ -1,0 +1,22 @@
+use tauri_mcp_agent_lib::agent::{tools::runtime_allowed_builtin_service_aliases, AgentConfig};
+use tauri_mcp_agent_lib::mcp::builtin::service_id::BuiltinServiceId;
+
+#[test]
+fn runtime_builtin_capabilities_keep_core_services_even_with_restricted_config() {
+    let config = AgentConfig {
+        allowed_built_in_service_aliases: Some(vec![
+            BuiltinServiceId::Workspace,
+            BuiltinServiceId::Planning,
+        ]),
+        ..AgentConfig::default()
+    };
+
+    let effective = runtime_allowed_builtin_service_aliases(&config);
+
+    assert!(effective.contains(&"planning".to_string()));
+    assert!(effective.contains(&"workspace".to_string()));
+    assert!(effective.contains(&"scratchpad".to_string()));
+    assert!(effective.contains(&"playbook".to_string()));
+    assert!(effective.contains(&"attachments".to_string()));
+    assert!(!effective.contains(&"browser".to_string()));
+}

--- a/src-tauri/tests/agent_prompt_identity_tests.rs
+++ b/src-tauri/tests/agent_prompt_identity_tests.rs
@@ -1,0 +1,20 @@
+use tauri_mcp_agent_lib::agent::llm::prompt::build_system_prompt;
+use tauri_mcp_agent_lib::agent::AgentConfig;
+
+#[tokio::test]
+async fn system_prompt_exposes_agent_runtime_identity() {
+    let config = AgentConfig {
+        id: Some("agent-123".to_string()),
+        name: "Ops Bot".to_string(),
+        system_prompt: "You are a precise operator.".to_string(),
+        ..AgentConfig::default()
+    };
+
+    let prompt = build_system_prompt(&config, None, None, None, None, Vec::new())
+        .await
+        .expect("prompt should build");
+
+    assert!(prompt.contains("## Agent Runtime Identity"));
+    assert!(prompt.contains("Agent Name: Ops Bot"));
+    assert!(prompt.contains("Agent ID: agent-123"));
+}

--- a/src-tauri/tests/builtin_service_registry_tests.rs
+++ b/src-tauri/tests/builtin_service_registry_tests.rs
@@ -7,11 +7,12 @@
 
 use std::collections::HashMap;
 
+use serde_json::json;
 use tauri_mcp_agent_lib::agent::state::PendingToolExecution;
 use tauri_mcp_agent_lib::agent::tools::{
     canonicalize_builtin_service_alias, classify_tool_result, create_error_tool_result,
     create_tool_result_message, create_tool_result_message_with_content, extract_builtin_tool_ids,
-    ToolResultAcceptance,
+    runtime_allowed_builtin_service_aliases_from_value, ToolResultAcceptance,
 };
 use tauri_mcp_agent_lib::agent::AgentConfig;
 use tauri_mcp_agent_lib::mcp::builtin::agent::tools as agent_tools;
@@ -232,6 +233,37 @@ fn extract_builtin_tool_ids_always_includes_core_aliases() {
         tool_ids.contains(&"browser".to_string()),
         "browser was explicitly requested and must be present"
     );
+}
+
+#[test]
+fn runtime_allowed_builtin_aliases_from_value_keeps_explicit_lists_explicit_on_parse_failure() {
+    let config = json!({
+        "name": "Legacy Assistant",
+        "systemPrompt": "You are helpful",
+        "allowedBuiltInServiceAliases": ["workspace", "not-a-real-service"]
+    });
+
+    let effective = runtime_allowed_builtin_service_aliases_from_value(&config);
+
+    assert!(effective.contains(&"workspace".to_string()));
+    assert!(effective.contains(&"planning".to_string()));
+    assert!(effective.contains(&"scratchpad".to_string()));
+    assert!(!effective.contains(&"browser".to_string()));
+    assert!(!effective.contains(&"knowledge".to_string()));
+}
+
+#[test]
+fn runtime_allowed_builtin_aliases_from_value_keeps_optional_defaults_when_list_is_missing() {
+    let config = json!({
+        "name": "Default Assistant",
+        "systemPrompt": "You are helpful"
+    });
+
+    let effective = runtime_allowed_builtin_service_aliases_from_value(&config);
+
+    assert!(effective.contains(&"browser".to_string()));
+    assert!(effective.contains(&"knowledge".to_string()));
+    assert!(effective.contains(&"attachments".to_string()));
 }
 
 /// Regression: tool was registered as optional:false but omitted from

--- a/src-tauri/tests/builtin_service_registry_tests.rs
+++ b/src-tauri/tests/builtin_service_registry_tests.rs
@@ -595,6 +595,38 @@ fn compact_session_context_tool_schema_is_exposed() {
 }
 
 #[test]
+fn agent_list_tool_schema_supports_verbose_descriptions() {
+    let list_tool = agent_tools::all_tools()
+        .into_iter()
+        .find(|tool| tool.name == "list")
+        .expect("list tool must exist");
+    let props = extract_object_properties(&list_tool.input_schema, "list");
+
+    assert!(
+        props.contains_key("verbose"),
+        "list input_schema must include 'verbose'"
+    );
+}
+
+#[test]
+fn message_to_session_tool_schema_supports_inline_waiting() {
+    let message_tool = agent_tools::all_tools()
+        .into_iter()
+        .find(|tool| tool.name == "messageToSession")
+        .expect("messageToSession tool must exist");
+    let props = extract_object_properties(&message_tool.input_schema, "messageToSession");
+
+    assert!(
+        props.contains_key("waitForResponse"),
+        "messageToSession input_schema must include 'waitForResponse'"
+    );
+    assert!(
+        props.contains_key("timeout"),
+        "messageToSession input_schema must include 'timeout'"
+    );
+}
+
+#[test]
 fn tool_transport_schema_allows_env_and_header_maps() {
     let register_tool = tool_tools::register_server_tool();
     let props = extract_object_properties(&register_tool.input_schema, "register");


### PR DESCRIPTION
## Summary
- align agent tool schemas and responses with actual builtin capability behavior
- add config echo-back, prompt-visible runtime identity, and inline wait support for messageToSession
- improve list/stopSession UX and fix assistant_service test mock drift

## Validation
- pnpm refactor:validate
- cargo test --test builtin_service_registry_tests --test check_session_terminal_result_tests --test agent_capability_contract_tests --test agent_prompt_identity_tests --manifest-path src-tauri/Cargo.toml
- cargo test --lib --manifest-path src-tauri/Cargo.toml *(targeted mock issue resolved; unrelated pre-existing lib test failures remain)*