### PR TITLE
⚡ Bolt: Optimize token estimation loops

### DIFF
--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -265,31 +265,33 @@ export function calculateContextSafetyMargin(effectiveLimit: number): number {
 }
 
 export function estimateMCPContentTokens(content: MCPContent[]): number {
-  return content.reduce((total, item) => {
+  // ⚡ Bolt: Replace .reduce() with for-loop for better token estimation performance on hot paths
+  let total = 0;
+  for (const item of content) {
     switch (item.type) {
       case 'text':
-        return total + estimateTextTokens(item.text);
+        total += estimateTextTokens(item.text);
+        break;
       case 'resource':
-        return (
-          total +
-          estimateTextTokens(
-            typeof item.resource?.text === 'string' ? item.resource.text : '',
-          )
+        total += estimateTextTokens(
+          typeof item.resource?.text === 'string' ? item.resource.text : '',
         );
+        break;
       case 'tool_call':
-        return (
-          total +
-          estimateTextTokens(`${item.name ?? ''} ${item.arguments ?? ''}`)
-        );
+        total += estimateTextTokens(`${item.name ?? ''} ${item.arguments ?? ''}`);
+        break;
       case 'thinking':
-        return total + estimateTextTokens(item.thinking ?? '');
+        total += estimateTextTokens(item.thinking ?? '');
+        break;
       case 'image':
       case 'audio':
-        return total + 1000;
+        total += 1000;
+        break;
       default:
-        return total;
+        break;
     }
-  }, 0);
+  }
+  return total;
 }
 
 export function estimateMessageTokens(message: Message): number {
@@ -297,14 +299,12 @@ export function estimateMessageTokens(message: Message): number {
   total += estimateMCPContentTokens(message.content);
 
   if (message.tool_calls) {
-    total += message.tool_calls.reduce(
-      (sum, toolCall) =>
-        sum +
-        estimateTextTokens(
-          `${toolCall.function?.name ?? ''} ${toolCall.function?.arguments ?? ''}`,
-        ),
-      0,
-    );
+    // ⚡ Bolt: Replace .reduce() with for-loop for better token estimation performance on hot paths
+    for (const toolCall of message.tool_calls) {
+      total += estimateTextTokens(
+        `${toolCall.function?.name ?? ''} ${toolCall.function?.arguments ?? ''}`,
+      );
+    }
   }
 
   if (message.tool_use) {


### PR DESCRIPTION
💡 What: Replaced `.reduce()` with single-pass `for...of` loops in `estimateMCPContentTokens` and `estimateMessageTokens` in `src/lib/message-preprocessor.ts`.

🎯 Why: `.reduce()` array iteration causes O(N) functional allocation overhead on a hot path, scaling poorly for deep trees.

📊 Impact: Eliminates callback allocations, reducing GC pressure and marginally improving performance when processing large LLM context windows.

🔬 Measurement: Verify changes passed the full `pnpm test` suite. Run `pnpm lint` and assure no regressions in the frontend's token limits and behavior.

---
*PR created automatically by Jules for task [11346009334270273298](https://jules.google.com/task/11346009334270273298) started by @fritzprix*