### PR TITLE
Improve external tool recovery guidance

### DIFF
--- a/docs/guides/builtin_tool_bp.md
+++ b/docs/guides/builtin_tool_bp.md
@@ -16,6 +16,7 @@ We design tools for an entity that has **High Reasoning** capabilities but **Zer
 1. **Cognitive Ergonomics:** The Agent is blind to JSON. It only "sees" text descriptions and text responses.
 2. **Zero Trust Architecture:** The Agent is an unreliable user. Validate everything (especially IDs) against the database before execution.
 3. **Course Correction:** Errors are not failures; they are navigational aids.
+4. **Environment Legibility:** A harness tool must teach the Agent what environment it is currently in (session-visible tools, platform inventory, permissions, attachment state) and which recovery paths remain open.
 
 ---
 
@@ -207,14 +208,88 @@ Context generation (e.g., DOM scraping) can be expensive.
 
 **Rule:** Never return a raw error. Always pair an error with a solution.
 
-### 6.2 Tool Group Isolation
+### 6.2 Environment Legibility
 
-**Rule:** Only suggest tools from the **same domain** (Tool Group).
+**Rule:** Recovery text must explain **why** the current path is blocked in harness terms, not just report the symptom.
+
+- Distinguish:
+  - **Unknown capability:** the server/tool does not exist in the registered inventory
+  - **Unavailable in this session:** the capability exists globally but is not attached to the current session
+  - **Permission / ownership violation:** the capability exists and is attached, but this operation is not allowed
+  - **Transport / internal failure:** the capability exists, but the underlying system failed
+- Surface the state the Agent needs to reason:
+  - current session visibility
+  - inventory visibility
+  - concrete IDs needed for repair (server ID, agent ID, session ID)
+- Never leak raw harness internals like `Server not found: grok` without interpretation.
+
+**Correct pattern:**
+
+```text
+✗ Call External Tool
+
+Source: External(grok)
+Tool: grok__search_web
+Category: PermissionDenied
+Cause: Tool 'grok__search_web' belongs to registered external server 'grok' (Server ID: srv_123),
+but that server is not attached to session 'sess_456'.
+
+Recovery:
+- Use tool__list({"availability":"session"}) to inspect tools callable right now.
+- Use tool__list({"availability":"inventory"}) to inspect registered servers and Server IDs.
+- Attach Server ID "srv_123" with agent__update(id:"<agentId>", externalMcpServers:["srv_123"]).
+- If changing this agent is the wrong move, use agent__list(type="configs") and
+  delegate with agent__startSession(agentId:"<agentId>", task:"...").
+```
+
+**Why This Matters:** In a harness, the error must teach the Agent whether it should repair the current session, inspect global inventory, or switch strategy entirely.
+
+### 6.3 Tool Group Isolation (Default) + Meta-Recovery Exception
+
+**Rule:** By default, suggest tools from the **same domain** (Tool Group).
 
 - _Correct:_ Browser Error → Suggest `scrollPage`.
 - _Incorrect:_ Browser Error → Suggest `createTodo` (Planning).
 
-### 6.3 Success/Error Channel Separation
+**Harness Exception:** When the failure is about the **tool environment itself** rather than the domain operation, meta-tools may be suggested across tool groups.
+
+Allowed cross-group recovery examples:
+
+- `tool__list(...)` to inspect current session visibility vs global inventory
+- `agent__update(...)` to attach missing external capabilities
+- `agent__list(type="configs")` to find a better-equipped agent
+- `agent__startSession(...)` to delegate when the current session should not be mutated
+
+This exception is for **environment repair / delegation only**. Do not use it to suggest unrelated business-domain actions.
+
+### 6.4 Alternatives Are Mandatory for Environment Failures
+
+**Rule:** If the current session lacks a capability, recovery guidance must expose at least one **repair path** and one **continuation path**.
+
+- **Repair path:** fix the current environment (`tool__list`, `agent__update`, reconnect, reattach)
+- **Continuation path:** continue the task elsewhere (`agent__list`, `agent__startSession`, delegated child session)
+
+**Anti-Pattern:**
+
+```text
+✗ Tool not available in this session.
+```
+
+**Correct Pattern:**
+
+```text
+✗ Tool not available in this session.
+
+Recovery:
+- Use tool__list({"availability":"session"}) to confirm the current callable set.
+- Use tool__list({"availability":"inventory"}) to inspect registered servers.
+- Attach the missing capability with agent__update(...).
+- Or delegate to another agent with agent__startSession(...).
+```
+
+The Agent must never be forced into a dead end when the system can still proceed by reconfiguration or delegation.
+
+### 6.5 Success/Error Channel Separation
 
 **Rule:** Never mix success hints with error responses.
 
