### PR TITLE
Refactor compaction follow-up handling

### DIFF
--- a/src-tauri/src/agent/compact_recovery.rs
+++ b/src-tauri/src/agent/compact_recovery.rs
@@ -7,12 +7,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CompactErrorAction {
-    None,
-    FinalizeWorkflow,
-}
-
 async fn clear_compaction_state(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     session_id: &str,
@@ -46,7 +40,7 @@ pub async fn handle_compact_error_state(
     dispatcher: &dyn AgentEventDispatcher,
     session_id: String,
     error: AgentRuntimeError,
-) -> Result<CompactErrorAction, String> {
+) -> Result<(), String> {
     let (snapshot, session_name) = {
         let active = active_sessions.read().await;
         if let Some(session) = active.get(&session_id) {
@@ -64,7 +58,6 @@ pub async fn handle_compact_error_state(
                     in_flight: false,
                     last_compacted_tail_id: None,
                     awaiting_completion: false,
-                    finalize_workflow_after_compact: false,
                     deferred_workflow_step: None,
                     started_at_ms: None,
                 },
@@ -100,8 +93,10 @@ pub async fn handle_compact_error_state(
         session_id,
         if snapshot.awaiting_completion {
             "preflight"
+        } else if snapshot.deferred_workflow_step.is_some() {
+            "post-response"
         } else {
-            "background"
+            "manual"
         },
         elapsed_ms
             .map(|value| value.to_string())
@@ -128,11 +123,7 @@ pub async fn handle_compact_error_state(
             session_id,
             error: error.clone(),
         })?;
-
-        Ok(CompactErrorAction::None)
-    } else if snapshot.finalize_workflow_after_compact {
-        Ok(CompactErrorAction::FinalizeWorkflow)
-    } else {
-        Ok(CompactErrorAction::None)
     }
+
+    Ok(())
 }

--- a/src-tauri/src/agent/compact_recovery.rs
+++ b/src-tauri/src/agent/compact_recovery.rs
@@ -4,7 +4,6 @@ use crate::agent::llm::types::{AgentRuntimeError, CompactStateEvent, CompactStat
 use crate::agent::state::AgentSession;
 use crate::repositories::{SessionRepository, SessionStatus};
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -19,42 +18,19 @@ async fn clear_compaction_state(
     session_id: &str,
     clear_last_compacted_tail_id: bool,
 ) {
-    let handles = {
+    let compaction = {
         let active = active_sessions.read().await;
-        active.get(session_id).map(|session| {
-            session.compaction.in_flight.store(false, Ordering::SeqCst);
-            session
-                .compaction
-                .awaiting_completion
-                .store(false, Ordering::SeqCst);
-            session
-                .compaction
-                .finalize_workflow_after_compact
-                .store(false, Ordering::SeqCst);
-            (
-                session.compaction.started_at_ms.clone(),
-                clear_last_compacted_tail_id
-                    .then(|| session.compaction.last_compacted_tail_id.clone()),
-                session.compaction.deferred_workflow_step.clone(),
-            )
-        })
+        active
+            .get(session_id)
+            .map(|session| session.compaction.clone())
     };
 
-    let Some((
-        compact_started_at_ms_handle,
-        last_compacted_tail_id_handle,
-        deferred_workflow_step_handle,
-    )) = handles
-    else {
+    let Some(compaction) = compaction else {
         return;
     };
-
-    if let Some(last_compacted_tail_id_handle) = last_compacted_tail_id_handle {
-        *last_compacted_tail_id_handle.write().await = None;
-    }
-
-    *deferred_workflow_step_handle.write().await = None;
-    *compact_started_at_ms_handle.write().await = None;
+    compaction
+        .clear_runtime_state(clear_last_compacted_tail_id)
+        .await;
 }
 
 pub async fn clear_compact_in_flight(
@@ -71,55 +47,34 @@ pub async fn handle_compact_error_state(
     session_id: String,
     error: AgentRuntimeError,
 ) -> Result<CompactErrorAction, String> {
-    let (
-        was_awaiting,
-        should_finalize_after_compact,
-        deferred_workflow_step,
-        session_name,
-        compact_started_at_ms_handle,
-    ) = {
+    let (snapshot, session_name) = {
         let active = active_sessions.read().await;
         if let Some(session) = active.get(&session_id) {
             (
-                session
-                    .compaction
-                    .awaiting_completion
-                    .load(Ordering::SeqCst),
-                session
-                    .compaction
-                    .finalize_workflow_after_compact
-                    .load(Ordering::SeqCst),
-                session
-                    .compaction
-                    .deferred_workflow_step
-                    .read()
-                    .await
-                    .clone(),
+                session.compaction.snapshot().await,
                 session
                     .metadata
                     .name
                     .clone()
                     .unwrap_or_else(|| session_id.chars().take(8).collect::<String>()),
-                Some(session.compaction.started_at_ms.clone()),
             )
         } else {
             (
-                false,
-                false,
-                None,
+                crate::agent::state::CompactionSnapshot {
+                    in_flight: false,
+                    last_compacted_tail_id: None,
+                    awaiting_completion: false,
+                    finalize_workflow_after_compact: false,
+                    deferred_workflow_step: None,
+                    started_at_ms: None,
+                },
                 session_id.chars().take(8).collect::<String>(),
-                None,
             )
         }
     };
-    let elapsed_ms = if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-        compact_started_at_ms_handle
-            .read()
-            .await
-            .map(|started_at| chrono::Utc::now().timestamp_millis() - started_at)
-    } else {
-        None
-    };
+    let elapsed_ms = snapshot
+        .started_at_ms
+        .map(|started_at| chrono::Utc::now().timestamp_millis() - started_at);
 
     let error_code = error
         .details
@@ -143,7 +98,7 @@ pub async fn handle_compact_error_state(
     log::warn!(
         "❌ Compaction failed: session={}, mode={}, elapsed_ms={}, error_code={}, message={}",
         session_id,
-        if was_awaiting {
+        if snapshot.awaiting_completion {
             "preflight"
         } else {
             "background"
@@ -155,7 +110,7 @@ pub async fn handle_compact_error_state(
         error.display_message
     );
 
-    if was_awaiting || deferred_workflow_step.is_some() {
+    if snapshot.awaiting_completion || snapshot.deferred_workflow_step.is_some() {
         log::warn!(
             "Blocking compaction failed for session {}. Failing workflow.",
             session_id
@@ -175,7 +130,7 @@ pub async fn handle_compact_error_state(
         })?;
 
         Ok(CompactErrorAction::None)
-    } else if should_finalize_after_compact {
+    } else if snapshot.finalize_workflow_after_compact {
         Ok(CompactErrorAction::FinalizeWorkflow)
     } else {
         Ok(CompactErrorAction::None)

--- a/src-tauri/src/agent/lifecycle/cache.rs
+++ b/src-tauri/src/agent/lifecycle/cache.rs
@@ -35,7 +35,7 @@ pub async fn init_session_with_messages(
         let mut synced_at = session.last_synced_at.write().await;
         *synced_at = Some(SystemTime::now());
 
-        crate::agent::lifecycle::replace_compact_context(session, compact_context).await;
+        crate::agent::lifecycle::overwrite_compact_context(session, compact_context).await;
 
         session.cache_initialized.store(true, Ordering::Release);
 

--- a/src-tauri/src/agent/lifecycle/cache.rs
+++ b/src-tauri/src/agent/lifecycle/cache.rs
@@ -1,5 +1,4 @@
 use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
-use crate::repositories::compact_context_repository::CompactContextRepository;
 use crate::repositories::message_repository::MessageRepository as MessageRepositoryTrait;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
@@ -24,16 +23,8 @@ pub async fn init_session_with_messages(
     let loaded_count = page.items.len();
 
     // Load compact context if exists (SP17)
-    let compact_repo = crate::state::get_compact_context_repository();
-    let compact_context = compact_repo
-        .get_by_session_id(session_id)
-        .await
-        .map_err(|e| {
-            format!(
-                "Failed to load compact context for session {}: {}",
-                session_id, e
-            )
-        })?;
+    let compact_context =
+        crate::agent::lifecycle::load_compact_context_record(session_id, "cache init").await?;
 
     // Populate in-memory cache
     let sessions = active_sessions.read().await;
@@ -44,8 +35,7 @@ pub async fn init_session_with_messages(
         let mut synced_at = session.last_synced_at.write().await;
         *synced_at = Some(SystemTime::now());
 
-        let mut session_compact = session.compact_context.write().await;
-        *session_compact = compact_context;
+        crate::agent::lifecycle::replace_compact_context(session, compact_context).await;
 
         session.cache_initialized.store(true, Ordering::Release);
 

--- a/src-tauri/src/agent/lifecycle/compact_context.rs
+++ b/src-tauri/src/agent/lifecycle/compact_context.rs
@@ -28,7 +28,8 @@ pub async fn load_compact_context_record(
     Ok(compact_context)
 }
 
-pub async fn replace_compact_context(
+/// Overwrite the in-memory compact context, even when the loaded value is `None`.
+pub async fn overwrite_compact_context(
     session: &AgentSession,
     compact_context: Option<CompactContextRecord>,
 ) {
@@ -36,7 +37,8 @@ pub async fn replace_compact_context(
     *session_compact = compact_context;
 }
 
-pub async fn apply_compact_context_if_present(
+/// Only update the in-memory compact context when a loaded record is present.
+pub async fn set_compact_context_if_loaded(
     session: &AgentSession,
     compact_context: Option<CompactContextRecord>,
 ) {

--- a/src-tauri/src/agent/lifecycle/compact_context.rs
+++ b/src-tauri/src/agent/lifecycle/compact_context.rs
@@ -1,0 +1,47 @@
+use crate::agent::state::AgentSession;
+use crate::repositories::{
+    compact_context_repository::CompactContextRepository, CompactContextRecord,
+};
+
+pub async fn load_compact_context_record(
+    session_id: &str,
+    operation: &str,
+) -> Result<Option<CompactContextRecord>, String> {
+    let repo = crate::state::get_compact_context_repository();
+    let compact_context = repo.get_by_session_id(session_id).await.map_err(|e| {
+        format!(
+            "Failed to load compact context for session {} during {}: {}",
+            session_id, operation, e
+        )
+    })?;
+
+    if let Some(record) = &compact_context {
+        log::info!(
+            "Loaded compact context during {}: session={} (range: {} to {})",
+            operation,
+            session_id,
+            record.from_id,
+            record.to_id
+        );
+    }
+
+    Ok(compact_context)
+}
+
+pub async fn replace_compact_context(
+    session: &AgentSession,
+    compact_context: Option<CompactContextRecord>,
+) {
+    let mut session_compact = session.compact_context.write().await;
+    *session_compact = compact_context;
+}
+
+pub async fn apply_compact_context_if_present(
+    session: &AgentSession,
+    compact_context: Option<CompactContextRecord>,
+) {
+    if let Some(record) = compact_context {
+        let mut session_compact = session.compact_context.write().await;
+        *session_compact = Some(record);
+    }
+}

--- a/src-tauri/src/agent/lifecycle/creation.rs
+++ b/src-tauri/src/agent/lifecycle/creation.rs
@@ -205,7 +205,7 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
         );
         existing_session.metadata = session.clone();
         // Update compact context if it was loaded
-        crate::agent::lifecycle::apply_compact_context_if_present(
+        crate::agent::lifecycle::set_compact_context_if_loaded(
             existing_session,
             compact_context_record,
         )

--- a/src-tauri/src/agent/lifecycle/creation.rs
+++ b/src-tauri/src/agent/lifecycle/creation.rs
@@ -3,7 +3,7 @@ use crate::agent::state::AgentSession;
 use crate::mcp::MCPServiceProxyManager;
 use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::settings_repository::SettingsRepository;
-use crate::repositories::{CompactContextRepository, SessionMetadata, SessionStatus};
+use crate::repositories::{SessionMetadata, SessionStatus};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -192,12 +192,9 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
     );
 
     // Load compact context if exists (SP17)
-    let compact_context_record = {
-        let repo = crate::state::get_compact_context_repository();
-        repo.get_by_session_id(&session_id)
-            .await
-            .map_err(|e| format!("Failed to get compact context: {}", e))?
-    };
+    let compact_context_record =
+        crate::agent::lifecycle::load_compact_context_record(&session_id, "session creation")
+            .await?;
 
     // Add to active sessions with cancellation token and empty cache
     let mut active = active_sessions.write().await;
@@ -208,10 +205,11 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
         );
         existing_session.metadata = session.clone();
         // Update compact context if it was loaded
-        if let Some(record) = compact_context_record {
-            let mut compact = existing_session.compact_context.write().await;
-            *compact = Some(record);
-        }
+        crate::agent::lifecycle::apply_compact_context_if_present(
+            existing_session,
+            compact_context_record,
+        )
+        .await;
     } else {
         log::info!("Initializing new active state for session: {}", session_id);
         active.insert(

--- a/src-tauri/src/agent/lifecycle/management.rs
+++ b/src-tauri/src/agent/lifecycle/management.rs
@@ -102,7 +102,7 @@ pub async fn resume_session(
         // changed between sessions, so it must be rebuilt on the next LLM call.
         *existing_session.cached_stable_prompt.write().await = None;
         // Update compact context if it was loaded
-        crate::agent::lifecycle::apply_compact_context_if_present(
+        crate::agent::lifecycle::set_compact_context_if_loaded(
             existing_session,
             compact_context_record,
         )

--- a/src-tauri/src/agent/lifecycle/management.rs
+++ b/src-tauri/src/agent/lifecycle/management.rs
@@ -5,7 +5,7 @@ use crate::agent::state::{AgentSession, SessionStatusTransition};
 use crate::agent::tauri_events::TauriEventDispatcher;
 use crate::mcp::MCPServiceProxyManager;
 use crate::repositories::session_repository::SessionRepository;
-use crate::repositories::{CompactContextRepository, SessionMetadata, SessionStatus};
+use crate::repositories::{SessionMetadata, SessionStatus};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -87,21 +87,8 @@ pub async fn resume_session(
     );
 
     // Load compact context if exists (SP17)
-    let compact_context_record = {
-        let repo = crate::state::get_compact_context_repository();
-        repo.get_by_session_id(session_id)
-            .await
-            .map_err(|e| format!("Failed to get compact context: {}", e))?
-    };
-
-    if let Some(record) = &compact_context_record {
-        log::info!(
-            "Loaded compact context for resumed session: {} (range: {} to {})",
-            session_id,
-            record.from_id,
-            record.to_id
-        );
-    }
+    let compact_context_record =
+        crate::agent::lifecycle::load_compact_context_record(session_id, "session resume").await?;
 
     // Add to active sessions with cancellation token and empty cache
     let mut active = active_sessions.write().await;
@@ -115,10 +102,11 @@ pub async fn resume_session(
         // changed between sessions, so it must be rebuilt on the next LLM call.
         *existing_session.cached_stable_prompt.write().await = None;
         // Update compact context if it was loaded
-        if let Some(record) = compact_context_record {
-            let mut compact = existing_session.compact_context.write().await;
-            *compact = Some(record);
-        }
+        crate::agent::lifecycle::apply_compact_context_if_present(
+            existing_session,
+            compact_context_record,
+        )
+        .await;
         // Transient states (pending_execution, messages, cancellation_token, etc.) are preserved
     } else {
         log::info!(

--- a/src-tauri/src/agent/lifecycle/mod.rs
+++ b/src-tauri/src/agent/lifecycle/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod compact_context;
 pub mod creation;
 pub mod deletion;
 pub mod management;
@@ -6,6 +7,7 @@ pub mod queries;
 pub mod recovery;
 
 pub use cache::*;
+pub use compact_context::*;
 pub use creation::*;
 pub use deletion::*;
 pub use management::*;

--- a/src-tauri/src/agent/llm/completion/compaction/trigger.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/trigger.rs
@@ -1,8 +1,10 @@
 use crate::agent::llm::completion::context::load_context_management_settings;
 use crate::agent::llm::completion::request::normalize_request_messages;
-use crate::agent::llm::types::{CompactRequest, CompactionParentRequest};
+use crate::agent::llm::types::{CompactRequest, CompactStatePhase, CompactionParentRequest};
 use crate::agent::state::{AgentSession, DeferredWorkflowStep};
-use crate::agent::tauri_events::{emit_compact_request, emit_compact_started};
+use crate::agent::tauri_events::{
+    emit_compact_finished, emit_compact_request, emit_compact_started,
+};
 use crate::models::chat::Message;
 use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
@@ -259,7 +261,7 @@ async fn prepare_compaction_request(
     }))
 }
 
-async fn trigger_post_response_background_compaction(
+async fn trigger_post_response_blocking_compaction(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     app_handle: &AppHandle,
     session_id: &str,
@@ -333,40 +335,55 @@ async fn trigger_post_response_background_compaction(
 
     let log_from_id = prepared.compact_event.from_id.clone();
     let log_to_id = prepared.compact_event.to_id.clone();
-    let app = app_handle.clone();
-    let state_session_id = session_id.to_string();
-    let state_session_name = session_name.to_string();
-    let in_flight_flag = handles.compact_in_flight_arc.clone();
     let tail_id_for_task = prepared.current_tail_id.clone();
     let compact_event = prepared.compact_event;
     let started_at_ms = prepared.started_at_ms;
 
-    tokio::spawn(async move {
-        if let Err(e) = emit_compact_started(
-            &app,
-            state_session_id.clone(),
-            Some(state_session_name),
-            false,
+    if let Some(compaction_state) = compaction_state {
+        compaction_state
+            .mark_compaction_started(tail_id_for_task, started_at_ms, true)
+            .await;
+
+        if let Err(error) = emit_compact_started(
+            app_handle,
+            session_id.to_string(),
+            Some(session_name.to_string()),
+            true,
         ) {
-            log::error!("Failed to emit llm:compact-state: {}", e);
-            in_flight_flag.store(false, Ordering::SeqCst);
-            return;
+            compaction_state.clear_runtime_state(true).await;
+            return Err(error);
         }
-        if let Err(e) = emit_compact_request(&app, compact_event) {
-            log::error!("Failed to emit llm:compact-request: {}", e);
-            in_flight_flag.store(false, Ordering::SeqCst);
-            return;
+
+        if let Err(error) = emit_compact_request(app_handle, compact_event) {
+            compaction_state.clear_runtime_state(true).await;
+            if let Err(emit_error) = emit_compact_finished(
+                app_handle,
+                session_id.to_string(),
+                Some(session_name.to_string()),
+                CompactStatePhase::Failed,
+                Some(error.clone()),
+            ) {
+                log::warn!(
+                    "Failed to emit post-response compaction failure state for session {}: {}",
+                    session_id,
+                    emit_error
+                );
+            }
+            return Err(error);
         }
-        if let Some(compaction_state) = compaction_state {
-            compaction_state
-                .mark_compaction_started(tail_id_for_task, started_at_ms, false)
-                .await;
-        }
-    });
+    } else {
+        emit_compact_started(
+            app_handle,
+            session_id.to_string(),
+            Some(session_name.to_string()),
+            true,
+        )?;
+        emit_compact_request(app_handle, compact_event)?;
+    }
 
     in_flight_guard.disarm();
     log::info!(
-        "🔧 Background compaction triggered: session={}, from_id={}, to_id={}, split_idx={}, compacted_delta_count={}, reused_prior_summary={}, tail={}, started_at_ms={}",
+        "🔧 Post-response compaction triggered: session={}, from_id={}, to_id={}, split_idx={}, compacted_delta_count={}, reused_prior_summary={}, tail={}, started_at_ms={}",
         session_id,
         log_from_id,
         log_to_id,
@@ -431,9 +448,9 @@ pub async fn trigger_post_response_compaction_if_needed(
     };
 
     compaction_state
-        .arm_finalize_after_compact(deferred_step)
+        .set_deferred_workflow_step(deferred_step)
         .await;
-    let triggered = trigger_post_response_background_compaction(
+    let triggered = match trigger_post_response_blocking_compaction(
         active_sessions,
         app_handle,
         session_id,
@@ -442,13 +459,20 @@ pub async fn trigger_post_response_compaction_if_needed(
         None,
         &handles,
     )
-    .await?;
+    .await
+    {
+        Ok(triggered) => triggered,
+        Err(error) => {
+            compaction_state.clear_deferred_workflow_step().await;
+            return Err(error);
+        }
+    };
 
     if !triggered {
-        compaction_state.clear_finalize_after_compact().await;
+        compaction_state.clear_deferred_workflow_step().await;
     } else {
         log::info!(
-            "🧹 Post-response compaction triggered synchronously from completed response usage: session={}, total_tokens={}, limit={}",
+            "🧹 Blocking post-response compaction armed from completed response usage: session={}, total_tokens={}, limit={}",
             session_id,
             usage_total_tokens,
             safe_input_token_limit

--- a/src-tauri/src/agent/llm/completion/compaction/trigger.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/trigger.rs
@@ -292,17 +292,21 @@ async fn trigger_post_response_background_compaction(
     }
 
     let started_at_ms = chrono::Utc::now().timestamp_millis();
-    let compact_context_record = {
+    let compact_context_handles = {
         let active = active_sessions.read().await;
         active
             .get(session_id)
-            .map(|session| session.compact_context.clone())
+            .map(|session| (session.compact_context.clone(), session.compaction.clone()))
     };
-    let compact_context_record = if let Some(compact_context_handle) = compact_context_record {
-        compact_context_handle.read().await.clone()
-    } else {
-        None
-    };
+    let (compact_context_record, compaction_state) =
+        if let Some((compact_context_handle, compaction_state)) = compact_context_handles {
+            (
+                compact_context_handle.read().await.clone(),
+                Some(compaction_state),
+            )
+        } else {
+            (None, None)
+        };
 
     let Some(prepared) = prepare_compaction_request(
         active_sessions,
@@ -327,20 +331,12 @@ async fn trigger_post_response_background_compaction(
         return Ok(false);
     };
 
-    let compact_started_at_ms_handle = {
-        let active = active_sessions.read().await;
-        active
-            .get(session_id)
-            .map(|session| session.compaction.started_at_ms.clone())
-    };
-
     let log_from_id = prepared.compact_event.from_id.clone();
     let log_to_id = prepared.compact_event.to_id.clone();
     let app = app_handle.clone();
     let state_session_id = session_id.to_string();
     let state_session_name = session_name.to_string();
     let in_flight_flag = handles.compact_in_flight_arc.clone();
-    let last_compacted_tail_id_arc = handles.last_compacted_tail_id_arc.clone();
     let tail_id_for_task = prepared.current_tail_id.clone();
     let compact_event = prepared.compact_event;
     let started_at_ms = prepared.started_at_ms;
@@ -361,9 +357,10 @@ async fn trigger_post_response_background_compaction(
             in_flight_flag.store(false, Ordering::SeqCst);
             return;
         }
-        *last_compacted_tail_id_arc.write().await = tail_id_for_task;
-        if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-            *compact_started_at_ms_handle.write().await = Some(started_at_ms);
+        if let Some(compaction_state) = compaction_state {
+            compaction_state
+                .mark_compaction_started(tail_id_for_task, started_at_ms, false)
+                .await;
         }
     });
 
@@ -419,7 +416,7 @@ pub async fn trigger_post_response_compaction_if_needed(
         return Ok(false);
     }
 
-    let (handles, finalize_workflow_after_compact, deferred_workflow_step_handle) = {
+    let (handles, compaction_state) = {
         let active = active_sessions.read().await;
         let session = active
             .get(session_id)
@@ -429,13 +426,13 @@ pub async fn trigger_post_response_compaction_if_needed(
                 compact_in_flight_arc: session.compaction.in_flight.clone(),
                 last_compacted_tail_id_arc: session.compaction.last_compacted_tail_id.clone(),
             },
-            session.compaction.finalize_workflow_after_compact.clone(),
-            session.compaction.deferred_workflow_step.clone(),
+            session.compaction.clone(),
         )
     };
 
-    finalize_workflow_after_compact.store(true, Ordering::SeqCst);
-    *deferred_workflow_step_handle.write().await = Some(deferred_step);
+    compaction_state
+        .arm_finalize_after_compact(deferred_step)
+        .await;
     let triggered = trigger_post_response_background_compaction(
         active_sessions,
         app_handle,
@@ -448,8 +445,7 @@ pub async fn trigger_post_response_compaction_if_needed(
     .await?;
 
     if !triggered {
-        finalize_workflow_after_compact.store(false, Ordering::SeqCst);
-        *deferred_workflow_step_handle.write().await = None;
+        compaction_state.clear_finalize_after_compact().await;
     } else {
         log::info!(
             "🧹 Post-response compaction triggered synchronously from completed response usage: session={}, total_tokens={}, limit={}",
@@ -489,12 +485,7 @@ pub(crate) async fn try_trigger_preflight_compaction(
         return Ok(false);
     }
 
-    let (
-        compact_in_flight_arc,
-        last_compacted_tail_id_arc,
-        awaiting_compact_arc,
-        compact_context_handle,
-    ) = {
+    let (compact_in_flight_arc, last_compacted_tail_id_arc, compact_context_handle, compaction) = {
         let active = active_sessions.read().await;
         let session = active
             .get(session_id)
@@ -502,15 +493,13 @@ pub(crate) async fn try_trigger_preflight_compaction(
         (
             session.compaction.in_flight.clone(),
             session.compaction.last_compacted_tail_id.clone(),
-            session.compaction.awaiting_completion.clone(),
             session.compact_context.clone(),
+            session.compaction.clone(),
         )
     };
 
     let Some(mut in_flight_guard) = try_claim_in_flight(&compact_in_flight_arc) else {
-        if resume_completion_after_compact {
-            awaiting_compact_arc.store(true, Ordering::SeqCst);
-        }
+        compaction.mark_reused_in_flight(resume_completion_after_compact);
         emit_compact_started(
             app_handle,
             session_id.to_string(),
@@ -571,13 +560,6 @@ pub(crate) async fn try_trigger_preflight_compaction(
         return Ok(false);
     };
 
-    let compact_started_at_ms_handle = {
-        let active = active_sessions.read().await;
-        active
-            .get(session_id)
-            .map(|session| session.compaction.started_at_ms.clone())
-    };
-
     let log_from_id = prepared.compact_event.from_id.clone();
     let log_to_id = prepared.compact_event.to_id.clone();
     emit_compact_started(
@@ -587,13 +569,13 @@ pub(crate) async fn try_trigger_preflight_compaction(
         resume_completion_after_compact,
     )?;
     emit_compact_request(app_handle, prepared.compact_event)?;
-    if resume_completion_after_compact {
-        awaiting_compact_arc.store(true, Ordering::SeqCst);
-    }
-    *last_compacted_tail_id_arc.write().await = prepared.current_tail_id.clone();
-    if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-        *compact_started_at_ms_handle.write().await = Some(prepared.started_at_ms);
-    }
+    compaction
+        .mark_compaction_started(
+            prepared.current_tail_id.clone(),
+            prepared.started_at_ms,
+            resume_completion_after_compact,
+        )
+        .await;
     in_flight_guard.disarm();
 
     if resume_completion_after_compact {

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -917,20 +917,15 @@ impl AgentSessionManager {
         let started_at = Instant::now();
 
         loop {
-            let (compact_in_flight, awaiting_compact_completion) = {
+            let is_settled = {
                 let active = self.active_sessions.read().await;
                 let session = active
                     .get(session_id)
                     .ok_or_else(|| format!("Session not found: {}", session_id))?;
-                (
-                    session.compaction.in_flight.clone(),
-                    session.compaction.awaiting_completion.clone(),
-                )
+                session.compaction.is_settled()
             };
 
-            if !compact_in_flight.load(Ordering::SeqCst)
-                && !awaiting_compact_completion.load(Ordering::SeqCst)
-            {
+            if is_settled {
                 return Ok(());
             }
 

--- a/src-tauri/src/agent/session_manager/compact.rs
+++ b/src-tauri/src/agent/session_manager/compact.rs
@@ -8,7 +8,6 @@ use crate::agent::state::{AgentSession, DeferredWorkflowStep};
 use crate::agent::tauri_events::emit_compact_finished;
 use crate::repositories::{CompactContextRecord, SessionRepository, SessionStatus};
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -134,17 +133,17 @@ pub async fn handle_compact_response(
     to_id: String,
     summary: String,
 ) -> Result<(), String> {
-    let (compact_started_at_ms_handle, session_name) = {
+    let (compaction, session_name) = {
         let active = manager.active_sessions.read().await;
         active.get(session_id).map_or((None, None), |session| {
             (
-                Some(session.compaction.started_at_ms.clone()),
+                Some(session.compaction.clone()),
                 session.metadata.name.clone(),
             )
         })
     };
-    let started_at_ms = if let Some(compact_started_at_ms_handle) = compact_started_at_ms_handle {
-        *compact_started_at_ms_handle.read().await
+    let started_at_ms = if let Some(compaction) = compaction {
+        compaction.snapshot().await.started_at_ms
     } else {
         None
     };
@@ -171,29 +170,23 @@ pub async fn handle_compact_response(
     };
     manager.save_compact_context(session_id, record).await?;
 
-    let (should_resume_completion, should_finalize_after_compact, deferred_workflow_step) = {
+    let completion_plan = {
         let active = manager.active_sessions.read().await;
         if let Some(session) = active.get(session_id) {
-            (
-                session
-                    .compaction
-                    .awaiting_completion
-                    .swap(false, Ordering::SeqCst),
-                session
-                    .compaction
-                    .finalize_workflow_after_compact
-                    .swap(false, Ordering::SeqCst),
-                session
-                    .compaction
-                    .deferred_workflow_step
-                    .write()
-                    .await
-                    .take(),
-            )
+            Some(session.compaction.take_completion_plan().await)
         } else {
-            (false, false, None)
+            None
         }
     };
+    let should_resume_completion = completion_plan
+        .as_ref()
+        .map(|plan| plan.should_resume_completion)
+        .unwrap_or(false);
+    let should_finalize_after_compact = completion_plan
+        .as_ref()
+        .map(|plan| plan.should_finalize_after_compact)
+        .unwrap_or(false);
+    let deferred_workflow_step = completion_plan.and_then(|plan| plan.deferred_workflow_step);
 
     log::info!(
         "📌 Compact completion decision for session {}: should_resume_completion={}, should_finalize_after_compact={}, deferred_step={}",

--- a/src-tauri/src/agent/session_manager/compact.rs
+++ b/src-tauri/src/agent/session_manager/compact.rs
@@ -1,7 +1,5 @@
 use super::AgentSessionManager;
-use crate::agent::compact_recovery::{
-    clear_compact_in_flight, handle_compact_error_state, CompactErrorAction,
-};
+use crate::agent::compact_recovery::{clear_compact_in_flight, handle_compact_error_state};
 use crate::agent::events::AgentEventDispatcher;
 use crate::agent::llm::types::CompactStatePhase;
 use crate::agent::state::{AgentSession, DeferredWorkflowStep};
@@ -95,35 +93,7 @@ pub async fn handle_compact_error_with_dispatcher(
     session_id: String,
     error: crate::agent::llm::types::AgentRuntimeError,
 ) -> Result<(), String> {
-    if matches!(
-        handle_compact_error_state(
-            session_repo,
-            active_sessions,
-            dispatcher,
-            session_id.clone(),
-            error
-        )
-        .await?,
-        CompactErrorAction::FinalizeWorkflow
-    ) {
-        if let Some(app_handle) = crate::state::get_app_handle() {
-            crate::agent::lifecycle::update_session_status(
-                session_repo,
-                active_sessions,
-                app_handle,
-                &session_id,
-                SessionStatus::Idle,
-            )
-            .await?;
-        }
-
-        dispatcher.emit_agent_event(crate::agent::events::AgentEvent::WorkflowCompleted {
-            session_id,
-            reason: crate::agent::events::WorkflowCompletionReason::Natural,
-        })?;
-    }
-
-    Ok(())
+    handle_compact_error_state(session_repo, active_sessions, dispatcher, session_id, error).await
 }
 
 pub async fn handle_compact_response(
@@ -182,17 +152,12 @@ pub async fn handle_compact_response(
         .as_ref()
         .map(|plan| plan.should_resume_completion)
         .unwrap_or(false);
-    let should_finalize_after_compact = completion_plan
-        .as_ref()
-        .map(|plan| plan.should_finalize_after_compact)
-        .unwrap_or(false);
     let deferred_workflow_step = completion_plan.and_then(|plan| plan.deferred_workflow_step);
 
     log::info!(
-        "📌 Compact completion decision for session {}: should_resume_completion={}, should_finalize_after_compact={}, deferred_step={}",
+        "📌 Compact completion decision for session {}: should_resume_completion={}, deferred_step={}",
         session_id,
         should_resume_completion,
-        should_finalize_after_compact,
         deferred_workflow_step.is_some()
     );
 
@@ -262,13 +227,6 @@ pub async fn handle_compact_response(
             session_id
         );
         spawn_resume_completion(manager, session_id, "LLM completion");
-    } else if should_finalize_after_compact {
-        finalize_workflow_completion(
-            manager,
-            session_id,
-            crate::agent::events::WorkflowCompletionReason::Natural,
-        )
-        .await?;
     }
 
     Ok(())

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -119,7 +119,6 @@ pub struct CompactionSnapshot {
     pub in_flight: bool,
     pub last_compacted_tail_id: Option<String>,
     pub awaiting_completion: bool,
-    pub finalize_workflow_after_compact: bool,
     pub deferred_workflow_step: Option<DeferredWorkflowStep>,
     pub started_at_ms: Option<i64>,
 }
@@ -127,7 +126,6 @@ pub struct CompactionSnapshot {
 #[derive(Debug, Clone)]
 pub struct CompactionCompletionPlan {
     pub should_resume_completion: bool,
-    pub should_finalize_after_compact: bool,
     pub deferred_workflow_step: Option<DeferredWorkflowStep>,
 }
 
@@ -147,10 +145,6 @@ pub struct CompactionRuntimeState {
     /// before Rust should retry the LLM request.
     pub awaiting_completion: Arc<AtomicBool>,
 
-    /// True when the current workflow has already produced its assistant response
-    /// and must not be marked complete until the triggered compaction finishes.
-    pub finalize_workflow_after_compact: Arc<AtomicBool>,
-
     /// Workflow continuation deferred until the current compaction finishes.
     /// This lets Rust block the next workflow step on a completed assistant response.
     pub deferred_workflow_step: Arc<RwLock<Option<DeferredWorkflowStep>>>,
@@ -166,7 +160,6 @@ impl CompactionRuntimeState {
             in_flight: Arc::new(AtomicBool::new(false)),
             last_compacted_tail_id: Arc::new(RwLock::new(None)),
             awaiting_completion: Arc::new(AtomicBool::new(false)),
-            finalize_workflow_after_compact: Arc::new(AtomicBool::new(false)),
             deferred_workflow_step: Arc::new(RwLock::new(None)),
             started_at_ms: Arc::new(RwLock::new(None)),
         }
@@ -181,7 +174,6 @@ impl CompactionRuntimeState {
             in_flight: Arc::new(AtomicBool::new(in_flight)),
             last_compacted_tail_id: Arc::new(RwLock::new(last_tail_id)),
             awaiting_completion: Arc::new(AtomicBool::new(awaiting_completion)),
-            finalize_workflow_after_compact: Arc::new(AtomicBool::new(false)),
             deferred_workflow_step: Arc::new(RwLock::new(None)),
             started_at_ms: Arc::new(RwLock::new(None)),
         }
@@ -192,9 +184,6 @@ impl CompactionRuntimeState {
             in_flight: self.in_flight.load(Ordering::SeqCst),
             last_compacted_tail_id: self.last_compacted_tail_id.read().await.clone(),
             awaiting_completion: self.awaiting_completion.load(Ordering::SeqCst),
-            finalize_workflow_after_compact: self
-                .finalize_workflow_after_compact
-                .load(Ordering::SeqCst),
             deferred_workflow_step: self.deferred_workflow_step.read().await.clone(),
             started_at_ms: *self.started_at_ms.read().await,
         }
@@ -203,8 +192,6 @@ impl CompactionRuntimeState {
     pub async fn clear_runtime_state(&self, clear_last_compacted_tail_id: bool) {
         self.in_flight.store(false, Ordering::SeqCst);
         self.awaiting_completion.store(false, Ordering::SeqCst);
-        self.finalize_workflow_after_compact
-            .store(false, Ordering::SeqCst);
         *self.deferred_workflow_step.write().await = None;
         *self.started_at_ms.write().await = None;
 
@@ -231,24 +218,17 @@ impl CompactionRuntimeState {
         }
     }
 
-    pub async fn arm_finalize_after_compact(&self, deferred_step: DeferredWorkflowStep) {
-        self.finalize_workflow_after_compact
-            .store(true, Ordering::SeqCst);
+    pub async fn set_deferred_workflow_step(&self, deferred_step: DeferredWorkflowStep) {
         *self.deferred_workflow_step.write().await = Some(deferred_step);
     }
 
-    pub async fn clear_finalize_after_compact(&self) {
-        self.finalize_workflow_after_compact
-            .store(false, Ordering::SeqCst);
+    pub async fn clear_deferred_workflow_step(&self) {
         *self.deferred_workflow_step.write().await = None;
     }
 
     pub async fn take_completion_plan(&self) -> CompactionCompletionPlan {
         CompactionCompletionPlan {
             should_resume_completion: self.awaiting_completion.swap(false, Ordering::SeqCst),
-            should_finalize_after_compact: self
-                .finalize_workflow_after_compact
-                .swap(false, Ordering::SeqCst),
             deferred_workflow_step: self.deferred_workflow_step.write().await.take(),
         }
     }

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -5,7 +5,7 @@ use crate::agent::types::ToolCall;
 use crate::models::chat::Message;
 use crate::repositories::{CompactContextRecord, SessionMetadata};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::oneshot;
@@ -115,6 +115,23 @@ pub enum DeferredWorkflowStep {
 }
 
 #[derive(Debug, Clone)]
+pub struct CompactionSnapshot {
+    pub in_flight: bool,
+    pub last_compacted_tail_id: Option<String>,
+    pub awaiting_completion: bool,
+    pub finalize_workflow_after_compact: bool,
+    pub deferred_workflow_step: Option<DeferredWorkflowStep>,
+    pub started_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompactionCompletionPlan {
+    pub should_resume_completion: bool,
+    pub should_finalize_after_compact: bool,
+    pub deferred_workflow_step: Option<DeferredWorkflowStep>,
+}
+
+#[derive(Debug, Clone)]
 pub struct CompactionRuntimeState {
     /// Guard: true while a llm:compact-request is in-flight (frontend hasn't returned yet).
     /// Prevents double-triggering compaction within the same session.
@@ -168,6 +185,76 @@ impl CompactionRuntimeState {
             deferred_workflow_step: Arc::new(RwLock::new(None)),
             started_at_ms: Arc::new(RwLock::new(None)),
         }
+    }
+
+    pub async fn snapshot(&self) -> CompactionSnapshot {
+        CompactionSnapshot {
+            in_flight: self.in_flight.load(Ordering::SeqCst),
+            last_compacted_tail_id: self.last_compacted_tail_id.read().await.clone(),
+            awaiting_completion: self.awaiting_completion.load(Ordering::SeqCst),
+            finalize_workflow_after_compact: self
+                .finalize_workflow_after_compact
+                .load(Ordering::SeqCst),
+            deferred_workflow_step: self.deferred_workflow_step.read().await.clone(),
+            started_at_ms: *self.started_at_ms.read().await,
+        }
+    }
+
+    pub async fn clear_runtime_state(&self, clear_last_compacted_tail_id: bool) {
+        self.in_flight.store(false, Ordering::SeqCst);
+        self.awaiting_completion.store(false, Ordering::SeqCst);
+        self.finalize_workflow_after_compact
+            .store(false, Ordering::SeqCst);
+        *self.deferred_workflow_step.write().await = None;
+        *self.started_at_ms.write().await = None;
+
+        if clear_last_compacted_tail_id {
+            *self.last_compacted_tail_id.write().await = None;
+        }
+    }
+
+    pub async fn mark_compaction_started(
+        &self,
+        current_tail_id: Option<String>,
+        started_at_ms: i64,
+        awaiting_completion: bool,
+    ) {
+        self.awaiting_completion
+            .store(awaiting_completion, Ordering::SeqCst);
+        *self.last_compacted_tail_id.write().await = current_tail_id;
+        *self.started_at_ms.write().await = Some(started_at_ms);
+    }
+
+    pub fn mark_reused_in_flight(&self, awaiting_completion: bool) {
+        if awaiting_completion {
+            self.awaiting_completion.store(true, Ordering::SeqCst);
+        }
+    }
+
+    pub async fn arm_finalize_after_compact(&self, deferred_step: DeferredWorkflowStep) {
+        self.finalize_workflow_after_compact
+            .store(true, Ordering::SeqCst);
+        *self.deferred_workflow_step.write().await = Some(deferred_step);
+    }
+
+    pub async fn clear_finalize_after_compact(&self) {
+        self.finalize_workflow_after_compact
+            .store(false, Ordering::SeqCst);
+        *self.deferred_workflow_step.write().await = None;
+    }
+
+    pub async fn take_completion_plan(&self) -> CompactionCompletionPlan {
+        CompactionCompletionPlan {
+            should_resume_completion: self.awaiting_completion.swap(false, Ordering::SeqCst),
+            should_finalize_after_compact: self
+                .finalize_workflow_after_compact
+                .swap(false, Ordering::SeqCst),
+            deferred_workflow_step: self.deferred_workflow_step.write().await.take(),
+        }
+    }
+
+    pub fn is_settled(&self) -> bool {
+        !self.in_flight.load(Ordering::SeqCst) && !self.awaiting_completion.load(Ordering::SeqCst)
     }
 }
 

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -16,16 +16,7 @@ pub async fn reset_session_execution_state(session: &mut AgentSession) {
     *session.repeated_thinking_retry_count.write().await = 0;
     // Safety valve: clear any stale in-flight compaction state before
     // explicitly starting or restarting a workflow from the current stack.
-    session.compaction.in_flight.store(false, Ordering::SeqCst);
-    session
-        .compaction
-        .awaiting_completion
-        .store(false, Ordering::SeqCst);
-    session
-        .compaction
-        .finalize_workflow_after_compact
-        .store(false, Ordering::SeqCst);
-    *session.compaction.deferred_workflow_step.write().await = None;
+    session.compaction.clear_runtime_state(false).await;
 }
 
 pub async fn start_workflow(

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -11,7 +11,6 @@ pub use channel_commands::{
 };
 pub use compaction_commands::{
     agent_get_compact_context, agent_handle_compact_error, agent_handle_compact_response,
-    agent_save_compact_context,
 };
 pub use contracts::{
     AgentOpenSessionResponse, AgentResponse, AgentSessionListResponse, CreateAgentSessionRequest,

--- a/src-tauri/src/commands/agent_commands/compaction_commands.rs
+++ b/src-tauri/src/commands/agent_commands/compaction_commands.rs
@@ -12,22 +12,6 @@ pub async fn agent_get_compact_context(
     manager.get_compact_context(&session_id).await
 }
 
-/// Save compacted context for a session
-#[command]
-pub async fn agent_save_compact_context(
-    manager: State<'_, AgentSessionManager>,
-    session_id: String,
-    record: CompactContextRecord,
-) -> Result<AgentResponse, String> {
-    manager.save_compact_context(&session_id, record).await?;
-
-    Ok(AgentResponse {
-        success: true,
-        message: format!("Compact context saved for session: {}", session_id),
-        data: None,
-    })
-}
-
 /// Handle a successful compact response from the frontend LLM call.
 /// Stores the summary in-memory + DB and clears the in-flight flag.
 #[command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,9 +40,9 @@ use commands::agent_commands::{
     agent_list_attention_sessions, agent_list_sessions, agent_mark_session_viewed,
     agent_open_session, agent_pause_workflow, agent_report_llm_streaming_issue,
     agent_respond_channel_permission, agent_respond_tool_approval, agent_resume_session,
-    agent_resume_workflow, agent_save_compact_context, agent_send_message,
-    agent_set_execution_mode, agent_set_unsafe_mode, agent_set_yolo_mode, agent_terminate_workflow,
-    agent_toggle_session_bookmark, agent_update_session_config,
+    agent_resume_workflow, agent_send_message, agent_set_execution_mode, agent_set_unsafe_mode,
+    agent_set_yolo_mode, agent_terminate_workflow, agent_toggle_session_bookmark,
+    agent_update_session_config,
 };
 use commands::assistant_crud_commands::{
     batch_upsert_assistants, create_assistant, delete_assistant, get_assistant,
@@ -276,7 +276,6 @@ pub fn run() {
                 agent_set_execution_mode,
                 agent_respond_tool_approval,
                 agent_get_compact_context,
-                agent_save_compact_context,
                 agent_handle_compact_response,
                 agent_handle_compact_error,
                 // CRUD Commands

--- a/src-tauri/tests/compact_error_recovery_tests.rs
+++ b/src-tauri/tests/compact_error_recovery_tests.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use tauri_mcp_agent_lib::agent::compact_recovery::{
-    handle_compact_error_state, CompactErrorAction,
-};
+use tauri_mcp_agent_lib::agent::compact_recovery::handle_compact_error_state;
 use tauri_mcp_agent_lib::agent::concurrency::{
     ConcurrencyGate, DEFAULT_MAX_ACTIVE_AGENTS, DEFAULT_MAX_ACTIVE_PROCESSES,
     DEFAULT_MAX_SUSPENDED_AGENTS, DEFAULT_MAX_SUSPENDED_PROCESSES,
@@ -16,7 +14,7 @@ use tauri_mcp_agent_lib::agent::llm::types::{
     AgentRuntimeError, AgentRuntimeErrorType, CompactStateEvent, CompactStatePhase,
 };
 use tauri_mcp_agent_lib::agent::session_bus::SessionBus;
-use tauri_mcp_agent_lib::agent::state::{AgentSession, PendingEventManager};
+use tauri_mcp_agent_lib::agent::state::{AgentSession, DeferredWorkflowStep, PendingEventManager};
 use tauri_mcp_agent_lib::repositories::{
     InMemorySessionRepository, SessionMetadata, SessionRepository, SessionStatus,
 };
@@ -157,7 +155,7 @@ async fn preflight_compact_failure_transitions_workflow_to_error() {
     let dispatcher = RecordingDispatcher::default();
     let error = AgentRuntimeError::new(AgentRuntimeErrorType::RateLimitError, "LLM rate limit hit");
 
-    let action = handle_compact_error_state(
+    handle_compact_error_state(
         &session_repo,
         &active_sessions,
         &dispatcher,
@@ -166,7 +164,6 @@ async fn preflight_compact_failure_transitions_workflow_to_error() {
     )
     .await
     .expect("compact error handling should succeed");
-    assert_eq!(action, CompactErrorAction::None);
 
     let persisted = repo
         .get_session(session_id)
@@ -226,7 +223,7 @@ async fn preflight_compact_failure_transitions_workflow_to_error() {
 }
 
 #[tokio::test]
-async fn background_compact_failure_clears_flags_without_failing_workflow() {
+async fn manual_compact_failure_clears_flags_without_failing_workflow() {
     init_runtime_primitives();
 
     let session_id = "compact-error-background";
@@ -243,7 +240,7 @@ async fn background_compact_failure_clears_flags_without_failing_workflow() {
     )])));
     let dispatcher = RecordingDispatcher::default();
 
-    let action = handle_compact_error_state(
+    handle_compact_error_state(
         &session_repo,
         &active_sessions,
         &dispatcher,
@@ -252,7 +249,6 @@ async fn background_compact_failure_clears_flags_without_failing_workflow() {
     )
     .await
     .expect("compact error handling should succeed");
-    assert_eq!(action, CompactErrorAction::None);
 
     let persisted = repo
         .get_session(session_id)
@@ -280,4 +276,77 @@ async fn background_compact_failure_clears_flags_without_failing_workflow() {
 
     assert_eq!(dispatcher.compact_states().len(), 1);
     assert!(dispatcher.agent_events().is_empty());
+}
+
+#[tokio::test]
+async fn post_response_compact_failure_with_deferred_step_transitions_workflow_to_error() {
+    init_runtime_primitives();
+
+    let session_id = "compact-error-post-response";
+    let metadata = build_session_metadata(session_id, SessionStatus::Busy);
+    let repo = Arc::new(InMemorySessionRepository::new());
+    repo.upsert_session(&metadata)
+        .await
+        .expect("session upsert should succeed");
+    let session_repo: Arc<dyn SessionRepository> = repo.clone();
+
+    let session = build_agent_session(metadata.clone(), false);
+    *session.compaction.deferred_workflow_step.write().await =
+        Some(DeferredWorkflowStep::FinalizeWorkflow {
+            reason: tauri_mcp_agent_lib::agent::events::WorkflowCompletionReason::Natural,
+        });
+    let active_sessions = Arc::new(RwLock::new(HashMap::from([(
+        session_id.to_string(),
+        session,
+    )])));
+    let dispatcher = RecordingDispatcher::default();
+    let error = AgentRuntimeError::new(
+        AgentRuntimeErrorType::AiServiceError,
+        "post-response compaction failed",
+    );
+
+    handle_compact_error_state(
+        &session_repo,
+        &active_sessions,
+        &dispatcher,
+        session_id.to_string(),
+        error.clone(),
+    )
+    .await
+    .expect("compact error handling should succeed");
+
+    let persisted = repo
+        .get_session(session_id)
+        .await
+        .expect("session lookup should succeed")
+        .expect("session should exist");
+    assert_eq!(persisted.status, SessionStatus::Error);
+
+    let active = active_sessions.read().await;
+    let session = active.get(session_id).expect("active session should exist");
+    assert_eq!(session.metadata.status, SessionStatus::Error);
+    assert!(session
+        .compaction
+        .deferred_workflow_step
+        .read()
+        .await
+        .is_none());
+    drop(active);
+
+    let agent_events = dispatcher.agent_events();
+    assert_eq!(agent_events.len(), 2);
+    assert!(matches!(
+        &agent_events[0],
+        AgentEvent::StatusChanged {
+            session_id: emitted_session_id,
+            status: SessionStatus::Error,
+        } if emitted_session_id == session_id
+    ));
+    assert!(matches!(
+        &agent_events[1],
+        AgentEvent::WorkflowError {
+            session_id: emitted_session_id,
+            error: emitted_error,
+        } if emitted_session_id == session_id && emitted_error.display_message == error.display_message
+    ));
 }

--- a/src-tauri/tests/workflow_restart_state_tests.rs
+++ b/src-tauri/tests/workflow_restart_state_tests.rs
@@ -81,10 +81,6 @@ async fn reset_session_execution_state_clears_cancel_poison_and_stale_compaction
         .compaction
         .awaiting_completion
         .store(true, Ordering::SeqCst);
-    session
-        .compaction
-        .finalize_workflow_after_compact
-        .store(true, Ordering::SeqCst);
     *session.compaction.deferred_workflow_step.write().await =
         Some(DeferredWorkflowStep::RequestCompletion);
 
@@ -96,10 +92,6 @@ async fn reset_session_execution_state_clears_cancel_poison_and_stale_compaction
     assert!(!session
         .compaction
         .awaiting_completion
-        .load(Ordering::SeqCst));
-    assert!(!session
-        .compaction
-        .finalize_workflow_after_compact
         .load(Ordering::SeqCst));
     assert!(session
         .compaction

--- a/src/context/llm/compact-listener.ts
+++ b/src/context/llm/compact-listener.ts
@@ -1,0 +1,187 @@
+import { handleCompactError, handleCompactResponse } from '@/lib/backend/agent-commands';
+import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
+import type {
+  AIContextCompactionService,
+  AIServiceConfig,
+} from '@/lib/ai-service/types';
+import { normalizeRustMessage } from '@/lib/ai-service/utils';
+import { getLogger } from '@/lib/logger';
+import type { Settings } from '@/context/SettingsContext';
+import { listen } from '@tauri-apps/api/event';
+import type { MutableRefObject } from 'react';
+import { toast } from 'sonner';
+import { buildServiceRuntimeConfig } from './service-runtime-config';
+import { toAgentRuntimeError } from './listener-utils';
+import type { CompactRequest, CompactedRange } from './types';
+
+const logger = getLogger('compact-listener');
+
+interface CompactRequestListenerOptions {
+  settingsRef: MutableRefObject<Settings>;
+  clearCompactionPressureForSession: (sessionId: string) => void;
+  setCompactedRangeForSession: (
+    sessionId: string,
+    range: CompactedRange | undefined,
+  ) => void;
+  isMounted: () => boolean;
+  onRegistered: () => void;
+}
+
+interface CompactStateEventPayload {
+  sessionId: string;
+  sessionName?: string;
+  compacting: boolean;
+  awaitingCompact: boolean;
+  phase: 'STARTED' | 'SUCCEEDED' | 'FAILED';
+  error?: string;
+}
+
+interface CompactStateListenerOptions {
+  setCompactingFromEvent: (sessionId: string, value: boolean) => void;
+  setAwaitingCompactForSession: (sessionId: string, value: boolean) => void;
+  isMounted: () => boolean;
+  onRegistered: () => void;
+}
+
+export async function setupCompactRequestListener({
+  settingsRef,
+  clearCompactionPressureForSession,
+  setCompactedRangeForSession,
+  isMounted,
+  onRegistered,
+}: CompactRequestListenerOptions): Promise<(() => void) | undefined> {
+  const unlisten = await listen<CompactRequest>(
+    'llm:compact-request',
+    async (event) => {
+      const {
+        sessionId,
+        messages: rawMessages,
+        fromId,
+        toId,
+        parentRequest,
+      } = event.payload;
+      const messages = rawMessages.map(normalizeRustMessage);
+      logger.info(
+        `📦 Compact request received: session=${sessionId}, fromId=${fromId}, toId=${toId}`,
+      );
+
+      const settings = settingsRef.current;
+      if (!settings) {
+        logger.error('No settings available for compact request');
+        await handleCompactError(
+          sessionId,
+          toAgentRuntimeError(
+            new Error('No settings available for compact request'),
+          ),
+        );
+        return;
+      }
+
+      const provider = (parentRequest?.provider ??
+        settings.preferredModel.provider) as AIServiceProvider;
+      const apiKey = settings.serviceConfigs?.[provider]?.apiKey ?? '';
+      const model = parentRequest?.model ?? settings.preferredModel.model;
+      const providerConfig: AIServiceConfig =
+        settings.serviceConfigs?.[provider] ?? {};
+
+      try {
+        const runtimeConfig = buildServiceRuntimeConfig(settings, providerConfig);
+        const service: AIContextCompactionService = AIServiceFactory.getService(
+          provider,
+          apiKey,
+          providerConfig,
+        );
+        const summary = await service.compact(messages, {
+          modelName: model,
+          systemPrompt: parentRequest?.systemPrompt,
+          sessionContext: parentRequest?.sessionContext,
+          availableTools: parentRequest?.availableTools,
+          config: runtimeConfig,
+        });
+        await handleCompactResponse(sessionId, fromId, toId, summary);
+        setCompactedRangeForSession(sessionId, {
+          fromId,
+          toId,
+          summary,
+        });
+        clearCompactionPressureForSession(sessionId);
+        logger.info(`✅ Compact summary stored: session=${sessionId}`);
+      } catch (error) {
+        const compactRuntimeError = toAgentRuntimeError(error);
+        logger.error(
+          `Compact LLM call failed: session=${sessionId}`,
+          compactRuntimeError,
+        );
+        await handleCompactError(sessionId, compactRuntimeError);
+      }
+    },
+  );
+
+  if (!isMounted()) {
+    unlisten();
+    return undefined;
+  }
+
+  onRegistered();
+  return () => {
+    unlisten();
+    logger.info('LLM compact request listener cleaned up');
+  };
+}
+
+export async function setupCompactStateListener({
+  setCompactingFromEvent,
+  setAwaitingCompactForSession,
+  isMounted,
+  onRegistered,
+}: CompactStateListenerOptions): Promise<(() => void) | undefined> {
+  const unlisten = await listen<CompactStateEventPayload>(
+    'llm:compact-state',
+    (event) => {
+      const {
+        sessionId,
+        sessionName,
+        compacting,
+        awaitingCompact,
+        phase,
+        error,
+      } = event.payload;
+      const toastId = `compact-${sessionId}`;
+      const description = sessionName ?? sessionId.slice(0, 8);
+
+      setCompactingFromEvent(sessionId, compacting);
+      setAwaitingCompactForSession(sessionId, awaitingCompact);
+
+      if (phase === 'STARTED') {
+        toast.loading(`Compacting context…`, {
+          id: toastId,
+          description,
+          duration: Infinity,
+        });
+      } else if (phase === 'SUCCEEDED') {
+        toast.success(`Context compacted`, {
+          id: toastId,
+          description,
+          duration: 3000,
+        });
+      } else if (phase === 'FAILED') {
+        toast.error(`Compaction failed`, {
+          id: toastId,
+          description: error ? `${description} - ${error}` : description,
+          duration: 4000,
+        });
+      }
+    },
+  );
+
+  if (!isMounted()) {
+    unlisten();
+    return undefined;
+  }
+
+  onRegistered();
+  return () => {
+    unlisten();
+    logger.info('LLM compact state listener cleaned up');
+  };
+}

--- a/src/context/llm/compact-listener.ts
+++ b/src/context/llm/compact-listener.ts
@@ -1,4 +1,7 @@
-import { handleCompactError, handleCompactResponse } from '@/lib/backend/agent-commands';
+import {
+  handleCompactError,
+  handleCompactResponse,
+} from '@/lib/backend/agent-commands';
 import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
 import type {
   AIContextCompactionService,
@@ -85,7 +88,10 @@ export async function setupCompactRequestListener({
         settings.serviceConfigs?.[provider] ?? {};
 
       try {
-        const runtimeConfig = buildServiceRuntimeConfig(settings, providerConfig);
+        const runtimeConfig = buildServiceRuntimeConfig(
+          settings,
+          providerConfig,
+        );
         const service: AIContextCompactionService = AIServiceFactory.getService(
           provider,
           apiKey,

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -1,28 +1,20 @@
 import {
   handleLLMError,
   handleLLMResponse,
-  handleCompactResponse,
-  handleCompactError,
 } from '@/lib/backend/agent-commands';
 import { useEffect } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { toast } from 'sonner';
 
 import { messageToRustMessage, type Message } from '@/models/chat';
 import type { CompactionPressure } from '@/models/agent-ipc';
 import type { MCPTool } from '@/lib/mcp';
 import type { Settings } from '@/context/SettingsContext';
-import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
-import type {
-  AIContextCompactionService,
-  AIServiceConfig,
-} from '@/lib/ai-service/types';
+import type { AIServiceProvider } from '@/lib/ai-service';
 import { normalizeRustMessage } from '@/lib/ai-service/utils';
 import { getLogger } from '@/lib/logger';
 import { sleep } from '@/lib/retry-utils';
 import type {
   CompletionCancelRequest,
-  CompactRequest,
   CompactedRange,
   CompletionRequest,
 } from './types';
@@ -31,12 +23,15 @@ import {
   isSupersededRequestError,
   isWorkflowCancelledError,
 } from './types';
-import { buildServiceRuntimeConfig } from './service-runtime-config';
 import {
   extractCompactionPressure,
   shouldBypassRetryAndFallback,
   toAgentRuntimeError,
 } from './listener-utils';
+import {
+  setupCompactRequestListener,
+  setupCompactStateListener,
+} from './compact-listener';
 
 const logger = getLogger('useLLMListener');
 const startupLifecycleLogKeys = new Set<string>();
@@ -109,6 +104,8 @@ export function useLLMListener({
     let isMounted = true;
     let unlisten: (() => void) | undefined;
     let unlistenCancel: (() => void) | undefined;
+    let unlistenCompact: (() => void) | undefined;
+    let unlistenCompactState: (() => void) | undefined;
 
     const setupListener = async () => {
       logStartupLifecycleOnce(
@@ -418,150 +415,34 @@ export function useLLMListener({
     };
 
     setupCancelListener();
-
-    // --- Compact request listener ---
-    let unlistenCompact: (() => void) | undefined;
-
-    const setupCompactListener = async () => {
-      const unlistenFn = await listen<CompactRequest>(
-        'llm:compact-request',
-        async (event) => {
-          const {
-            sessionId,
-            messages: rawMessages,
-            fromId,
-            toId,
-            parentRequest,
-          } = event.payload;
-          const messages = rawMessages.map(normalizeRustMessage);
-          logger.info(
-            `📦 Compact request received: session=${sessionId}, fromId=${fromId}, toId=${toId}`,
-          );
-
-          const settings = settingsRef.current;
-          if (!settings) {
-            logger.error('No settings available for compact request');
-            await handleCompactError(
-              sessionId,
-              toAgentRuntimeError(
-                new Error('No settings available for compact request'),
-              ),
-            );
-            return;
-          }
-
-          const provider = (parentRequest?.provider ??
-            settings.preferredModel.provider) as AIServiceProvider;
-          const apiKey = settings.serviceConfigs?.[provider]?.apiKey ?? '';
-          const model = parentRequest?.model ?? settings.preferredModel.model;
-          const providerConfig: AIServiceConfig =
-            settings.serviceConfigs?.[provider] ?? {};
-
-          try {
-            const runtimeConfig = buildServiceRuntimeConfig(
-              settings,
-              providerConfig,
-            );
-            const service: AIContextCompactionService =
-              AIServiceFactory.getService(provider, apiKey, providerConfig);
-            const summary = await service.compact(messages, {
-              modelName: model,
-              systemPrompt: parentRequest?.systemPrompt,
-              sessionContext: parentRequest?.sessionContext,
-              availableTools: parentRequest?.availableTools,
-              config: runtimeConfig,
-            });
-            await handleCompactResponse(sessionId, fromId, toId, summary);
-            setCompactedRangeForSession(sessionId, {
-              fromId,
-              toId,
-              summary,
-            });
-            clearCompactionPressureForSession(sessionId);
-            logger.info(`✅ Compact summary stored: session=${sessionId}`);
-          } catch (error) {
-            const compactRuntimeError = toAgentRuntimeError(error);
-            logger.error(
-              `Compact LLM call failed: session=${sessionId}`,
-              compactRuntimeError,
-            );
-            await handleCompactError(sessionId, compactRuntimeError);
-          }
-        },
-      );
-
-      if (!isMounted) {
-        unlistenFn();
-      } else {
-        unlistenCompact = unlistenFn;
+    void setupCompactRequestListener({
+      settingsRef,
+      clearCompactionPressureForSession,
+      setCompactedRangeForSession,
+      isMounted: () => isMounted,
+      onRegistered: () => {
         logStartupLifecycleOnce(
           'compact-request-registered',
           'LLM compact request listener registered',
         );
-      }
-    };
+      },
+    }).then((cleanup) => {
+      unlistenCompact = cleanup;
+    });
 
-    setupCompactListener();
-
-    // --- Compact state listener (Rust-owned: compacting = true/false) ---
-    let unlistenCompactState: (() => void) | undefined;
-
-    const setupCompactStateListener = async () => {
-      const unlistenFn = await listen<{
-        sessionId: string;
-        sessionName?: string;
-        compacting: boolean;
-        awaitingCompact: boolean;
-        phase: 'STARTED' | 'SUCCEEDED' | 'FAILED';
-        error?: string;
-      }>('llm:compact-state', (event) => {
-        const {
-          sessionId,
-          sessionName,
-          compacting,
-          awaitingCompact,
-          phase,
-          error,
-        } = event.payload;
-        const toastId = `compact-${sessionId}`;
-        const description = sessionName ?? sessionId.slice(0, 8);
-
-        setCompactingFromEvent(sessionId, compacting);
-        setAwaitingCompactForSession(sessionId, awaitingCompact);
-
-        if (phase === 'STARTED') {
-          toast.loading(`Compacting context…`, {
-            id: toastId,
-            description,
-            duration: Infinity,
-          });
-        } else if (phase === 'SUCCEEDED') {
-          toast.success(`Context compacted`, {
-            id: toastId,
-            description,
-            duration: 3000,
-          });
-        } else if (phase === 'FAILED') {
-          toast.error(`Compaction failed`, {
-            id: toastId,
-            description: error ? `${description} - ${error}` : description,
-            duration: 4000,
-          });
-        }
-      });
-
-      if (!isMounted) {
-        unlistenFn();
-      } else {
-        unlistenCompactState = unlistenFn;
+    void setupCompactStateListener({
+      setCompactingFromEvent,
+      setAwaitingCompactForSession,
+      isMounted: () => isMounted,
+      onRegistered: () => {
         logStartupLifecycleOnce(
           'compact-state-registered',
           'LLM compact state listener registered',
         );
-      }
-    };
-
-    setupCompactStateListener();
+      },
+    }).then((cleanup) => {
+      unlistenCompactState = cleanup;
+    });
 
     return () => {
       isMounted = false;
@@ -575,11 +456,9 @@ export function useLLMListener({
       }
       if (unlistenCompact) {
         unlistenCompact();
-        logger.info('LLM compact request listener cleaned up');
       }
       if (unlistenCompactState) {
         unlistenCompactState();
-        logger.info('LLM compact state listener cleaned up');
       }
     };
   }, [cancelCompletionRequest]); // cancel handler identity must stay in sync

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -415,34 +415,46 @@ export function useLLMListener({
     };
 
     setupCancelListener();
-    void setupCompactRequestListener({
-      settingsRef,
-      clearCompactionPressureForSession,
-      setCompactedRangeForSession,
-      isMounted: () => isMounted,
-      onRegistered: () => {
-        logStartupLifecycleOnce(
-          'compact-request-registered',
-          'LLM compact request listener registered',
-        );
-      },
-    }).then((cleanup) => {
-      unlistenCompact = cleanup;
-    });
+    void (async () => {
+      try {
+        const [compactRequestCleanup, compactStateCleanup] = await Promise.all([
+          setupCompactRequestListener({
+            settingsRef,
+            clearCompactionPressureForSession,
+            setCompactedRangeForSession,
+            isMounted: () => isMounted,
+            onRegistered: () => {
+              logStartupLifecycleOnce(
+                'compact-request-registered',
+                'LLM compact request listener registered',
+              );
+            },
+          }),
+          setupCompactStateListener({
+            setCompactingFromEvent,
+            setAwaitingCompactForSession,
+            isMounted: () => isMounted,
+            onRegistered: () => {
+              logStartupLifecycleOnce(
+                'compact-state-registered',
+                'LLM compact state listener registered',
+              );
+            },
+          }),
+        ]);
 
-    void setupCompactStateListener({
-      setCompactingFromEvent,
-      setAwaitingCompactForSession,
-      isMounted: () => isMounted,
-      onRegistered: () => {
-        logStartupLifecycleOnce(
-          'compact-state-registered',
-          'LLM compact state listener registered',
-        );
-      },
-    }).then((cleanup) => {
-      unlistenCompactState = cleanup;
-    });
+        if (!isMounted) {
+          compactRequestCleanup?.();
+          compactStateCleanup?.();
+          return;
+        }
+
+        unlistenCompact = compactRequestCleanup;
+        unlistenCompactState = compactStateCleanup;
+      } catch (error) {
+        logger.error('Failed to register compact listeners', error);
+      }
+    })();
 
     return () => {
       isMounted = false;


### PR DESCRIPTION
## Summary
- extract frontend compaction event handling into a dedicated compact-listener module
- deduplicate Rust compact-context lifecycle loading through a shared helper module
- wrap compaction runtime flag choreography behind CompactionRuntimeState transition helpers
- remove the unused public agent_save_compact_context Tauri command and keep compact persistence on the handle_compact_response path
- track a future explicit compaction phase model as backlog issue #1251 instead of doing a risky rewrite now

## Validation
- cargo test --test llm_context_tests --test compact_error_recovery_tests --manifest-path src-tauri\Cargo.toml
