### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal via Broken Symlink

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Prevent Unresolved Symlink Target File Write/Read Path Traversal
+**Vulnerability:** `SecurityValidator` allows creating or writing to files via unresolved symlinks (where the symlink itself is the target path, not its parent directory).
+**Learning:** `canonicalize()` fails if a symlink target doesn't exist, leading the fallback logic to check parent directories. Since the parent directory (`test_dir`) exists and is canonical, validation incorrectly passes, but the file creation actually follows the dangling symlink outside the allowed base directory.
+**Prevention:** Check if the exact target path is an unresolved (broken) symlink using `std::fs::symlink_metadata` before recursively traversing up and canonicalizing parent directories.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3902,7 +3902,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -139,6 +139,18 @@ impl SecurityValidator {
         let canonical_path = match absolute_path.canonicalize() {
             Ok(path) => path,
             Err(_) => {
+                // If canonicalize fails, it might be because the target doesn't exist yet.
+                // However, check if the exact target path itself is an unresolved symlink.
+                // If it is, we must reject it to prevent arbitrary file writes via dangling symlinks.
+                if let Ok(metadata) = std::fs::symlink_metadata(&absolute_path) {
+                    if metadata.file_type().is_symlink() {
+                        return Err(SecurityError::PathTraversal(format!(
+                            "Path '{}' is an unresolved symlink: {:?}",
+                            user_path, absolute_path
+                        )));
+                    }
+                }
+
                 // The full path may not exist yet during create/write flows, so walk upward until we
                 // find an existing parent. Reject unresolved symlink parents instead of skipping them,
                 // because a dangling symlink can later resolve outside base_dir.

--- a/src-tauri/tests/builtin_security_validator_tests.rs
+++ b/src-tauri/tests/builtin_security_validator_tests.rs
@@ -210,6 +210,24 @@ fn test_dangling_symlink_parent_is_rejected() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_dangling_symlink_target_is_rejected_for_write() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_with_base_dir(temp_dir.path().to_path_buf());
+
+    let outside_dir = tempdir().expect("outside dir");
+    let missing_target_file = outside_dir.path().join("missing-target.txt");
+
+    let link_path = temp_dir.path().join("dangling_link_file");
+    symlink(&missing_target_file, &link_path).expect("create symlink");
+
+    let result = validator.validate_path_for_write("dangling_link_file");
+    assert!(matches!(result, Err(SecurityError::PathTraversal(_))));
+}
+
+#[test]
 fn test_scoped_validator_blocks_absolute_paths_outside_base_dir() {
     let temp_dir = tempdir().expect("temp dir");
     let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `SecurityValidator` allows path traversal by creating a dangling symlink pointing outside the base directory, which bypasses canonicalization checks because the target file does not yet exist.
🎯 Impact: Arbitrary file write outside the allowed base directory.
🔧 Fix: Add `std::fs::symlink_metadata` check on the absolute path itself before falling back to parent directory canonicalization.
✅ Verification: Ran `cargo test` and verified unit tests pass.

---
*PR created automatically by Jules for task [9978731885243227431](https://jules.google.com/task/9978731885243227431) started by @fritzprix*