@@ -254,7 +329,7 @@ match execute_script(...) {
 
 **Why This Matters:** If `clickElement` fails due to invalid CSS selector, suggesting "check for page changes" wastes AI tokens on non-existent changes.
 
-### 6.4 Implemented Builtin Error Semantics (March 2026)
+### 6.6 Implemented Builtin Error Semantics (March 2026)
 
 The current builtin behavior now follows MCP-style outcome semantics more closely than the older
 "only agent-fixable failures are hard errors" approach.
@@ -357,7 +432,9 @@ Before deploying a tool, validation against these checks is mandatory:
 - [ ] **Firewall:** All input IDs are validated (`db.exists()`) before use.
 - [ ] **Dual Channel:** Text output contains all IDs/Status needed for reasoning.
 - [ ] **Hints:** Errors provide actionable next steps.
-- [ ] **Isolation:** Hints only suggest tools from the same Tool Group.
+- [ ] **Environment Legibility:** Harness failures explain whether the capability is unknown, detached from the session, permission-blocked, or internally broken.
+- [ ] **Alternatives:** Environment failures expose both a repair path and a continuation path (for example, attach vs delegate).
+- [ ] **Isolation:** Hints stay within the same Tool Group by default; cross-group suggestions are limited to environment repair / delegation.
 - [ ] **Channel Separation:** Success hints only appear after confirmed operation success, never in error responses.
 - [ ] **Vocabulary:** Descriptions use "Extract/Target" instead of "Copy/Click".
 - [ ] **Testing:** Unit tests exist for Error Guidance formatting.

--- a/src-tauri/src/mcp/error_normalization.rs
+++ b/src-tauri/src/mcp/error_normalization.rs
@@ -1,6 +1,7 @@
 use serde_json::json;
 
 use crate::mcp::types::{MCPContent, MCPResult, ServiceInfo};
+use crate::repositories::MCPServerRepository;
 
 /// Normalized error category for external MCP failures.
 ///
@@ -91,6 +92,72 @@ pub fn external_tool_error_result(
           }
         })),
         is_error: Some(true),
