### PR TITLE
Backport stable context canonicalization fixes to dev/0.7.x

### DIFF
--- a/.github/skills/critique-builtin-tool/SKILL.md
+++ b/.github/skills/critique-builtin-tool/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when:
 
 ### Step 1: Understand the Tool Design Manifesto Rules
 
-Before auditing, internalize these 5 critical rules:
+Before auditing, internalize these 6 critical rules:
 
 #### **Rule 1: The Immutable ID Rule (Schema Design)**
 
@@ -57,6 +57,14 @@ Before auditing, internalize these 5 critical rules:
 - Format: "❌ Problem. 💡 Use toolName() to fix"
 - Never raw "Not Found" without context
 
+#### **Rule 6: Cache-Safe Stable Contexts (Prompt Prefix Stability)**
+
+- `ContextVolatility::Stable` content becomes part of the cacheable prompt prefix
+- Equivalent state must render **byte-for-byte identical** `context_prompt` text
+- Canonicalize unordered inputs before formatting text: `HashMap`, `HashSet`, directory scans, filesystem/API listings, DB queries without `ORDER BY`
+- Live or frequently changing state must **not** be marked `Stable`
+- If you limit a list (`take(5)`), sort first and truncate second
+
 ---
 
 ## Step 2: Gather Code Artifacts
@@ -77,6 +85,8 @@ src-tauri/src/mcp/builtin/your_server/
 2. **Tool Handlers** - Check for validation before mutations
 3. **Response Building** - Check dual-channel compliance
 4. **Error Messages** - Check for recovery hints
+5. **Service Context Builders** - Check `get_service_context()` text and volatility
+6. **Backing Repositories / Iterators** - Check ordering guarantees feeding service context text
 
 ---
 
