### PR TITLE
🎨 Palette: Add tooltips to Draft Workspace Preview panel

### DIFF
--- a/src/features/agent/components/AgentDraftWorkspacePreviewPanel.tsx
+++ b/src/features/agent/components/AgentDraftWorkspacePreviewPanel.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useTranslation } from 'react-i18next';
 import { FolderOpen, RefreshCw, X } from 'lucide-react';
 
@@ -27,26 +28,36 @@ export function AgentDraftWorkspacePreviewPanel({
             <span>{t('agent.workspace.title')}</span>
           </div>
           <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-muted-foreground hover:text-foreground"
-              onClick={() => void refresh()}
-              aria-label={t('agent.workspace.refreshAria')}
-            >
-              <RefreshCw
-                className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
-              />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-muted-foreground hover:text-foreground"
-              onClick={onClear}
-              aria-label={t('common:close', 'Close')}
-            >
-              <X className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                  onClick={() => void refresh()}
+                  aria-label={t('agent.workspace.refreshAria')}
+                >
+                  <RefreshCw
+                    className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('agent.workspace.refreshAria')}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                  onClick={onClear}
+                  aria-label={t('common:close', 'Close')}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('common:close', 'Close')}</TooltipContent>
+            </Tooltip>
           </div>
         </div>
 

--- a/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,6 +11,12 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => fallback ?? key,
   }),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
+  TooltipTrigger: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
+  TooltipContent: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
 }));
 
 vi.mock('../workspace-panel/useDraftWorkspacePreviewTree', () => ({

--- a/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
@@ -14,9 +14,9 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
-  TooltipTrigger: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
-  TooltipContent: ({ children }: Record<string, unknown>) => <div>{children as React.ReactNode}</div>,
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children, asChild }: { children?: React.ReactNode; asChild?: boolean }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('../workspace-panel/useDraftWorkspacePreviewTree', () => ({
@@ -100,5 +100,7 @@ describe('AgentDraftWorkspacePreviewPanel', () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(onClear).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('agent.workspace.refreshAria')).toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
   });
 });

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
💡 What: Added tooltips to the icon-only Refresh and Close buttons in the Draft Workspace Preview panel.
🎯 Why: Improves discoverability of icon actions for sighted users, reducing ambiguity.
📸 Before/After: Visual tooltips are now shown on hover.
♿ Accessibility: The buttons already had aria-labels; the tooltips now match these labels and ensure sighted keyboard users also receive context via `TooltipTrigger`.

---
*PR created automatically by Jules for task [3640808393219190513](https://jules.google.com/task/3640808393219190513) started by @fritzprix*