+    }
+}
+
+/// Build a guided external-tool error when the target server is unavailable to the current session.
+///
+/// This teaches the agent about the current tool environment instead of leaking a raw
+/// session-manager error like `Server not found: <server>`.
+pub async fn missing_external_tool_result(
+    server_name: &str,
+    tool_name: &str,
+    session_id: &str,
+) -> MCPResult {
+    let full_tool_name = format!("{server_name}__{tool_name}");
+    let repo = crate::state::get_mcp_server_repository();
+
+    match repo.get_by_name(server_name).await {
+        Ok(Some(server)) => external_tool_error_result(
+            "Call External Tool",
+            server_name,
+            tool_name,
+            ExternalMcpErrorCategory::PermissionDenied,
+            &format!(
+                "Tool '{}' belongs to registered external server '{}' (Server ID: {}), but that server is not attached to session '{}'.",
+                full_tool_name, server_name, server.id, session_id
+            ),
+            vec![
+                "Use tool__list({\"availability\":\"session\"}) to inspect the tools callable right now in this session.".to_string(),
+                "Use tool__list({\"availability\":\"inventory\"}) to inspect registered external servers, inventory, and Server IDs.".to_string(),
+                format!(
+                    "If this session should gain access, attach Server ID \"{}\" with agent__update(id:\"<agentId>\", externalMcpServers:[\"{}\", ...]).",
+                    server.id, server.id
+                ),
+                "If changing the current agent is the wrong move, use agent__list(type=\"configs\") to find a better-equipped agent and delegate with agent__startSession(agentId:\"<agentId>\", task:\"...\").".to_string(),
+            ],
+        ),
+        Ok(None) => external_tool_error_result(
+            "Call External Tool",
+            server_name,
+            tool_name,
+            ExternalMcpErrorCategory::NotFound,
+            &format!(
+                "Tool '{}' is not callable in session '{}' and no registered external server named '{}' was found.",
+                full_tool_name, session_id, server_name
+            ),
+            vec![
+                "Use tool__list({\"availability\":\"session\"}) to inspect the tools callable in the current session.".to_string(),
+                "Use tool__list({\"availability\":\"inventory\"}) to inspect all registered external servers and tool inventory.".to_string(),
+                "Verify the server name and tool name match the registered inventory exactly.".to_string(),
+                "If you expected another agent environment to provide this tool, use agent__list(type=\"configs\") and delegate with agent__startSession(agentId:\"<agentId>\", task:\"...\").".to_string(),
+            ],
+        ),
+        Err(error) => external_tool_error_result(
+            "Call External Tool",
+            server_name,
+            tool_name,
+            ExternalMcpErrorCategory::Internal,
+            &format!(
+                "Could not verify whether external server '{}' is registered: {}",
+                server_name, error
+            ),
+            vec![
+                "Use tool__list({\"availability\":\"session\"}) to inspect currently callable tools.".to_string(),
+                "Use tool__list({\"availability\":\"inventory\"}) to inspect registered external servers if repository access recovers.".to_string(),
+                "Retry the operation or delegate to another agent with a known-good tool environment if the task is urgent.".to_string(),
+            ],
+        ),
     }
 }
 

--- a/src-tauri/src/mcp/service_proxy/mod.rs
+++ b/src-tauri/src/mcp/service_proxy/mod.rs
@@ -9,7 +9,6 @@ use super::builtin::BuiltinMCPServer;
 use super::error_normalization::{external_tool_error_result, ExternalMcpErrorCategory};
 use super::session_isolation::{HttpSessionManager, SessionMCPManager};
 use super::types::{ContextVolatility, MCPResponse, MCPTool, ServiceContext};
-use crate::repositories::mcp_server_repository::MCPServerRepository;
 use crate::session::SessionManager;
 
 pub mod builder;
@@ -87,6 +86,20 @@ impl MCPServiceProxy {
                 }),
             ),
         ))
+    }
+
+    async fn missing_external_tool_response(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+    ) -> MCPResponse {
+        let result = crate::mcp::error_normalization::missing_external_tool_result(
+            server_name,
+            tool_name,
+            &self.session_id,
+        )
+        .await;
+        Self::tool_call_response(result)
     }
 
     /// Create a new session-bound proxy using builder
@@ -231,46 +244,9 @@ impl MCPServiceProxy {
                         return response;
                     }
 
-                    let repo = crate::state::get_mcp_server_repository();
-                    let is_global_server =
-                        matches!(repo.get_by_name(&server_name).await, Ok(Some(_)));
-
-                    let (error_msg, guidance) = if is_global_server {
-                        (
-                            format!(
-                                "Tool '{}' is not permitted for your current session.",
-                                tool_name
-                            ),
-                            vec![
-                                "This tool exists in the system, but your current session is not allowed to call it.".to_string(),
-                                "Use agent__list(type=\"configs\") to find an agent with the required capability, or update the responsible agent with agent__update(...).".to_string(),
-                            ],
-                        )
-                    } else {
-                        (
-                            format!(
-                                "Tool '{}' not found in session '{}'",
-                                tool_name, self.session_id
-                            ),
-                            vec![
-                                "Verify the server is enabled for this agent/session".to_string(),
-                                "Use tool__list to inspect the current session's callable tool set"
-                                    .to_string(),
-                                "Confirm the tool name matches the server tool list".to_string(),
-                            ],
-                        )
-                    };
-
-                    let result = external_tool_error_result(
-                        "Call External Tool",
-                        &server_name,
-                        &real_tool_name,
-                        ExternalMcpErrorCategory::NotFound,
-                        &error_msg,
-                        guidance,
-                    );
-
-                    Ok(Self::tool_call_response(result))
+                    Ok(self
+                        .missing_external_tool_response(&server_name, &real_tool_name)
+                        .await)
                 }
             };
         }
