### PR TITLE
Clean up Rust technical debt suppressions

### DIFF
--- a/src-tauri/src/mcp/builtin/attachments/operations.rs
+++ b/src-tauri/src/mcp/builtin/attachments/operations.rs
@@ -1,6 +1,6 @@
 use super::server::AttachmentsServer;
 use super::types::*;
-use super::{helpers, parsers, search};
+use super::{helpers, parsers, search, storage::AddContentInput};
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, not_found_error, ErrorCategory, SuccessHint, ToolGroup,
 };
@@ -154,15 +154,15 @@ pub async fn add_content(
     // Store the content
     let mut storage = server.storage.lock().await;
     let content_item = match storage
-        .add_content(
+        .add_content(AddContentInput {
             session_id,
-            &final_filename,
-            &mime_type,
-            final_size as usize,
-            &content_text,
+            filename: &final_filename,
+            mime_type: &mime_type,
+            size: final_size as usize,
+            content: &content_text,
             chunks,
-            args.src_url.clone(),
-        )
+            src_url: args.src_url.clone(),
+        })
         .await
     {
         Ok(item) => item,
@@ -223,7 +223,6 @@ pub async fn add_content(
             filename: content_item.filename.clone(),
             mime_type: content_item.mime_type.clone(),
             line_count: content_item.line_count,
-            uploaded_at: content_item.uploaded_at.clone(),
         });
 
         // Keep only last 10 uploads

--- a/src-tauri/src/mcp/builtin/attachments/search.rs
+++ b/src-tauri/src/mcp/builtin/attachments/search.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Search result for keyword queries
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     pub content_id: String,
@@ -20,14 +19,6 @@ pub struct TextChunk {
     pub content_id: String,
     pub text: String,
     pub line_range: (usize, usize),
-}
-
-/// Index statistics
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IndexStats {
-    pub num_docs: usize,
-    pub num_segments: usize,
 }
 
 /// BM25 Search Engine Implementation using bm25 crate

--- a/src-tauri/src/mcp/builtin/attachments/server.rs
+++ b/src-tauri/src/mcp/builtin/attachments/server.rs
@@ -16,8 +16,6 @@ pub struct RecentUploadInfo {
     pub filename: String,
     pub mime_type: String,
     pub line_count: usize,
-    #[allow(dead_code)]
-    pub uploaded_at: String,
 }
 
 /// Attachments built-in MCP server (native backend)

--- a/src-tauri/src/mcp/builtin/attachments/storage.rs
+++ b/src-tauri/src/mcp/builtin/attachments/storage.rs
@@ -102,6 +102,16 @@ impl Default for AttachmentsStorage {
     }
 }
 
+pub(super) struct AddContentInput<'a> {
+    pub(super) session_id: &'a str,
+    pub(super) filename: &'a str,
+    pub(super) mime_type: &'a str,
+    pub(super) size: usize,
+    pub(super) content: &'a str,
+    pub(super) chunks: Vec<String>,
+    pub(super) src_url: Option<String>,
+}
+
 impl AttachmentsStorage {
     /// Create in-memory storage (default)
     pub fn new() -> Self {
@@ -160,15 +170,6 @@ impl AttachmentsStorage {
             contents: HashMap::new(),
             chunks: HashMap::new(),
             db: Some(db),
-        })
-    }
-
-    /// Get database connection for operations
-    #[allow(dead_code)]
-    fn db(&self) -> Result<&DatabaseConnection, String> {
-        self.db.as_ref().ok_or_else(|| {
-            "Database not initialized. Use new_sqlite() to create SQLite-backed storage."
-                .to_string()
         })
     }
 
@@ -264,21 +265,6 @@ impl AttachmentsStorage {
         self.stores.contains_key(session_id)
     }
 
