### PR TITLE
Fix agent chat scroll restore and token metrics persistence

### DIFF
--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -394,6 +394,7 @@ export function AgentChatMessages() {
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
   const isPinnedToBottomRef = useRef(true);
   const autoScrollFrameRef = useRef<number | null>(null);
+  const groupedMessageCountRef = useRef(groupedMessages.length);
   const hasHydratedMessagesRef = useRef<{
     sessionId: string | undefined;
     hasMessages: boolean;
@@ -452,17 +453,19 @@ export function AgentChatMessages() {
   // Memoize references so ErrorBubble memo stays effective during streaming re-renders
   const agentError = useMemo(() => error, [error]);
   const agentLlmError = useMemo(() => llmError, [llmError]);
+  groupedMessageCountRef.current = groupedMessages.length;
 
   const scrollToBottomNow = useCallback(() => {
+    const itemCount = groupedMessageCountRef.current;
     const scrolledWithVirtuoso = scrollVirtuosoToBottom(
       virtuosoRef.current,
-      groupedMessages.length,
+      itemCount,
     );
 
-    if (!scrolledWithVirtuoso || groupedMessages.length === 0) {
+    if (!scrolledWithVirtuoso || itemCount === 0) {
       scrollFooterSentinelIntoView(footerEndRef.current);
     }
-  }, [groupedMessages.length]);
+  }, []);
 
   useEffect(() => {
     const previous = previousListStateRef.current;

--- a/src/features/agent/components/AgentChatStatusBar.tsx
+++ b/src/features/agent/components/AgentChatStatusBar.tsx
@@ -18,13 +18,14 @@ import {
 import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker';
 import { useAgentTools } from '@/hooks/use-agent-tools';
 import { useLLMService } from '@/context/LLMServiceContext';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getLogger } from '@/lib/logger';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import AgentToolsModal from './AgentToolsModal';
 import { useTokenMetrics } from '@/hooks/use-token-metrics';
 import { TokenMetricsBadge } from './TokenMetricsBadge';
 import { TokenUsage } from '@/lib/ai-service/types';
+import type { Message } from '@/models/chat';
 import { toast } from 'sonner';
 import { isBuiltinTool } from '@/lib/tool-call-utils';
 import { useTranslation } from 'react-i18next';
@@ -35,12 +36,67 @@ import { useSettings } from '@/context/SettingsContext';
 
 const logger = getLogger('AgentChatStatusBar');
 
+function hasTokenUsageData(
+  usage: TokenUsage | null | undefined,
+): usage is TokenUsage {
+  if (!usage) {
+    return false;
+  }
+
+  return (
+    usage.promptTokens > 0 ||
+    usage.completionTokens > 0 ||
+    usage.totalTokens > 0 ||
+    (usage.cachedPromptTokens ?? 0) > 0
+  );
+}
+
+function mergePersistedTokenUsage(
+  previousUsage: TokenUsage | null,
+  nextUsage: TokenUsage,
+): TokenUsage {
+  if (!previousUsage) {
+    return nextUsage;
+  }
+
+  return {
+    ...previousUsage,
+    ...nextUsage,
+    details: {
+      ...previousUsage.details,
+      ...nextUsage.details,
+      evalDuration:
+        nextUsage.details?.evalDuration ?? previousUsage.details?.evalDuration,
+      timeToFirstToken:
+        nextUsage.details?.timeToFirstToken ??
+        previousUsage.details?.timeToFirstToken,
+      promptEvalDuration:
+        nextUsage.details?.promptEvalDuration ??
+        previousUsage.details?.promptEvalDuration,
+      loadDuration:
+        nextUsage.details?.loadDuration ?? previousUsage.details?.loadDuration,
+    },
+  };
+}
+
+function findLatestAssistantUsage(messages: Message[]): TokenUsage | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (message?.role === 'assistant' && hasTokenUsageData(message.usage)) {
+      return message.usage;
+    }
+  }
+
+  return null;
+}
+
 export function AgentChatStatusBar() {
   const { t } = useTranslation();
   const { value: settings } = useSettings();
   const { session, executionMode, setExecutionMode, updateSessionConfig } =
     useAgentSession();
-  const { workflowStatus, error, llmError, retryMessage, resume } =
+  const { messages, workflowStatus, error, llmError, retryMessage, resume } =
     useAgentChat();
   const { isCompacting, isAwaitingCompact, getCompactionPressure } =
     useLLMService();
@@ -63,69 +119,83 @@ export function AgentChatStatusBar() {
     sessionId,
     usage: null,
   });
+  const lastObservedMetricsRef = useRef<{
+    sessionId?: string;
+    usage: TokenUsage | null;
+  }>({
+    sessionId,
+    usage: null,
+  });
 
-  useEffect(() => {
-    if (!sessionId || !metrics) {
-      return;
-    }
-
-    const hasData =
-      metrics.promptTokens > 0 ||
-      metrics.completionTokens > 0 ||
-      (metrics.cachedPromptTokens ?? 0) > 0;
-
-    if (!hasData) {
-      return;
-    }
-
-    setPersistedMetrics((previous) => {
-      const previousUsage =
-        previous.sessionId === sessionId ? previous.usage : null;
-
-      if (!previousUsage) {
-        return {
-          sessionId,
-          usage: metrics,
-        };
+  const persistMetrics = useCallback(
+    (usage: TokenUsage) => {
+      if (!sessionId) {
+        return;
       }
 
-      return {
+      setPersistedMetrics((previous) => ({
         sessionId,
-        usage: {
-          ...previousUsage,
-          ...metrics,
-          details: {
-            ...previousUsage.details,
-            ...metrics.details,
-            evalDuration:
-              metrics.details?.evalDuration ||
-              previousUsage.details?.evalDuration,
-            timeToFirstToken:
-              metrics.details?.timeToFirstToken ||
-              previousUsage.details?.timeToFirstToken,
-            promptEvalDuration:
-              metrics.details?.promptEvalDuration ||
-              previousUsage.details?.promptEvalDuration,
-            loadDuration:
-              metrics.details?.loadDuration ||
-              previousUsage.details?.loadDuration,
-          },
-        },
+        usage: mergePersistedTokenUsage(
+          previous.sessionId === sessionId ? previous.usage : null,
+          usage,
+        ),
+      }));
+    },
+    [sessionId],
+  );
+
+  useEffect(() => {
+    if (!sessionId) {
+      lastObservedMetricsRef.current = {
+        sessionId: undefined,
+        usage: null,
       };
-    });
-  }, [metrics, sessionId]);
+      return;
+    }
+
+    const previousObserved = lastObservedMetricsRef.current;
+
+    if (previousObserved.sessionId !== sessionId) {
+      lastObservedMetricsRef.current = {
+        sessionId,
+        usage: metrics,
+      };
+
+      if (hasTokenUsageData(metrics)) {
+        persistMetrics(metrics);
+      }
+
+      return;
+    }
+
+    if (hasTokenUsageData(metrics)) {
+      persistMetrics(metrics);
+    } else if (!metrics && hasTokenUsageData(previousObserved.usage)) {
+      persistMetrics(previousObserved.usage);
+    }
+
+    lastObservedMetricsRef.current = {
+      sessionId,
+      usage: metrics,
+    };
+  }, [metrics, persistMetrics, sessionId]);
+
+  const latestAssistantUsage = useMemo(
+    () => findLatestAssistantUsage(messages),
+    [messages],
+  );
+  const sessionPersistedUsage =
+    persistedMetrics.sessionId === sessionId ? persistedMetrics.usage : null;
 
   // Derive displayMetrics during render to ensure UI reflects the absolute latest chunk
   // without mutating state during render.
   const displayMetrics = useMemo(
     () =>
       mergeDisplayTokenUsage(
-        persistedMetrics.sessionId === sessionId
-          ? persistedMetrics.usage
-          : null,
+        mergeDisplayTokenUsage(sessionPersistedUsage, latestAssistantUsage),
         metrics,
       ),
-    [metrics, persistedMetrics, sessionId],
+    [latestAssistantUsage, metrics, sessionPersistedUsage],
   );
 
   // ✅ Single Source of Truth: Fetch filtered tools from Rust backend

--- a/src/features/agent/components/__tests__/AgentChatStatusBar.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatStatusBar.test.tsx
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { TokenUsage } from '@/lib/ai-service/types';
+import type { Message } from '@/models/chat';
 import type { ExecutionMode } from '@/context/agent-session/types';
 import { AgentChatStatusBar } from '../AgentChatStatusBar';
 
@@ -50,12 +52,17 @@ const mockAgentSession = {
 };
 
 const mockAgentChat = {
+  messages: [] as Message[],
   workflowStatus: 'idle' as WorkflowStatus,
   error: null,
   llmError: null,
   retryMessage: mocks.retryMessage,
   resume: mocks.resume,
 };
+
+const tokenMetricsState = vi.hoisted(() => ({
+  metrics: null as TokenUsage | null,
+}));
 
 vi.mock('@/context/AgentSessionContext', () => ({
   useAgentSession: () => mockAgentSession,
@@ -91,7 +98,7 @@ vi.mock('@/hooks/use-agent-tools', () => ({
 
 vi.mock('@/hooks/use-token-metrics', () => ({
   useTokenMetrics: () => ({
-    metrics: null,
+    metrics: tokenMetricsState.metrics,
   }),
 }));
 
@@ -131,10 +138,6 @@ vi.mock('@/components/ui', () => ({
 
 vi.mock('../AgentToolsModal', () => ({
   default: () => null,
-}));
-
-vi.mock('./TokenMetricsBadge', () => ({
-  TokenMetricsBadge: () => null,
 }));
 
 vi.mock('@/components/ui/LoadingSpinner', () => ({
@@ -188,9 +191,11 @@ describe('AgentChatStatusBar', () => {
     mockAgentSession.executionMode = 'normal';
     mockAgentSession.yoloModeEnabled = false;
     mockAgentSession.unsafeModeEnabled = false;
+    mockAgentChat.messages = [];
     mockAgentChat.workflowStatus = 'idle';
     mockAgentChat.error = null;
     mockAgentChat.llmError = null;
+    tokenMetricsState.metrics = null;
     mocks.safeInvoke.mockResolvedValue({
       success: true,
       message: 'updated',
@@ -280,5 +285,27 @@ describe('AgentChatStatusBar', () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       'Model updated. Retry to recover the session.',
     );
+  });
+
+  it('keeps showing the last token metrics when streaming clears before persistence catches up', () => {
+    tokenMetricsState.metrics = {
+      promptTokens: 120,
+      completionTokens: 45,
+      totalTokens: 165,
+      details: {
+        evalDuration: 321,
+      },
+    };
+
+    const { rerender } = render(<AgentChatStatusBar />);
+
+    expect(screen.getByTestId('metrics-badge')).toHaveTextContent('120');
+    expect(screen.getByTestId('metrics-badge')).toHaveTextContent('45');
+
+    tokenMetricsState.metrics = null;
+    rerender(<AgentChatStatusBar />);
+
+    expect(screen.getByTestId('metrics-badge')).toHaveTextContent('120');
+    expect(screen.getByTestId('metrics-badge')).toHaveTextContent('45');
   });
 });


### PR DESCRIPTION
## Summary
- stabilize agent chat auto-scroll callbacks across session remounts
- persist final token metrics when streaming state clears and fall back to persisted assistant usage
- add a regression test for the metrics null-transition case

## Validation
- pnpm vitest run src/features/agent/components/__tests__/AgentChatStatusBar.test.tsx src/features/agent/components/__tests__/AgentChatMessages.compaction.test.tsx
- pnpm refactor:validate