### PR TITLE
Fix agent model picker refresh UX

### DIFF
--- a/src/features/agent/components/AgentModelPicker.tsx
+++ b/src/features/agent/components/AgentModelPicker.tsx
@@ -30,8 +30,13 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
   onConfigUpdate,
 }) => {
   const { t } = useTranslation('common');
-  const { availableModels, isRefreshing, refreshModels } =
-    useAgentModels(currentProvider);
+  const {
+    availableModels,
+    isRefreshing,
+    refreshModels,
+    canRefresh,
+    refreshBlockedReason,
+  } = useAgentModels(currentProvider);
 
   const modelOptions = useMemo(() => {
     return Object.entries(availableModels).map(([key, value]) => ({
@@ -47,6 +52,24 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
       value: key,
     }));
   }, []);
+
+  const showRefreshButton =
+    Boolean(currentProvider) &&
+    (canRefresh || refreshBlockedReason === 'missing-api-key');
+
+  const refreshButtonLabel = useMemo(() => {
+    if (canRefresh) {
+      return t('agent.modelPicker.refreshModels');
+    }
+
+    if (refreshBlockedReason === 'missing-api-key') {
+      return t('agent.modelPicker.refreshRequiresApiKey', {
+        defaultValue: 'Add an API key to enable model refresh',
+      });
+    }
+
+    return '';
+  }, [canRefresh, refreshBlockedReason, t]);
 
   const handleProviderChange = useCallback(
     (newProvider: string) => {
@@ -125,15 +148,14 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
         </SelectContent>
       </Select>
 
-      {/* Refresh Button — available for all providers */}
-      {currentProvider && (
+      {showRefreshButton && (
         <button
           type="button"
           onClick={() => refreshModels()}
-          disabled={disabled || isRefreshing}
+          disabled={disabled || isRefreshing || !canRefresh}
           className="p-1 hover:bg-primary/10 rounded text-muted-foreground hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          title={t('agent.modelPicker.refreshModels')}
-          aria-label={t('agent.modelPicker.refreshModels')}
+          title={refreshButtonLabel}
+          aria-label={refreshButtonLabel}
         >
           <RefreshCw
             className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`}

--- a/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
+++ b/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModelPicker } from '../AgentModelPicker';
+
+const mockUseAgentModelsState = vi.hoisted(() => ({
+  availableModels: {
+    'model-1': {
+      name: 'Model 1',
+    },
+  },
+  isRefreshing: false,
+  refreshModels: vi.fn().mockResolvedValue(undefined),
+  canRefresh: true,
+  refreshBlockedReason: 'allowed',
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === 'string') {
+        return options;
+      }
+      if (options && typeof options === 'object' && 'defaultValue' in options) {
+        return String(options.defaultValue);
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+}));
+
+vi.mock('../../hooks/useAgentModels', () => ({
+  useAgentModels: () => mockUseAgentModelsState,
+}));
+
+describe('AgentModelPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAgentModelsState.availableModels = {
+      'model-1': { name: 'Model 1' },
+    };
+    mockUseAgentModelsState.isRefreshing = false;
+    mockUseAgentModelsState.canRefresh = true;
+    mockUseAgentModelsState.refreshBlockedReason = 'allowed';
+  });
+
+  it('revalidates models when refresh is available', () => {
+    render(
+      <AgentModelPicker currentModel="model-1" currentProvider="ollama" />,
+    );
+
+    const refreshButton = screen.getByRole('button', {
+      name: 'agent.modelPicker.refreshModels',
+    });
+
+    fireEvent.click(refreshButton);
+
+    expect(mockUseAgentModelsState.refreshModels).toHaveBeenCalledTimes(1);
+    expect(refreshButton).toBeEnabled();
+  });
+
+  it('keeps the refresh button visible but disabled when an API key is required', () => {
+    mockUseAgentModelsState.canRefresh = false;
+    mockUseAgentModelsState.refreshBlockedReason = 'missing-api-key';
+
+    render(
+      <AgentModelPicker currentModel="model-1" currentProvider="anthropic" />,
+    );
+
+    const refreshButton = screen.getByRole('button', {
+      name: 'Add an API key to enable model refresh',
+    });
+
+    expect(refreshButton).toBeDisabled();
+    expect(refreshButton).toHaveAttribute(
+      'title',
+      'Add an API key to enable model refresh',
+    );
+  });
+
+  it('hides refresh when custom openai model discovery is intentionally disabled', () => {
+    mockUseAgentModelsState.canRefresh = false;
+    mockUseAgentModelsState.refreshBlockedReason = 'custom-openai-model';
+
+    render(
+      <AgentModelPicker currentModel="model-1" currentProvider="openai" />,
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: /refresh/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/agent/hooks/__tests__/useAgentModels.test.tsx
+++ b/src/features/agent/hooks/__tests__/useAgentModels.test.tsx
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AIServiceProvider } from '@/lib/ai-service';
+import { useAgentModels } from '../useAgentModels';
+
+const mockState = vi.hoisted(() => ({
+  mutate: vi.fn().mockResolvedValue({}),
+  data: {},
+  isValidating: false,
+  swrKey: undefined as unknown,
+  serviceConfigs: {} as Record<string, Record<string, unknown>>,
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn((key: unknown) => {
+    mockState.swrKey = key;
+    return {
+      data: mockState.data,
+      mutate: mockState.mutate,
+      isValidating: mockState.isValidating,
+    };
+  }),
+}));
+
+vi.mock('@/hooks/use-settings', () => ({
+  useSettings: () => ({
+    value: {
+      serviceConfigs: mockState.serviceConfigs,
+    },
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+describe('useAgentModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.data = {};
+    mockState.isValidating = false;
+    mockState.swrKey = undefined;
+    mockState.serviceConfigs = {};
+  });
+
+  it('does not call mutate when dynamic refresh is unavailable', async () => {
+    const { result } = renderHook(() =>
+      useAgentModels(AIServiceProvider.Anthropic),
+    );
+
+    expect(result.current.canRefresh).toBe(false);
+    expect(result.current.refreshBlockedReason).toBe('missing-api-key');
+    expect(mockState.swrKey).toBeNull();
+
+    await act(async () => {
+      await result.current.refreshModels();
+    });
+
+    expect(mockState.mutate).not.toHaveBeenCalled();
+  });
+
+  it('revalidates the active SWR entry when dynamic refresh is available', async () => {
+    const { result } = renderHook(() =>
+      useAgentModels(AIServiceProvider.Ollama),
+    );
+
+    expect(result.current.canRefresh).toBe(true);
+    expect(result.current.refreshBlockedReason).toBe('allowed');
+    expect(mockState.swrKey).toEqual(['local-models', 'ollama', '', '']);
+
+    await act(async () => {
+      await result.current.refreshModels();
+    });
+
+    expect(mockState.mutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/agent/hooks/useAgentModels.ts
+++ b/src/features/agent/hooks/useAgentModels.ts
@@ -4,13 +4,15 @@ import { toast } from 'sonner';
 
 import { useSettings } from '@/hooks/use-settings';
 import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
-import { shouldFetchDynamicModels } from '@/lib/ai-service/model-fetch-policy';
+import { getDynamicModelFetchPolicy } from '@/lib/ai-service/model-fetch-policy';
 import type { AIModelLookupService } from '@/lib/ai-service/types';
 import { llmConfigManager, ModelInfo } from '@/lib/llm-config-manager';
 import { withTimeout } from '@/lib/retry-utils';
 import { getLogger } from '@/lib/logger';
 
 const logger = getLogger('useAgentModels');
+type DynamicModelMap = Record<string, ModelInfo>;
+type ModelSWRKey = readonly [string, string, string, string];
 
 export const useAgentModels = (provider?: string) => {
   const {
@@ -36,11 +38,30 @@ export const useAgentModels = (provider?: string) => {
     return providerConfig.baseUrl || '';
   }, [providerConfig]);
 
+  const dynamicModelPolicy = useMemo(
+    () =>
+      getDynamicModelFetchPolicy({
+        provider,
+        apiKey,
+        use3rdParty: providerConfig.use3rdParty,
+        customModelId: providerConfig.customModelId,
+      }),
+    [apiKey, provider, providerConfig],
+  );
+
+  const swrKey = useMemo<ModelSWRKey | null>(() => {
+    if (!provider || !dynamicModelPolicy.canFetch) {
+      return null;
+    }
+
+    return ['local-models', provider, apiKey, baseUrl] as const;
+  }, [apiKey, baseUrl, dynamicModelPolicy.canFetch, provider]);
+
   // Fetcher for models — delegates entirely to service.listModels().
   // Each provider's implementation decides static vs dynamic;
   // no hardcoded allowlist needed here.
   const fetchDynamicModels = useCallback(
-    async ([, p, key]: [string, string, string]) => {
+    async ([, p, key]: ModelSWRKey) => {
       // Use a non-empty placeholder so validateApiKey() doesn't throw.
       // Services that need a real key will fail gracefully in their API calls;
       // services using public endpoints (OpenRouter) or no key (Ollama) work normally.
@@ -73,23 +94,20 @@ export const useAgentModels = (provider?: string) => {
 
   const {
     data: dynamicModels = {},
-    mutate: refreshModels,
+    mutate: mutateModels,
     isValidating: isRefreshing,
-  } = useSWR(
-    shouldFetchDynamicModels({
-      provider,
-      apiKey,
-      use3rdParty: providerConfig.use3rdParty,
-      customModelId: providerConfig.customModelId,
-    })
-      ? ['local-models', provider, apiKey, baseUrl]
-      : null,
-    fetchDynamicModels,
-    {
-      revalidateOnFocus: false,
-      dedupingInterval: 30000,
-    },
-  );
+  } = useSWR<DynamicModelMap>(swrKey, fetchDynamicModels, {
+    revalidateOnFocus: false,
+    dedupingInterval: 30000,
+  });
+
+  const refreshModels = useCallback(async () => {
+    if (!dynamicModelPolicy.canFetch) {
+      return dynamicModels;
+    }
+
+    return await mutateModels();
+  }, [dynamicModelPolicy.canFetch, dynamicModels, mutateModels]);
 
   // Combine static and dynamic models
   const availableModels = useMemo(() => {
@@ -132,5 +150,7 @@ export const useAgentModels = (provider?: string) => {
     availableModels,
     isRefreshing,
     refreshModels,
+    canRefresh: dynamicModelPolicy.canFetch,
+    refreshBlockedReason: dynamicModelPolicy.reason,
   };
 };

--- a/src/lib/ai-service/__tests__/model-fetch-policy.test.ts
+++ b/src/lib/ai-service/__tests__/model-fetch-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { AIServiceProvider } from '../types';
-import { shouldFetchDynamicModels } from '../model-fetch-policy';
+import {
+  getDynamicModelFetchPolicy,
+  shouldFetchDynamicModels,
+} from '../model-fetch-policy';
 
 describe('shouldFetchDynamicModels', () => {
   it('skips providers without enough configuration', () => {
@@ -54,5 +57,43 @@ describe('shouldFetchDynamicModels', () => {
         customModelId: 'local-model',
       }),
     ).toBe(false);
+  });
+
+  it('returns a missing api key reason for providers gated by credentials', () => {
+    expect(
+      getDynamicModelFetchPolicy({
+        provider: AIServiceProvider.Anthropic,
+        apiKey: '',
+      }),
+    ).toEqual({
+      canFetch: false,
+      reason: 'missing-api-key',
+    });
+  });
+
+  it('returns a custom model reason for openai-compatible custom model setups', () => {
+    expect(
+      getDynamicModelFetchPolicy({
+        provider: AIServiceProvider.OpenAI,
+        apiKey: '',
+        use3rdParty: true,
+        customModelId: 'local-model',
+      }),
+    ).toEqual({
+      canFetch: false,
+      reason: 'custom-openai-model',
+    });
+  });
+
+  it('returns allowed for providers with dynamic discovery enabled', () => {
+    expect(
+      getDynamicModelFetchPolicy({
+        provider: AIServiceProvider.Ollama,
+        apiKey: '',
+      }),
+    ).toEqual({
+      canFetch: true,
+      reason: 'allowed',
+    });
   });
 });

--- a/src/lib/ai-service/model-fetch-policy.ts
+++ b/src/lib/ai-service/model-fetch-policy.ts
@@ -7,14 +7,28 @@ interface DynamicModelFetchPolicyArgs {
   customModelId?: string;
 }
 
-export function shouldFetchDynamicModels({
+export type DynamicModelFetchPolicyReason =
+  | 'missing-provider'
+  | 'missing-api-key'
+  | 'custom-openai-model'
+  | 'allowed';
+
+export interface DynamicModelFetchPolicyDecision {
+  canFetch: boolean;
+  reason: DynamicModelFetchPolicyReason;
+}
+
+export function getDynamicModelFetchPolicy({
   provider,
   apiKey,
   use3rdParty,
   customModelId,
-}: DynamicModelFetchPolicyArgs): boolean {
+}: DynamicModelFetchPolicyArgs): DynamicModelFetchPolicyDecision {
   if (!provider) {
-    return false;
+    return {
+      canFetch: false,
+      reason: 'missing-provider',
+    };
   }
 
   if (
@@ -22,15 +36,45 @@ export function shouldFetchDynamicModels({
     use3rdParty &&
     customModelId?.trim()
   ) {
-    return false;
+    return {
+      canFetch: false,
+      reason: 'custom-openai-model',
+    };
   }
 
   if (
     provider === AIServiceProvider.Ollama ||
     provider === AIServiceProvider.OpenRouter
   ) {
-    return true;
+    return {
+      canFetch: true,
+      reason: 'allowed',
+    };
   }
 
-  return Boolean(apiKey?.trim());
+  if (apiKey?.trim()) {
+    return {
+      canFetch: true,
+      reason: 'allowed',
+    };
+  }
+
+  return {
+    canFetch: false,
+    reason: 'missing-api-key',
+  };
+}
+
+export function shouldFetchDynamicModels({
+  provider,
+  apiKey,
+  use3rdParty,
+  customModelId,
+}: DynamicModelFetchPolicyArgs): boolean {
+  return getDynamicModelFetchPolicy({
+    provider,
+    apiKey,
+    use3rdParty,
+    customModelId,
+  }).canFetch;
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -755,7 +755,8 @@
       "provider": "Anbieter",
       "model": "Modell",
       "loading": "Ladevorgang...",
-      "refreshModels": "Modelle aktualisieren"
+      "refreshModels": "Modelle aktualisieren",
+      "refreshRequiresApiKey": "Fügen Sie einen API-Schlüssel hinzu, um die Modellaktualisierung zu aktivieren"
     },
     "toolsModal": {
       "title": "Verfügbare Werkzeuge",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -902,7 +902,8 @@
       "provider": "Provider",
       "model": "Model",
       "loading": "Loading...",
-      "refreshModels": "Refresh models"
+      "refreshModels": "Refresh models",
+      "refreshRequiresApiKey": "Add an API key to enable model refresh"
     },
     "toolsModal": {
       "title": "Available Tools",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -755,7 +755,8 @@
       "provider": "Proveedor",
       "model": "Modelo",
       "loading": "Cargando...",
-      "refreshModels": "Actualizar modelos"
+      "refreshModels": "Actualizar modelos",
+      "refreshRequiresApiKey": "Agrega una clave API para habilitar la actualización de modelos"
     },
     "toolsModal": {
       "title": "Herramientas disponibles",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -755,7 +755,8 @@
       "provider": "Fournisseur",
       "model": "Modèle",
       "loading": "Chargement...",
-      "refreshModels": "Actualiser les modèles"
+      "refreshModels": "Actualiser les modèles",
+      "refreshRequiresApiKey": "Ajoutez une clé API pour activer l’actualisation des modèles"
     },
     "toolsModal": {
       "title": "Outils disponibles",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -745,7 +745,8 @@
       "provider": "プロバイダー",
       "model": "モデル",
       "loading": "読み込み中...",
-      "refreshModels": "モデルを更新"
+      "refreshModels": "モデルを更新",
+      "refreshRequiresApiKey": "モデルの更新を有効にするには API キーを追加してください"
     },
     "toolsModal": {
       "title": "利用可能なツール",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -872,7 +872,8 @@
       "provider": "제공자",
       "model": "모델",
       "loading": "로딩 중...",
-      "refreshModels": "모델 새로고침"
+      "refreshModels": "모델 새로고침",
+      "refreshRequiresApiKey": "모델 새로고침을 사용하려면 API 키를 추가하세요"
     },
     "toolsModal": {
       "title": "사용 가능한 도구",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -755,7 +755,8 @@
       "provider": "Provedor",
       "model": "Modelo",
       "loading": "Carregando...",
-      "refreshModels": "Atualizar modelos"
+      "refreshModels": "Atualizar modelos",
+      "refreshRequiresApiKey": "Adicione uma chave de API para habilitar a atualização de modelos"
     },
     "toolsModal": {
       "title": "Ferramentas Disponíveis",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -755,7 +755,8 @@
       "provider": "提供商",
       "model": "模型",
       "loading": "正在加载...",
-      "refreshModels": "刷新模型"
+      "refreshModels": "刷新模型",
+      "refreshRequiresApiKey": "添加 API 密钥以启用模型刷新"
     },
     "toolsModal": {
       "title": "可用工具",


### PR DESCRIPTION
## Summary
- align model refresh availability with the dynamic model discovery policy
- expose refresh block reasons so the picker can disable or hide refresh appropriately
- add regression coverage for the policy, hook, and picker behavior

## Validation
- pnpm refactor:validate