### PR TITLE
Support pasted image attachments in AgentChatInput

### DIFF
--- a/src/components/ui/FileAttachment.tsx
+++ b/src/components/ui/FileAttachment.tsx
@@ -14,6 +14,7 @@ interface FileAttachmentProps {
   onRemove?: (index: number) => void;
   onAdd: (e: React.ChangeEvent<HTMLInputElement>) => void;
   maxFileSize?: number;
+  accept?: string;
   allowedExtensions?: string[];
   compact?: boolean;
   disabled?: boolean;
@@ -25,6 +26,7 @@ export default function FileAttachment({
   files,
   onRemove,
   onAdd,
+  accept,
   allowedExtensions = [
     'txt',
     'md',
@@ -52,10 +54,11 @@ export default function FileAttachment({
 }: FileAttachmentProps) {
   const { t } = useTranslation('common');
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const accept =
-    allowedExtensions.length > 0
+  const fileAccept =
+    accept ??
+    (allowedExtensions.length > 0
       ? allowedExtensions.map((ext) => `.${ext}`).join(',')
-      : undefined;
+      : undefined);
 
   const handleFileSelect = () => {
     if (disabled) return;
@@ -70,7 +73,7 @@ export default function FileAttachment({
           ref={fileInputRef}
           type="file"
           multiple
-          accept={accept}
+          accept={fileAccept}
           onChange={onAdd}
           disabled={disabled}
           className="hidden"
@@ -137,7 +140,7 @@ export default function FileAttachment({
         ref={fileInputRef}
         type="file"
         multiple
-        accept={accept}
+        accept={fileAccept}
         onChange={onAdd}
         disabled={disabled}
         className="hidden"

--- a/src/components/ui/__tests__/FileAttachment.test.tsx
+++ b/src/components/ui/__tests__/FileAttachment.test.tsx
@@ -62,4 +62,20 @@ describe('FileAttachment', () => {
     expect(screen.getByRole('button', { name: 'Remove test.txt' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Remove image.png' })).toBeInTheDocument();
   });
+
+  it('prefers an explicit accept attribute override', () => {
+    const { container } = render(
+      <FileAttachment
+        files={mockFiles}
+        onRemove={mockOnRemove}
+        onAdd={mockOnAdd}
+        accept="image/*,audio/*"
+      />
+    );
+
+    expect(container.querySelector('input[type="file"]')).toHaveAttribute(
+      'accept',
+      'image/*,audio/*',
+    );
+  });
 });

--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 import { InputTokenDropdown } from './components/InputTokenDropdown';
 import { useAgentDraftChat } from './hooks/useAgentDraftChat';
 import { useWorkspaceFiles } from './hooks/useWorkspaceFiles';
+import { AGENT_ATTACHMENT_PICKER_ACCEPT } from './lib/attachment-picker';
 import { useTextareaAutosize } from '@/hooks/useTextareaAutosize';
 
 const textareaStyle = {
@@ -284,7 +285,7 @@ function DraftChatInner() {
                     compact={true}
                     disabled={isSubmitting || isAttachmentLoading}
                     showFileCount={false}
-                    allowedExtensions={[]}
+                    accept={AGENT_ATTACHMENT_PICKER_ACCEPT}
                     buttonClassName="mb-1 h-8 w-8 hover:text-primary hover:bg-primary/5 transition-colors"
                   />
 

--- a/src/features/agent/components/AgentChatInput.tsx
+++ b/src/features/agent/components/AgentChatInput.tsx
@@ -28,6 +28,7 @@ import { useScopedSkills } from '../hooks/useScopedSkills';
 import { useAgentTools } from '@/hooks/use-agent-tools';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
 import { useTextareaAutosize } from '@/hooks/useTextareaAutosize';
+import { AGENT_ATTACHMENT_PICKER_ACCEPT } from '../lib/attachment-picker';
 
 const logger = getLogger('AgentChatInput');
 
@@ -92,6 +93,7 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
     commitPendingFiles,
     clearPendingFiles,
     isAttachmentLoading,
+    attachFiles,
     handleFileAttachment,
     removeFile,
     processFileDrop,
@@ -196,6 +198,29 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
     void refreshScopedSkills();
   }, [refreshScopedSkills]);
 
+  const insertTextAtSelection = useCallback(
+    (text: string) => {
+      const textarea = textareaRef.current;
+      const selectionStart = textarea?.selectionStart ?? input.length;
+      const selectionEnd = textarea?.selectionEnd ?? input.length;
+      const nextValue =
+        input.slice(0, selectionStart) + text + input.slice(selectionEnd);
+      const nextCursorPosition = selectionStart + text.length;
+
+      setInput(nextValue);
+      onTokenInputChange(nextValue, nextCursorPosition);
+
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        textareaRef.current?.setSelectionRange(
+          nextCursorPosition,
+          nextCursorPosition,
+        );
+      });
+    },
+    [input, onTokenInputChange, setInput],
+  );
+
   // Handle Enter/Shift+Enter for line breaks and submission
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -260,6 +285,40 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
       logger.error('Failed to resume workflow:', err);
     }
   }, [resume]);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const clipboardData = e.clipboardData;
+      const imageFilesFromItems = Array.from(clipboardData.items)
+        .filter(
+          (item) => item.kind === 'file' && item.type.startsWith('image/'),
+        )
+        .flatMap((item) => {
+          const file = item.getAsFile();
+          return file ? [file] : [];
+        });
+      const imageFiles =
+        imageFilesFromItems.length > 0
+          ? imageFilesFromItems
+          : Array.from(clipboardData.files).filter((file) =>
+              file.type.startsWith('image/'),
+            );
+
+      if (imageFiles.length === 0) {
+        return;
+      }
+
+      e.preventDefault();
+
+      const pastedText = clipboardData.getData('text/plain');
+      if (pastedText) {
+        insertTextAtSelection(pastedText);
+      }
+
+      void attachFiles(imageFiles);
+    },
+    [attachFiles, insertTextAtSelection],
+  );
 
   // Drag-and-drop handlers
   useEffect(() => {
@@ -387,6 +446,7 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
           onRemove={handleRemoveFile}
           onAdd={handleFileAttachment}
           compact={true}
+          accept={AGENT_ATTACHMENT_PICKER_ACCEPT}
         />
         {children}
         <textarea
@@ -395,6 +455,7 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
           onChange={handleAgentInputChange}
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder={inputPlaceholder}
           className={inputClassName}
           style={textareaStyle}

--- a/src/features/agent/components/__tests__/AgentChatInput.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatInput.test.tsx
@@ -1,0 +1,284 @@
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentChatInput } from '../AgentChatInput';
+import { AGENT_ATTACHMENT_PICKER_ACCEPT } from '@/features/agent/lib/attachment-picker';
+
+const fileAttachmentProps = vi.hoisted(
+  () =>
+    ({
+      current: null as null | Record<string, unknown>,
+    }) as { current: null | Record<string, unknown> },
+);
+
+const mocks = vi.hoisted(() => ({
+  attachFiles: vi.fn(),
+  handleFileAttachment: vi.fn(),
+  removeFile: vi.fn(),
+  processFileDrop: vi.fn(),
+  validateFiles: vi.fn(() => true),
+  commitPendingFiles: vi.fn(),
+  clearPendingFiles: vi.fn(),
+  refetchSessionFiles: vi.fn(),
+  cancel: vi.fn(),
+  resume: vi.fn(),
+  submit: vi.fn(),
+  refreshSkills: vi.fn(),
+  setInput: vi.fn(),
+  onTokenInputChange: vi.fn(),
+  handleSubmit: vi.fn((e?: Event) => e?.preventDefault?.()),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: {
+      id: 'session-1',
+      assistant: {
+        id: 'assistant-1',
+      },
+    },
+  }),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChat: () => ({
+    submit: mocks.submit,
+    isSessionLoading: false,
+    workflowStatus: 'idle',
+    cancel: mocks.cancel,
+    resume: mocks.resume,
+  }),
+}));
+
+vi.mock('@/context/LLMServiceContext', () => ({
+  useLLMService: () => ({
+    isCompacting: () => false,
+  }),
+}));
+
+vi.mock('@/context/DnDContext', () => ({
+  useDnDContext: () => ({
+    subscribe: () => () => undefined,
+  }),
+}));
+
+vi.mock('@/features/agent/hooks/useScopedSkills', () => ({
+  useScopedSkills: () => ({
+    skills: [],
+    refresh: mocks.refreshSkills,
+  }),
+}));
+
+vi.mock('@/hooks/use-agent-tools', () => ({
+  useAgentTools: () => ({
+    availableTools: [],
+  }),
+}));
+
+vi.mock('@/features/agent/hooks/useWorkspaceFiles', () => ({
+  useWorkspaceFiles: () => [],
+}));
+
+vi.mock('@/features/agent/hooks/usePlaybookSearch', () => ({
+  usePlaybookSearch: () => [],
+}));
+
+vi.mock('@/features/agent/hooks/useInputToken', () => ({
+  useInputToken: () => ({
+    stage: { kind: 'idle' },
+    typeResults: [],
+    skillResults: [],
+    toolResults: [],
+    onInputChange: mocks.onTokenInputChange,
+    onTypeSelect: vi.fn(),
+    onArgSelect: vi.fn(),
+    onDismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTextareaAutosize', () => ({
+  useTextareaAutosize: vi.fn(),
+}));
+
+vi.mock('@/features/agent/hooks/useAgentFileAttachment', () => ({
+  useAgentFileAttachment: () => ({
+    pendingFiles: [],
+    commitPendingFiles: mocks.commitPendingFiles,
+    clearPendingFiles: mocks.clearPendingFiles,
+    isAttachmentLoading: false,
+    attachFiles: mocks.attachFiles,
+    handleFileAttachment: mocks.handleFileAttachment,
+    removeFile: mocks.removeFile,
+    processFileDrop: mocks.processFileDrop,
+    validateFiles: mocks.validateFiles,
+    refetchSessionFiles: mocks.refetchSessionFiles,
+  }),
+}));
+
+vi.mock('@/features/agent/hooks/useChatSubmit', () => ({
+  useChatSubmit: () => ({
+    input: '',
+    setInput: mocks.setInput,
+    isSubmitting: false,
+    handleSubmit: mocks.handleSubmit,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/ui', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  FileAttachment: (props: Record<string, unknown>) => {
+    fileAttachmentProps.current = props;
+    return <div data-testid="file-attachment" />;
+  },
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('AgentChatInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileAttachmentProps.current = null;
+  });
+
+  it('passes the explicit agent attachment accept policy to the picker', () => {
+    render(<AgentChatInput />);
+
+    expect(fileAttachmentProps.current).toMatchObject({
+      accept: AGENT_ATTACHMENT_PICKER_ACCEPT,
+    });
+  });
+
+  it('attaches pasted images from clipboard items', () => {
+    render(<AgentChatInput />);
+
+    const textarea = screen.getByLabelText('agent.input.ariaLabel');
+    const imageFile = new File(['image-bytes'], 'clipboard.png', {
+      type: 'image/png',
+    });
+    const pasteEvent = createEvent.paste(textarea);
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+        files: [],
+        getData: vi.fn(() => ''),
+      },
+    });
+
+    fireEvent(textarea, pasteEvent);
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    expect(mocks.attachFiles).toHaveBeenCalledWith([imageFile]);
+  });
+
+  it('preserves pasted text while attaching clipboard images', () => {
+    render(<AgentChatInput />);
+
+    const textarea = screen.getByLabelText('agent.input.ariaLabel');
+    const imageFile = new File(['image-bytes'], 'clipboard.png', {
+      type: 'image/png',
+    });
+    const pasteEvent = createEvent.paste(textarea);
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+        files: [],
+        getData: vi.fn((type: string) =>
+          type === 'text/plain' ? 'pasted text' : '',
+        ),
+      },
+    });
+
+    fireEvent(textarea, pasteEvent);
+
+    expect(mocks.setInput).toHaveBeenCalledWith('pasted text');
+    expect(mocks.onTokenInputChange).toHaveBeenCalledWith('pasted text', 11);
+    expect(mocks.attachFiles).toHaveBeenCalledWith([imageFile]);
+  });
+
+  it('ignores non-image paste payloads', () => {
+    render(<AgentChatInput />);
+
+    const textarea = screen.getByLabelText('agent.input.ariaLabel');
+    const pasteEvent = createEvent.paste(textarea);
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [
+          {
+            kind: 'string',
+            type: 'text/plain',
+            getAsFile: () => null,
+          },
+        ],
+        files: [],
+        getData: vi.fn(() => 'plain text'),
+      },
+    });
+
+    fireEvent(textarea, pasteEvent);
+
+    expect(pasteEvent.defaultPrevented).toBe(false);
+    expect(mocks.attachFiles).not.toHaveBeenCalled();
+    expect(mocks.setInput).not.toHaveBeenCalled();
+  });
+
+  it('falls back to clipboard files when items are unavailable', () => {
+    render(<AgentChatInput />);
+
+    const textarea = screen.getByLabelText('agent.input.ariaLabel');
+    const imageFile = new File(['image-bytes'], 'clipboard.png', {
+      type: 'image/png',
+    });
+    const pasteEvent = createEvent.paste(textarea);
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [],
+        files: [imageFile],
+        getData: vi.fn(() => ''),
+      },
+    });
+
+    fireEvent(textarea, pasteEvent);
+
+    expect(mocks.attachFiles).toHaveBeenCalledWith([imageFile]);
+  });
+});

