### PR TITLE
🕸️ Weaver: Refactor AgentChatView using Ref Lazy Initialization

### DIFF
--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -2,7 +2,6 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useState,
   type ReactNode,
   type CSSProperties,
 } from 'react';
@@ -188,19 +187,25 @@ function AgentChatInner() {
   const { injectMessages } = useAgentChatActions();
   const { workflowStatus } = useAgentChatState();
   const hasExecutedPlaybookRef = useRef(false);
-  const [hasOpenedWorkspaceDesktop, setHasOpenedWorkspaceDesktop] = useState(
-    !isMobile && showWorkspacePanel,
-  );
-  const [hasOpenedPlanningDesktop, setHasOpenedPlanningDesktop] = useState(
-    !isMobile && showPlanningPanel,
-  );
+  const hasOpenedWorkspaceRef = useRef(!isMobile && showWorkspacePanel);
+  const hasOpenedPlanningRef = useRef(!isMobile && showPlanningPanel);
 
-  if (!isMobile && showWorkspacePanel && !hasOpenedWorkspaceDesktop) {
-    setHasOpenedWorkspaceDesktop(true);
-  }
-  if (!isMobile && showPlanningPanel && !hasOpenedPlanningDesktop) {
-    setHasOpenedPlanningDesktop(true);
-  }
+  useEffect(() => {
+    if (!isMobile && showWorkspacePanel) {
+      hasOpenedWorkspaceRef.current = true;
+    }
+  }, [isMobile, showWorkspacePanel]);
+
+  useEffect(() => {
+    if (!isMobile && showPlanningPanel) {
+      hasOpenedPlanningRef.current = true;
+    }
+  }, [isMobile, showPlanningPanel]);
+
+  const hasOpenedWorkspaceDesktop =
+    !isMobile && (showWorkspacePanel || hasOpenedWorkspaceRef.current);
+  const hasOpenedPlanningDesktop =
+    !isMobile && (showPlanningPanel || hasOpenedPlanningRef.current);
 
   const playbookId = searchParams.get('playbookId');
   const sessionId = session?.id;


### PR DESCRIPTION
### 🚫 Eradicated
Removed derived state and state-setting during render in `AgentChatInner`. Previously, the component conditionally called `setHasOpenedWorkspaceDesktop(true)` during the render phase to track whether side panels had ever been opened, which violates React's Rule of Purity and forces unnecessary synchronous re-render cycles.

### ✨ Woven
Implemented the Ref Lazy Initialization Pattern. Replaced `useState` with `useRef` to track the historical 'has been opened' state. The refs are updated cleanly inside `useEffect` hooks, and the component rendering logic uses pure derivation (`showWorkspacePanel || hasOpenedWorkspaceRef.current`).

### 📉 Impact
Prevents double re-render cycles every time a side panel is toggled open for the first time, ensuring strict compliance with React Concurrent Mode and eradicating React warnings about state updates during render.

---
*PR created automatically by Jules for task [3787588329837414984](https://jules.google.com/task/3787588329837414984) started by @fritzprix*