-    /// Get debug information about all stores
-    #[allow(dead_code)]
-    pub fn debug_stores_info(&self) -> Vec<String> {
-        self.stores
-            .iter()
-            .map(|(id, store)| {
-                format!(
-                    "Store {}: name={}",
-                    id,
-                    store.name.as_deref().unwrap_or("unnamed")
-                )
-            })
-            .collect()
-    }
-
     /// Get content count for a specific session
     pub fn get_content_count(&self, session_id: &str) -> usize {
         self.contents
@@ -342,17 +328,20 @@ impl AttachmentsStorage {
     }
 
     /// Add content to a session's store
-    #[allow(clippy::too_many_arguments)]
-    pub async fn add_content(
+    pub(super) async fn add_content(
         &mut self,
-        session_id: &str,
-        filename: &str,
-        mime_type: &str,
-        size: usize,
-        content: &str,
-        chunks: Vec<String>,
-        src_url: Option<String>,
+        input: AddContentInput<'_>,
     ) -> Result<AttachmentItem, String> {
+        let AddContentInput {
+            session_id,
+            filename,
+            mime_type,
+            size,
+            content,
+            chunks,
+            src_url,
+        } = input;
+
         // Verify store exists for this session
         if !self.stores.contains_key(session_id) {
             return Err(format!(

--- a/src-tauri/src/mcp/builtin/attachments/test_functional.rs
+++ b/src-tauri/src/mcp/builtin/attachments/test_functional.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::mcp::builtin::attachments::storage::AttachmentsStorage;
+    use crate::mcp::builtin::attachments::storage::{AddContentInput, AttachmentsStorage};
     use tempfile::TempDir;
 
     async fn setup_storage() -> (AttachmentsStorage, TempDir, String) {
@@ -56,15 +56,15 @@ mod tests {
         let src_url = Some("http://example.com/test".to_string());
 
         let content_item = storage
-            .add_content(
-                &session_id,
+            .add_content(AddContentInput {
+                session_id: &session_id,
                 filename,
                 mime_type,
                 size,
                 content,
                 chunks,
-                src_url.clone(),
-            )
+                src_url: src_url.clone(),
+            })
             .await
             .expect("Failed to add content");
 
@@ -111,15 +111,15 @@ mod tests {
         let src_url = Some("https://github.com/example/repo".to_string());
 
         let content_item = storage
-            .add_content(
-                &session_id,
-                "github_file.md",
-                "text/markdown",
-                100,
-                "# GitHub Content",
-                vec!["# GitHub Content".to_string()],
-                src_url.clone(),
-            )
+            .add_content(AddContentInput {
+                session_id: &session_id,
+                filename: "github_file.md",
+                mime_type: "text/markdown",
+                size: 100,
+                content: "# GitHub Content",
+                chunks: vec!["# GitHub Content".to_string()],
+                src_url: src_url.clone(),
+            })
             .await
             .expect("Failed to add content");
 

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -12,6 +12,16 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::types::MCPResult;
 
+struct ExportUiResponse<'a> {
+    title: &'a str,
+    items: &'a [String],
+    type_label: &'a str,
+    relative_path: &'a str,
+    filename: &'a str,
+    tool_name: &'a str,
+    text_response: &'a str,
+}
+
 impl WorkspaceServer {
     pub async fn handle_export(
         &self,
@@ -141,20 +151,23 @@ impl WorkspaceServer {
                 .join("exports")
                 .join("files")
                 .join(&export_filename);
+            let response_items = vec![single_file_rel_path_str];
+            let response_title = format!("File Export: {display_name}");
+            let response_relative_path = relative_path.to_string_lossy().replace('\\', "/");
+            let response_text = format!(
+                "✓ File '{}' exported successfully\n\nSaved export: `{}`\nDownload link available below",
+                display_name, response_relative_path
+            );
 
-            return Ok(self.build_ui_response(
-                &format!("File Export: {display_name}"),
-                &[single_file_rel_path_str],
-                "Single File",
-                &relative_path.to_string_lossy().replace('\\', "/"),
-                &display_name,
-                "export",
-                &format!(
-                    "✓ File '{}' exported successfully\n\nSaved export: `{}`\nDownload link available below",
-                    display_name,
-                    relative_path.to_string_lossy().replace('\\', "/")
-                ),
-            ));
+            return Ok(self.build_ui_response(&ExportUiResponse {
+                title: &response_title,
+                items: &response_items,
+                type_label: "Single File",
+                relative_path: &response_relative_path,
+                filename: &display_name,
+                tool_name: "export",
+                text_response: &response_text,
+            }));
         }
 
         // === ZIP PACKAGE EXPORT ===
@@ -313,49 +326,47 @@ impl WorkspaceServer {
             .join("exports")
             .join("packages")
             .join(&zip_filename);
+        let response_title = format!("ZIP Package: {package_name}");
+        let response_relative_path = relative_path.to_string_lossy().replace('\\', "/");
+        let response_text = format!(
+            "✓ ZIP package '{}' created successfully\n\nContains {} files\nSaved export: `{}`\nDownload link available below",
+            package_name,
+            processed_files.len(),
+            response_relative_path
+        );
 
-        Ok(self.build_ui_response(
-            &format!("ZIP Package: {package_name}"),
-            &processed_files,
-            "ZIP Package",
-            &relative_path.to_string_lossy().replace('\\', "/"),
-            &zip_filename,
-            "export",
-            &format!(
-                "✓ ZIP package '{}' created successfully\n\nContains {} files\nSaved export: `{}`\nDownload link available below",
-                package_name,
-                processed_files.len(),
-                relative_path.to_string_lossy().replace('\\', "/")
-            ),
-        ))
+        Ok(self.build_ui_response(&ExportUiResponse {
+            title: &response_title,
+            items: &processed_files,
+            type_label: "ZIP Package",
+            relative_path: &response_relative_path,
+            filename: &zip_filename,
+            tool_name: "export",
+            text_response: &response_text,
+        }))
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn build_ui_response(
-        &self,
-        title: &str,
-        items: &[String],
-        type_label: &str,
-        relative_path: &str,
-        filename: &str,
-        tool_name: &str,
-        text_response: &str,
-    ) -> MCPResult {
+    fn build_ui_response(&self, response: &ExportUiResponse<'_>) -> MCPResult {
         let uid = cuid2::create_id();
         let ui_request_id: u64 = uid
             .chars()
             .filter_map(|c| c.to_digit(36))
             .fold(0u64, |acc, d| acc.wrapping_mul(36).wrapping_add(d as u64));
 
-        let html_content =
-            ui_resources::create_html_export_ui(title, items, type_label, relative_path, filename);
+        let html_content = ui_resources::create_html_export_ui(
+            response.title,
+            response.items,
+            response.type_label,
+            response.relative_path,
+            response.filename,
+        );
 
         let ui_resource = ui_resources::create_export_ui_resource(
             ui_request_id,
-            title,
-            items,
-            type_label,
-            relative_path,
+            response.title,
+            response.items,
+            response.type_label,
+            response.relative_path,
             html_content,
         );
 
@@ -390,8 +401,8 @@ impl WorkspaceServer {
             }
         };
         let full_text = format!(
-            "{text_response}\nUI resource: `{}`\nUse the UI resource to trigger the download workflow.",
-            resource_uri
+            "{}\nUI resource: `{}`\nUse the UI resource to trigger the download workflow.",
+            response.text_response, resource_uri
         );
 
         crate::mcp::builtin::utils::create_resource_response(
@@ -399,7 +410,7 @@ impl WorkspaceServer {
             "text/html",
             resource_text,
             "workspace",
-            tool_name,
+            response.tool_name,
             Some(&full_text),
         )
     }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -8,17 +8,37 @@ use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};
 use std::path::Path;
 
-#[allow(clippy::too_many_arguments)]
+pub(super) struct SearchContentRequest<'a> {
+    pub display_path: &'a str,
+    pub regex: &'a regex::Regex,
+    pub query: &'a str,
+    pub show_hashes: bool,
+    pub ignore_case: bool,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+pub(super) struct SearchDirectoryRequest<'a> {
+    pub workspace_root: &'a Path,
+    pub dir: &'a Path,
+    pub file_pattern: Option<&'a glob::Pattern>,
+    pub search: SearchContentRequest<'a>,
+}
+
 pub(super) async fn search_content_in_file(
     file_path: &Path,
-    display_path: &str,
-    regex: &regex::Regex,
-    query: &str,
-    show_hashes: bool,
-    ignore_case: bool,
-    limit: usize,
-    offset: usize,
+    request: SearchContentRequest<'_>,
 ) -> Result<MCPResult, String> {
+    let SearchContentRequest {
+        display_path,
+        regex,
+        query,
+        show_hashes,
+        ignore_case,
+        limit,
+        offset,
+    } = request;
+
     let max_size = effective_search_content_file_size_limit();
     if let Ok(metadata) = tokio::fs::metadata(file_path).await {
         let file_size = metadata.len() as usize;
@@ -177,20 +197,26 @@ pub(super) async fn search_content_in_file(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn search_content_in_dir(
-    workspace_root: &Path,
-    dir: &Path,
-    display_path: &str,
-    regex: &regex::Regex,
-    query: &str,
-    file_pattern: Option<&glob::Pattern>,
-    show_hashes: bool,
-    ignore_case: bool,
-    limit: usize,
-    offset: usize,
+    request: SearchDirectoryRequest<'_>,
 ) -> Result<MCPResult, String> {
     use walkdir::WalkDir;
+
+    let SearchDirectoryRequest {
+        workspace_root,
+        dir,
+        file_pattern,
+        search:
+            SearchContentRequest {
+                display_path,
+                regex,
+                query,
+                show_hashes,
+                ignore_case,
+                limit,
+                offset,
+            },
+    } = request;
 
     struct FileMatch {
         rel_path: String,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -188,29 +188,33 @@ impl WorkspaceServer {
         };
 
         if safe_path.is_dir() {
-            content::search_content_in_dir(
-                &workspace_root,
-                &safe_path,
-                search_path,
-                &regex,
-                query_str,
-                glob_pat.as_ref(),
-                show_line_anchors,
-                ignore_case,
-                limit,
-                offset,
-            )
+            content::search_content_in_dir(content::SearchDirectoryRequest {
+                workspace_root: &workspace_root,
+                dir: &safe_path,
+                file_pattern: glob_pat.as_ref(),
+                search: content::SearchContentRequest {
+                    display_path: search_path,
+                    regex: &regex,
+                    query: query_str,
+                    show_hashes: show_line_anchors,
+                    ignore_case,
+                    limit,
+                    offset,
+                },
+            })
             .await
         } else {
             content::search_content_in_file(
                 &safe_path,
-                search_path,
-                &regex,
-                query_str,
-                show_line_anchors,
-                ignore_case,
-                limit,
-                offset,
+                content::SearchContentRequest {
+                    display_path: search_path,
+                    regex: &regex,
+                    query: query_str,
+                    show_hashes: show_line_anchors,
+                    ignore_case,
+                    limit,
+                    offset,
+                },
             )
             .await
         }

--- a/src-tauri/src/mcp/builtin/workspace/persistent_shell/manager.rs
+++ b/src-tauri/src/mcp/builtin/workspace/persistent_shell/manager.rs
@@ -19,10 +19,6 @@ use crate::session_isolation::types::ShellType;
 pub struct PersistentShellManager {
     /// session_id -> PersistentShell mapping
     shells: Arc<Mutex<HashMap<String, Arc<Mutex<PersistentShell>>>>>,
-
-    /// Maximum shells per session (resource limit)
-    #[allow(dead_code)]
-    max_shells_per_session: usize,
 }
 
 impl PersistentShellManager {
@@ -30,7 +26,6 @@ impl PersistentShellManager {
     pub fn new() -> Self {
         Self {
             shells: Arc::new(Mutex::new(HashMap::new())),
-            max_shells_per_session: 3,
         }
     }
 
@@ -218,10 +213,7 @@ impl PersistentShellManager {
         Ok(())
     }
 
-    /// Cleanup all shells
-    ///
-    /// Terminates all active shells. Used during shutdown.
-    #[allow(dead_code)]
+    /// Terminates all active shells. Used during shutdown and integration tests.
     pub async fn cleanup_all(&self) -> Result<(), String> {
         let mut shells = self.shells.lock().await;
         let count = shells.len();

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -264,7 +264,6 @@ pub struct MCPResult {
 
 impl MCPResult {
     /// Creates a successful MCPResult with text content.
-    #[allow(dead_code)]
     pub fn success(text: &str) -> Self {
         Self {
             content: Some(vec![MCPContent::Text {
@@ -277,7 +276,6 @@ impl MCPResult {
     }
 
     /// Creates a successful MCPResult with text and structured content.
-    #[allow(dead_code)]
     pub fn success_with_data(text: &str, data: serde_json::Value) -> Self {
         Self {
             content: Some(vec![MCPContent::Text {
@@ -290,19 +288,16 @@ impl MCPResult {
     }
 
     /// Creates a non-error informational MCPResult.
-    #[allow(dead_code)]
     pub fn informational(message: &str) -> Self {
         Self::success(message)
     }
 
     /// Creates a non-error informational MCPResult with structured data.
-    #[allow(dead_code)]
     pub fn informational_with_data(message: &str, data: serde_json::Value) -> Self {
         Self::success_with_data(message, data)
     }
 
     /// Creates an error MCPResult.
-    #[allow(dead_code)]
     pub fn error(message: &str) -> Self {
         Self {
             content: Some(vec![MCPContent::Text {
@@ -310,21 +305,6 @@ impl MCPResult {
                 is_error: Some(true),
             }]),
             structured_content: None,
-            is_error: Some(true),
-        }
-    }
-
-    /// Creates an error MCPResult with additional structured data.
-    #[allow(dead_code)]
-    pub fn error_with_data(message: &str, data: serde_json::Value) -> Self {
-        Self {
-            content: Some(vec![MCPContent::Text {
-                text: message.to_string(),
-                is_error: Some(true),
-            }]),
-            structured_content: Some(serde_json::json!({
-                "error": data
-            })),
             is_error: Some(true),
         }
     }


### PR DESCRIPTION
## Summary
- remove stale Rust dead_code suppressions and delete genuinely unused helpers/fields
- replace a few clippy::too_many_arguments sites with small request/input structs
- narrow attachments add-content internals to module-only visibility while preserving behavior

## Validation
- pnpm refactor:validate