### PR TITLE
Refine builtin MCP tool descriptions

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -145,7 +145,7 @@ fn start_session_tool() -> MCPTool {
         description: "Spawn a new child agent session to delegate a specific task. When the current session already belongs to an explicit org, the child joins that org automatically and, unless workspaceOverride is provided, shares the org root workspace by default. Set includeCurrentOrg=false to opt out. Returns immediately with session info unless waitForResult=true.".to_string(),
         input_schema: object_prop(
             vec![
-                ("agentId".to_string(), string_prop_required("Exact agent configuration ID to use. Call `list(type='configs')` first, then copy the returned ID. Do not put the agent name here.")),
+                ("agentId".to_string(), string_prop_required("Exact agent configuration ID to use. Call `list(type='configs')` first, then use the returned ID. Do not put the agent name here.")),
                 ("task".to_string(), string_prop_required("The specific task description for the sub-agent.")),
                 ("workspaceOverride".to_string(), string_prop(None, None, Some("Absolute workspace path for the child session. If omitted, a plain child uses its default isolated workspace; an org child inherits the explicit org root workspace by default."))),
                 ("model".to_string(), string_prop(None, None, Some("Optional model override for the child session. If omitted, the child inherits the caller session model."))),

--- a/src-tauri/src/mcp/builtin/browser/tools.rs
+++ b/src-tauri/src/mcp/builtin/browser/tools.rs
@@ -57,7 +57,7 @@ Behavior:
 
 Next Steps:
 - use `getPageContent({})` or listInteractable before another `navigateToUrl`
-- Use listInteractable to see clickable elements"
+- Use listInteractable to inspect actionable elements"
             .to_string(),
         input_schema: object_prop(
             vec![(

--- a/src-tauri/src/mcp/builtin/knowledge/tools.rs
+++ b/src-tauri/src/mcp/builtin/knowledge/tools.rs
@@ -186,15 +186,14 @@ pub fn prune_knowledge_tool() -> MCPTool {
                     "target_ids".to_string(),
                     array_schema(
                         integer_prop(None, None, None),
-                        Some("Knowledge chunk IDs to delete. Copy these IDs from search_knowledge results."),
+                        Some(
+                            "Knowledge chunk IDs to delete. Use IDs returned by search_knowledge.",
+                        ),
                     ),
                 ),
                 (
                     "action".to_string(),
-                    enum_prop_required(
-                        vec!["delete"],
-                        "Delete the targeted knowledge chunks.",
-                    ),
+                    enum_prop_required(vec!["delete"], "Delete the targeted knowledge chunks."),
                 ),
             ],
             vec!["target_ids".to_string(), "action".to_string()],

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -25,7 +25,7 @@ pub fn create_run_shell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution (max 300; use spawnProcess for longer work)"),
+            Some("Timeout in seconds for synchronous execution."),
         ),
     );
 
@@ -33,8 +33,8 @@ pub fn create_run_shell_tool() -> MCPTool {
         name: "runShell".to_string(),
         title: Some("Run Shell Command (Isolated)".to_string()),
         description: "Run a synchronous shell command (bash/sh). Stateless — each call starts fresh at workspace root.\n\
-                       Use 'cd dir && command' for subdirectories.\n\
-                      For persistent cd/env vars: runInPersistentShell. Sync execution is capped at 300 seconds; use spawnProcess for longer or non-blocking tasks."
+                        Use 'cd dir && command' for subdirectories.\n\
+                       For persistent cd/env vars: runInPersistentShell. For longer or non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -65,13 +65,13 @@ pub fn create_execute_shell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution (max 300; use spawnProcess for longer work)"),
+            Some("Timeout in seconds for synchronous execution."),
         ),
     );
     props.insert(
         "requireUserInput".to_string(),
         {
-            let mut schema = boolean_prop(Some("Request user input before execution (e.g., sudo password). Auto-detects sudo/su/doas/pkexec on Unix."));
+            let mut schema = boolean_prop(Some("Request user input before execution. Auto-detects privilege-escalation commands such as sudo, su, doas, and pkexec on Unix."));
             schema.default = Some(json!(false));
             schema
         },
@@ -97,9 +97,9 @@ pub fn create_execute_shell_tool() -> MCPTool {
         name: "runInPersistentShell".to_string(),
         title: Some("Execute Shell Command (Persistent Session)".to_string()),
         description: "Run a shell command in a persistent session that preserves working directory and env vars across calls.\n\
-                       Use when you need 'cd' to stick, 'export' to carry forward, or interactive commands (sudo).\n\
+                       Use when you need 'cd' to stick, 'export' to carry forward, or commands that require user input such as sudo.\n\
                        File tools accept relative paths from the workspace or absolute paths, but they do not follow the shell's current directory automatically.\n\
-                       Sync execution is capped at 300 seconds; use spawnProcess for longer work.\n\
+                       For longer work: spawnProcess.\n\
                        For simple stateless commands: runShell."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
@@ -138,7 +138,7 @@ pub fn create_spawn_process_tool() -> MCPTool {
     MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
-        description: "Start a command as a non-blocking background process. Returns process_id immediately.\n\
+        description: "Start a command as a non-blocking background process. Returns the background process ID immediately.\n\
                        Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
                        Stateless — starts from workspace root each call. No interactive input.\n\
                        Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
@@ -172,7 +172,7 @@ pub fn create_run_powershell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution (max 300; use spawnProcess for longer work)"),
+            Some("Timeout in seconds for synchronous execution."),
         ),
     );
 
@@ -215,7 +215,7 @@ pub fn create_execute_shell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution (max 300; use spawnProcess for longer work)"),
+            Some("Timeout in seconds for synchronous execution."),
         ),
     );
     props.insert("requireUserInput".to_string(), {
@@ -282,7 +282,7 @@ pub fn create_spawn_process_tool() -> MCPTool {
     MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
-        description: "Start a command as a non-blocking background process. Returns process_id immediately.\n\
+        description: "Start a command as a non-blocking background process. Returns the background process ID immediately.\n\
                        Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
                        Stateless — starts from workspace root each call. No interactive input.\n\
                        Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -184,7 +184,8 @@ pub fn create_run_powershell_tool() -> MCPTool {
 Guidelines:
 - Use ';' to chain multiple commands (e.g. 'cd src; pnpm test'). Note: '&&' is not supported in PowerShell 5.1.
 - Access environment variables using '$env:VARNAME'.
-- Each call starts fresh at the workspace root. For persistent state, use runInPersistentPowerShell."
+- Each call starts fresh at the workspace root. For persistent state, use runInPersistentPowerShell.
+- For longer or non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -244,6 +245,7 @@ pub fn create_execute_shell_tool() -> MCPTool {
         description: "Run PowerShell in a persistent session that preserves location (Set-Location) and env vars across calls.\n\
                        - Use ';' to chain commands.\n\
                        - File tools accept relative paths from the workspace or absolute paths, but they do not follow the shell's current location automatically.\n\
+                       - For longer work: spawnProcess.\n\
                        - For simple stateless commands: runPowerShell."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -58,7 +58,9 @@ pub fn create_wait_for_process_tool() -> MCPTool {
             Some(0),
             Some(3600),
             30,
-            Some("Maximum wait before returning. Use 0 to return current status immediately."),
+            Some(
+                "Maximum wait in seconds before returning. Use 0 to return current status immediately.",
+            ),
         ),
     );
 

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -58,9 +58,7 @@ pub fn create_wait_for_process_tool() -> MCPTool {
             Some(0),
             Some(3600),
             30,
-            Some(
-                "Timeout in seconds. Use 0 to return current status immediately without blocking.",
-            ),
+            Some("Maximum wait before returning. Use 0 to return current status immediately."),
         ),
     );
 


### PR DESCRIPTION
## Summary
- tighten builtin MCP tool descriptions to keep AI-facing wording precise
- replace copy-oriented ID guidance with use-oriented guidance
- trim schema-duplicated timeout wording while keeping shell guidance useful

## Scope
- browser builtin tool descriptions
- knowledge and agent ID guidance text
- workspace shell/process tool descriptions

## Validation
- pnpm refactor:validate