@@ -333,45 +309,9 @@ impl MCPServiceProxy {
                         return response;
                     }
 
-                    let repo = crate::state::get_mcp_server_repository();
-                    let is_global_server =
-                        matches!(repo.get_by_name(&server_name).await, Ok(Some(_)));
-
-                    let (error_msg, guidance) = if is_global_server {
-                        (
-                            format!(
-                                "Tool '{}' is not permitted for your current session.",
-                                tool_name
-                            ),
-                            vec![
-                                "This tool exists in the system, but your current session is not allowed to call it.".to_string(),
-                                "Use agent__list(type=\"configs\") to find an agent with the required capability, or update the responsible agent with agent__update(...).".to_string(),
-                            ],
-                        )
-                    } else {
-                        (
-                            format!(
-                                "Tool '{}' not found in session '{}'",
-                                tool_name, self.session_id
-                            ),
-                            vec![
-                                "Verify the server is enabled for this agent/session".to_string(),
-                                "Use tool__list to inspect the current session's callable tool set".to_string(),
-                                "Confirm the tool name matches the server tool list".to_string(),
-                            ],
-                        )
-                    };
-
-                    let result = external_tool_error_result(
-                        "Call External Tool",
-                        &server_name,
-                        &real_tool_name,
-                        ExternalMcpErrorCategory::NotFound,
-                        &error_msg,
-                        guidance,
-                    );
-
-                    Ok(Self::tool_call_response(result))
+                    Ok(self
+                        .missing_external_tool_response(&server_name, &real_tool_name)
+                        .await)
                 }
             }
         })

