### PR TITLE
Refactor agent chat side panels

### DIFF
--- a/src/context/AgentPlanningContext.tsx
+++ b/src/context/AgentPlanningContext.tsx
@@ -5,6 +5,8 @@ const logger = getLogger('AgentPlanningContext');
 
 interface AgentPlanningContextValue {
   showPlanningPanel: boolean;
+  openPlanningPanel: () => void;
+  closePlanningPanel: () => void;
   togglePlanningPanel: () => void;
 }
 
@@ -21,17 +23,39 @@ export function AgentPlanningProvider({
 }: AgentPlanningProviderProps) {
   const [showPlanningPanel, setShowPlanningPanel] = useState(false);
 
-  const togglePlanningPanel = useCallback(() => {
-    const newValue = !showPlanningPanel;
-    logger.info('Planning panel toggled', {
-      from: showPlanningPanel,
-      to: newValue,
+  const openPlanningPanel = useCallback(() => {
+    setShowPlanningPanel((current) => {
+      if (!current) {
+        logger.info('Planning panel opened');
+      }
+      return true;
     });
-    setShowPlanningPanel(newValue);
-  }, [showPlanningPanel]);
+  }, []);
+
+  const closePlanningPanel = useCallback(() => {
+    setShowPlanningPanel((current) => {
+      if (current) {
+        logger.info('Planning panel closed');
+      }
+      return false;
+    });
+  }, []);
+
+  const togglePlanningPanel = useCallback(() => {
+    setShowPlanningPanel((current) => {
+      const next = !current;
+      logger.info('Planning panel toggled', {
+        from: current,
+        to: next,
+      });
+      return next;
+    });
+  }, []);
 
   const value: AgentPlanningContextValue = {
     showPlanningPanel,
+    openPlanningPanel,
+    closePlanningPanel,
     togglePlanningPanel,
   };
 

--- a/src/context/AgentWorkspaceContext.tsx
+++ b/src/context/AgentWorkspaceContext.tsx
@@ -5,6 +5,8 @@ const logger = getLogger('AgentWorkspaceContext');
 
 interface AgentWorkspaceContextValue {
   showWorkspacePanel: boolean;
+  openWorkspacePanel: () => void;
+  closeWorkspacePanel: () => void;
   toggleWorkspacePanel: () => void;
 }
 
@@ -21,17 +23,39 @@ export function AgentWorkspaceProvider({
 }: AgentWorkspaceProviderProps) {
   const [showWorkspacePanel, setShowWorkspacePanel] = useState(false);
 
-  const toggleWorkspacePanel = useCallback(() => {
-    const newValue = !showWorkspacePanel;
-    logger.info('Workspace panel toggled', {
-      from: showWorkspacePanel,
-      to: newValue,
+  const openWorkspacePanel = useCallback(() => {
+    setShowWorkspacePanel((current) => {
+      if (!current) {
+        logger.info('Workspace panel opened');
+      }
+      return true;
     });
-    setShowWorkspacePanel(newValue);
-  }, [showWorkspacePanel]);
+  }, []);
+
+  const closeWorkspacePanel = useCallback(() => {
+    setShowWorkspacePanel((current) => {
+      if (current) {
+        logger.info('Workspace panel closed');
+      }
+      return false;
+    });
+  }, []);
+
+  const toggleWorkspacePanel = useCallback(() => {
+    setShowWorkspacePanel((current) => {
+      const next = !current;
+      logger.info('Workspace panel toggled', {
+        from: current,
+        to: next,
+      });
+      return next;
+    });
+  }, []);
 
   const value: AgentWorkspaceContextValue = {
     showWorkspacePanel,
+    openWorkspacePanel,
+    closeWorkspacePanel,
     toggleWorkspacePanel,
   };
 

--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, type CSSProperties } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type CSSProperties,
+} from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { agentCallBuiltinTool } from '@/lib/backend/agent-commands';
 import { createId } from '@paralleldrive/cuid2';
@@ -35,11 +42,120 @@ import { SessionLoadingOverlay } from './components/SessionLoadingOverlay';
 import { getLogger } from '@/lib/logger';
 import { AgentResourceAttachmentProvider } from './hooks/useAgentResourceAttachment';
 import { useTranslation } from 'react-i18next';
+import { useIsMobile } from '@/hooks/use-mobile';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
 
 const logger = getLogger('AgentChatView');
 
-function getSessionLoadingLabel(isStartingSession: boolean, t: (key: string) => string): string {
-  return isStartingSession ? t('agent.start.startingSession') : t('agent.chat.loadingSession');
+function getSessionLoadingLabel(
+  isStartingSession: boolean,
+  t: (key: string) => string,
+): string {
+  return isStartingSession
+    ? t('agent.start.startingSession')
+    : t('agent.chat.loadingSession');
+}
+
+interface DesktopPanelRailProps {
+  side: 'left' | 'right';
+  open: boolean;
+  children: ReactNode;
+}
+
+function DesktopPanelRail({ side, open, children }: DesktopPanelRailProps) {
+  const railRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) {
+      return;
+    }
+
+    if (!open) {
+      rail.setAttribute('inert', '');
+      return;
+    }
+
+    rail.removeAttribute('inert');
+  }, [open]);
+
+  return (
+    <aside
+      ref={railRef}
+      aria-hidden={!open}
+      data-open={open}
+      className={cn(
+        'absolute inset-y-0 z-20 w-80 transition-transform duration-300 ease-out',
+        !open && 'pointer-events-none',
+        side === 'left'
+          ? 'left-0 data-[open=false]:-translate-x-full'
+          : 'right-0 data-[open=false]:translate-x-full',
+      )}
+    >
+      {children}
+    </aside>
+  );
+}
+
+interface MobilePanelSheetProps {
+  description: string;
+  open: boolean;
+  side: 'left' | 'right';
+  title: string;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+function MobilePanelSheet({
+  children,
+  description,
+  open,
+  side,
+  title,
+  onOpenChange,
+}: MobilePanelSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side={side}
+        className="w-full max-w-none gap-0 p-0 sm:max-w-sm"
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+        <div className="h-full pt-12">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function AgentChatComposer() {
+  return (
+    <div className="relative shrink-0 px-4 pb-4">
+      <div
+        aria-hidden="true"
+        style={{ height: 'var(--agent-chat-composer-overlap, 64px)' }}
+      />
+      <div
+        className="relative z-10"
+        style={{
+          marginTop: 'calc(var(--agent-chat-composer-overlap, 64px) * -1)',
+        }}
+      >
+        <div className="pointer-events-none absolute inset-x-0 -top-12 h-32 bg-gradient-to-t from-background/80 via-background/28 to-transparent" />
+        <AgentChatAttachedFiles />
+        <AgentChatInput />
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -60,8 +176,11 @@ function getSessionLoadingLabel(isStartingSession: boolean, t: (key: string) => 
  */
 
 function AgentChatInner() {
-  const { showWorkspacePanel } = useAgentWorkspace();
-  const { showPlanningPanel } = useAgentPlanning();
+  const isMobile = useIsMobile();
+  const { closeWorkspacePanel, openWorkspacePanel, showWorkspacePanel } =
+    useAgentWorkspace();
+  const { closePlanningPanel, openPlanningPanel, showPlanningPanel } =
+    useAgentPlanning();
   const { t } = useTranslation();
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -69,6 +188,10 @@ function AgentChatInner() {
   const { injectMessages } = useAgentChatActions();
   const { workflowStatus } = useAgentChatState();
   const hasExecutedPlaybookRef = useRef(false);
+  const [hasOpenedWorkspaceDesktop, setHasOpenedWorkspaceDesktop] =
+    useState(showWorkspacePanel);
+  const [hasOpenedPlanningDesktop, setHasOpenedPlanningDesktop] =
+    useState(showPlanningPanel);
   const playbookId = searchParams.get('playbookId');
   const sessionId = session?.id;
   const assistantId = session?.assistant?.id;
@@ -139,47 +262,103 @@ function AgentChatInner() {
     workflowStatus,
   ]);
 
+  useEffect(() => {
+    if (!isMobile && showWorkspacePanel) {
+      setHasOpenedWorkspaceDesktop(true);
+    }
+  }, [isMobile, showWorkspacePanel]);
+
+  useEffect(() => {
+    if (!isMobile && showPlanningPanel) {
+      setHasOpenedPlanningDesktop(true);
+    }
+  }, [isMobile, showPlanningPanel]);
+
+  const handleWorkspaceSheetOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        openWorkspacePanel();
+        return;
+      }
+      closeWorkspacePanel();
+    },
+    [closeWorkspacePanel, openWorkspacePanel],
+  );
+
+  const handlePlanningSheetOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        openPlanningPanel();
+        return;
+      }
+      closePlanningPanel();
+    },
+    [closePlanningPanel, openPlanningPanel],
+  );
+
   return (
     <>
-      <div className="flex h-full w-full overflow-hidden rounded-2xl border border-border/50 bg-background font-sans shadow-[0_18px_48px_-28px_rgba(0,0,0,0.35)]">
-        {/* Workspace side panel */}
-        {showWorkspacePanel && <AgentWorkspacePanel />}
-
-        {/* Main chat area - components rendered directly inside provider scope */}
+      <div
+        className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-border/50 bg-background font-sans shadow-[0_18px_48px_-28px_rgba(0,0,0,0.35)]"
+        style={
+          {
+            '--agent-chat-composer-overlap': '64px',
+          } as CSSProperties
+        }
+      >
+        <AgentChatHeader />
         <div
-          className="flex-1 flex flex-col min-h-0 min-w-0"
-          style={
-            {
-              '--agent-chat-composer-overlap': '64px',
-            } as CSSProperties
-          }
+          className="relative flex min-h-0 flex-1 overflow-hidden"
+          data-testid="agent-chat-body"
         >
-          <AgentChatHeader />
-          <AgentChatStatusBar />
-          <AgentChatMessages />
+          {!isMobile && hasOpenedWorkspaceDesktop && (
+            <DesktopPanelRail side="left" open={showWorkspacePanel}>
+              <AgentWorkspacePanel
+                isVisible={showWorkspacePanel}
+                variant="rail"
+              />
+            </DesktopPanelRail>
+          )}
 
-          <div className="relative shrink-0 px-4 pb-4">
-            <div
-              aria-hidden="true"
-              style={{ height: 'var(--agent-chat-composer-overlap, 64px)' }}
-            />
-            <div
-              className="relative z-10"
-              style={{
-                marginTop:
-                  'calc(var(--agent-chat-composer-overlap, 64px) * -1)',
-              }}
-            >
-              <div className="pointer-events-none absolute inset-x-0 -top-12 h-32 bg-gradient-to-t from-background/80 via-background/28 to-transparent" />
-              <AgentChatAttachedFiles />
-              <AgentChatInput />
-            </div>
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <AgentChatStatusBar />
+            <AgentChatMessages />
           </div>
-        </div>
 
-        {/* Planning side panel */}
-        {showPlanningPanel && <AgentPlanningPanel />}
+          {!isMobile && hasOpenedPlanningDesktop && (
+            <DesktopPanelRail side="right" open={showPlanningPanel}>
+              <AgentPlanningPanel
+                isVisible={showPlanningPanel}
+                variant="rail"
+              />
+            </DesktopPanelRail>
+          )}
+        </div>
+        <AgentChatComposer />
       </div>
+
+      {isMobile && (
+        <>
+          <MobilePanelSheet
+            open={showWorkspacePanel}
+            onOpenChange={handleWorkspaceSheetOpenChange}
+            side="left"
+            title={t('agent.workspace.title')}
+            description={t('agent.workspace.title')}
+          >
+            <AgentWorkspacePanel isVisible variant="sheet" />
+          </MobilePanelSheet>
+          <MobilePanelSheet
+            open={showPlanningPanel}
+            onOpenChange={handlePlanningSheetOpenChange}
+            side="right"
+            title={t('agent.planning.title')}
+            description={t('agent.planning.title')}
+          >
+            <AgentPlanningPanel isVisible variant="sheet" />
+          </MobilePanelSheet>
+        </>
+      )}
       <AgentPlanningUpdates />
     </>
   );
@@ -203,7 +382,9 @@ export default function AgentChatView() {
   if (!optionalSessionState) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <div className="text-destructive">{t('agent.chat.sessionContextUnavailable')}</div>
+        <div className="text-destructive">
+          {t('agent.chat.sessionContextUnavailable')}
+        </div>
       </div>
     );
   }

--- a/src/features/agent/__tests__/AgentChatView.test.tsx
+++ b/src/features/agent/__tests__/AgentChatView.test.tsx
@@ -10,6 +10,9 @@ import AgentChatView from '../AgentChatView';
 
 const mocks = vi.hoisted(() => ({
   agentSessionState: undefined as AgentSessionStateContextValue | undefined,
+  isMobile: false,
+  showWorkspacePanel: false,
+  showPlanningPanel: false,
 }));
 
 function createBaseRuntimeState(): SessionRuntimeState {
@@ -110,7 +113,10 @@ vi.mock('@/context/AgentWorkspaceContext', () => ({
     <>{children}</>
   ),
   useAgentWorkspace: () => ({
-    showWorkspacePanel: false,
+    showWorkspacePanel: mocks.showWorkspacePanel,
+    openWorkspacePanel: vi.fn(),
+    closeWorkspacePanel: vi.fn(),
+    toggleWorkspacePanel: vi.fn(),
   }),
 }));
 
@@ -119,8 +125,15 @@ vi.mock('@/context/AgentPlanningContext', () => ({
     <>{children}</>
   ),
   useAgentPlanning: () => ({
-    showPlanningPanel: false,
+    showPlanningPanel: mocks.showPlanningPanel,
+    openPlanningPanel: vi.fn(),
+    closePlanningPanel: vi.fn(),
+    togglePlanningPanel: vi.fn(),
   }),
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => mocks.isMobile,
 }));
 
 vi.mock('../hooks/useAgentResourceAttachment', () => ({
@@ -162,6 +175,28 @@ vi.mock('../components/AgentPlanningUpdates', () => ({
   AgentPlanningUpdates: () => <div>mock-planning-updates</div>,
 }));
 
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({
+    children,
+    open,
+  }: {
+    children: ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => <div data-testid={open ? 'sheet-open' : 'sheet-closed'}>{children}</div>,
+  SheetContent: ({
+    children,
+    side,
+  }: {
+    children: ReactNode;
+    side: string;
+    className?: string;
+  }) => <div data-testid={`sheet-content-${side}`}>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SheetDescription: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 vi.mock('@/components/ui/LoadingSpinner', () => ({
   default: ({ label }: { label?: string }) => <div>{label ?? 'spinner'}</div>,
 }));
@@ -197,6 +232,9 @@ vi.mock('@/lib/logger', () => ({
 describe('AgentChatView', () => {
   beforeEach(() => {
     mocks.agentSessionState = createSessionState();
+    mocks.isMobile = false;
+    mocks.showWorkspacePanel = false;
+    mocks.showPlanningPanel = false;
   });
 
   it('shows the blocking loader when there is no hydrated session yet', () => {
@@ -238,5 +276,36 @@ describe('AgentChatView', () => {
     expect(screen.getByText('mock-header')).toBeInTheDocument();
     expect(screen.getAllByText('Loading session...')).not.toHaveLength(0);
     expect(screen.getByTestId('chat-provider')).toBeInTheDocument();
+  });
+
+  it('renders both desktop side panels at the same time', () => {
+    mocks.agentSessionState = createSessionState({
+      session: createMockSession(),
+    });
+    mocks.showWorkspacePanel = true;
+    mocks.showPlanningPanel = true;
+
+    render(<AgentChatView />);
+
+    expect(screen.getByText('mock-workspace-panel')).toBeInTheDocument();
+    expect(screen.getByText('mock-planning-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('sheet-content-left')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sheet-content-right')).not.toBeInTheDocument();
+  });
+
+  it('renders mobile panels inside sheets instead of desktop rails', () => {
+    mocks.agentSessionState = createSessionState({
+      session: createMockSession(),
+    });
+    mocks.isMobile = true;
+    mocks.showWorkspacePanel = true;
+    mocks.showPlanningPanel = true;
+
+    render(<AgentChatView />);
+
+    expect(screen.getByTestId('sheet-content-left')).toBeInTheDocument();
+    expect(screen.getByTestId('sheet-content-right')).toBeInTheDocument();
+    expect(screen.getAllByText('mock-workspace-panel')).toHaveLength(1);
+    expect(screen.getAllByText('mock-planning-panel')).toHaveLength(1);
   });
 });

--- a/src/features/agent/components/AgentChatHeader.tsx
+++ b/src/features/agent/components/AgentChatHeader.tsx
@@ -33,23 +33,6 @@ export function AgentChatHeader({
   const [isCopying, setIsCopying] = useState(false);
   const { copyToClipboard } = useClipboard();
 
-  // Planning toggle comes from AgentPlanningContext to keep state in sync
-  const handleTogglePlanning = () => {
-    if (!showPlanningPanel) {
-      // About to open planning; ensure workspace is closed
-      if (showWorkspacePanel) toggleWorkspacePanel();
-    }
-    togglePlanningPanel();
-  };
-
-  const handleToggleWorkspace = () => {
-    if (!showWorkspacePanel) {
-      // About to open workspace; ensure planning is closed
-      if (showPlanningPanel) togglePlanningPanel();
-    }
-    toggleWorkspacePanel();
-  };
-
   const handleCopyMessages = async () => {
     if (isCopying) return;
     setIsCopying(true);
@@ -102,8 +85,10 @@ export function AgentChatHeader({
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={handleToggleWorkspace}
+                onClick={toggleWorkspacePanel}
                 aria-label={t('agent.header.toggleWorkspaceAria')}
+                aria-controls="agent-workspace-panel"
+                aria-expanded={showWorkspacePanel}
                 className="h-6 px-2"
               >
                 <FolderOpen
@@ -122,8 +107,10 @@ export function AgentChatHeader({
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={handleTogglePlanning}
+                onClick={togglePlanningPanel}
                 aria-label={t('agent.header.togglePlanningAria')}
+                aria-controls="agent-planning-panel"
+                aria-expanded={showPlanningPanel}
                 className="h-6 px-2"
               >
                 <PanelRight

--- a/src/features/agent/components/AgentPlanningPanel.tsx
+++ b/src/features/agent/components/AgentPlanningPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Circle, PanelRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAgentChat } from '@/context/AgentChatContext';
@@ -8,23 +8,32 @@ import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui';
 import { getLogger } from '@/lib/logger';
 import { parsePlanningState, parseScratchpadState } from '@/models/planning';
+import { cn } from '@/lib/utils';
 
 const logger = getLogger('AgentPlanningPanel');
 
-export function AgentPlanningPanel() {
+interface AgentPlanningPanelProps {
+  isVisible?: boolean;
+  variant?: 'rail' | 'sheet';
+}
+
+export function AgentPlanningPanel({
+  isVisible = true,
+  variant = 'rail',
+}: AgentPlanningPanelProps) {
   const { t } = useTranslation();
   const { session } = useAgentSessionState();
   const { serviceContexts, updateServiceContexts } = useAgentChat();
+  const wasVisibleRef = useRef(false);
 
-  // Component lifecycle logging
   useEffect(() => {
-    logger.info('AGENT_PLANNING_PANEL: Component mounted');
-    // Ensure we have the latest planning state when the panel opens
-    updateServiceContexts();
-    return () => {
-      logger.info('AGENT_PLANNING_PANEL: Component unmounted');
-    };
-  }, [updateServiceContexts]);
+    if (isVisible && !wasVisibleRef.current) {
+      logger.info('AGENT_PLANNING_PANEL: Panel became visible');
+      void updateServiceContexts();
+    }
+
+    wasVisibleRef.current = isVisible;
+  }, [isVisible, updateServiceContexts]);
 
   const planningState = useMemo(
     () => parsePlanningState(serviceContexts.planning?.structuredState),
@@ -54,7 +63,15 @@ export function AgentPlanningPanel() {
   if (!session) return null;
 
   return (
-    <Card className="h-full w-80 flex-shrink-0 rounded-none border-y-0 border-r-0 border-l border-border/40 bg-background py-0 shadow-none gap-0 overflow-hidden">
+    <Card
+      id="agent-planning-panel"
+      className={cn(
+        'h-full overflow-hidden rounded-none bg-background py-0 shadow-none gap-0',
+        variant === 'rail'
+          ? 'w-80 flex-shrink-0 border-y-0 border-r-0 border-l border-border/40'
+          : 'w-full border-0',
+      )}
+    >
       <CardHeader className="border-b border-border/40 px-4 py-3">
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted-foreground">

--- a/src/features/agent/components/AgentWorkspacePanel.tsx
+++ b/src/features/agent/components/AgentWorkspacePanel.tsx
@@ -38,6 +38,7 @@ import {
   type DragAndDropPayload,
 } from '@/context/DnDContext';
 import { useAgentSessionState } from '@/context/AgentSessionContext';
+import { cn } from '@/lib/utils';
 
 import { FileTreeNode } from './workspace-panel/FileTreeNode';
 import { useWorkspaceFiles } from './workspace-panel/useWorkspaceFiles';
@@ -66,7 +67,15 @@ async function withNativeOpenLock(
   }
 }
 
-export function AgentWorkspacePanel() {
+interface AgentWorkspacePanelProps {
+  isVisible?: boolean;
+  variant?: 'rail' | 'sheet';
+}
+
+export function AgentWorkspacePanel({
+  isVisible = true,
+  variant = 'rail',
+}: AgentWorkspacePanelProps) {
   const { t } = useTranslation();
   const { openWorkspaceFileWithDefaultApp } = useRustBackend();
   const { session } = useAgentSessionState();
@@ -159,6 +168,11 @@ export function AgentWorkspacePanel() {
 
   // Subscribe to DnD events
   useEffect(() => {
+    if (!isVisible) {
+      setDragState((current) => (current.isOver ? { isOver: false } : current));
+      return;
+    }
+
     logger.debug('Setting up DnD subscription for AgentWorkspacePanel');
 
     const handler = (event: DragAndDropEvent, payload: DragAndDropPayload) => {
@@ -185,7 +199,7 @@ export function AgentWorkspacePanel() {
       logger.debug('Cleaning up DnD subscription for AgentWorkspacePanel');
       unsub();
     };
-  }, [subscribe, handleWorkspacePathDrop]);
+  }, [subscribe, handleWorkspacePathDrop, isVisible]);
 
   const handleOpenInExplorer = async () => {
     try {
@@ -275,13 +289,22 @@ export function AgentWorkspacePanel() {
 
   return (
     <div
+      id="agent-workspace-panel"
       ref={panelRef}
-      className={`h-full w-80 flex-shrink-0 ${dragState.isOver ? 'ring-2 ring-inset ring-success' : ''}`}
+      className={cn(
+        'h-full',
+        variant === 'rail' ? 'w-80 flex-shrink-0' : 'w-full',
+        dragState.isOver && 'ring-2 ring-inset ring-success',
+      )}
     >
       <Card
-        className={`h-full w-full rounded-none border-y-0 border-l-0 border-r border-border/40 bg-background py-0 shadow-none gap-0 ${
-          dragState.isOver ? 'border-success bg-success/5' : ''
-        }`}
+        className={cn(
+          'h-full w-full rounded-none bg-background py-0 shadow-none gap-0',
+          variant === 'rail'
+            ? 'border-y-0 border-l-0 border-r border-border/40'
+            : 'border-0',
+          dragState.isOver && 'border-success bg-success/5',
+        )}
       >
         <CardHeader className="border-b border-border/40 px-4 py-3">
           <div className="space-y-3">

--- a/src/features/agent/components/__tests__/AgentPlanningPanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentPlanningPanel.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentPlanningPanel } from '../AgentPlanningPanel';
+
+const mockUpdateServiceContexts = vi.fn();
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: {
+      id: 'session-1',
+    },
+  }),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChat: () => ({
+    serviceContexts: {},
+    updateServiceContexts: mockUpdateServiceContexts,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AgentPlanningPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes planning contexts when it becomes visible', () => {
+    const { rerender } = render(<AgentPlanningPanel isVisible={false} />);
+
+    expect(mockUpdateServiceContexts).not.toHaveBeenCalled();
+
+    rerender(<AgentPlanningPanel isVisible />);
+
+    expect(mockUpdateServiceContexts).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh again on rerender while still visible', () => {
+    const { rerender } = render(<AgentPlanningPanel isVisible />);
+
+    expect(mockUpdateServiceContexts).toHaveBeenCalledTimes(1);
+
+    rerender(<AgentPlanningPanel isVisible />);
+
+    expect(mockUpdateServiceContexts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/agent/components/__tests__/AgentWorkspacePanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentWorkspacePanel.test.tsx
@@ -14,6 +14,17 @@ import * as pathApi from '@tauri-apps/api/path';
 let latestHandler:
   | ((event: DragAndDropEvent, payload: DragAndDropPayload) => void)
   | undefined;
+const mocks = vi.hoisted(() => ({
+  subscribe: vi.fn(
+    (
+      _ref: unknown,
+      handler: (event: DragAndDropEvent, payload: DragAndDropPayload) => void,
+    ) => {
+      latestHandler = handler;
+      return vi.fn();
+    },
+  ),
+}));
 const mockRustBackend = {
   listWorkspaceFiles: vi.fn().mockResolvedValue([]),
   openWorkspaceFileWithDefaultApp: vi.fn(),
@@ -67,15 +78,7 @@ vi.mock('@/context/AgentChatContext', () => {
 
 vi.mock('@/context/DnDContext', () => {
   const mockDnD = {
-    subscribe: vi.fn(
-      (
-        _ref: unknown,
-        handler: (event: DragAndDropEvent, payload: DragAndDropPayload) => void,
-      ) => {
-        latestHandler = handler;
-        return vi.fn();
-      },
-    ),
+    subscribe: mocks.subscribe,
   };
   return {
     useDnDContext: () => mockDnD,
@@ -130,6 +133,18 @@ describe('AgentWorkspacePanel', () => {
         return `${basePath}/${childPath}`;
       },
     );
+  });
+
+  it('skips DnD subscription while hidden', async () => {
+    render(<AgentWorkspacePanel isVisible={false} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('agent.workspace.title').length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    expect(mocks.subscribe).not.toHaveBeenCalled();
   });
 
   it('renders accessibility labels correctly', async () => {


### PR DESCRIPTION
## Summary
- switch agent chat side panels to desktop body-only overlay rails and mobile sheets
- remove workspace/planning mutual exclusion and add explicit open/close panel actions
- move panel side effects to visibility-driven behavior and add focused regression tests

## Testing
- pnpm refactor:validate