### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in file export package name

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** `SecurityValidator` allows creating or writing to files via unresolved symlinks (where the symlink itself is the target path, not its parent directory).
 **Learning:** `canonicalize()` fails if a symlink target doesn't exist, leading the fallback logic to check parent directories. Since the parent directory (`test_dir`) exists and is canonical, validation incorrectly passes, but the file creation actually follows the dangling symlink outside the allowed base directory.
 **Prevention:** Check if the exact target path is an unresolved (broken) symlink using `std::fs::symlink_metadata` before recursively traversing up and canonicalizing parent directories.
+## 2024-05-20 - Path Traversal in File Export Package Name
+**Vulnerability:** Path traversal in `FileExportService::create_zip_export` where `package_name` is directly interpolated into a path passed to `temp_dir.path().join()`.
+**Learning:** `Path::join` allows directory traversal if the right-hand side contains relative components like `..`, potentially escaping intended directories (e.g., `temp_dir`). This can be exploited to overwrite arbitrary files when creating zip exports.
+**Prevention:** Sanitize variables from external input used in path constructions, even for temporary filenames. Replace non-alphanumeric characters with safe alternatives like underscores.

--- a/src-tauri/src/services/file_export_service.rs
+++ b/src-tauri/src/services/file_export_service.rs
@@ -210,19 +210,37 @@ mod tests {
 
     #[test]
     fn test_sanitize_package_name_safe_inputs() {
-        assert_eq!(FileExportService::sanitize_package_name("my-awesome-package"), "my-awesome-package");
-        assert_eq!(FileExportService::sanitize_package_name("package_name_123"), "package_name_123");
+        assert_eq!(
+            FileExportService::sanitize_package_name("my-awesome-package"),
+            "my-awesome-package"
+        );
+        assert_eq!(
+            FileExportService::sanitize_package_name("package_name_123"),
+            "package_name_123"
+        );
     }
 
     #[test]
     fn test_sanitize_package_name_directory_traversal() {
-        assert_eq!(FileExportService::sanitize_package_name("../../../evil"), "_________evil");
-        assert_eq!(FileExportService::sanitize_package_name("..\\..\\..\\evil"), "_________evil");
+        assert_eq!(
+            FileExportService::sanitize_package_name("../../../evil"),
+            "_________evil"
+        );
+        assert_eq!(
+            FileExportService::sanitize_package_name("..\\..\\..\\evil"),
+            "_________evil"
+        );
     }
 
     #[test]
     fn test_sanitize_package_name_special_characters() {
-        assert_eq!(FileExportService::sanitize_package_name("package!@#name"), "package___name");
-        assert_eq!(FileExportService::sanitize_package_name("  trimmed package  "), "__trimmed_package__");
+        assert_eq!(
+            FileExportService::sanitize_package_name("package!@#name"),
+            "package___name"
+        );
+        assert_eq!(
+            FileExportService::sanitize_package_name("  trimmed package  "),
+            "__trimmed_package__"
+        );
     }
 }

--- a/src-tauri/src/services/file_export_service.rs
+++ b/src-tauri/src/services/file_export_service.rs
@@ -75,16 +75,7 @@ impl FileExportService {
             tempfile::tempdir().map_err(|e| format!("Failed to create temp dir: {e}"))?;
 
         // Sanitize package_name to prevent path traversal via malicious characters
-        let safe_package_name = package_name
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '-' || c == '_' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect::<String>();
+        let safe_package_name = Self::sanitize_package_name(package_name);
 
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
         let zip_filename = format!("{safe_package_name}_{timestamp}.zip");
@@ -196,5 +187,42 @@ impl FileExportService {
             content: zip_content,
             file_count: Some(processed_files.len()),
         })