--- a/src-tauri/src/mcp/service_proxy_manager/management.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/management.rs
@@ -215,11 +215,11 @@ impl MCPServiceProxyManager {
             .split_once("__")
             .map(|(server, _)| BuiltinServiceId::from_alias(server).is_some())
             .unwrap_or(false);
-        let proxy = match self.get_proxy(session_id).await {
-            Some(proxy) => proxy,
-            None => {
-                let active_sessions = self.list_sessions().await;
-                if is_builtin {
+        let active_sessions = self.list_sessions().await;
+        let proxy = if is_builtin {
+            match self.get_proxy(session_id).await {
+                Some(proxy) => proxy,
+                None => {
                     log::debug!(
                         "No proxy for session {}, attempting lazy builtin proxy init",
                         session_id
@@ -233,26 +233,26 @@ impl MCPServiceProxyManager {
                         );
                         format!("Session context not found or expired (ID: {})", session_id)
                     })?
-                } else {
-                    log::debug!(
-                        "No proxy for session {}, attempting config-aware proxy init for external tool '{}'",
-                        session_id,
-                        tool_name
-                    );
-                    self.ensure_configured_proxy(session_id, None)
-                        .await
-                        .map_err(|error| {
-                            log::error!(
-                                "Failed to lazily init configured proxy for session {} before external tool '{}': {}. Active sessions: {:?}",
-                                session_id,
-                                tool_name,
-                                error,
-                                active_sessions
-                            );
-                            error
-                        })?
                 }
             }
+        } else {
+            log::debug!(
+                "Ensuring config-aware proxy for session {} before external tool '{}'",
+                session_id,
+                tool_name
+            );
+            self.ensure_configured_proxy(session_id, None)
+                .await
+                .map_err(|error| {
+                    log::error!(
+                        "Failed to ensure configured proxy for session {} before external tool '{}': {}. Active sessions: {:?}",
+                        session_id,
+                        tool_name,
+                        error,
+                        active_sessions
+                    );
+                    error
+                })?
         };
 
         proxy.call_tool(tool_name, args).await

--- a/src-tauri/src/mcp/service_proxy_manager/management.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/management.rs
@@ -184,10 +184,8 @@ impl MCPServiceProxyManager {
     /// Call a tool via the appropriate session proxy
     ///
     /// This is the primary entry point for tool execution from agent workflows.
-    /// It implements dual routing:
-    /// - Builtin tools -> session proxy
-    /// - External stdio tools -> session-specific stdio manager
-    /// - External HTTP tools -> shared HTTP manager
+    /// It routes both builtin and external tools through the session proxy so that
+    /// tool availability, guided recovery, and session-scoped MCP dispatch share one path.
     ///
     /// # Arguments
     /// * `session_id` - The session making the tool call
@@ -213,79 +211,51 @@ impl MCPServiceProxyManager {
         tool_name: &str,
         args: serde_json::Value,
     ) -> Result<MCPResponse, String> {
-        // Builtin tools route through proxy (identified by known service alias prefix)
         let is_builtin = tool_name
             .split_once("__")
             .map(|(server, _)| BuiltinServiceId::from_alias(server).is_some())
             .unwrap_or(false);
-        if is_builtin {
-            let proxy = match self.get_proxy(session_id).await {
-                Some(proxy) => proxy,
-                None => {
-                    // No proxy exists yet — lazily initialise a builtin-only proxy so that
-                    // idle sessions (exist in DB but have not run a workflow in this app
-                    // session) can still serve builtin tool calls such as content-store
-                    // listing from AgentResourceAttachmentContext.
+        let proxy = match self.get_proxy(session_id).await {
+            Some(proxy) => proxy,
+            None => {
+                let active_sessions = self.list_sessions().await;
+                if is_builtin {
                     log::debug!(
                         "No proxy for session {}, attempting lazy builtin proxy init",
                         session_id
                     );
-                    match self.ensure_builtin_proxy(session_id).await {
-                        Ok(proxy) => proxy,
-                        Err(e) => {
-                            let active_sessions = self.list_sessions().await;
+                    self.ensure_builtin_proxy(session_id).await.map_err(|error| {
+                        log::error!(
+                            "Failed to lazily init builtin proxy for session {}: {}. Active sessions: {:?}",
+                            session_id,
+                            error,
+                            active_sessions
+                        );
+                        format!("Session context not found or expired (ID: {})", session_id)
+                    })?
+                } else {
+                    log::debug!(
+                        "No proxy for session {}, attempting config-aware proxy init for external tool '{}'",
+                        session_id,
+                        tool_name
+                    );
+                    self.ensure_configured_proxy(session_id, None)
+                        .await
+                        .map_err(|error| {
                             log::error!(
-                                "Failed to lazily init proxy for session {}: {}. Active sessions: {:?}",
+                                "Failed to lazily init configured proxy for session {} before external tool '{}': {}. Active sessions: {:?}",
                                 session_id,
-                                e,
+                                tool_name,
+                                error,
                                 active_sessions
                             );
-                            return Err(format!(
-                                "Session context not found or expired (ID: {})",
-                                session_id
-                            ));
-                        }
-                    }
+                            error
+                        })?
                 }
-            };
-            return proxy.call_tool(tool_name, args).await;
-        }
+            }
+        };
 
-        // External tools: parse server__tool format
-        let (server_name, real_tool_name) = tool_name
-            .split_once("__")
-            .ok_or_else(|| format!("Invalid tool name format: {}", tool_name))?;
-
-        // Check if server exists in session-specific stdio manager first (primary check)
-        let stdio_managers = self.session_stdio_managers.read().await;
-        let has_stdio = stdio_managers
-            .get(session_id)
-            .map(|mgr| mgr.has_server(server_name))
-            .unwrap_or(false);
-
-        if has_stdio {
-            // Route to session-specific stdio manager
-            let manager = stdio_managers
-                .get(session_id)
-                .ok_or_else(|| format!("No stdio manager for session: {}", session_id))?;
-
-            return manager
-                .call_tool(server_name, real_tool_name, args)
-                .await
-                .map_err(|e| format!("{}", e));
-        }
-        drop(stdio_managers);
-
-        // Otherwise, route to session-specific HTTP manager
-        let http_managers = self.session_http_managers.read().await;
-        let manager = http_managers
-            .get(session_id)
-            .ok_or_else(|| format!("No HTTP manager for session: {}", session_id))?;
-
-        manager
-            .call_tool(server_name, real_tool_name, args)
-            .await
-            .map_err(|e| format!("{}", e))
+        proxy.call_tool(tool_name, args).await
     }
 
     /// Get the number of active proxies

--- a/src-tauri/tests/external_tool_recovery_tests.rs
+++ b/src-tauri/tests/external_tool_recovery_tests.rs
@@ -1,0 +1,167 @@
+#![cfg(not(windows))]
+
+mod common;
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::service_proxy_manager::MCPServiceProxyManager;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResponseResult};
+use tauri_mcp_agent_lib::repositories::{
+    MCPServerRepository, SessionMetadata, SessionRepository, SessionStatus,
+    SqliteMCPServerRepository, SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tauri_mcp_agent_lib::{set_mcp_server_repository, set_session_repository};
+use tempfile::TempDir;
+use tokio::sync::OnceCell;
+
+struct TestContext {
+    db: Arc<sea_orm::DatabaseConnection>,
+    _temp_dir: TempDir,
+}
+
+static TEST_CONTEXT: OnceCell<TestContext> = OnceCell::const_new();
+
+async fn test_context() -> &'static TestContext {
+    TEST_CONTEXT
+        .get_or_init(|| async {
+            let db = Arc::new(common::setup_test_db_with_migrations().await);
+            set_mcp_server_repository(SqliteMCPServerRepository::new((*db).clone()));
+            set_session_repository(SqliteSessionRepository::new((*db).clone()));
+            TestContext {
+                db,
+                _temp_dir: TempDir::new().expect("temp dir"),
+            }
+        })
+        .await
+}
+
+fn extract_text(response: &tauri_mcp_agent_lib::mcp::types::MCPResponse) -> String {
+    let result = response.result.as_ref().expect("tool result");
+    let MCPResponseResult::ToolCall(result) = result else {
+        panic!("expected tool-call result");
+    };
+    result
+        .content
+        .as_ref()
+        .expect("text content")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn detached_external_server_returns_delegate_or_attach_guidance() {
+    let context = test_context().await;
+    let db = context.db.clone();
+
+    let session_repo = SqliteSessionRepository::new((*db).clone());
+    let server_repo = SqliteMCPServerRepository::new((*db).clone());
+
+    let session_id = "external-recovery-session";
+    session_repo
+        .upsert_session(&SessionMetadata {
+            id: session_id.to_string(),
+            name: Some("External Recovery Session".to_string()),
+            status: SessionStatus::Idle,
+            model: "gpt-4.1".to_string(),
+            provider: "openai".to_string(),
+            agent_config: Some(
+                json!({
+                    "assistantId": "agent-recovery",
+                    "name": "Recovery Agent",
+                    "systemPrompt": "You recover intelligently.",
+                    "allowedBuiltInServiceAliases": ["planning", "workspace", "agent", "tool", "attachments", "ui", "skills", "playbook", "scratchpad"],
+                    "mcpServerIds": []
+                })
+                .to_string(),
+            ),
+            parent_session_id: None,
+            lineage_id: None,
+            depth: Some(0),
+            max_depth: None,
+            max_fanout: None,
+            org_id: None,
+            org_name: None,
+            org_root_session_id: None,
+            created_at: 1,
+            updated_at: 1,
+            last_viewed_at: None,
+            last_message_at: None,
+            last_attention_at: None,
+            last_attention_reason: None,
+            is_bookmarked: false,
+            yolo_mode: false,
+            unsafe_mode: false,
+            workspace_override: None,
+        })
+        .await
+        .expect("session should insert");
+
+    let created = server_repo
+        .create(
+            "grok",
+            json!({
+                "name": "grok",
+                "transport": { "type": "http", "url": "https://example.com/mcp" }
+            }),
+        )
+        .await
+        .expect("server should insert");
+
+    let session_root = TempDir::new().expect("temp dir");
+    let session_manager = Arc::new(
+        SessionManager::new_with_base_dir(session_root.path().join("session-root"))
+            .expect("session manager"),
+    );
+    let manager = MCPServiceProxyManager::new(db, session_manager);
+
+    let response = manager
+        .call_tool(
+            session_id,
+            "grok__search_web",
+            json!({ "query": "S&P 500 gold oil price May 2026" }),
+        )
+        .await
+        .expect("guided tool error should still return MCPResponse");
+
+    let text = extract_text(&response);
+    let result = response.result.as_ref().expect("tool result");
+    let MCPResponseResult::ToolCall(result) = result else {
+        panic!("expected tool-call result");
+    };
+
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("Category: PermissionDenied"),
+        "should classify detached global server as permission/session-attachment issue: {text}"
+    );
+    assert!(
+        text.contains(&format!("Server ID: {}", created.id)),
+        "guidance should surface the concrete server id needed for attachment: {text}"
+    );
+    assert!(
+        text.contains("tool__list({\"availability\":\"session\"})"),
+        "guidance should teach session-visible inventory inspection: {text}"
+    );
+    assert!(
+        text.contains("tool__list({\"availability\":\"inventory\"})"),
+        "guidance should teach global inventory inspection: {text}"
+    );
+    assert!(
+        text.contains("agent__update"),
+        "guidance should explain how to attach the missing server: {text}"
+    );
+    assert!(
+        text.contains("agent__list(type=\"configs\")"),
+        "guidance should point toward alternative agents: {text}"
+    );
+    assert!(
+        text.contains("agent__startSession"),
+        "guidance should explicitly mention delegation as a recovery path: {text}"
+    );
+}

--- a/src-tauri/tests/external_tool_recovery_tests.rs
+++ b/src-tauri/tests/external_tool_recovery_tests.rs
@@ -2,21 +2,27 @@
 
 mod common;
 
+use migration::MigratorTrait;
+use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
 use serde_json::json;
+use std::str::FromStr;
 use std::sync::Arc;
 use tauri_mcp_agent_lib::mcp::service_proxy_manager::MCPServiceProxyManager;
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResponseResult};
+use tauri_mcp_agent_lib::migration::Migrator;
 use tauri_mcp_agent_lib::repositories::{
     MCPServerRepository, SessionMetadata, SessionRepository, SessionStatus,
     SqliteMCPServerRepository, SqliteSessionRepository,
 };
 use tauri_mcp_agent_lib::session::SessionManager;
+use tauri_mcp_agent_lib::utils::sqlite::format_sqlite_url;
 use tauri_mcp_agent_lib::{set_mcp_server_repository, set_session_repository};
 use tempfile::TempDir;
 use tokio::sync::OnceCell;
 
 struct TestContext {
-    db: Arc<sea_orm::DatabaseConnection>,
+    db: Arc<DatabaseConnection>,
     _temp_dir: TempDir,
 }
 
@@ -25,12 +31,27 @@ static TEST_CONTEXT: OnceCell<TestContext> = OnceCell::const_new();
 async fn test_context() -> &'static TestContext {
     TEST_CONTEXT
         .get_or_init(|| async {
-            let db = Arc::new(common::setup_test_db_with_migrations().await);
+            common::register_sqlite_vec();
+            let temp_dir = tempfile::tempdir().expect("temp dir should create");
+            let db_path = temp_dir.path().join("external-tool-recovery-tests.db");
+            let url = format_sqlite_url(&db_path.to_string_lossy());
+            let options = SqliteConnectOptions::from_str(&url)
+                .expect("sqlite url should be valid")
+                .create_if_missing(true);
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(options)
+                .await
+                .expect("sqlite pool should connect");
+            let db = Arc::new(SqlxSqliteConnector::from_sqlx_sqlite_pool(pool));
+            Migrator::up(&*db, None)
+                .await
+                .expect("migrations should run");
             set_mcp_server_repository(SqliteMCPServerRepository::new((*db).clone()));
             set_session_repository(SqliteSessionRepository::new((*db).clone()));
             TestContext {
                 db,
-                _temp_dir: TempDir::new().expect("temp dir"),
+                _temp_dir: temp_dir,
             }
         })
         .await
@@ -163,5 +184,120 @@ async fn detached_external_server_returns_delegate_or_attach_guidance() {
     assert!(
         text.contains("agent__startSession"),
         "guidance should explicitly mention delegation as a recovery path: {text}"
+    );
+}
+
+#[tokio::test]
+async fn external_call_reconfigures_existing_builtin_only_proxy() {
+    let context = test_context().await;
+    let db = context.db.clone();
+
+    let session_repo = SqliteSessionRepository::new((*db).clone());
+    let server_repo = SqliteMCPServerRepository::new((*db).clone());
+
+    let created = server_repo
+        .create(
+            "grok-configured",
+            json!({
+                "name": "grok-configured",
+                "transport": { "type": "http", "url": "https://example.com/mcp" }
+            }),
+        )
+        .await
+        .expect("server should insert");
+
+    let session_id = "external-recovery-configured-session";
+    session_repo
+        .upsert_session(&SessionMetadata {
+            id: session_id.to_string(),
+            name: Some("External Recovery Configured Session".to_string()),
+            status: SessionStatus::Idle,
+            model: "gpt-4.1".to_string(),
+            provider: "openai".to_string(),
+            agent_config: Some(
+                json!({
+                    "assistantId": "agent-recovery-configured",
+                    "name": "Recovery Agent Configured",
+                    "systemPrompt": "You recover intelligently.",
+                    "allowedBuiltInServiceAliases": ["planning", "workspace", "agent", "tool", "attachments", "ui", "skills", "playbook", "scratchpad"],
+                    "mcpServerIds": [created.id.clone()]
+                })
+                .to_string(),
+            ),
+            parent_session_id: None,
+            lineage_id: None,
+            depth: Some(0),
+            max_depth: None,
+            max_fanout: None,
+            org_id: None,
+            org_name: None,
+            org_root_session_id: None,
+            created_at: 1,
+            updated_at: 1,
+            last_viewed_at: None,
+            last_message_at: None,
+            last_attention_at: None,
+            last_attention_reason: None,
+            is_bookmarked: false,
+            yolo_mode: false,
+            unsafe_mode: false,
+            workspace_override: None,
+        })
+        .await
+        .expect("session should insert");
+
+    let session_root = TempDir::new().expect("temp dir");
+    let session_manager = Arc::new(
+        SessionManager::new_with_base_dir(session_root.path().join("session-root"))
+            .expect("session manager"),
+    );
+    let manager = MCPServiceProxyManager::new(db, session_manager);
+
+    manager
+        .call_tool(
+            session_id,
+            "tool__list",
+            json!({ "availability": "session" }),
+        )
+        .await
+        .expect("builtin tool should succeed and create a lazy builtin-only proxy");
+
+    let initial_proxy = manager
+        .get_proxy(session_id)
+        .await
+        .expect("builtin call should create proxy");
+    assert!(
+        initial_proxy
+            .configured_external_server_names()
+            .await
+            .is_empty(),
+        "lazy builtin proxy should not yet have configured external servers"
+    );
+
+    let response = manager
+        .call_tool(
+            session_id,
+            "grok-configured__search_web",
+            json!({ "query": "S&P 500 gold oil price May 2026" }),
+        )
+        .await
+        .expect("configured external call should return an MCP response");
+
+    let text = extract_text(&response);
+    let reconfigured_proxy = manager
+        .get_proxy(session_id)
+        .await
+        .expect("external call should keep a proxy");
+    let configured_servers = reconfigured_proxy.configured_external_server_names().await;
+
+    assert!(
+        configured_servers
+            .iter()
+            .any(|server_name| server_name == "grok-configured"),
+        "external call should replace builtin-only proxy with config-aware proxy containing attached external servers"
+    );
+    assert!(
+        !text.contains("Category: PermissionDenied"),
+        "configured attached server must not be misreported as detached from the session: {text}"
     );
 }


### PR DESCRIPTION
## Summary
- centralize external tool calls through the session proxy so recovery is consistent on the agent hot path
- return guided missing-tool MCP errors that explain session vs inventory visibility and suggest attach or delegation paths
- add an integration test covering detached external server recovery guidance

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml --test external_tool_recovery_tests
- pnpm refactor:validate