### PR TITLE
🎨 Palette: Add aria-label to PlaybookGroup toggle

### DIFF
--- a/src/features/playbook/PlaybookGroup.tsx
+++ b/src/features/playbook/PlaybookGroup.tsx
@@ -34,9 +34,9 @@ export function PlaybookGroup({
           type="button"
           aria-expanded={!isCollapsed}
           aria-controls={panelId}
-          aria-label={t('playbook.group.title', {
+          aria-label={t('playbook.group.ariaLabel', {
             title,
-            defaultValue: `${title} playbooks`,
+            defaultValue: `${title} ${t('playbook.title')}`,
           })}
           className="flex w-full items-center gap-2 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
           onClick={() => setIsCollapsed(!isCollapsed)}

--- a/src/features/playbook/PlaybookGroup.tsx
+++ b/src/features/playbook/PlaybookGroup.tsx
@@ -34,6 +34,10 @@ export function PlaybookGroup({
           type="button"
           aria-expanded={!isCollapsed}
           aria-controls={panelId}
+          aria-label={t('playbook.group.title', {
+            title,
+            defaultValue: `${title} playbooks`,
+          })}
           className="flex w-full items-center gap-2 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
           onClick={() => setIsCollapsed(!isCollapsed)}
         >

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "Lesezeichen zuerst"
     },
     "group": {
+      "ariaLabel": "Playbooks: {{title}}",
       "today": "Heute",
       "yesterday": "Gestern",
       "thisWeek": "Diese Woche",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -734,6 +734,7 @@
       "bookmarksFirst": "Bookmarks First"
     },
     "group": {
+      "ariaLabel": "{{title}} playbooks",
       "today": "Today",
       "yesterday": "Yesterday",
       "thisWeek": "This Week",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "Marcadores primero"
     },
     "group": {
+      "ariaLabel": "{{title}} guías",
       "today": "Hoy",
       "yesterday": "Ayer",
       "thisWeek": "Esta semana",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "Signets en premier"
     },
     "group": {
+      "ariaLabel": "{{title}} scénarios",
       "today": "Aujourd'hui",
       "yesterday": "Hier",
       "thisWeek": "Cette semaine",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "ブックマークを優先"
     },
     "group": {
+      "ariaLabel": "{{title}} のプレイブック",
       "today": "今日",
       "yesterday": "昨日",
       "thisWeek": "今週",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -704,6 +704,7 @@
       "bookmarksFirst": "북마크 우선"
     },
     "group": {
+      "ariaLabel": "{{title}} 플레이북",
       "today": "오늘",
       "yesterday": "어제",
       "thisWeek": "이번 주",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "Favoritos primeiro"
     },
     "group": {
+      "ariaLabel": "{{title}} roteiros",
       "today": "Hoje",
       "yesterday": "Ontem",
       "thisWeek": "Esta Semana",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -591,6 +591,7 @@
       "bookmarksFirst": "书签优先"
     },
     "group": {
+      "ariaLabel": "{{title}}剧本",
       "today": "今天",
       "yesterday": "昨天",
       "thisWeek": "本周",


### PR DESCRIPTION
💡 What: Added an `aria-label` to the accordion trigger button in `PlaybookGroup` component.

🎯 Why: To improve screen reader accessibility by providing an explicit and meaningful accessible name for the playbook group toggle button. It uses the group title and avoids redundant action words like 'Toggle' since the state is announced natively.

📸 Before/After: 
Before: `aria-label` was missing on the button.
After: `aria-label` is set to `${title} playbooks` with translation fallback.

♿ Accessibility:
- Satisfies WCAG 2.5.3 (Label in Name) as the visible text is part of the accessible name.
- Improves screen reader context when navigating through playbook groups.

---
*PR created automatically by Jules for task [13992754667387790819](https://jules.google.com/task/13992754667387790819) started by @fritzprix*