### PR TITLE
Remove max execution timeout config

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -14,7 +14,6 @@
 /// # Available Environment Variables
 /// - `LIBRAGENT_MAX_FILE_SIZE`: Maximum file size in bytes (default: 104857600 = 100MB)
 /// - `LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT`: Default command timeout in seconds (default: 30)
-/// - `LIBRAGENT_MAX_EXECUTION_TIMEOUT`: Maximum command timeout in seconds (default: 300)
 /// - `LIBRAGENT_MAX_OUTPUT_SIZE`: Maximum process output size in bytes (default: 104857600 = 100MB)
 /// - `LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT`: Graceful shutdown timeout in seconds (default: 3)
 /// - `LIBRAGENT_POLL_THRESHOLD`: Excessive polling detection threshold (default: 5 consecutive polls)
@@ -29,9 +28,6 @@ const DEFAULT_MAX_FILE_SIZE: usize = 100 * 1024 * 1024;
 
 /// Default execution timeout (30 seconds)
 const DEFAULT_EXECUTION_TIMEOUT: u64 = 30;
-
-/// Default maximum execution timeout (5 minutes)
-const DEFAULT_MAX_EXECUTION_TIMEOUT: u64 = 300;
 
 /// Default snippet length for message index (200 characters)
 const DEFAULT_SNIPPET_LENGTH: usize = 200;
@@ -110,36 +106,6 @@ pub fn default_execution_timeout() -> u64 {
             );
             DEFAULT_EXECUTION_TIMEOUT
         })
-}
-
-/// Get maximum execution timeout from environment or use default
-///
-/// Environment variable: LIBRAGENT_MAX_EXECUTION_TIMEOUT
-/// Default: 300 seconds (5 minutes)
-pub fn max_execution_timeout() -> u64 {
-    let max_timeout = env::var("LIBRAGENT_MAX_EXECUTION_TIMEOUT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or_else(|| {
-            tracing::debug!(
-                "Using default max execution timeout: {} seconds",
-                DEFAULT_MAX_EXECUTION_TIMEOUT
-            );
-            DEFAULT_MAX_EXECUTION_TIMEOUT
-        });
-
-    // Ensure max timeout is at least as large as default timeout
-    let default_timeout = default_execution_timeout();
-    if max_timeout < default_timeout {
-        tracing::warn!(
-            "Max execution timeout ({}) is less than default timeout ({}). Using default as max.",
-            max_timeout,
-            default_timeout
-        );
-        default_timeout
-    } else {
-        max_timeout
-    }
 }
 
 /// Get message index snippet length from environment or use default
@@ -248,15 +214,6 @@ mod tests {
         // In a real test environment, you might want to use a library like `temp-env`
         assert_eq!(max_file_size(), DEFAULT_MAX_FILE_SIZE);
         assert_eq!(default_execution_timeout(), DEFAULT_EXECUTION_TIMEOUT);
-        assert_eq!(max_execution_timeout(), DEFAULT_MAX_EXECUTION_TIMEOUT);
         assert_eq!(message_index_snippet_length(), DEFAULT_SNIPPET_LENGTH);
-    }
-
-    #[test]
-    fn test_max_timeout_validation() {
-        // max_execution_timeout should be at least as large as default_execution_timeout
-        let max = max_execution_timeout();
-        let default = default_execution_timeout();
-        assert!(max >= default);
     }
 }

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/interactive/interactive_shell.rs
@@ -44,7 +44,10 @@ impl WorkspaceServer {
             executable_command: command.to_string(), // Will be executed (may get -S flag)
             display_command: sanitized_command.clone(), // For logs/UI
             run_mode,                                // Store for 2nd call
-            timeout: args.get("timeout").and_then(|v| v.as_u64()).unwrap_or(30), // Command execution timeout
+            timeout: args
+                .get("timeout")
+                .and_then(|v| v.as_u64())
+                .unwrap_or_else(crate::config::default_execution_timeout), // Command execution timeout
             created_at: chrono::Utc::now(),
         };
 

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
@@ -53,36 +53,6 @@ impl WorkspaceServer {
         None
     }
 
