### PR TITLE
Fix workspace search multiline regex support

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -6,6 +6,7 @@ use super::helpers::*;
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};
+use std::collections::BTreeSet;
 use std::path::Path;
 
 pub(super) struct SearchContentRequest<'a> {
@@ -23,6 +24,73 @@ pub(super) struct SearchDirectoryRequest<'a> {
     pub dir: &'a Path,
     pub file_pattern: Option<&'a glob::Pattern>,
     pub search: SearchContentRequest<'a>,
+}
+
+struct LineInfo {
+    start: usize,
+}
+
+fn collect_line_infos(content: &str) -> Vec<LineInfo> {
+    let mut line_infos = Vec::new();
+    let mut cursor = 0usize;
+
+    for line in content.lines() {
+        line_infos.push(LineInfo { start: cursor });
+
+        cursor += line.len();
+        let remainder = &content[cursor..];
+        if remainder.starts_with("\r\n") {
+            cursor += 2;
+        } else if remainder.starts_with('\n') || remainder.starts_with('\r') {
+            cursor += 1;
+        }
+    }
+
+    line_infos
+}
+
+fn line_index_for_offset(line_infos: &[LineInfo], offset: usize) -> Option<usize> {
+    if line_infos.is_empty() {
+        return None;
+    }
+
+    match line_infos.binary_search_by_key(&offset, |line| line.start) {
+        Ok(index) => Some(index),
+        Err(0) => Some(0),
+        Err(index) => Some(index - 1),
+    }
+}
+
+fn collect_matched_line_indices(content: &str, regex: &regex::Regex) -> BTreeSet<usize> {
+    let line_infos = collect_line_infos(content);
+    let mut matched_lines = BTreeSet::new();
+
+    if line_infos.is_empty() {
+        return matched_lines;
+    }
+
+    for matched in regex.find_iter(content) {
+        let start_line = match line_index_for_offset(&line_infos, matched.start()) {
+            Some(index) => index,
+            None => continue,
+        };
+
+        let end_offset = if matched.start() == matched.end() {
+            matched.start()
+        } else {
+            matched.end().saturating_sub(1)
+        };
+        let end_line = match line_index_for_offset(&line_infos, end_offset) {
+            Some(index) => index,
+            None => continue,
+        };
+
+        for line_index in start_line..=end_line {
+            matched_lines.insert(line_index);
+        }
+    }
+
+    matched_lines
 }
 
 pub(super) async fn search_content_in_file(
@@ -94,10 +162,11 @@ pub(super) async fn search_content_in_file(
         }
     };
 
