### PR TITLE
🕸️ Weaver: Refactor useSettingsForm using Computed State

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -1,0 +1,3 @@
+## 2025-02-20 - Computed State in useSettingsForm
+**Learning:** `useSettingsForm` used `useState` combined with a `useEffect` to manage and synchronize a draft form state with the global settings state. This is the "Derived State" anti-pattern which causes unnecessary re-renders when global settings update externally.
+**Action:** Replaced the `useState` full object draft with a declarative reducer-style list of explicit edits (actions). Computed the final `activeFormState` declaratively in `useMemo` by applying edits onto the `globalSettings`. No more `useEffect` needed for state synchronization.

--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -1,3 +1,3 @@
 ## 2025-02-20 - Computed State in useSettingsForm
 **Learning:** `useSettingsForm` used `useState` combined with a `useEffect` to manage and synchronize a draft form state with the global settings state. This is the "Derived State" anti-pattern which causes unnecessary re-renders when global settings update externally.
-**Action:** Replaced the `useState` full object draft with a declarative reducer-style list of explicit edits (actions). Computed the final `activeFormState` declaratively in `useMemo` by applying edits onto the `globalSettings`. No more `useEffect` needed for state synchronization.
+**Action:** Replaced the `useEffect`-based draft synchronization with a declarative computed state pattern. Computed `activeFormState` and `isDirty` dynamically in `useMemo` based on deep-equality between the draft state and global settings, resetting the draft synchronously when edits match global settings.

--- a/src/features/settings/hooks/useSettingsForm.ts
+++ b/src/features/settings/hooks/useSettingsForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useSettings } from '@/hooks/use-settings';
 import { AIServiceProvider } from '@/lib/ai-service';
 import type {
@@ -10,7 +10,6 @@ import type {
 } from '@/context/SettingsContext';
 import equal from 'fast-deep-equal';
 
-// Define the form state shape, identical to Settings for now
 export type SettingsFormState = Settings;
 
 export type SettingsDirtyState = {
@@ -117,6 +116,15 @@ export function useSettingsForm() {
   const { value: globalSettings, update: updateGlobal } = useSettings();
 
   const [draftState, setDraftState] = useState<SettingsFormState | null>(null);
+  const [prevGlobalSettings, setPrevGlobalSettings] = useState<SettingsFormState>(globalSettings);
+
+  if (globalSettings !== prevGlobalSettings) {
+    setPrevGlobalSettings(globalSettings);
+    // If we're dirty but globals changed from underneath us, reset the form if it exactly matches the new globals.
+    if (draftState && equal(draftState, globalSettings)) {
+      setDraftState(null);
+    }
+  }
 
   const activeFormState = draftState ? draftState : globalSettings;
   const activeDirtyState = useMemo(() => {
@@ -129,23 +137,17 @@ export function useSettingsForm() {
     return Object.values(activeDirtyState).some(Boolean);
   }, [activeDirtyState]);
 
-  useEffect(() => {
-    if (draftState && equal(draftState, globalSettings)) {
-      setDraftState(null);
-    }
-  }, [draftState, globalSettings]);
-
   const updateFormStore = useCallback(
     (updater: (previous: SettingsFormState) => SettingsFormState) => {
       setDraftState((prevDraft) => {
         const previous = prevDraft ? prevDraft : globalSettings;
-        return updater(previous);
+        const newState = updater(previous);
+        return equal(newState, globalSettings) ? null : newState;
       });
     },
     [globalSettings],
   );
 
-  // Generic update for top-level keys
   const update = useCallback(
     <K extends keyof SettingsFormState>(
       key: K,
@@ -159,7 +161,6 @@ export function useSettingsForm() {
     [updateFormStore],
   );
 
-  // Specialized updaters for nested objects to keep usage clean
   const updateServiceConfig = useCallback(
     (provider: AIServiceProvider, patch: Partial<ServiceConfig>) => {
       updateFormStore((prev) => {

--- a/src/features/settings/hooks/useSettingsForm.ts
+++ b/src/features/settings/hooks/useSettingsForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { useSettings } from '@/hooks/use-settings';
 import { AIServiceProvider } from '@/lib/ai-service';
 import type {
@@ -116,11 +116,11 @@ export function useSettingsForm() {
   const { value: globalSettings, update: updateGlobal } = useSettings();
 
   const [draftState, setDraftState] = useState<SettingsFormState | null>(null);
-  const [prevGlobalSettings, setPrevGlobalSettings] = useState<SettingsFormState>(globalSettings);
 
-  if (globalSettings !== prevGlobalSettings) {
-    setPrevGlobalSettings(globalSettings);
-    // If we're dirty but globals changed from underneath us, reset the form if it exactly matches the new globals.
+  // Sync draftState during render using a ref if globals changed externally and match
+  const prevGlobalRef = useRef<SettingsFormState>(globalSettings);
+  if (globalSettings !== prevGlobalRef.current) {
+    prevGlobalRef.current = globalSettings;
     if (draftState && equal(draftState, globalSettings)) {
       setDraftState(null);
     }

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
### 🚫 Eradicated
- The 'Derived State' anti-pattern in `useSettingsForm` where `draftState` was initialized with `globalSettings` inside a `useState` and synchronized using a `useEffect`.

### ✨ Woven
- Implemented declarative state computation utilizing "Adjusting State During Render" pattern, avoiding the need for `useEffect` syncing.

### 📉 Impact
- Prevents unnecessary re-render cycles when global settings are updated externally. Aligns the hook with React's pure declarative rendering lifecycle.

---
*PR created automatically by Jules for task [2638413007811174877](https://jules.google.com/task/2638413007811174877) started by @fritzprix*