### PR TITLE
Improve agent attachment guidance

### DIFF
--- a/src-tauri/src/mcp/builtin/attachments/server.rs
+++ b/src-tauri/src/mcp/builtin/attachments/server.rs
@@ -247,6 +247,8 @@ impl AttachmentsServer {
                 "- {} available, 5 tools\n",
                 Self::format_file_count(total_count)
             ),
+            "- This service shows indexed attachments only. Workspace-only files and inline media do not appear here.\n".to_string(),
+            "- If a referenced file is missing here, it was likely kept in the workspace instead; use workspace tools for text-readable files.\n".to_string(),
         ];
 
         if !recent_files.is_empty() {

--- a/src/features/agent/lib/resource-attachment-operations.ts
+++ b/src/features/agent/lib/resource-attachment-operations.ts
@@ -4,7 +4,7 @@ import { getWorkspaceDir } from '@/lib/backend/workspace';
 import { workspacePathToFileUrl } from '@/lib/file-url';
 import { getMimeTypeFromFilename } from '@/lib/mime-utils';
 import { saveAgentFile } from '@/features/agent/api/agent-backend';
-import type { AttachmentReference } from '@/models/chat';
+import type { AttachmentAgentAccess, AttachmentReference } from '@/models/chat';
 import {
   convertToBlobUrl,
   extractFilenameFromUrl,
@@ -18,11 +18,75 @@ const TEXT_EXTENSIONS =
 const SUPPORTED_EXTENSIONS =
   /\.(txt|md|markdown|json|jsonc|json5|yaml|yml|toml|js|jsx|ts|tsx|mjs|cjs|py|rb|rs|go|java|c|cpp|h|hpp|css|scss|less|html|htm|svg|sh|bash|zsh|fish|ps1|sql|graphql|csv|log|xml|proto|pdf|docx|xlsx)$/i;
 
+const BINARY_WORKSPACE_EXTENSIONS = /\.(pdf|docx|xlsx)$/i;
+
 function isTextFile(filename: string, mimeType: string): boolean {
   return (
     /^text\/|\/(json|xml|javascript|typescript)/.test(mimeType) ||
     TEXT_EXTENSIONS.test(filename)
   );
+}
+
+function classifyWorkspaceAccessMode(
+  filename: string,
+  mimeType: string,
+): 'workspace-text' | 'workspace-binary' {
+  if (isTextFile(filename, mimeType)) {
+    return 'workspace-text';
+  }
+
+  if (
+    BINARY_WORKSPACE_EXTENSIONS.test(filename) ||
+    /^(image|audio|video)\//.test(mimeType)
+  ) {
+    return 'workspace-binary';
+  }
+
+  return 'workspace-binary';
+}
+
+function buildIndexedAgentAccess(): AttachmentAgentAccess {
+  return {
+    mode: 'indexed',
+    reason: 'indexed',
+    note: 'Indexed in the attachments store. Use attachments tools such as list/read/search instead of guessing via workspace tools.',
+  };
+}
+
+function buildInlineAgentAccess(): AttachmentAgentAccess {
+  return {
+    mode: 'inline-media',
+    reason: 'inline_media',
+    note: 'Inline media attachment. The model should use the media payload already attached to the message, not attachments or workspace text tools.',
+  };
+}
+
+function buildWorkspaceOnlyAgentAccess(
+  filename: string,
+  mimeType: string,
+  reason: 'unsupported_extension' | 'processing_failed',
+): AttachmentAgentAccess {
+  const mode = classifyWorkspaceAccessMode(filename, mimeType);
+
+  if (mode === 'workspace-text') {
+    return {
+      mode,
+      reason,
+      note:
+        reason === 'processing_failed'
+          ? 'Stored in the workspace because normal attachment processing failed. Do not use attachments tools for this file; use workspace__readFile if you need the text content.'
+          : 'Stored in the workspace only. It is not indexed in the attachments store, so attachments tools will not find it. Use workspace__readFile for text inspection.',
+    };
+  }
+
+  return {
+    mode,
+    reason,
+    note:
+      reason === 'processing_failed'
+        ? 'Stored in the workspace because normal attachment processing failed. It is a binary/non-text artifact, so attachments tools will not find it and workspace__readFile is not the right tool.'
+        : 'Stored in the workspace only because this binary/media type is not indexed in the attachments store. attachments tools will not find it, and workspace__readFile should not be used on it.',
+  };
 }
 
 interface AddAgentAttachmentArgs {
@@ -213,6 +277,7 @@ async function toInlineAttachment(
     lineCount: 0,
     preview: filename,
     uploadedAt: new Date().toISOString(),
+    agentAccess: buildInlineAgentAccess(),
     inlineContent: {
       type: inlineType,
       data: fallbackBase64Data,
@@ -228,6 +293,9 @@ export function toWorkspaceOnlyAttachment(
   mimeType: string,
   fileSize: number,
   workspacePath?: string,
+  reason:
+    | 'unsupported_extension'
+    | 'processing_failed' = 'unsupported_extension',
 ): AttachmentReference {
   logger.info(
     'File type not supported by Attachments, saving to workspace only',
@@ -246,6 +314,7 @@ export function toWorkspaceOnlyAttachment(
     preview: filename,
     uploadedAt: new Date().toISOString(),
     workspacePath,
+    agentAccess: buildWorkspaceOnlyAgentAccess(filename, mimeType, reason),
   };
 }
 
@@ -313,6 +382,7 @@ async function commitAttachmentToStore(
     chunkCount: result.chunkCount,
     lastAccessedAt: new Date().toISOString(),
     workspacePath: resolvedWorkspacePath,
+    agentAccess: buildIndexedAgentAccess(),
   };
 }
 
@@ -379,6 +449,7 @@ export async function addAgentAttachment({
           source.actualMimeType,
           source.fileSize,
           source.workspacePath,
+          'processing_failed',
         );
       }
     }
@@ -390,6 +461,7 @@ export async function addAgentAttachment({
         source.actualMimeType,
         source.fileSize,
         source.workspacePath,
+        'unsupported_extension',
       );
     }
 
@@ -417,6 +489,7 @@ export async function addAgentAttachment({
         source.actualMimeType,
         source.fileSize,
         source.workspacePath,
+        'processing_failed',
       );
     }
   } finally {

--- a/src/features/agent/lib/resource-attachment-operations.ts
+++ b/src/features/agent/lib/resource-attachment-operations.ts
@@ -49,7 +49,7 @@ function buildIndexedAgentAccess(): AttachmentAgentAccess {
   return {
     mode: 'indexed',
     reason: 'indexed',
-    note: 'Indexed in the attachments store. Use attachments tools such as list/read/search instead of guessing via workspace tools.',
+    note: 'Indexed in the attachments store. Use attachments__list, attachments__read, and attachments__search instead of guessing via workspace tools.',
   };
 }
 

--- a/src/lib/__tests__/message-preprocessor.test.ts
+++ b/src/lib/__tests__/message-preprocessor.test.ts
@@ -91,10 +91,12 @@ describe('message-preprocessor', () => {
       expect(text).toContain('"filename": "test.txt"');
       expect(text).toContain('"mode": "indexed"');
       expect(text).toContain(
-        'read(contentId: "content-1", fromLine: 1, toLine: 200)',
+        'attachments__read(contentId: "content-1", fromLine: 1, toLine: 200)',
       );
-      expect(text).toContain('search(query: "your search query")');
-      expect(text).toContain('list()');
+      expect(text).toContain(
+        'attachments__search(query: "your search query")',
+      );
+      expect(text).toContain('attachments__list()');
     });
 
     it('logs the effective default for includeLatestMediaPayload', async () => {

--- a/src/lib/__tests__/message-preprocessor.test.ts
+++ b/src/lib/__tests__/message-preprocessor.test.ts
@@ -89,6 +89,7 @@ describe('message-preprocessor', () => {
 
       expect(text).toContain('<attachment_0>');
       expect(text).toContain('"filename": "test.txt"');
+      expect(text).toContain('"mode": "indexed"');
       expect(text).toContain(
         'read(contentId: "content-1", fromLine: 1, toLine: 200)',
       );
@@ -148,10 +149,8 @@ describe('message-preprocessor', () => {
       const text = (processed.content[1] as MCPTextContent).text;
 
       expect(text).toContain('workspace__readFile(path: "/path/to/file.txt")');
-      expect(text).toContain('list()');
-      expect(text).toContain(
-        'read(contentId: <id from list>, fromLine: 1, toLine: 200)',
-      );
+      expect(text).toContain('"mode": "workspace-text"');
+      expect(text).toContain('attachments tools: do not use them for this file');
     });
 
     it('should append attachment hints for metadata-only files', async () => {
@@ -176,7 +175,31 @@ describe('message-preprocessor', () => {
       const text = (processed.content[1] as MCPTextContent).text;
 
       expect(text).toContain('File metadata only');
-      expect(text).toContain('list()');
+      expect(text).toContain('"mode": "metadata-only"');
+    });
+
+    it('marks workspace-only binary attachments as not readable through text tools', async () => {
+      const message = createMessage({
+        attachments: [
+          {
+            sessionId: 'session-1',
+            workspacePath: '/path/to/video.mp4',
+            filename: 'video.mp4',
+            mimeType: 'video/mp4',
+            size: 1024,
+            lineCount: 0,
+            preview: 'video.mp4',
+            uploadedAt: new Date().toISOString(),
+            status: 'workspace-only',
+          },
+        ],
+      });
+
+      const processed = await prepareMessageForLLM(message);
+      const text = (processed.content[1] as MCPTextContent).text;
+
+      expect(text).toContain('"mode": "workspace-binary"');
+      expect(text).toContain('workspace__readFile: do not use it; this is binary/non-text');
     });
 
     it('should handle multiple attachments', async () => {
@@ -553,6 +576,11 @@ describe('message-preprocessor', () => {
       ) as MCPTextContent[];
       expect(
         olderTextBlocks.some((c) => c.text.includes('<historical_media_0>')),
+      ).toBe(true);
+      expect(
+        olderTextBlocks.some((c) =>
+          c.text.includes('Do not call attachments tools or workspace__readFile'),
+        ),
       ).toBe(true);
 
       const latestImageBlocks = processedLatest.content.filter(

--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -2,7 +2,7 @@ import { Message } from '@/models/chat';
 import type { MCPContent } from '@/lib/mcp/protocol/content';
 import { getLogger } from './logger';
 import { stringToMCPContentArray } from './utils';
-import type { AttachmentReference } from '@/models/chat';
+import type { AttachmentAgentAccess, AttachmentReference } from '@/models/chat';
 import { readLocalFileAsBase64 } from '@/lib/backend/workspace';
 
 const logger = getLogger('message-preprocessor');
@@ -31,17 +31,132 @@ function truncateText(value: string, maxLength: number): string {
 function createAttachmentHintPayload(
   attachment: AttachmentReference,
 ): AttachmentReference {
-  if (
+  const preview =
     typeof attachment.preview === 'string' &&
     attachment.preview.length > ATTACHMENT_PREVIEW_CHAR_LIMIT
+      ? truncateText(attachment.preview, ATTACHMENT_PREVIEW_CHAR_LIMIT)
+      : attachment.preview;
+
+  return {
+    ...attachment,
+    preview,
+    agentAccess: deriveAttachmentAgentAccess(attachment),
+  };
+}
+
+function isWorkspaceTextReadable(attachment: AttachmentReference): boolean {
+  if (
+    /^text\/|\/(json|xml|javascript|typescript)/.test(attachment.mimeType) ||
+    /\.(txt|md|markdown|json|jsonc|json5|yaml|yml|toml|js|jsx|ts|tsx|mjs|cjs|py|rb|rs|go|java|c|cpp|h|hpp|css|scss|less|html|htm|svg|sh|bash|zsh|fish|ps1|sql|graphql|csv|log|xml|proto)$/i.test(
+      attachment.filename,
+    )
   ) {
+    return true;
+  }
+
+  return false;
+}
+
+function deriveAttachmentAgentAccess(
+  attachment: AttachmentReference,
+): AttachmentAgentAccess {
+  if (attachment.agentAccess) {
+    return attachment.agentAccess;
+  }
+
+  if (attachment.contentId || attachment.status === 'committed') {
     return {
-      ...attachment,
-      preview: truncateText(attachment.preview, ATTACHMENT_PREVIEW_CHAR_LIMIT),
+      mode: 'indexed',
+      reason: 'indexed',
+      note: 'Indexed in the attachments store. Use attachments tools such as list/read/search.',
     };
   }
 
-  return attachment;
+  if (attachment.status === 'inline' || attachment.inlineContent) {
+    return {
+      mode: 'inline-media',
+      reason: 'inline_media',
+      note: 'Inline media attachment. Use the media payload already present in the message instead of attachments or workspace text tools.',
+    };
+  }
+
+  if (attachment.workspacePath) {
+    return isWorkspaceTextReadable(attachment)
+      ? {
+          mode: 'workspace-text',
+          reason: 'workspace_only',
+          note: 'Workspace-only attachment. attachments tools will not find it; use workspace__readFile if you need the text content.',
+        }
+      : {
+          mode: 'workspace-binary',
+          reason: 'workspace_only',
+          note: 'Workspace-only binary/media attachment. attachments tools will not find it, and workspace__readFile is not appropriate.',
+        };
+  }
+
+  return {
+    mode: 'metadata-only',
+    reason: 'metadata_only',
+    note: 'Only metadata is available. Do not assume this attachment is readable until the storage mode is clarified.',
+  };
+}
+
+function buildAttachmentGuidanceLines(
+  attachment: AttachmentReference,
+  access: AttachmentAgentAccess,
+): string[] {
+  const lines = [
+    'Agent guidance:',
+    `- Access mode: ${access.mode}`,
+    `- Reason: ${access.reason}`,
+    `- ${access.note}`,
+  ];
+
+  if (attachment.workspacePath) {
+    lines.push(`- Workspace path: ${attachment.workspacePath}`);
+  }
+
+  switch (access.mode) {
+    case 'indexed':
+      if (attachment.contentId) {
+        lines.push(
+          '- Valid tools: attachments list/read/search',
+          `- Read full content: read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
+          '- Search indexed content: search(query: "your search query")',
+          '- List indexed attachments: list()',
+        );
+      }
+      break;
+    case 'workspace-text':
+      if (attachment.workspacePath) {
+        lines.push(
+          '- attachments tools: do not use them for this file',
+          `- Read text via workspace: workspace__readFile(path: "${attachment.workspacePath}")`,
+        );
+      }
+      break;
+    case 'workspace-binary':
+      lines.push(
+        '- attachments tools: do not use them for this file',
+        '- workspace__readFile: do not use it; this is binary/non-text',
+        '- Refer to the file by filename/path or use a media/specialized tool if one exists',
+      );
+      break;
+    case 'inline-media':
+      lines.push(
+        '- The media payload is already part of the message content',
+        '- Do not call attachments tools or workspace__readFile for this attachment',
+      );
+      break;
+    case 'metadata-only':
+      lines.push(
+        '- File metadata only — do not guess a read path',
+        '- Clarify storage mode before attempting tool calls',
+      );
+      break;
+  }
+
+  return lines;
 }
 
 function estimateTextTokens(text: string): number {
@@ -164,6 +279,7 @@ function summarizeInlineAttachment(
   index: number,
 ): string {
   const source = attachment.inlineContent;
+  const access = deriveAttachmentAgentAccess(attachment);
   return buildHistoricalMediaSummary(index, {
     kind: source?.type ?? 'unknown',
     filename: attachment.filename,
@@ -172,6 +288,8 @@ function summarizeInlineAttachment(
     uploadedAt: attachment.uploadedAt,
     uri: source?.uri,
     hasInlineBytes: typeof source?.data === 'string' && source.data.length > 0,
+    agentAccess: access,
+    note: 'Inline media history item. Do not call attachments tools or workspace__readFile for it.',
   });
 }
 
@@ -188,6 +306,7 @@ function summarizeHistoricalMediaItem(
     mimeType: item.mimeType ?? source?.mimeType,
     uri,
     embeddedBytes: rawData ? estimateBase64Bytes(rawData) : undefined,
+    note: 'Historical media item. Do not call attachments tools or workspace__readFile for it.',
   });
 }
 
@@ -436,23 +555,15 @@ export async function prepareMessageForLLM(
     // Build text hint blocks for workspace/committed attachments
     const attachmentHintBlocks = textAttachments.map((attachment, i) => {
       const safeAttachment = createAttachmentHintPayload(attachment);
-      const accessHints = attachment.contentId
-        ? `To read the full content of this file, use:
-- read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)
-- For keyword search: search(query: "your search query")
-- For file list: list()`
-        : attachment.workspacePath
-          ? `This file is in your workspace (may not be indexed in content store yet):
-- To read it via workspace: workspace__readFile(path: "${attachment.workspacePath}")
-- To check if it has been indexed: list()
-- If listed, use read(contentId: <id from list>, fromLine: 1, toLine: 200)`
-          : `File metadata only — use list() to find available files`;
+      const access = deriveAttachmentAgentAccess(safeAttachment);
+      const guidance = buildAttachmentGuidanceLines(
+        safeAttachment,
+        access,
+      ).join('\n');
 
       return `<attachment_${i}>
 ${JSON.stringify(safeAttachment, null, 2)}
-<!--
-${accessHints}
--->
+${guidance}
 </attachment_${i}>`;
     });
 

--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -68,7 +68,7 @@ function deriveAttachmentAgentAccess(
     return {
       mode: 'indexed',
       reason: 'indexed',
-      note: 'Indexed in the attachments store. Use attachments tools such as list/read/search.',
+      note: 'Indexed in the attachments store. Use attachments tools such as attachments__list, attachments__read, and attachments__search.',
     };
   }
 
@@ -120,10 +120,10 @@ function buildAttachmentGuidanceLines(
     case 'indexed':
       if (attachment.contentId) {
         lines.push(
-          '- Valid tools: attachments list/read/search',
-          `- Read full content: read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
-          '- Search indexed content: search(query: "your search query")',
-          '- List indexed attachments: list()',
+          '- Valid tools: attachments__list, attachments__read, attachments__search',
+          `- Read full content: attachments__read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
+          '- Search indexed content: attachments__search(query: "your search query")',
+          '- List indexed attachments: attachments__list()',
         );
       }
       break;

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -28,6 +28,23 @@ export interface UIResource {
   blob?: string; // base64-encoded content when used
 }
 
+export interface AttachmentAgentAccess {
+  mode:
+    | 'indexed'
+    | 'workspace-text'
+    | 'workspace-binary'
+    | 'inline-media'
+    | 'metadata-only';
+  reason:
+    | 'indexed'
+    | 'workspace_only'
+    | 'unsupported_extension'
+    | 'processing_failed'
+    | 'inline_media'
+    | 'metadata_only';
+  note: string;
+}
+
 // MCP file attachment reference type
 export interface AttachmentReference {
   sessionId: string; // MCP file store ID (same as session ID)
@@ -43,6 +60,12 @@ export interface AttachmentReference {
   workspacePath?: string; // File path where it's saved in the workspace
   // Explicit state tracking (replaces brittle contentId prefix checking)
   status: 'pending' | 'committed' | 'workspace-only' | 'inline' | 'processing'; // File upload/storage status
+  /**
+   * AI-facing access guidance for this attachment.
+   * This is intentionally separate from lifecycle status so prompts can tell the
+   * model which tool family is valid without guessing from contentId/workspacePath.
+   */
+  agentAccess?: AttachmentAgentAccess;
   pendingId?: string; // Temporary ID for pending files (before commit)
   // For pending files only - used during upload process
   originalUrl?: string; // Original URL or blob URL


### PR DESCRIPTION
## Summary
- add explicit AI-facing attachment access guidance for indexed, workspace-only, binary, inline, and metadata-only files
- inject plain-text attachment guidance into message preprocessing so agents stop guessing between attachments and workspace tools
- clarify in attachments service context that only indexed attachments appear there

## Validation
- pnpm exec vitest run src/lib/__tests__/message-preprocessor.test.ts src/features/agent/api/agent-backend.test.ts --reporter=dot
- pnpm refactor:validate *(stops on pre-existing Rust clippy failure in src-tauri/src/agent/llm/response_admission.rs:60-112)*