### PR TITLE
🪨 Rosetta: Localize AppSidebar & Expand Languages

### DIFF
--- a/.jules/rosetta.md
+++ b/.jules/rosetta.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - MediaContentRenderer
 **Extracted:** 18
 **Languages updated:** EN, KO, FR, ES, DE, ZH, JA, PT
+## 2025-05-20 - [AppSidebar]
+**Extracted:** 2 Strings
+**Languages updated:** EN, KO, ZH, JA, FR, ES, DE, PT

--- a/.jules/rosetta.md
+++ b/.jules/rosetta.md
@@ -1,6 +1,6 @@
 ## 2024-05-18 - MediaContentRenderer
 **Extracted:** 18
 **Languages updated:** EN, KO, FR, ES, DE, ZH, JA, PT
-## 2025-05-20 - [AppSidebar]
+## 2026-05-20 - [AppSidebar]
 **Extracted:** 2 Strings
 **Languages updated:** EN, KO, ZH, JA, FR, ES, DE, PT

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -208,14 +208,14 @@ export default function AppSidebar() {
                 <SidebarMenuButton
                   asChild
                   isActive={location.pathname.startsWith('/knowledge')}
-                  tooltip={t('sidebar.knowledge', 'Knowledge')}
+                  tooltip={t('sidebar.knowledge')}
                 >
                   <Link
                     to="/knowledge"
                     className="flex w-full items-center gap-2"
                   >
                     <Database className="shrink-0" />
-                    <span>{t('sidebar.knowledge', 'Knowledge')}</span>
+                    <span>{t('sidebar.knowledge')}</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -268,11 +268,11 @@ export default function AppSidebar() {
                 <SidebarMenuButton
                   asChild
                   isActive={location.pathname.startsWith('/org')}
-                  tooltip={t('sidebar.org', 'Org')}
+                  tooltip={t('sidebar.org')}
                 >
                   <Link to="/org" className="flex w-full items-center gap-2">
                     <Network className="shrink-0" />
-                    <span>{t('sidebar.org', 'Org')}</span>
+                    <span>{t('sidebar.org')}</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -150,7 +150,9 @@
     "settings": "Einstellungen",
     "history": "Verlauf",
     "scheduledTasks": "Geplante Aufgaben",
-    "session": "Sitzung"
+    "session": "Sitzung",
+    "knowledge": "Wissen",
+    "org": "Organisation"
   },
   "sessionHistory": {
     "heading": "Sitzungsverlauf",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -150,7 +150,9 @@
     "settings": "Settings",
     "history": "History",
     "scheduledTasks": "Scheduled Tasks",
-    "session": "Session"
+    "session": "Session",
+    "knowledge": "Knowledge",
+    "org": "Org"
   },
   "sessionHistory": {
     "heading": "Session History",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -150,7 +150,9 @@
     "settings": "Configuración",
     "history": "Historial",
     "scheduledTasks": "Tareas programadas",
-    "session": "Sesión"
+    "session": "Sesión",
+    "knowledge": "Conocimiento",
+    "org": "Organización"
   },
   "sessionHistory": {
     "heading": "Historial de sesiones",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -150,7 +150,9 @@
     "settings": "Paramètres",
     "history": "Historique",
     "scheduledTasks": "Tâches planifiées",
-    "session": "Session"
+    "session": "Session",
+    "knowledge": "Connaissance",
+    "org": "Organisation"
   },
   "sessionHistory": {
     "heading": "Historique des sessions",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -149,7 +149,9 @@
     "settings": "設定",
     "history": "履歴",
     "scheduledTasks": "スケジュール済みタスク",
-    "session": "セッション"
+    "session": "セッション",
+    "knowledge": "知識",
+    "org": "組織"
   },
   "sessionHistory": {
     "heading": "セッション履歴",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -150,7 +150,9 @@
     "settings": "설정",
     "history": "기록",
     "scheduledTasks": "예약된 작업",
-    "session": "세션"
+    "session": "세션",
+    "knowledge": "지식",
+    "org": "조직"
   },
   "sessionHistory": {
     "heading": "세션 기록",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -150,7 +150,9 @@
     "settings": "Configurações",
     "history": "Histórico",
     "scheduledTasks": "Tarefas Agendadas",
-    "session": "Sessão"
+    "session": "Sessão",
+    "knowledge": "Conhecimento",
+    "org": "Organização"
   },
   "sessionHistory": {
     "heading": "Histórico de Sessões",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -150,7 +150,9 @@
     "settings": "设置",
     "history": "历史记录",
     "scheduledTasks": "计划任务",
-    "session": "会话"
+    "session": "会话",
+    "knowledge": "知识",
+    "org": "组织"
   },
   "sessionHistory": {
     "heading": "会话历史",


### PR DESCRIPTION
🌐 Scope: Extracted Knowledge and Org text from src/components/layout/AppSidebar.tsx.
🔑 Keys Added: 2 keys added (sidebar.knowledge, sidebar.org).
🌍 Languages: en.json, ko.json, zh.json, ja.json, fr.json, es.json, de.json, pt.json.
⚠️ Visual QA: Verified that longer text strings do not break layouts.

---
*PR created automatically by Jules for task [7313591754622422521](https://jules.google.com/task/7313591754622422521) started by @fritzprix*