+    let matched_lines = collect_matched_line_indices(&content, regex);
     let mut matches = Vec::new();
     let mut prefix_state = initial_prefix_hash_state();
     for (idx, line) in content.lines().enumerate() {
-        if regex.is_match(line) {
+        if matched_lines.contains(&idx) {
             if show_hashes {
                 let anchor = compute_anchor(line, &mut prefix_state);
                 matches.push(json!({
@@ -332,10 +401,11 @@ pub(super) async fn search_content_in_dir(
             p
         };
 
+        let matched_lines = collect_matched_line_indices(&content, regex);
         let mut hits = Vec::new();
         let mut prefix_state = initial_prefix_hash_state();
         for (idx, line) in content.lines().enumerate() {
-            if regex.is_match(line) {
+            if matched_lines.contains(&idx) {
                 if show_hashes {
                     let anchor = compute_anchor(line, &mut prefix_state);
                     hits.push(json!({

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -427,6 +427,8 @@ pub(super) async fn search_content_in_dir(
         }
     }
 
+    file_matches.sort_by(|left, right| left.rel_path.cmp(&right.rel_path));
+
     let options_str = if ignore_case {
         "case-insensitive"
     } else {
@@ -476,13 +478,44 @@ pub(super) async fn search_content_in_dir(
     );
 
     let total_files = file_matches.len();
-    let paginated_files: Vec<_> = file_matches.into_iter().skip(offset).take(limit).collect();
-    let has_more = offset + paginated_files.len() < total_files;
+    let mut paginated_results: Vec<FileMatch> = Vec::new();
+    let mut skipped_matches = offset;
+    let mut taken_matches = 0usize;
 
-    let per_file_preview_limit = 5usize;
-    for fm in &paginated_files {
+    for file_match in &file_matches {
+        let mut paginated_hits = Vec::new();
+
+        for hit in &file_match.hits {
+            if skipped_matches > 0 {
+                skipped_matches -= 1;
+                continue;
+            }
+
+            if taken_matches == limit {
+                break;
+            }
+
+            paginated_hits.push(hit.clone());
+            taken_matches += 1;
+        }
+
+        if !paginated_hits.is_empty() {
+            paginated_results.push(FileMatch {
+                rel_path: file_match.rel_path.clone(),
+                hits: paginated_hits,
+            });
+        }
+
+        if taken_matches == limit {
+            break;
+        }
+    }
+
+    let has_more = offset + taken_matches < total_hits;
+
+    for fm in &paginated_results {
         text.push_str(&format!("### `{}`\n", fm.rel_path));
-        for hit in fm.hits.iter().take(per_file_preview_limit) {
+        for hit in &fm.hits {
             let line_num = hit.get("line").and_then(|v| v.as_u64()).unwrap_or(0);
             let t = hit.get("text").and_then(|v| v.as_str()).unwrap_or("");
             if let Some(anchor) = hit.get("anchor").and_then(|v| v.as_str()) {
@@ -491,30 +524,28 @@ pub(super) async fn search_content_in_dir(
                 text.push_str(&format!("- L{}: `{}`\n", line_num, t.trim()));
             }
         }
-        if fm.hits.len() > per_file_preview_limit {
-            text.push_str(&format!(
-                "  ... and {} more matches in this file (showing first {} per file)\n",
-                fm.hits.len() - per_file_preview_limit,
-                per_file_preview_limit
-            ));
-        }
         text.push('\n');
     }
 
-    if has_more {
+    if taken_matches == 0 && offset > 0 {
         text.push_str(&format!(
-            "*(Showing {} to {} of {} total files with matches. Call search with offset: {} to see more)*\n",
+            "*(Offset {} is beyond {} total matches. Call search with a smaller offset.)*\n",
+            offset, total_hits
+        ));
+    } else if has_more {
+        text.push_str(&format!(
+            "*(Showing {} to {} of {} total matches. Call search with offset: {} to see more)*\n",
             offset + 1,
-            offset + paginated_files.len(),
-            total_files,
+            offset + taken_matches,
+            total_hits,
             offset + limit
         ));
     } else if offset > 0 {
         text.push_str(&format!(
-            "*(Showing {} to {} of {} total files with matches)*\n",
+            "*(Showing {} to {} of {} total matches)*\n",
             offset + 1,
-            offset + paginated_files.len(),
-            total_files
+            offset + taken_matches,
+            total_hits
         ));
     }
     if skipped_heavy_dirs > 0
@@ -571,7 +602,7 @@ pub(super) async fn search_content_in_dir(
         "skipped_binary_files": skipped_binary_files,
         "skipped_large_files": skipped_large_files,
         "max_file_size": max_size,
-        "results": paginated_files.iter().map(|fm| json!({
+        "results": paginated_results.iter().map(|fm| json!({
             "file": fm.rel_path,
             "matches": fm.hits,
         })).collect::<Vec<_>>(),

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -180,6 +180,7 @@ impl WorkspaceServer {
         let regex = match regex::RegexBuilder::new(query_str)
             .case_insensitive(ignore_case)
             .multi_line(true)
+            .crlf(true)
             .build()
         {
             Ok(r) => r,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -23,6 +23,30 @@ impl WorkspaceServer {
 
         let query = args.get("query").and_then(|v| v.as_str());
         let file_pattern = args.get("filePattern").and_then(|v| v.as_str());
+        if matches!(query, Some("")) {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Invalid query: query must not be empty".to_string(),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Provide a non-empty regex pattern for content search".to_string(),
+                "Omit query and use filePattern when you only want to find files".to_string(),
+            ])
+            .to_mcp_result());
+        }
+        if matches!(file_pattern, Some("")) {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Invalid filePattern: filePattern must not be empty".to_string(),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string(),
+                "Omit filePattern when you want content search across all files".to_string(),
+            ])
+            .to_mcp_result());
+        }
         let ignore_case = args
             .get("ignoreCase")
             .and_then(|v| v.as_bool())

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -155,6 +155,7 @@ impl WorkspaceServer {
         let query_str = query.unwrap();
         let regex = match regex::RegexBuilder::new(query_str)
             .case_insensitive(ignore_case)
+            .multi_line(true)
             .build()
         {
             Ok(r) => r,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -189,7 +189,7 @@ pub fn create_search_tool() -> MCPTool {
         integer_prop(
             Some(1),
             Some(1000),
-            Some("Maximum number of file entries to return (default: 50). For content search, this limits files with matches, not individual matching lines."),
+            Some("Maximum number of results to return (default: 50). For file-name search this limits matched files/directories; for content search this limits matching lines after regex expansion."),
         ),
     );
     props.insert(
@@ -230,7 +230,7 @@ pub fn create_search_tool() -> MCPTool {
     MCPTool {
         name: "search".to_string(),
         title: Some("Search Workspace".to_string()),
-        description: "Search files by name or content. Content search uses regex against full file text with multiline mode enabled, while results are still reported as line-based hits. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
+        description: "Search files by name or content. Content search uses regex against full file text with multiline mode enabled, reports line-based hits, and paginates by matching lines rather than files. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -205,7 +205,7 @@ pub fn create_search_tool() -> MCPTool {
         string_prop(
             Some(1),
             Some(1000),
-            Some("Regular expression pattern to search for text inside files. If omitted, only searches for file names."),
+            Some("Regular expression pattern to search for text inside files. Matched against full file content with multiline mode enabled, so ^ and $ match line boundaries. '.' does not match newlines unless you opt into that in the regex itself (for example with (?s)). If omitted, only searches for file names."),
         ),
     );
     props.insert(
@@ -230,7 +230,7 @@ pub fn create_search_tool() -> MCPTool {
     MCPTool {
         name: "search".to_string(),
         title: Some("Search Workspace".to_string()),
-        description: "Search files by name or content. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
+        description: "Search files by name or content. Content search uses regex against full file text with multiline mode enabled, while results are still reported as line-based hits. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -254,6 +254,123 @@ async fn search_rejects_direct_internal_artifact_file_paths() {
 }
 
 #[tokio::test]
+async fn search_single_file_supports_multiline_regex_queries() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-single-file-multiline-regex";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("notes.txt"), "alpha\n  beta\ngamma\n")
+        .expect("write test file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": "notes.txt",
+                "query": "alpha\\s+beta",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Line 1: alpha"),
+        "multiline regex should report the first covered line: {text}"
+    );
+    assert!(
+        text.contains("Line 2:   beta"),
+        "multiline regex should report the second covered line: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert_eq!(structured["total_matches"], json!(2));
+}
+
+#[tokio::test]
+async fn search_directory_supports_multiline_regex_queries() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-directory-multiline-regex";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(
+        workspace_dir.join("src/main.ts"),
+        "const alpha = true;\nconst beta = true;\n",
+    )
+    .expect("write matching file");
+    std::fs::write(workspace_dir.join("src/other.ts"), "const nope = true;\n")
+        .expect("write non-matching file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": ".",
+                "query": "alpha\\s*=\\s*true;\\s+const beta",
+                "filePattern": "*.ts",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("src/main.ts"),
+        "directory search should report the file containing the multiline match: {text}"
+    );
+    assert!(
+        text.contains("- L1: `const alpha = true;`"),
+        "directory search should include the first covered line: {text}"
+    );
+    assert!(
+        text.contains("- L2: `const beta = true;`"),
+        "directory search should include the second covered line: {text}"
+    );
+    assert!(
+        !text.contains("src/other.ts"),
+        "non-matching files should stay excluded: {text}"
+    );
+}
+
+#[tokio::test]
+async fn search_multiline_mode_keeps_line_anchored_regex_working() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-multiline-mode-line-anchors";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("notes.txt"), "first\nsecond\nthird\n")
+        .expect("write test file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": "notes.txt",
+                "query": "^second$",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Line 2: second"),
+        "^ and $ should still work as line anchors after multiline regex support: {text}"
+    );
+    assert!(
+        !text.contains("Line 1: first") && !text.contains("Line 3: third"),
+        "line-anchored regex should not overmatch: {text}"
+    );
+}
+
+#[tokio::test]
 async fn search_respects_gitignore_rules_during_recursive_content_search() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "search-gitignore";

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -557,6 +557,41 @@ async fn search_multiline_mode_keeps_line_anchored_regex_working() {
 }
 
 #[tokio::test]
+async fn search_multiline_mode_keeps_line_anchored_regex_working_on_crlf_files() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-multiline-mode-line-anchors-crlf";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(
+        workspace_dir.join("notes.txt"),
+        "first\r\nsecond\r\nthird\r\n",
+    )
+    .expect("write test file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": "notes.txt",
+                "query": "^second$",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Line 2: second"),
+        "^ and $ should still work as line anchors on CRLF content: {text}"
+    );
+    assert!(
+        !text.contains("Line 1: first") && !text.contains("Line 3: third"),
+        "CRLF line-anchored regex should not overmatch: {text}"
+    );
+}
+
+#[tokio::test]
 async fn search_respects_gitignore_rules_during_recursive_content_search() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "search-gitignore";

--- a/src-tauri/tests/workspace_search_tests.rs
+++ b/src-tauri/tests/workspace_search_tests.rs
@@ -254,6 +254,62 @@ async fn search_rejects_direct_internal_artifact_file_paths() {
 }
 
 #[tokio::test]
+async fn search_rejects_empty_query_strings() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-empty-query";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("notes.txt"), "alpha\nbeta\n").expect("write test file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": "notes.txt",
+                "query": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should return validation error");
+
+    let text = extract_text_content(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("Invalid query: query must not be empty"),
+        "empty query should be rejected explicitly: {text}"
+    );
+}
+
+#[tokio::test]
+async fn search_rejects_empty_file_patterns() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-empty-file-pattern";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("notes.txt"), "alpha\nbeta\n").expect("write test file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": ".",
+                "filePattern": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should return validation error");
+
+    let text = extract_text_content(&result);
+    assert_eq!(result.is_error, Some(true));
+    assert!(
+        text.contains("Invalid filePattern: filePattern must not be empty"),
+        "empty filePattern should be rejected explicitly: {text}"
+    );
+}
+
+#[tokio::test]
 async fn search_single_file_supports_multiline_regex_queries() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "search-single-file-multiline-regex";
@@ -335,6 +391,136 @@ async fn search_directory_supports_multiline_regex_queries() {
     assert!(
         !text.contains("src/other.ts"),
         "non-matching files should stay excluded: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert_eq!(structured["files_with_matches"], json!(1));
+    assert_eq!(structured["total_matches"], json!(2));
+}
+
+#[tokio::test]
+async fn search_directory_paginates_content_results_by_match() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-directory-paginates-by-match";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(
+        workspace_dir.join("src/alpha.ts"),
+        "needle one\nneedle two\nneedle three\n",
+    )
+    .expect("write matching file");
+    std::fs::write(workspace_dir.join("src/beta.ts"), "needle four\n").expect("write other file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "filePattern": "*.ts",
+                "limit": 2,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("### `src/alpha.ts`"),
+        "first page should include the first matching file: {text}"
+    );
+    assert!(
+        text.contains("- L1: `needle one`") && text.contains("- L2: `needle two`"),
+        "first page should include the first two matches, not all matches from the file: {text}"
+    );
+    assert!(
+        !text.contains("needle three") && !text.contains("beta.ts"),
+        "match pagination should stop after the requested number of matches: {text}"
+    );
+    assert!(
+        text.contains("Showing 1 to 2 of 4 total matches"),
+        "pagination summary should be match-based: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert_eq!(structured["files_with_matches"], json!(2));
+    assert_eq!(structured["total_matches"], json!(4));
+    assert_eq!(structured["results"][0]["file"], json!("src/alpha.ts"));
+    assert_eq!(
+        structured["results"][0]["matches"].as_array().map(Vec::len),
+        Some(2)
+    );
+}
+
+#[tokio::test]
+async fn search_directory_match_pagination_can_cross_file_boundaries() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-directory-cross-file-pagination";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(
+        workspace_dir.join("src/alpha.ts"),
+        "needle one\nneedle two\n",
+    )
+    .expect("write first file");
+    std::fs::write(
+        workspace_dir.join("src/beta.ts"),
+        "needle three\nneedle four\n",
+    )
+    .expect("write second file");
+
+    let result = server
+        .handle_search(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "filePattern": "*.ts",
+                "limit": 2,
+                "offset": 1,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("search should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("### `src/alpha.ts`") && text.contains("### `src/beta.ts`"),
+        "offset inside one file should still continue into the next file when needed: {text}"
+    );
+    assert!(
+        text.contains("- L2: `needle two`") && text.contains("- L1: `needle three`"),
+        "second page should contain the second and third matches overall: {text}"
+    );
+    assert!(
+        !text.contains("- L1: `needle one`") && !text.contains("- L2: `needle four`"),
+        "pagination should exclude matches outside the requested match window: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert_eq!(structured["results"].as_array().map(Vec::len), Some(2));
+    assert_eq!(structured["results"][0]["file"], json!("src/alpha.ts"));
+    assert_eq!(
+        structured["results"][0]["matches"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(structured["results"][1]["file"], json!("src/beta.ts"));
+    assert_eq!(
+        structured["results"][1]["matches"].as_array().map(Vec::len),
+        Some(1)
     );
 }
 


### PR DESCRIPTION
## Summary\n- make workspace search apply regex against full file content instead of line-by-line only\n- preserve line-based output and edit anchors while supporting multiline matches\n- add regression tests for multiline searches and line-anchored regex behavior\n\n## Validation\n- cargo test --manifest-path src-tauri\\Cargo.toml --test workspace_search_tests\n- pnpm refactor:validate