-    fn validate_sync_timeout(&self, timeout_secs: u64) -> Option<MCPResult> {
-        let sync_max = crate::config::default_execution_timeout();
-        if timeout_secs <= sync_max {
-            return None;
-        }
-
-        Some(
-            guided_error(
-                ErrorCategory::InvalidInput,
-                format!(
-                    "Timeout ({} seconds) exceeds maximum ({} seconds)",
-                    timeout_secs, sync_max
-                ),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
-                format!(
-                    "Use spawnProcess for commands longer than {} seconds",
-                    sync_max
-                ),
-                "spawnProcess runs in background and returns process_id".to_string(),
-                format!(
-                    "Current maximum timeout: {}s (LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT)",
-                    sync_max
-                ),
-            ])
-            .to_mcp_result(),
-        )
-    }
-
     pub async fn handle_execute_shell(
         &self,
         args: Value,
@@ -133,11 +103,6 @@ impl WorkspaceServer {
 
         // Sync mode: persistent shell execution
         let timeout_secs = utils::validate_timeout(args.get("timeout").and_then(|v| v.as_u64()));
-
-        // Enforce maximum sync timeout
-        if let Some(result) = self.validate_sync_timeout(timeout_secs) {
-            return Ok(result);
-        }
 
         // Execute with persistent shell (state preservation)
         self.execute_shell_persistent(raw_command, PERSISTENT_SHELL_TOOL, timeout_secs, session_id)
@@ -195,11 +160,6 @@ impl WorkspaceServer {
 
         // Get timeout (use default if not specified)
         let timeout_secs = utils::validate_timeout(args.get("timeout").and_then(|v| v.as_u64()));
-
-        // Enforce maximum sync timeout
-        if let Some(result) = self.validate_sync_timeout(timeout_secs) {
-            return Ok(result);
-        }
 
         // Execute with configured isolation level (always workspace root anchored)
         let isolation_level = utils::get_shell_isolation_level().await;

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
@@ -102,7 +102,7 @@ impl WorkspaceServer {
         }
 
         // Sync mode: persistent shell execution
-        let timeout_secs = utils::validate_timeout(args.get("timeout").and_then(|v| v.as_u64()));
+        let timeout_secs = utils::resolve_timeout(args.get("timeout").and_then(|v| v.as_u64()));
 
         // Execute with persistent shell (state preservation)
         self.execute_shell_persistent(raw_command, PERSISTENT_SHELL_TOOL, timeout_secs, session_id)
@@ -159,7 +159,7 @@ impl WorkspaceServer {
         }
 
         // Get timeout (use default if not specified)
-        let timeout_secs = utils::validate_timeout(args.get("timeout").and_then(|v| v.as_u64()));
+        let timeout_secs = utils::resolve_timeout(args.get("timeout").and_then(|v| v.as_u64()));
 
         // Execute with configured isolation level (always workspace root anchored)
         let isolation_level = utils::get_shell_isolation_level().await;

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -23,7 +23,7 @@ pub fn create_run_shell_tool() -> MCPTool {
         "timeout".to_string(),
         integer_prop_with_default(
             Some(1),
-            Some(crate::config::max_execution_timeout() as i64),
+            None,
             crate::config::default_execution_timeout() as i64,
             Some("Timeout in seconds"),
         ),
@@ -34,7 +34,7 @@ pub fn create_run_shell_tool() -> MCPTool {
         title: Some("Run Shell Command (Isolated)".to_string()),
         description: "Run a synchronous shell command (bash/sh). Stateless — each call starts fresh at workspace root.\n\
                       Use 'cd dir && command' for subdirectories.\n\
-                      For persistent cd/env vars: runInPersistentShell. For commands >30s: spawnProcess."
+                      For persistent cd/env vars: runInPersistentShell. For long-running or non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -63,7 +63,7 @@ pub fn create_execute_shell_tool() -> MCPTool {
         "timeout".to_string(),
         integer_prop_with_default(
             Some(1),
-            Some(crate::config::max_execution_timeout() as i64),
+            None,
             crate::config::default_execution_timeout() as i64,
             Some("Timeout in seconds"),
         ),
@@ -169,7 +169,7 @@ pub fn create_run_powershell_tool() -> MCPTool {
         "timeout".to_string(),
         integer_prop_with_default(
             Some(1),
-            Some(crate::config::max_execution_timeout() as i64),
+            None,
             crate::config::default_execution_timeout() as i64,
             Some("Timeout in seconds"),
         ),
@@ -212,7 +212,7 @@ pub fn create_execute_shell_tool() -> MCPTool {
         "timeout".to_string(),
         integer_prop_with_default(
             Some(1),
-            Some(crate::config::max_execution_timeout() as i64),
+            None,
             crate::config::default_execution_timeout() as i64,
             Some("Timeout in seconds"),
         ),

--- a/src-tauri/src/mcp/builtin/workspace/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/utils.rs
@@ -61,11 +61,9 @@ pub async fn get_diff_context_lines() -> usize {
     }
 }
 
-/// Validate timeout value, applying default and max limits
+/// Validate timeout value, applying the configured default when absent
 pub fn validate_timeout(timeout: Option<u64>) -> u64 {
-    let default = crate::config::default_execution_timeout();
-    let max = crate::config::max_execution_timeout();
-    timeout.unwrap_or(default).min(max)
+    timeout.unwrap_or_else(crate::config::default_execution_timeout)
 }
 
 /// Remove sensitive flags from command for logging

--- a/src-tauri/src/mcp/builtin/workspace/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/utils.rs
@@ -61,8 +61,8 @@ pub async fn get_diff_context_lines() -> usize {
     }
 }
 
-/// Validate timeout value, applying the configured default when absent
-pub fn validate_timeout(timeout: Option<u64>) -> u64 {
+/// Resolve a timeout value, applying the configured default when absent
+pub fn resolve_timeout(timeout: Option<u64>) -> u64 {
     timeout.unwrap_or_else(crate::config::default_execution_timeout)
 }
 


### PR DESCRIPTION
## Summary
- remove the unused LIBRAGENT_MAX_EXECUTION_TIMEOUT configuration path
- treat LIBRAGENT_DEFAULT_EXECUTION_TIMEOUT as the default-only fallback when no timeout is passed
- align workspace shell tool schemas and messaging with the new timeout behavior

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml --test persistent_shell_tests --test persistent_shell_isolation --test workspace_guidance_tests --test shell_policy_tests
- pnpm lint
- pnpm build

## Notes
- cargo test --tests --manifest-path src-tauri/Cargo.toml still hits the existing unrelated failure in secure_file_manager_tests::test_external_paths_are_allowed_and_sensitive_targets_are_scoped