--- a/src/features/agent/hooks/__tests__/useAgentFileAttachment.test.tsx
+++ b/src/features/agent/hooks/__tests__/useAgentFileAttachment.test.tsx
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAgentFileAttachment } from '../useAgentFileAttachment';
+
+const mockResourceAttachment = vi.hoisted(() => ({
+  pendingFiles: [],
+  addPendingFiles: vi.fn(),
+  updatePendingFile: vi.fn(),
+  commitPendingFiles: vi.fn(),
+  removeFile: vi.fn(),
+  clearPendingFiles: vi.fn(),
+  refetchSessionFiles: vi.fn(),
+  isLoading: false,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.error
+        ? `${key}:${String(options.error)}`
+        : key,
+  }),
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: {
+      id: 'session-1',
+    },
+  }),
+}));
+
+vi.mock('@/features/agent/hooks/useAgentResourceAttachment', () => ({
+  useAgentResourceAttachment: () => mockResourceAttachment,
+}));
+
+vi.mock('@/hooks/use-settings', () => ({
+  useSettings: () => ({
+    value: {
+      system: {
+        maxFileUploadSizeMB: 1,
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/use-rust-backend', () => ({
+  useRustBackend: () => ({
+    registerDroppedFiles: vi.fn(),
+    readDroppedFile: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+describe('useAgentFileAttachment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResourceAttachment.addPendingFiles.mockImplementation(
+      (
+        files: Array<{
+          filename: string;
+          status: string;
+        }>,
+      ) =>
+        files.map((file, index) => ({
+          pendingId: `pending-${index}`,
+          filename: file.filename,
+          status: file.status,
+        })),
+    );
+  });
+
+  it('assigns stable generated names to pasted clipboard images without filenames', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234567890);
+
+    const { result } = renderHook(() => useAgentFileAttachment());
+
+    const unnamedPng = new File(['png-bytes'], '', { type: 'image/png' });
+    const unnamedGif = new File(['gif-bytes'], '', { type: 'image/gif' });
+
+    await act(async () => {
+      await result.current.attachFiles([unnamedPng, unnamedGif]);
+    });
+
+    expect(mockResourceAttachment.addPendingFiles).toHaveBeenCalledWith([
+      {
+        url: '',
+        filename: 'pasted-image-1234567890.png',
+        mimeType: 'image/png',
+        status: 'processing',
+      },
+      {
+        url: '',
+        filename: 'pasted-image-1234567890-2.gif',
+        mimeType: 'image/gif',
+        status: 'processing',
+      },
+    ]);
+
+    expect(mockResourceAttachment.updatePendingFile).toHaveBeenNthCalledWith(
+      1,
+      'pending-0',
+      expect.objectContaining({
+        size: unnamedPng.size,
+        status: 'pending',
+        file: expect.objectContaining({
+          name: 'pasted-image-1234567890.png',
+          type: 'image/png',
+        }),
+      }),
+    );
+    expect(mockResourceAttachment.updatePendingFile).toHaveBeenNthCalledWith(
+      2,
+      'pending-1',
+      expect.objectContaining({
+        size: unnamedGif.size,
+        status: 'pending',
+        file: expect.objectContaining({
+          name: 'pasted-image-1234567890-2.gif',
+          type: 'image/gif',
+        }),
+      }),
+    );
+  });
+
+  it('removes oversized files after optimistic placeholder creation', async () => {
+    const { result } = renderHook(() => useAgentFileAttachment());
+    const oversizedFile = new File(
+      [new Uint8Array(1024 * 1024 + 1)],
+      'huge-image.png',
+      { type: 'image/png' },
+    );
+
+    await act(async () => {
+      await result.current.attachFiles([oversizedFile]);
+    });
+
+    expect(mockResourceAttachment.removeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pendingId: 'pending-0',
+        filename: 'huge-image.png',
+      }),
+    );
+    expect(mockResourceAttachment.updatePendingFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/agent/hooks/useAgentFileAttachment.ts
+++ b/src/features/agent/hooks/useAgentFileAttachment.ts
@@ -14,6 +14,42 @@ import { useTranslation } from 'react-i18next';
 import type React from 'react';
 
 const logger = getLogger('AgentFileAttachment');
+const CLIPBOARD_IMAGE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/x-icon': 'ico',
+  'image/tiff': 'tiff',
+};
+
+function getClipboardImageExtension(mimeType: string): string {
+  return CLIPBOARD_IMAGE_EXTENSION_BY_MIME_TYPE[mimeType] ?? 'png';
+}
+
+function normalizeAttachmentFile(
+  file: File,
+  batchTimestamp: number,
+  index: number,
+): File {
+  const trimmedName = file.name.trim();
+  if (trimmedName.length > 0) {
+    return file;
+  }
+
+  const extension = getClipboardImageExtension(file.type);
+  const filename =
+    index === 0
+      ? `pasted-image-${batchTimestamp}.${extension}`
+      : `pasted-image-${batchTimestamp}-${index + 1}.${extension}`;
+
+  return new File([file], filename, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+}
 
 /**
  * Agent V2 file attachment hook
@@ -44,6 +80,86 @@ export function useAgentFileAttachment() {
   const rustBackend = useRustBackend();
 
   const getMimeType = getMimeTypeFromFilename;
+
+  const attachFiles = useCallback(
+    async (inputFiles: File[]) => {
+      if (!session) {
+        logger.error('Cannot attach file: session not available.');
+        toast.error(t('agent.attachment.sessionError'));
+        return;
+      }
+
+      if (inputFiles.length === 0) {
+        return;
+      }
+
+      const batchTimestamp = Date.now();
+      const fileList = inputFiles.map((file, index) =>
+        normalizeAttachmentFile(file, batchTimestamp, index),
+      );
+
+      const placeholders = fileList.map((file) => ({
+        url: '',
+        filename: file.name,
+        mimeType: file.type || getMimeType(file.name),
+        status: 'processing' as const,
+      }));
+
+      const addedItems = addPendingFiles(placeholders);
+
+      await Promise.all(
+        fileList.map(async (file, index) => {
+          const pendingId = addedItems[index].pendingId!;
+
+          if (!validateFileSize(file, maxBytes)) {
+            toast.error(
+              createFileSizeErrorMessage(file.name, file.size, maxBytes),
+            );
+            removeFile(addedItems[index]);
+            return;
+          }
+
+          try {
+            logger.debug('Starting file processing', {
+              filename: file.name,
+              fileSize: file.size,
+              fileType: file.type,
+              sessionId: session.id,
+            });
+
+            updatePendingFile(pendingId, {
+              file,
+              size: file.size,
+              status: 'pending',
+            });
+
+            logger.info('File processed successfully', {
+              filename: file.name,
+              fileSize: file.size,
+            });
+          } catch (error) {
+            logger.error(`Error processing file ${file.name}:`, error);
+            toast.error(
+              t('agent.attachment.processingFileError', {
+                filePath: file.name,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            );
+            removeFile(addedItems[index]);
+          }
+        }),
+      );
+    },
+    [
+      session,
+      addPendingFiles,
+      getMimeType,
+      maxBytes,
+      removeFile,
+      t,
+      updatePendingFile,
+    ],
+  );
 
   const processFileDrop = useCallback(
     async (filePaths: string[]) => {
@@ -164,71 +280,14 @@ export function useAgentFileAttachment() {
   const handleFileAttachment = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
-      if (!files || !session) {
-        toast.error(t('agent.attachment.sessionError'));
+      if (!files) {
         return;
       }
 
-      const fileList = Array.from(files);
-
-      // --- STEP 1: Optimistic UI - Add placeholders immediately ---
-      const placeholders = fileList.map((file) => ({
-        url: '',
-        filename: file.name,
-        mimeType: file.type,
-        status: 'processing' as const,
-      }));
-
-      const addedItems = addPendingFiles(placeholders);
-
-      // --- STEP 2: Parallel Processing ---
-      await Promise.all(
-        fileList.map(async (file, index) => {
-          const pendingId = addedItems[index].pendingId!;
-
-          if (!validateFileSize(file, maxBytes)) {
-            toast.error(
-              createFileSizeErrorMessage(file.name, file.size, maxBytes),
-            );
-            removeFile(addedItems[index]);
-            return;
-          }
-
-          try {
-            logger.debug(`Starting file processing`, {
-              filename: file.name,
-              fileSize: file.size,
-              fileType: file.type,
-              sessionId: session?.id,
-            });
-
-            // Update the placeholder with actual file data and set to 'pending'
-            updatePendingFile(pendingId, {
-              file: file,
-              size: file.size,
-              status: 'pending',
-            });
-
-            logger.info(`File processed successfully`, {
-              filename: file.name,
-              fileSize: file.size,
-            });
-          } catch (error) {
-            logger.error(`Error processing file ${file.name}:`, error);
-            toast.error(
-              t('agent.attachment.processingFileError', {
-                filePath: file.name,
-                error: error instanceof Error ? error.message : String(error),
-              }),
-            );
-            removeFile(addedItems[index]);
-          }
-        }),
-      );
-
+      await attachFiles(Array.from(files));
       e.target.value = '';
     },
-    [session, addPendingFiles, updatePendingFile, removeFile, maxBytes, t],
+    [attachFiles],
   );
 
   const validateFiles = useCallback((paths: string[]): boolean => {
@@ -252,6 +311,7 @@ export function useAgentFileAttachment() {
     removeFile,
     clearPendingFiles,
     isAttachmentLoading,
+    attachFiles,
     handleFileAttachment,
     getMimeType,
     processFileDrop,

--- a/src/features/agent/lib/attachment-picker.ts
+++ b/src/features/agent/lib/attachment-picker.ts
@@ -1,0 +1,29 @@
+const AGENT_ATTACHMENT_PICKER_EXTENSION_ACCEPT = [
+  '.txt',
+  '.md',
+  '.json',
+  '.js',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.py',
+  '.java',
+  '.cpp',
+  '.c',
+  '.h',
+  '.css',
+  '.html',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.csv',
+  '.pdf',
+  '.docx',
+  '.xlsx',
+];
+
+export const AGENT_ATTACHMENT_PICKER_ACCEPT = [
+  ...AGENT_ATTACHMENT_PICKER_EXTENSION_ACCEPT,
+  'image/*',
+  'audio/*',
+].join(',');


### PR DESCRIPTION
## Summary
- add clipboard image paste support to AgentChatInput via the shared attachment pipeline
- preserve pasted text while attaching clipboard images and generate stable names for unnamed clipboard files
- make the agent file picker accept policy explicit for supported document, image, and audio types

## Testing
- pnpm refactor:validate

Closes #1270