### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in SecurityValidator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-05-16 - Path Traversal via Absolute Paths
-**Vulnerability:** The `SecurityValidator` allowed arbitrary path access by bypassing relative traversal checks if an absolute path was directly provided.
-**Learning:** `clean_path.is_absolute()` bypasses `base_dir.join()` making absolute inputs directly become the target path without checking containment.
-**Prevention:** Always verify that the final canonicalized or resolved absolute path explicitly `.starts_with()` the intended base directory.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - Path Traversal via Absolute Paths
+**Vulnerability:** The `SecurityValidator` allowed arbitrary path access by bypassing relative traversal checks if an absolute path was directly provided.
+**Learning:** `clean_path.is_absolute()` bypasses `base_dir.join()` making absolute inputs directly become the target path without checking containment.
+**Prevention:** Always verify that the final canonicalized or resolved absolute path explicitly `.starts_with()` the intended base directory.

--- a/src-tauri/src/mcp/builtin/browser/content.rs
+++ b/src-tauri/src/mcp/builtin/browser/content.rs
@@ -643,7 +643,8 @@ pub(crate) async fn save_downloaded_file(
     let target_session_id = session_id.unwrap_or("default");
     let session_manager = crate::session::get_session_manager().map_err(|e| e.to_string())?;
     let workspace_dir = session_manager.get_session_workspace_dir_by_id(target_session_id);
-    let file_manager_state = crate::services::SecureFileManager::new_with_base_dir(workspace_dir);
+    let file_manager_state =
+        crate::services::SecureFileManager::new_scoped_with_base_dir(workspace_dir);
 
     match file_manager_state.write_file(save_path, bytes).await {
         Ok(_) => {

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -22,13 +22,23 @@ pub enum SecurityError {
 /// Security utilities for built-in servers
 pub struct SecurityValidator {
     base_dir: PathBuf,
+    enforce_base_dir_containment: bool,
 }
 
 impl SecurityValidator {
     pub fn new_with_base_dir(base_dir: PathBuf) -> Self {
+        Self::new_internal(base_dir, false)
+    }
+
+    pub fn new_scoped_with_base_dir(base_dir: PathBuf) -> Self {
+        Self::new_internal(base_dir, true)
+    }
+
+    fn new_internal(base_dir: PathBuf, enforce_base_dir_containment: bool) -> Self {
         tracing::info!(
-            "SecurityValidator created with custom base_dir = {:?}",
-            base_dir
+            "SecurityValidator created with custom base_dir = {:?}, scoped = {}",
+            base_dir,
+            enforce_base_dir_containment
         );
 
         if let Err(e) = std::fs::create_dir_all(&base_dir) {
@@ -42,11 +52,25 @@ impl SecurityValidator {
 
         Self {
             base_dir: canonical_base,
+            enforce_base_dir_containment,
         }
     }
 
-    /// Validate and clean a file path to prevent directory traversal
+    /// Validate and clean a file path to prevent directory traversal.
+    ///
+    /// Read-only validation intentionally allows general absolute paths outside
+    /// `base_dir` as long as they are not sensitive and do not traverse via
+    /// parent segments or unsafe symlinks. Write validation tightens this by
+    /// requiring the resolved target to stay within `base_dir`.
     pub fn validate_path(&self, user_path: &str) -> Result<PathBuf, SecurityError> {
+        self.validate_path_internal(user_path, self.enforce_base_dir_containment)
+    }
+
+    fn validate_path_internal(
+        &self,
+        user_path: &str,
+        enforce_base_containment: bool,
+    ) -> Result<PathBuf, SecurityError> {
         // Log the input and effective base directory to simplify security debugging.
         tracing::debug!(
             "Validating path: '{}' against base: '{:?}'",
@@ -101,7 +125,7 @@ impl SecurityValidator {
 
         tracing::debug!("Resolved path: '{:?}'", absolute_path);
 
-        if !absolute_path.starts_with(&self.base_dir) {
+        if enforce_base_containment && !absolute_path.starts_with(&self.base_dir) {
             return Err(SecurityError::PathTraversal(format!(
                 "Access denied: Path '{user_path}' is outside the allowed base directory"
             )));
@@ -141,6 +165,11 @@ impl SecurityValidator {
                 }
 
                 if let Some(canon) = existing_canonical {
+                    if enforce_base_containment && !canon.starts_with(&self.base_dir) {
+                        return Err(SecurityError::PathTraversal(format!(
+                            "Access denied: Path '{user_path}' resolves outside the allowed base directory"
+                        )));
+                    }
                     self.ensure_not_sensitive_path(&canon, user_path)?;
                 }
 
@@ -151,6 +180,12 @@ impl SecurityValidator {
                 absolute_path.clone()
             }
         };
+
+        if enforce_base_containment && !canonical_path.starts_with(&self.base_dir) {
+            return Err(SecurityError::PathTraversal(format!(
+                "Access denied: Path '{user_path}' resolves outside the allowed base directory"
+            )));
+        }
 
         self.ensure_not_sensitive_path(&canonical_path, user_path)?;
 
@@ -209,7 +244,7 @@ impl SecurityValidator {
                 }
             }
         }
-        self.validate_path(user_path)
+        self.validate_path_internal(user_path, self.enforce_base_dir_containment)
     }
 
     /// Validate a path for read-only operations.

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -100,6 +100,13 @@ impl SecurityValidator {
         }
 
         tracing::debug!("Resolved path: '{:?}'", absolute_path);
+
+        if !absolute_path.starts_with(&self.base_dir) {
+            return Err(SecurityError::PathTraversal(format!(
+                "Access denied: Path '{user_path}' is outside the allowed base directory"
+            )));
+        }
+
         self.ensure_not_sensitive_path(&absolute_path, user_path)?;
 
         // SecurityValidator only validates paths. Directory creation is handled explicitly by callers.

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
@@ -45,10 +45,9 @@ impl WorkspaceServer {
             .unwrap_or_else(|| self.session_id.clone());
         let workspace_root = self.get_workspace_dir(&target_session_id);
 
-        let file_manager = self.get_file_manager(Some(target_session_id));
-        let safe_path = match file_manager
-            .get_security_validator()
-            .validate_path_for_read(&path_str)
+        let safe_path = match self
+            .validate_read_path_with_skill_access(&path_str, Some(target_session_id))
+            .await
         {
             Ok(path) => path,
             Err(e) => {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -120,9 +120,9 @@ impl WorkspaceServer {
 
         // 4. Path security validation
         let file_manager = self.get_file_manager(session_id.clone());
-        let safe_path = match file_manager
-            .get_security_validator()
-            .validate_path_for_read(path_str)
+        let safe_path = match self
+            .validate_read_path_with_skill_access(path_str, session_id.clone())
+            .await
         {
             Ok(path) => path,
             Err(e) => {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -92,10 +92,9 @@ impl WorkspaceServer {
         let workspace_root = self.get_workspace_dir(&target_session_id);
 
         // Security validation
-        let file_manager = self.get_file_manager(Some(target_session_id));
-        let safe_path = match file_manager
-            .get_security_validator()
-            .validate_path_for_read(search_path)
+        let safe_path = match self
+            .validate_read_path_with_skill_access(search_path, Some(target_session_id))
+            .await
         {
             Ok(path) => path,
             Err(e) => {

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
@@ -11,6 +12,7 @@ use super::BuiltinMCPServer;
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
 use crate::mcp::types::{ContextVolatility, MCPResult, ServiceContext};
 use crate::mcp::MCPTool;
+use crate::repositories::SessionRepository;
 use crate::services::SecureFileManager;
 use crate::session::SessionManager;
 
@@ -325,7 +327,93 @@ impl WorkspaceServer {
         let target_session_id = session_id.unwrap_or_else(|| self.session_id.clone());
 
         let workspace_dir = self.get_workspace_dir(&target_session_id);
-        Arc::new(SecureFileManager::new_with_base_dir(workspace_dir))
+        Arc::new(SecureFileManager::new_scoped_with_base_dir(workspace_dir))
+    }
+
+    async fn get_allowed_absolute_skill_roots(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<PathBuf>, String> {
+        let assistant_id = if let Some(repo) = crate::state::try_get_session_repository() {
+            repo.get_session(session_id)
+                .await
+                .map_err(|e| format!("Failed to load session metadata: {e}"))?
+                .and_then(|session| {
+                    let config_str = session.agent_config?;
+                    let config = serde_json::from_str::<Value>(&config_str).ok()?;
+                    config
+                        .get("assistantId")
+                        .or_else(|| config.get("id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+        } else {
+            None
+        };
+
+        let workspace_dir = self.get_workspace_dir(session_id);
+        let (system_dir, user_dir, assistant_dir, workspace_skill_dir) =
+            crate::services::skill_service::resolve_skill_directories(
+                assistant_id.as_deref(),
+                Some(session_id),
+                Some(&workspace_dir),
+            )
+            .await?;
+
+        Ok(crate::services::skill_service::collect_allowed_skill_roots(
+            system_dir,
+            user_dir,
+            assistant_dir,
+            workspace_skill_dir,
+        ))
+    }
+
+    fn path_is_within_any_root(candidate_path: &Path, allowed_roots: &[PathBuf]) -> bool {
+        let normalized_candidate = candidate_path
+            .canonicalize()
+            .unwrap_or_else(|_| candidate_path.to_path_buf());
+
+        allowed_roots.iter().any(|root| {
+            let normalized_root = root.canonicalize().unwrap_or_else(|_| root.clone());
+            normalized_candidate.starts_with(&normalized_root)
+        })
+    }
+
+    pub async fn validate_read_path_with_skill_access(
+        &self,
+        path_str: &str,
+        session_id: Option<String>,
+    ) -> Result<std::path::PathBuf, String> {
+        let target_session_id = session_id.unwrap_or_else(|| self.session_id.clone());
+        let file_manager = self.get_file_manager(Some(target_session_id.clone()));
+
+        match file_manager
+            .get_security_validator()
+            .validate_path_for_read(path_str)
+        {
+            Ok(path) => Ok(path),
+            Err(original_error) => {
+                let candidate_path = PathBuf::from(path_str);
+                if !candidate_path.is_absolute() {
+                    return Err(format!("Security error: {original_error}"));
+                }
+
+                let allowed_roots = self
+                    .get_allowed_absolute_skill_roots(&target_session_id)
+                    .await?;
+                if !Self::path_is_within_any_root(&candidate_path, &allowed_roots) {
+                    return Err(format!("Security error: {original_error}"));
+                }
+
+                let permissive_manager = SecureFileManager::new_with_base_dir(
+                    self.get_workspace_dir(&target_session_id),
+                );
+                permissive_manager
+                    .get_security_validator()
+                    .validate_path_for_read(path_str)
+                    .map_err(|e| format!("Security error: {e}"))
+            }
+        }
     }
 
     /// Validate path with security checks (helper for file operations)

--- a/src-tauri/src/services/secure_file_manager.rs
+++ b/src-tauri/src/services/secure_file_manager.rs
@@ -4,8 +4,8 @@ use tracing::{error, info};
 
 use crate::mcp::builtin::utils::SecurityValidator;
 
-/// Provides secure file system operations by ensuring that all paths are
-/// validated and constrained within a specific base directory.
+/// Provides secure file system operations with path validation and optional
+/// base-directory scoping depending on how the manager is constructed.
 pub struct SecureFileManager {
     security: SecurityValidator,
 }
@@ -14,10 +14,17 @@ impl SecureFileManager {
     /// Creates a new `SecureFileManager` with a specified base directory.
     ///
     /// # Arguments
-    /// * `base_dir` - The workspace anchor used for resolving relative paths.
+    /// * `base_dir` - The anchor used for resolving relative paths.
     pub fn new_with_base_dir(base_dir: std::path::PathBuf) -> Self {
         Self {
             security: SecurityValidator::new_with_base_dir(base_dir),
+        }
+    }
+
+    /// Creates a `SecureFileManager` that constrains both reads and writes to `base_dir`.
+    pub fn new_scoped_with_base_dir(base_dir: std::path::PathBuf) -> Self {
+        Self {
+            security: SecurityValidator::new_scoped_with_base_dir(base_dir),
         }
     }
 

--- a/src-tauri/src/services/workspace_service.rs
+++ b/src-tauri/src/services/workspace_service.rs
@@ -325,7 +325,8 @@ impl WorkspaceService {
             let workspace_dir =
                 crate::session::resolve_session_workspace_dir(session_manager, &sid).await?;
             // Create a temporary secure file manager for this operation
-            let manager = crate::services::SecureFileManager::new_with_base_dir(workspace_dir);
+            let manager =
+                crate::services::SecureFileManager::new_scoped_with_base_dir(workspace_dir);
             return manager.write_file(file_path, content).await;
         }
 

--- a/src-tauri/tests/builtin_security_validator_tests.rs
+++ b/src-tauri/tests/builtin_security_validator_tests.rs
@@ -208,3 +208,45 @@ fn test_dangling_symlink_parent_is_rejected() {
     let result = validator.validate_path("dangling_link_dir/new_file.txt");
     assert!(matches!(result, Err(SecurityError::PathTraversal(_))));
 }
+
+#[test]
+fn test_scoped_validator_blocks_absolute_paths_outside_base_dir() {
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());
+    let outside_dir = tempdir().expect("outside dir");
+    let outside_file = outside_dir.path().join("safe.txt");
+
+    assert!(matches!(
+        validator.validate_path_for_read(&outside_file.to_string_lossy()),
+        Err(SecurityError::PathTraversal(_))
+    ));
+    assert!(matches!(
+        validator.validate_path_for_write(&outside_file.to_string_lossy()),
+        Err(SecurityError::PathTraversal(_))
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_scoped_validator_blocks_symlink_to_general_external_file() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());
+
+    let outside_dir = tempdir().expect("outside dir");
+    let external_file = outside_dir.path().join("external.txt");
+    std::fs::write(&external_file, "safe").expect("write external file");
+
+    let link_path = temp_dir.path().join("safe_link");
+    symlink(&external_file, &link_path).expect("create symlink");
+
+    assert!(matches!(
+        validator.validate_path_for_read("safe_link"),
+        Err(SecurityError::PathTraversal(_))
+    ));
+    assert!(matches!(
+        validator.validate_path_for_write("safe_link"),
+        Err(SecurityError::PathTraversal(_))
+    ));
+}

--- a/src-tauri/tests/secure_file_manager_tests.rs
+++ b/src-tauri/tests/secure_file_manager_tests.rs
@@ -174,6 +174,7 @@ async fn test_copy_file_from_external_rejects_windows_reserved_filenames() {
 
 #[tokio::test]
 async fn test_external_paths_are_allowed_and_sensitive_targets_are_scoped() {
+    let _env_guard = EnvVarGuard::set_temp("LIBRAGENT_MAX_FILE_SIZE", "1048576");
     let workspace = tempdir().unwrap();
     let external_root = tempdir().unwrap();
     let external_file = external_root.path().join("external.txt");
@@ -205,5 +206,33 @@ async fn test_external_paths_are_allowed_and_sensitive_targets_are_scoped() {
     assert!(
         error.contains("protected location"),
         "unexpected sensitive path error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_scoped_file_manager_blocks_external_paths() {
+    let _env_guard = EnvVarGuard::set_temp("LIBRAGENT_MAX_FILE_SIZE", "1048576");
+    let workspace = tempdir().unwrap();
+    let external_root = tempdir().unwrap();
+    let external_file = external_root.path().join("external.txt");
+
+    let manager = SecureFileManager::new_scoped_with_base_dir(workspace.path().to_path_buf());
+
+    let write_error = manager
+        .write_file_string(&external_file.to_string_lossy(), "blocked")
+        .await
+        .expect_err("scoped manager should block writes outside base_dir");
+    assert!(
+        write_error.contains("outside the allowed base directory"),
+        "unexpected scoped write error: {write_error}"
+    );
+
+    let read_error = manager
+        .read_file_as_string(&external_file.to_string_lossy())
+        .await
+        .expect_err("scoped manager should block reads outside base_dir");
+    assert!(
+        read_error.contains("outside the allowed base directory"),
+        "unexpected scoped read error: {read_error}"
     );
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: Workspace-scoped file operations could escape the session workspace by passing absolute paths directly into `SecurityValidator` / `SecureFileManager`, because the default validator behavior intentionally allows general absolute paths.

🎯 Impact: Workspace MCP reads/writes/searches and other workspace-scoped save flows could reach files outside the intended session workspace instead of staying sandboxed.

🔧 Fix:
1. Added scoped `SecurityValidator` / `SecureFileManager` constructors that enforce `base_dir` containment.
2. Switched workspace-scoped call sites (`WorkspaceServer`, `WorkspaceService`, browser workspace downloads) to the scoped constructors.
3. Preserved existing global absolute-path behavior for non-workspace managers and explicitly restored allowed absolute skill-scope access for workspace read/list/search operations.
4. Added regression tests for scoped validation and removed the unrelated `.jules/sentinel.md` file.

✅ Verification: Verified with focused Rust regression tests for `builtin_security_validator_tests`, `secure_file_manager_tests`, and `workspace_skill_access_regression_tests`, then ran `pnpm refactor:validate` successfully.

---
*PR created automatically by Jules for task [16040175263784758406](https://jules.google.com/task/16040175263784758406) started by @fritzprix*