+    }
+
+    /// Sanitizes package_name to prevent path traversal via malicious characters.
+    pub fn sanitize_package_name(package_name: &str) -> String {
+        package_name
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_package_name_safe_inputs() {
+        assert_eq!(FileExportService::sanitize_package_name("my-awesome-package"), "my-awesome-package");
+        assert_eq!(FileExportService::sanitize_package_name("package_name_123"), "package_name_123");
+    }
+
+    #[test]
+    fn test_sanitize_package_name_directory_traversal() {
+        assert_eq!(FileExportService::sanitize_package_name("../../../evil"), "_________evil");
+        assert_eq!(FileExportService::sanitize_package_name("..\\..\\..\\evil"), "_________evil");
+    }
+
+    #[test]
+    fn test_sanitize_package_name_special_characters() {
+        assert_eq!(FileExportService::sanitize_package_name("package!@#name"), "package___name");
+        assert_eq!(FileExportService::sanitize_package_name("  trimmed package  "), "__trimmed_package__");
     }
 }

--- a/src-tauri/src/services/file_export_service.rs
+++ b/src-tauri/src/services/file_export_service.rs
@@ -75,7 +75,16 @@ impl FileExportService {
             tempfile::tempdir().map_err(|e| format!("Failed to create temp dir: {e}"))?;
 
         // Sanitize package_name to prevent path traversal via malicious characters
-        let safe_package_name = Self::sanitize_package_name(package_name);
+        let safe_package_name = package_name
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
 
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
         let zip_filename = format!("{safe_package_name}_{timestamp}.zip");
@@ -187,42 +196,5 @@ impl FileExportService {
             content: zip_content,
             file_count: Some(processed_files.len()),
         })
-    }
-
-    /// Sanitizes package_name to prevent path traversal via malicious characters.
-    pub fn sanitize_package_name(package_name: &str) -> String {
-        package_name
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '-' || c == '_' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_sanitize_package_name_safe_inputs() {
-        assert_eq!(FileExportService::sanitize_package_name("my-awesome-package"), "my-awesome-package");
-        assert_eq!(FileExportService::sanitize_package_name("package_name_123"), "package_name_123");
-    }
-
-    #[test]
-    fn test_sanitize_package_name_directory_traversal() {
-        assert_eq!(FileExportService::sanitize_package_name("../../../evil"), "_________evil");
-        assert_eq!(FileExportService::sanitize_package_name("..\\..\\..\\evil"), "_________evil");
-    }
-
-    #[test]
-    fn test_sanitize_package_name_special_characters() {
-        assert_eq!(FileExportService::sanitize_package_name("package!@#name"), "package___name");
-        assert_eq!(FileExportService::sanitize_package_name("  trimmed package  "), "__trimmed_package__");
     }
 }

--- a/src-tauri/src/services/file_export_service.rs
+++ b/src-tauri/src/services/file_export_service.rs
@@ -73,8 +73,15 @@ impl FileExportService {
         // Create a temporary ZIP file
         let temp_dir =
             tempfile::tempdir().map_err(|e| format!("Failed to create temp dir: {e}"))?;
+
+        // Sanitize package_name to prevent path traversal via malicious characters
+        let safe_package_name = package_name
+            .chars()
+            .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+            .collect::<String>();
+
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
-        let zip_filename = format!("{package_name}_{timestamp}.zip");
+        let zip_filename = format!("{safe_package_name}_{timestamp}.zip");
         let temp_zip_path = temp_dir.path().join(&zip_filename);
 
         // Create the ZIP archive

--- a/src-tauri/src/services/file_export_service.rs
+++ b/src-tauri/src/services/file_export_service.rs
@@ -77,7 +77,13 @@ impl FileExportService {
         // Sanitize package_name to prevent path traversal via malicious characters
         let safe_package_name = package_name
             .chars()
-            .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect::<String>();
 
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `create_zip_export` function in `FileExportService` concatenates `package_name` directly into the temporary zip filename without sanitization. An attacker could provide a `package_name` with directory traversal sequences (e.g., `../../../evil`) to write the zip file to arbitrary filesystem locations.
🎯 Impact: Arbitrary file write, which could lead to remote code execution or system compromise.
🔧 Fix: Sanitize `package_name` to only allow alphanumeric characters, dashes, and underscores, replacing all other characters with underscores.
✅ Verification: Ran `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [2401115319577213464](https://jules.google.com/task/2401115319577213464) started by @fritzprix*