### PR TITLE
🚪 Airlock: Move workspace file path listing commands to workspace_commands

### DIFF
--- a/src-tauri/src/commands/skill_commands.rs
+++ b/src-tauri/src/commands/skill_commands.rs
@@ -60,20 +60,3 @@ pub async fn get_skill_content(
 ) -> Result<String, String> {
     skill_service::get_skill_content(skill_path, assistant_id, session_id, workspace_path).await
 }
-
-#[tauri::command]
-pub async fn list_workspace_file_paths(
-    session_id: String,
-    max_depth: usize,
-) -> Result<Vec<String>, String> {
-    crate::agent::references::list_workspace_relative_paths(&session_id, max_depth).await
-}
-
-#[tauri::command]
-pub async fn list_workspace_file_paths_for_path(
-    workspace_path: String,
-    max_depth: usize,
-) -> Result<Vec<String>, String> {
-    crate::agent::references::list_relative_paths_in_root(Path::new(&workspace_path), max_depth)
-        .await
-}

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -194,6 +194,31 @@ pub async fn read_local_file_as_base64(
     Ok(general_purpose::STANDARD.encode(bytes))
 }
 
+#[tauri::command]
+pub async fn list_workspace_file_paths(
+    session_id: String,
+    max_depth: usize,
+) -> Result<Vec<String>, String> {
+    // 🚪 Airlock: Moved from `skill_commands.rs`
+    // Listing workspace files correctly belongs in workspace_commands.rs,
+    // severing an improper domain boundary where workspace operations were
+    // bundled under skill logic.
+    crate::agent::references::list_workspace_relative_paths(&session_id, max_depth).await
+}
+
+#[tauri::command]
+pub async fn list_workspace_file_paths_for_path(
+    workspace_path: String,
+    max_depth: usize,
+) -> Result<Vec<String>, String> {
+    // 🚪 Airlock: Moved from `skill_commands.rs`
+    // Listing workspace files correctly belongs in workspace_commands.rs,
+    // severing an improper domain boundary where workspace operations were
+    // bundled under skill logic.
+    crate::agent::references::list_relative_paths_in_root(Path::new(&workspace_path), max_depth)
+        .await
+}
+
 pub async fn resolve_workspace_scoped_file_path(
     file_path: &Path,
     workspace_dir: &Path,

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -199,10 +199,6 @@ pub async fn list_workspace_file_paths(
     session_id: String,
     max_depth: usize,
 ) -> Result<Vec<String>, String> {
-    // 🚪 Airlock: Moved from `skill_commands.rs`
-    // Listing workspace files correctly belongs in workspace_commands.rs,
-    // severing an improper domain boundary where workspace operations were
-    // bundled under skill logic.
     crate::agent::references::list_workspace_relative_paths(&session_id, max_depth).await
 }
 
@@ -211,10 +207,6 @@ pub async fn list_workspace_file_paths_for_path(
     workspace_path: String,
     max_depth: usize,
 ) -> Result<Vec<String>, String> {
-    // 🚪 Airlock: Moved from `skill_commands.rs`
-    // Listing workspace files correctly belongs in workspace_commands.rs,
-    // severing an improper domain boundary where workspace operations were
-    // bundled under skill logic.
     crate::agent::references::list_relative_paths_in_root(Path::new(&workspace_path), max_depth)
         .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,8 +91,7 @@ use commands::settings_commands::{
 };
 use commands::skill_commands::{
     get_aggregated_skills, get_default_skills_directory, get_managed_skills_overview,
-    get_skill_content, list_workspace_file_paths, list_workspace_file_paths_for_path,
-    open_skills_directory_in_explorer, scan_skills_directory,
+    get_skill_content, open_skills_directory_in_explorer, scan_skills_directory,
 };
 use commands::skill_management::{
     copy_global_to_assistant, delete_assistant_skill, delete_user_skill, import_assistant_skills,
@@ -102,9 +101,10 @@ use commands::skill_management::{
 use commands::url_commands::open_external_url;
 use commands::workspace_commands::{
     cancel_workspace_override, get_app_data_dir, get_app_logs_dir, get_update_install_capability,
-    get_workspace_dir, get_workspace_override, greet, list_workspace_files,
-    open_workspace_file_with_default_app, open_workspace_in_explorer, open_workspace_in_terminal,
-    read_local_file_as_base64, restart_app, set_workspace_override,
+    get_workspace_dir, get_workspace_override, greet, list_workspace_file_paths,
+    list_workspace_file_paths_for_path, list_workspace_files, open_workspace_file_with_default_app,
+    open_workspace_in_explorer, open_workspace_in_terminal, read_local_file_as_base64, restart_app,
+    set_workspace_override,
 };
 
 // Re-export state management functions


### PR DESCRIPTION
💡 What: Moved `list_workspace_file_paths` and `list_workspace_file_paths_for_path` from `skill_commands.rs` to `workspace_commands.rs`
🎯 Why: These commands list workspace paths, which properly belong in the workspace boundary, not the skills boundary.
📊 Impact: Cleaner domain boundaries, correctly categorizing workspace management functions.
🔬 Verification: Run cargo check and verify no type errors.

---
*PR created automatically by Jules for task [5758039594926076925](https://jules.google.com/task/5758039594926076925) started by @fritzprix*