### PR TITLE
🕸️ Weaver: Refactor State Syncing using Adjusting State Pattern

### DIFF
--- a/.jules/weaver.md
+++ b/.jules/weaver.md
@@ -1,3 +1,6 @@
 ## 2025-02-20 - Computed State in useSettingsForm
 **Learning:** `useSettingsForm` used `useState` combined with a `useEffect` to manage and synchronize a draft form state with the global settings state. This is the "Derived State" anti-pattern which causes unnecessary re-renders when global settings update externally.
 **Action:** Replaced the `useEffect`-based draft synchronization with a declarative computed state pattern. Computed `activeFormState` and `isDirty` dynamically in `useMemo` based on deep-equality between the draft state and global settings, resetting the draft synchronously when edits match global settings.
+## 2024-06-12 - Concurrent Mode Ref Mutation
+**Learning:** Mutating a React ref (`ref.current = value`) during the render cycle to sync previous prop values is a severe anti-pattern that violates the Rule of Purity and causes unpredictable bugs in Concurrent Mode. It also misses the opportunity to use "Adjusting State During Render" which tells React to restart the render immediately without committing the DOM.
+**Action:** Always use a local `useState` to track the previous prop or global value, and call `setState` directly during render to trigger an immediate restart, completely eradicating the extra `useEffect` re-render cycle.

--- a/src/features/knowledge/hooks/useKnowledgeBrowser.ts
+++ b/src/features/knowledge/hooks/useKnowledgeBrowser.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useKnowledgeDelete } from './useKnowledgeDelete';
 import { useKnowledgeDetail } from './useKnowledgeDetail';
 import { useKnowledgeList } from './useKnowledgeList';
@@ -30,6 +30,15 @@ export function useKnowledgeBrowser() {
     query,
     refreshToken: listRefreshToken,
   });
+
+  const [prevItems, setPrevItems] = useState(items);
+  if (items !== prevItems) {
+    setPrevItems(items);
+    if (selectedId !== null && !items.some((item) => item.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }
+
   const { detail, isDetailLoading } = useKnowledgeDetail(selectedId);
 
   const selectedItem = useMemo(
@@ -58,12 +67,6 @@ export function useKnowledgeBrowser() {
   const refresh = useCallback(() => {
     setListRefreshToken((current) => current + 1);
   }, []);
-
-  useEffect(() => {
-    if (selectedId !== null && !items.some((item) => item.id === selectedId)) {
-      setSelectedId(null);
-    }
-  }, [items, selectedId]);
 
   const handleDeleted = useCallback(() => {
     setSelectedId(null);

--- a/src/features/knowledge/hooks/useKnowledgeDelete.ts
+++ b/src/features/knowledge/hooks/useKnowledgeDelete.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
@@ -22,11 +22,13 @@ export function useKnowledgeDelete({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
 
-  useEffect(() => {
+  const [prevSelectedItem, setPrevSelectedItem] = useState(selectedItem);
+  if (selectedItem !== prevSelectedItem) {
+    setPrevSelectedItem(selectedItem);
     if (!selectedItem) {
       setIsDeleteConfirming(false);
     }
-  }, [selectedItem]);
+  }
 
   const requestDelete = useCallback(() => {
     if (!selectedItem || isDeleting) {

--- a/src/features/settings/hooks/useSettingsForm.ts
+++ b/src/features/settings/hooks/useSettingsForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useSettings } from '@/hooks/use-settings';
 import { AIServiceProvider } from '@/lib/ai-service';
 import type {
@@ -129,12 +129,12 @@ export function useSettingsForm() {
   const { value: globalSettings, update: updateGlobal } = useSettings();
 
   const [draftState, setDraftState] = useState<SettingsFormState | null>(null);
+  const [prevGlobal, setPrevGlobal] = useState<SettingsFormState>(globalSettings);
 
-  // Sync draftState during render using a ref if globals changed externally and match
-  const prevGlobalRef = useRef<SettingsFormState>(globalSettings);
-  if (globalSettings !== prevGlobalRef.current) {
-    prevGlobalRef.current = globalSettings;
-    if (draftState && equal(draftState, globalSettings)) {
+  // Sync draftState during render using Adjusting State pattern
+  if (globalSettings !== prevGlobal) {
+    setPrevGlobal(globalSettings);
+    if (!draftState || equal(draftState, globalSettings)) {
       setDraftState(null);
     }
   }


### PR DESCRIPTION
### 🚫 Eradicated
- Removed derived state and prop drilling via `useEffect` across settings and knowledge hooks.
- Eradicated dangerous `useRef` mutations during the render cycle in `useSettingsForm.ts`.

### ✨ Woven
- Implemented the 'Adjusting State During Render' pattern using `useState` to securely compute state changes without side effects.

### 📉 Impact
- Prevents multiple cascading re-render cycles caused by state syncing effects.
- Hardens the components for React Concurrent Mode by strictly obeying the Rule of Purity.

---
*PR created automatically by Jules for task [7190261799650210873](https://jules.google.com/task/7190261799650210873) started by @fritzprix*