@@ -486,6 +496,123 @@ return Ok(operation_failed_error(
 
 ---
 
+### 🧭 **Auditing Rule 6: Cache-Safe Stable Contexts**
+
+**Why this matters:**
+
+`ContextVolatility::Stable` is not just a UI hint. Stable service-context text is appended into the reusable prompt prefix, so nondeterministic rendering directly causes prompt cache misses even when message history is unchanged.
+
+**What to Look For:**
+
+```rust
+// ❌ VIOLATION: Stable context built from HashMap iteration
+async fn get_service_context(&self, _options: Option<&Value>) -> ServiceContext {
+    let installed: Vec<String> = platform
+        .installed_tools     // HashMap<String, ToolInfo>
+        .iter()              // ❌ Unordered
+        .filter(|(_, info)| info.installed)
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    ServiceContext::new(format!(
+        "## Bootstrap\n\nInstalled Tools: {}",
+        installed.join(", ")
+    ))
+    .with_volatility(ContextVolatility::Stable)
+}
+```
+
+```rust
+// ✅ COMPLIANT: Canonicalize before rendering Stable text
+async fn get_service_context(&self, _options: Option<&Value>) -> ServiceContext {
+    let mut installed: Vec<String> = platform
+        .installed_tools
+        .iter()
+        .filter(|(_, info)| info.installed)
+        .map(|(name, _)| name.clone())
+        .collect();
+    installed.sort_unstable();
+
+    ServiceContext::new(format!(
+        "## Bootstrap\n\nInstalled Tools: {}",
+        installed.join(", ")
+    ))
+    .with_volatility(ContextVolatility::Stable)
+}
+```
+
+```rust
+// ❌ VIOLATION: Truncating before sorting makes the visible subset unstable
+let processes = registry
+    .entries
+    .values()
+    .filter(|entry| entry.running)
+    .take(5)   // ❌ Picks arbitrary five first
+    .map(|entry| (entry.id.clone(), entry.command.clone()))
+    .collect::<Vec<_>>();
+```
+
+```rust
+// ✅ COMPLIANT: Sort first, then truncate
+let mut processes = registry
+    .entries
+    .values()
+    .filter(|entry| entry.running)
+    .map(|entry| (entry.id.clone(), entry.command.clone()))
+    .collect::<Vec<_>>();
+processes.sort_by(|left, right| left.0.cmp(&right.0));
+let visible = processes.into_iter().take(5).collect::<Vec<_>>();
+```
+
+```rust
+// ❌ VIOLATION: Repository query feeding service context without ORDER BY
+ScheduledTaskEntity::find()
+    .filter(scheduled_task::Column::Enabled.eq(true))
+    .all(&self.db)   // ❌ Row order is not guaranteed
+    .await
+```
+
+```rust
+// ✅ COMPLIANT: Deterministic DB ordering with tie-breaker
+ScheduledTaskEntity::find()
+    .filter(scheduled_task::Column::Enabled.eq(true))
+    .order_by(scheduled_task::Column::NextRunAt, Order::Asc)
+    .order_by(scheduled_task::Column::CreatedAt, Order::Asc)
+    .order_by(scheduled_task::Column::Id, Order::Asc)
+    .all(&self.db)
+    .await
+```
+
+**Audit Checklist:**
+
+- [ ] Every `ContextVolatility::Stable` context uses deterministic text rendering
+- [ ] Unordered collections are sorted before joining into prompt text
+- [ ] Filesystem scans / directory walks are sorted before rendering
+- [ ] DB queries feeding stable context use explicit `ORDER BY` with tie-breakers when needed
+- [ ] `take()/limit` happens **after** sort, not before
+- [ ] Frequently changing state is marked `Medium` or `Volatile`, not `Stable`
+- [ ] If a service context claims "Stable", equivalent state really produces identical text
+
+**Lower-Priority Extension:**
+
+Even `Medium` / `Volatile` contexts benefit from deterministic ordering for prompt quality and compaction stability. These are not prompt-cache blockers, but they are still worth flagging as cleanup if ordering is obviously arbitrary.
+
+**Common Pitfalls:**
+
+- `HashMap::iter()` / `.values()` inside `Stable` service context text ❌
+- `WalkDir` / `read_dir()` output rendered without sorting ❌
+- Relying on implicit DB row order ❌
+- Sorting after `.take(5)` ❌
+- Marking live process lists, browser session state, or recent uploads as `Stable` ❌
+
+**Priority Guidance:**
+
+- **P1 (High):** Nondeterministic text inside `ContextVolatility::Stable`
+- **P2 (Medium):** Ordering instability in `Medium` / `Volatile` contexts
+- **P2 (Medium):** Repository helpers lacking explicit ordering that could later feed prompt text
+
+---
+
 ## Step 4: Document Findings
 
 ### Compliance Matrix Template
@@ -493,14 +620,15 @@ return Ok(operation_failed_error(
 ```markdown
 ## Compliance Audit: [ServerName] Builtin Tools
 
-| Rule                        | Status   | Grade | Evidence  |
-| --------------------------- | -------- | ----- | --------- |
-| 1. Immutable ID Rule        | ✅/⚠️/🔴 | A-F   | [Details] |
-| 2. Hallucination Firewall   | ✅/⚠️/🔴 | A-F   | [Details] |
-| 3. Dual-Channel Response    | ✅/⚠️/🔴 | A-F   | [Details] |
-| 4. AI-Native Descriptions   | ✅/⚠️/🔴 | A-F   | [Details] |
-| 4b. Description/Param Split | ✅/⚠️/🔴 | A-F   | [Details] |
-| 5. Success Hint Pattern     | ✅/⚠️/🔴 | A-F   | [Details] |
+| Rule                          | Status   | Grade | Evidence  |
+| ----------------------------- | -------- | ----- | --------- |
+| 1. Immutable ID Rule          | ✅/⚠️/🔴 | A-F   | [Details] |
+| 2. Hallucination Firewall     | ✅/⚠️/🔴 | A-F   | [Details] |
+| 3. Dual-Channel Response      | ✅/⚠️/🔴 | A-F   | [Details] |
+| 4. AI-Native Descriptions     | ✅/⚠️/🔴 | A-F   | [Details] |
+| 4b. Description/Param Split   | ✅/⚠️/🔴 | A-F   | [Details] |
+| 5. Success Hint Pattern       | ✅/⚠️/🔴 | A-F   | [Details] |
+| 6. Cache-Safe Stable Contexts | ✅/⚠️/🔴 | A-F   | [Details] |
 
 **Overall Grade:** [A-F] - [Summary]
 ```
@@ -557,10 +685,12 @@ return Ok(operation_failed_error(
 **P1 (High):** Should fix soon
 - Rule 2 partial violations (poor error messages)
 - Rule 5 violations (no recovery hints)
+- Rule 6 violations in `ContextVolatility::Stable`
 
 **P2 (Medium):** Nice to have
 - Rule 4 improvements (better descriptions)
 - Inconsistent error formatting
+- Ordering instability in non-stable service contexts
 
 **P3 (Low):** Optional polish
 - Documentation improvements
@@ -697,6 +827,7 @@ Before submitting audit findings:
 - [ ] Assigned appropriate priorities
 - [ ] Tested recommended fixes compile (if providing code)
 - [ ] Acknowledged what's already good (not just problems)
+- [ ] Checked `get_service_context()` volatility + ordering, not just tool handlers
 
 ---
 
@@ -807,6 +938,15 @@ rg 'MCPResult|SuccessHint::new|to_mcp_result'
 
 # Rule 5: Find raw Err returns
 rg 'Err\(format!\(".*not found'
+
+# Rule 6: Find Stable service contexts
+rg -n 'ContextVolatility::Stable|with_volatility\(ContextVolatility::Stable\)' src-tauri/src/mcp
+
+# Rule 6: Find likely unordered inputs near service-context builders
+rg -n 'get_service_context|HashMap|HashSet|WalkDir|read_dir|\.values\(\)|\.keys\(\)|join\(' src-tauri/src/mcp src-tauri/src/services src-tauri/src/repositories
+
+# Rule 6: Find DB queries without explicit ordering in prompt-adjacent code
+rg -n 'find\(\)|all\(&self\.db\)|all\(&db\)' src-tauri/src/repositories src-tauri/src/mcp | rg -v 'order_by'
 ````
 
 ### Code Review Checklist
@@ -821,6 +961,8 @@ When reviewing PR:
 - [ ] No human UI verbs in descriptions
 - [ ] Success/error hints are context-specific
 - [ ] Structured content mirrors text content
+- [ ] Stable service-context text is canonicalized before rendering
+- [ ] Live state is not mislabeled as `ContextVolatility::Stable`
 
 ---
 

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ _Important: `bootstrap` is a builtin capability often used alongside these skill
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.7.27_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64-setup.exe) · [`LibrAgent_0.7.27_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.7.27_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.7.27_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.AppImage) · [`LibrAgent_0.7.27_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent_0.7.27_amd64.deb) · [`LibrAgent-0.7.27-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.7.27/LibrAgent-0.7.27-1.x86_64.rpm)

--- a/src-tauri/src/mcp/builtin/bootstrap/mod.rs
+++ b/src-tauri/src/mcp/builtin/bootstrap/mod.rs
@@ -41,6 +41,17 @@ impl BootstrapServer {
         }
     }
 
+    fn sorted_tool_names(platform: &platform::PlatformInfo, installed: bool) -> Vec<String> {
+        let mut tools: Vec<String> = platform
+            .installed_tools
+            .iter()
+            .filter(|(_, info)| info.installed == installed)
+            .map(|(name, _)| name.clone())
+            .collect();
+        tools.sort_unstable();
+        tools
+    }
+
     /// Build service context from platform info
     fn build_service_context(platform: &platform::PlatformInfo) -> ServiceContext {
         let mut context_parts = vec![
@@ -56,12 +67,7 @@ impl BootstrapServer {
             context_parts.push(format!("Package Manager: {}", pm));
         }
 
-        let installed: Vec<String> = platform
-            .installed_tools
-            .iter()
-            .filter(|(_, info)| info.installed)
-            .map(|(name, _)| name.clone())
-            .collect();
+        let installed = Self::sorted_tool_names(platform, true);
 
         if !installed.is_empty() {
             context_parts.push(format!("Installed Tools: {}", installed.join(", ")));
@@ -103,24 +109,13 @@ impl BootstrapServer {
         }
 
         // Add installed tools summary
-        let installed: Vec<&String> = platform
-            .installed_tools
-            .iter()
-            .filter(|(_, info)| info.installed)
-            .map(|(name, _)| name)
-            .collect();
-
-        let missing: Vec<&String> = platform
-            .installed_tools
-            .iter()
-            .filter(|(_, info)| !info.installed)
-            .map(|(name, _)| name)
-            .collect();
+        let installed = Self::sorted_tool_names(&platform, true);
+        let missing = Self::sorted_tool_names(&platform, false);
 
         if !installed.is_empty() {
             sections.push(format!("\nInstalled Tools ({}):", installed.len()));
             for tool in &installed {
-                if let Some(info) = platform.installed_tools.get(*tool) {
+                if let Some(info) = platform.installed_tools.get(tool) {
                     let version = info.version.as_deref().unwrap_or("unknown");
                     sections.push(format!("  ✓ {}: {}", tool, version));
                 }
@@ -308,6 +303,37 @@ impl BuiltinMCPServer for BootstrapServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    fn sample_platform(tool_order: &[(&str, bool, Option<&str>)]) -> platform::PlatformInfo {
+        let mut installed_tools = HashMap::new();
+        for (name, installed, version) in tool_order {
+            installed_tools.insert(
+                (*name).to_string(),
+                platform::ToolInfo {
+                    installed: *installed,
+                    version: version.map(str::to_string),
+                    path: Some(format!("/usr/bin/{name}")),
+                },
+            );
+        }
+
+        platform::PlatformInfo {
+            os: "linux".to_string(),
+            arch: "x64".to_string(),
+            shell: "bash".to_string(),
+            home_dir: Some("/home/test".to_string()),
+            temp_dir: "/tmp".to_string(),
+            distro: Some(platform::LinuxDistro {
+                name: "Ubuntu".to_string(),
+                id: "ubuntu".to_string(),
+                version: Some("24.04".to_string()),
+                pretty_name: Some("Ubuntu 24.04".to_string()),
+            }),
+            package_manager: Some("apt".to_string()),
+            installed_tools,
+        }
+    }
 
     #[tokio::test]
     async fn test_detect_platform() {
@@ -379,6 +405,47 @@ mod tests {
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(tool_names.contains(&"detectPlatform"));
         assert!(tool_names.contains(&"getBootstrapGuide"));
+    }
+
+    #[test]
+    fn test_build_service_context_sorts_installed_tools() {
+        let first = sample_platform(&[
+            ("python", true, Some("3.12.0")),
+            ("git", true, Some("2.47.0")),
+            ("node", true, Some("22.0.0")),
+        ]);
+        let second = sample_platform(&[
+            ("node", true, Some("22.0.0")),
+            ("python", true, Some("3.12.0")),
+            ("git", true, Some("2.47.0")),
+        ]);
+
+        let first_context = BootstrapServer::build_service_context(&first);
+        let second_context = BootstrapServer::build_service_context(&second);
+
+        assert_eq!(first_context.context_prompt, second_context.context_prompt);
+        assert!(first_context
+            .context_prompt
+            .contains("Installed Tools: git, node, python"));
+    }
+
+    #[test]
+    fn test_sorted_tool_names_are_deterministic_for_installed_and_missing_tools() {
+        let platform = sample_platform(&[
+            ("python", true, Some("3.12.0")),
+            ("docker", false, None),
+            ("git", true, Some("2.47.0")),
+            ("node", false, None),
+        ]);
+
+        assert_eq!(
+            BootstrapServer::sorted_tool_names(&platform, true),
+            vec!["git".to_string(), "python".to_string()]
+        );
+        assert_eq!(
+            BootstrapServer::sorted_tool_names(&platform, false),
+            vec!["docker".to_string(), "node".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/mcp/builtin/mod.rs
+++ b/src-tauri/src/mcp/builtin/mod.rs
@@ -94,6 +94,11 @@ pub trait BuiltinMCPServer: Send + Sync + std::fmt::Debug {
     ) -> Result<MCPResult, String>;
 
     /// Returns a markdown-formatted string describing the server's current status and context.
+    ///
+    /// If the returned context is marked `ContextVolatility::Stable`, its text must be
+    /// canonicalized. Equivalent state must produce byte-for-byte identical prompt text,
+    /// so sort unordered collections and normalize filesystem/API listing order before
+    /// rendering `context_prompt`.
     async fn get_service_context(&self, _options: Option<&Value>) -> ServiceContext {
         ServiceContext::new(format!(
             "## {}\n**Description**: {}",

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -603,16 +603,19 @@ Internal paths: .libragent/tmp/ (process outputs), .libragent/exports/ (exported
         let (running_count, total_count, running_processes_text) = {
             match self.process_registry.try_read() {
                 Ok(reg) => {
-                    let processes: Vec<(String, String)> = reg
+                    let mut running_processes: Vec<(String, String)> = reg
                         .entries
                         .values()
                         .filter(|e| e.session_id == session_id)
                         .filter(|e| matches!(e.status, terminal_manager::ProcessStatus::Running))
-                        .take(5) // Limit to prevent context bloat
                         .map(|e| (e.id.clone(), e.command.clone()))
                         .collect();
 
-                    let running_count = processes.len();
+                    running_processes.sort_by(|left, right| left.0.cmp(&right.0));
+                    let running_count = running_processes.len();
+                    let displayed_processes =
+                        running_processes.into_iter().take(5).collect::<Vec<_>>();
+
                     let total_count = reg
                         .entries
                         .values()
@@ -622,7 +625,7 @@ Internal paths: .libragent/tmp/ (process outputs), .libragent/exports/ (exported
                     let running_text = if running_count == 0 {
                         "None".to_string()
                     } else {
-                        let process_list = processes
+                        let process_list = displayed_processes
                             .iter()
                             .map(|(id, cmd)| {
                                 // Truncate command if too long (safe string slicing)

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -478,6 +478,11 @@ pub struct ServiceContextOptions {
 #[serde(rename_all = "camelCase")]
 pub enum ContextVolatility {
     /// Rarely changes during a session; keep earlier to maximize cached prefix reuse.
+    ///
+    /// Stable contexts become part of the cacheable prompt prefix, so their rendered
+    /// text must be deterministic for equivalent state. Canonicalize unordered inputs
+    /// such as `HashMap`, `HashSet`, directory scans, and similar listings before
+    /// formatting them into `context_prompt`.
     Stable,
     /// Changes occasionally, but still worth keeping ahead of the most volatile state.
     #[default]

--- a/src-tauri/src/repositories/scheduled_task_repository.rs
+++ b/src-tauri/src/repositories/scheduled_task_repository.rs
@@ -156,6 +156,9 @@ impl ScheduledTaskRepository for SqliteScheduledTaskRepository {
         ScheduledTaskEntity::find()
             .filter(scheduled_task::Column::Enabled.eq(true))
             .filter(scheduled_task::Column::NextRunAt.lte(now_ms))
+            .order_by(scheduled_task::Column::NextRunAt, Order::Asc)
+            .order_by(scheduled_task::Column::CreatedAt, Order::Asc)
+            .order_by(scheduled_task::Column::Id, Order::Asc)
             .all(&self.db)
             .await
     }

--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -613,45 +613,48 @@ export function AgentChatMessages() {
     [clearBottomLatchSettleTimeout, logScrollState, setEffectivePinnedState],
   );
 
-  const executeScrollToBottom = useCallback((reason: string) => {
-    const itemCount = groupedMessageCountRef.current;
-    selfScrollIgnoreUntilRef.current =
-      performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
-    logScrollState('executeScrollToBottom:start', {
-      itemCount,
-      reason,
-      bottomLatchActive: bottomLatchActiveRef.current,
-    });
-
-    if (footerEndRef.current) {
-      logScrollState('executeScrollToBottom:footer-sentinel', {
+  const executeScrollToBottom = useCallback(
+    (reason: string) => {
+      const itemCount = groupedMessageCountRef.current;
+      selfScrollIgnoreUntilRef.current =
+        performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
+      logScrollState('executeScrollToBottom:start', {
         itemCount,
         reason,
+        bottomLatchActive: bottomLatchActiveRef.current,
       });
-      scrollFooterSentinelIntoView(footerEndRef.current);
-      return;
-    }
 
-    const scrolledWithVirtuoso = scrollVirtuosoToBottom(
-      virtuosoRef.current,
-      itemCount,
-    );
+      if (footerEndRef.current) {
+        logScrollState('executeScrollToBottom:footer-sentinel', {
+          itemCount,
+          reason,
+        });
+        scrollFooterSentinelIntoView(footerEndRef.current);
+        return;
+      }
 
-    if (!scrolledWithVirtuoso) {
-      logScrollState('executeScrollToBottom:unavailable', {
+      const scrolledWithVirtuoso = scrollVirtuosoToBottom(
+        virtuosoRef.current,
+        itemCount,
+      );
+
+      if (!scrolledWithVirtuoso) {
+        logScrollState('executeScrollToBottom:unavailable', {
+          itemCount,
+          reason,
+          scrolledWithVirtuoso,
+        });
+        return;
+      }
+
+      logScrollState('executeScrollToBottom:virtuoso-scroll', {
         itemCount,
         reason,
         scrolledWithVirtuoso,
       });
-      return;
-    }
-
-    logScrollState('executeScrollToBottom:virtuoso-scroll', {
-      itemCount,
-      reason,
-      scrolledWithVirtuoso,
-    });
-  }, [logScrollState]);
+    },
+    [logScrollState],
+  );
 
   useLayoutEffect(() => {
     const previous = previousListStateRef.current;
@@ -870,7 +873,10 @@ export function AgentChatMessages() {
         scrollerElement.scrollHeight -
         currentScrollTop -
         scrollerElement.clientHeight;
-      const visualPinned = isPinnedToBottom(distanceFromBottom, bottomThreshold);
+      const visualPinned = isPinnedToBottom(
+        distanceFromBottom,
+        bottomThreshold,
+      );
       const nearBottomForLatch = isNearBottomForLatch(distanceFromBottom);
       const isSelfScroll = performance.now() < selfScrollIgnoreUntilRef.current;
 


### PR DESCRIPTION
## Summary
- backport stable service-context canonicalization fixes for prompt-cache stability
- stabilize workspace process ordering and scheduled-task due ordering
- include formatter-required README and AgentChatMessages changes plus the critique skill update

## Validation
- pnpm refactor:validate