### PR TITLE
Harden compaction context recovery

### DIFF
--- a/scripts/__tests__/refactor-pipeline.test.ts
+++ b/scripts/__tests__/refactor-pipeline.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  applyStageEnvironment,
+  deriveResourceCaps,
   formatDuration,
+  getStages,
   pruneRunDirectories,
   sanitizeStageName,
   summarizeFailureText,
@@ -49,5 +52,66 @@ describe('refactor-pipeline helpers', () => {
     );
 
     expect(stalePaths).toEqual(['/logs/old']);
+  });
+
+  it('keeps validate as the full validation pipeline', () => {
+    expect(getStages('validate').map((stage) => stage.name)).toEqual([
+      'sync-builtin-services',
+      'format',
+      'rust:fmt',
+      'lint',
+      'format:check:all',
+      'test:run',
+      'rust:fmt:check',
+      'rust:clippy:all',
+      'rust:test',
+      'rust:check:all',
+      'build:nosync',
+      'perf:bundle',
+      'dead-code',
+    ]);
+  });
+
+  it('derives adaptive resource caps from host capacity', () => {
+    expect(deriveResourceCaps({ cpuCount: 4, totalMemGiB: 8 })).toMatchObject({
+      vitestMaxWorkers: 1,
+      cargoBuildJobs: 1,
+      rustTestThreads: 1,
+      uvThreadpoolSize: 1,
+    });
+    expect(deriveResourceCaps({ cpuCount: 16, totalMemGiB: 32 })).toMatchObject(
+      {
+        vitestMaxWorkers: 4,
+        cargoBuildJobs: 3,
+        rustTestThreads: 1,
+        uvThreadpoolSize: 2,
+      },
+    );
+  });
+
+  it('applies stage resource caps to the child environment', () => {
+    const env = applyStageEnvironment(
+      { NODE_OPTIONS: '--trace-warnings' },
+      {
+        env: {
+          nodeHeapMb: 768,
+          uvThreadpoolSize: 2,
+          cargoBuildJobs: 3,
+          rustTestThreads: 1,
+          vitestMaxWorkers: 4,
+          vitestMinWorkers: 1,
+          vitestFileParallelism: false,
+        },
+      },
+    );
+
+    expect(env.NODE_OPTIONS).toContain('--trace-warnings');
+    expect(env.NODE_OPTIONS).toContain('--max-old-space-size=768');
+    expect(env.UV_THREADPOOL_SIZE).toBe('2');
+    expect(env.CARGO_BUILD_JOBS).toBe('3');
+    expect(env.RUST_TEST_THREADS).toBe('1');
+    expect(env.VITEST_MAX_WORKERS).toBe('4');
+    expect(env.VITEST_MIN_WORKERS).toBe('1');
+    expect(env.VITEST_FILE_PARALLELISM).toBe('false');
   });
 });

--- a/scripts/refactor-pipeline.js
+++ b/scripts/refactor-pipeline.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -16,6 +17,51 @@ const MAX_FAILURE_TAIL_LINES = 120;
 const MAX_LOG_RUN_DIRS = 10;
 const FAILURE_PATTERN =
   /\b(error|errors|failed|failure|panic|panicked|fatal|segfault|exception|✗|ELIFECYCLE)\b/i;
+const PROCESS_PRIORITY = 10;
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function getCpuCount() {
+  if (typeof os.availableParallelism === 'function') {
+    return os.availableParallelism();
+  }
+
+  return os.cpus().length;
+}
+
+function getTotalMemGiB() {
+  return os.totalmem() / 1024 ** 3;
+}
+
+export function deriveResourceCaps({
+  cpuCount = Math.max(1, getCpuCount()),
+  totalMemGiB = getTotalMemGiB(),
+} = {}) {
+  const vitestMaxWorkers = clamp(
+    Math.min(Math.floor(cpuCount / 4), Math.floor(totalMemGiB / 6)),
+    1,
+    6,
+  );
+  const cargoBuildJobs = clamp(
+    Math.min(Math.floor(cpuCount / 5), Math.floor(totalMemGiB / 8)),
+    1,
+    4,
+  );
+  const uvThreadpoolSize = clamp(Math.floor(cpuCount / 6), 1, 4);
+
+  return {
+    processPriority: PROCESS_PRIORITY,
+    vitestMaxWorkers,
+    vitestMinWorkers: 1,
+    cargoBuildJobs,
+    rustTestThreads: 1,
+    uvThreadpoolSize,
+  };
+}
+
+const resourceCaps = deriveResourceCaps();
 
 const PREPARE_STAGES = [
   {
@@ -45,34 +91,87 @@ const VALIDATE_STAGES = [
     name: 'format:check:all',
     command: pnpmCommand,
     args: ['format:check:all'],
-    env: { nodeHeapMb: 768 },
+    env: {
+      nodeHeapMb: 768,
+      uvThreadpoolSize: resourceCaps.uvThreadpoolSize,
+      processPriority: resourceCaps.processPriority,
+    },
   },
   {
     name: 'test:run',
     command: pnpmCommand,
     args: ['test:run'],
-    env: { nodeHeapMb: 768 },
+    env: {
+      nodeHeapMb: 768,
+      uvThreadpoolSize: resourceCaps.uvThreadpoolSize,
+      vitestMaxWorkers: resourceCaps.vitestMaxWorkers,
+      vitestMinWorkers: resourceCaps.vitestMinWorkers,
+      processPriority: resourceCaps.processPriority,
+    },
   },
-  { name: 'rust:fmt:check', command: pnpmCommand, args: ['rust:fmt:check'] },
-  { name: 'rust:clippy:all', command: pnpmCommand, args: ['rust:clippy:all'] },
-  { name: 'rust:test', command: pnpmCommand, args: ['rust:test'] },
+  {
+    name: 'rust:fmt:check',
+    command: pnpmCommand,
+    args: ['rust:fmt:check'],
+    env: { processPriority: resourceCaps.processPriority },
+  },
+  {
+    name: 'rust:clippy:all',
+    command: pnpmCommand,
+    args: ['rust:clippy:all'],
+    env: {
+      cargoBuildJobs: resourceCaps.cargoBuildJobs,
+      processPriority: resourceCaps.processPriority,
+    },
+  },
+  {
+    name: 'rust:test',
+    command: pnpmCommand,
+    args: ['rust:test'],
+    env: {
+      cargoBuildJobs: resourceCaps.cargoBuildJobs,
+      rustTestThreads: resourceCaps.rustTestThreads,
+      processPriority: resourceCaps.processPriority,
+    },
+  },
+  {
+    name: 'rust:check:all',
+    command: pnpmCommand,
+    args: ['rust:check:all'],
+    env: {
+      cargoBuildJobs: resourceCaps.cargoBuildJobs,
+      processPriority: resourceCaps.processPriority,
+    },
+  },
   {
     name: 'build:nosync',
     command: pnpmCommand,
     args: ['build:nosync'],
-    env: { nodeHeapMb: 768 },
+    env: {
+      nodeHeapMb: 768,
+      uvThreadpoolSize: resourceCaps.uvThreadpoolSize,
+      processPriority: resourceCaps.processPriority,
+    },
   },
   {
     name: 'perf:bundle',
     command: pnpmCommand,
     args: ['perf:bundle'],
-    env: { nodeHeapMb: 512 },
+    env: {
+      nodeHeapMb: 512,
+      uvThreadpoolSize: resourceCaps.uvThreadpoolSize,
+      processPriority: resourceCaps.processPriority,
+    },
   },
   {
     name: 'dead-code',
     command: pnpmCommand,
     args: ['dead-code'],
-    env: { nodeHeapMb: 512 },
+    env: {
+      nodeHeapMb: 512,
+      uvThreadpoolSize: resourceCaps.uvThreadpoolSize,
+      processPriority: resourceCaps.processPriority,
+    },
   },
 ];
 
@@ -124,7 +223,7 @@ export function pruneRunDirectories(entries, maxKeep) {
     .map((entry) => entry.path);
 }
 
-function getStages(mode) {
+export function getStages(mode) {
   if (mode === 'prepare') {
     return PREPARE_STAGES;
   }
@@ -191,7 +290,15 @@ function appendNodeOption(existingValue, nextValue) {
   return `${existingValue} ${nextValue}`;
 }
 
-function applyStageEnvironment(baseEnv, stage) {
+function appendEnvValue(env, key, value) {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  env[key] = String(value);
+}
+
+export function applyStageEnvironment(baseEnv, stage) {
   const env = { ...baseEnv };
 
   if (stage.env?.nodeHeapMb) {
@@ -201,7 +308,31 @@ function applyStageEnvironment(baseEnv, stage) {
     );
   }
 
+  appendEnvValue(env, 'UV_THREADPOOL_SIZE', stage.env?.uvThreadpoolSize);
+  appendEnvValue(env, 'CARGO_BUILD_JOBS', stage.env?.cargoBuildJobs);
+  appendEnvValue(env, 'RUST_TEST_THREADS', stage.env?.rustTestThreads);
+  appendEnvValue(env, 'VITEST_MAX_WORKERS', stage.env?.vitestMaxWorkers);
+  appendEnvValue(env, 'VITEST_MIN_WORKERS', stage.env?.vitestMinWorkers);
+  appendEnvValue(
+    env,
+    'VITEST_FILE_PARALLELISM',
+    stage.env?.vitestFileParallelism,
+  );
+
   return env;
+}
+
+export function trySetProcessPriority(pid, priority) {
+  if (priority === undefined || priority === null) {
+    return false;
+  }
+
+  try {
+    os.setPriority(pid, priority);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function renderStageCommand(stage) {
@@ -223,6 +354,7 @@ async function runStage(stage, stageIndex, totalStages, runDir) {
       env: applyStageEnvironment(buildStageEnvironment(), stage),
       stdio: ['inherit', 'pipe', 'pipe'],
     });
+    trySetProcessPriority(child.pid, stage.env?.processPriority);
   } catch (error) {
     logStream.end();
     throw error;

--- a/src-tauri/src/agent/compact_recovery.rs
+++ b/src-tauri/src/agent/compact_recovery.rs
@@ -1,7 +1,7 @@
 use crate::agent::events::{AgentEvent, AgentEventDispatcher};
 use crate::agent::lifecycle::update_session_status_with_dispatcher;
 use crate::agent::llm::types::{AgentRuntimeError, CompactStateEvent, CompactStatePhase};
-use crate::agent::state::AgentSession;
+use crate::agent::state::{AgentSession, CompactRepairState};
 use crate::repositories::{SessionRepository, SessionStatus};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -73,6 +73,7 @@ pub async fn handle_compact_error_state(
         .unwrap_or("none");
 
     clear_compaction_state(active_sessions, &session_id, true).await;
+    rearm_compact_repair_after_failure(active_sessions, &session_id).await;
 
     let state_event = CompactStateEvent {
         session_id: session_id.clone(),
@@ -117,4 +118,16 @@ pub async fn handle_compact_error_state(
     }
 
     Ok(())
+}
+
+async fn rearm_compact_repair_after_failure(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+) {
+    let active = active_sessions.read().await;
+    if let Some(session) = active.get(session_id) {
+        if session.compact_repair_state() == CompactRepairState::Attempted {
+            session.set_compact_repair_state(CompactRepairState::Needed);
+        }
+    }
 }

--- a/src-tauri/src/agent/lifecycle/cache.rs
+++ b/src-tauri/src/agent/lifecycle/cache.rs
@@ -1,10 +1,13 @@
-use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
+use crate::agent::state::{
+    AgentSession, CacheInitializationClaim, CompactRepairState, MAX_CACHED_MESSAGES,
+};
 use crate::repositories::message_repository::MessageRepository as MessageRepositoryTrait;
+use crate::repositories::SessionStatus;
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::RwLock;
+use tokio::time::{sleep, Duration};
 
 /// Load messages from DB into in-memory cache (called once per session)
 pub async fn init_session_with_messages(
@@ -13,14 +16,20 @@ pub async fn init_session_with_messages(
 ) -> Result<(), String> {
     let message_repo = crate::state::get_message_repository();
 
-    // Load last N messages from DB (one-time operation).
-    // get_page is 1-based: page=1 maps to offset=0 (first page).
-    let page = message_repo
-        .get_page(session_id, 1, MAX_CACHED_MESSAGES as u64)
+    // Load the most recent N messages from DB so the runtime cache lines up with
+    // persisted compaction boundaries and the active workflow tail.
+    let recent_slice = message_repo
+        .get_recent_slice(session_id, MAX_CACHED_MESSAGES as u64)
         .await
         .map_err(|e| format!("Failed to load messages for session {}: {}", session_id, e))?;
 
-    let loaded_count = page.items.len();
+    let loaded_count = recent_slice.items.len();
+    let has_incomplete_turn = recent_slice
+        .items
+        .iter()
+        .rfind(|m| !m.is_recovery_message())
+        .map(|m| m.role == "user")
+        .unwrap_or(false);
 
     // Load compact context if exists (SP17)
     let compact_context =
@@ -30,29 +39,31 @@ pub async fn init_session_with_messages(
     let sessions = active_sessions.read().await;
     if let Some(session) = sessions.get(session_id) {
         let mut messages = session.messages.write().await;
-        *messages = page.items.clone(); // Clone so we can use page.items later
+        *messages = recent_slice.items;
 
         let mut synced_at = session.last_synced_at.write().await;
         *synced_at = Some(SystemTime::now());
 
+        let needs_compact_repair = recent_slice.has_more_before
+            && compact_context.is_none()
+            && session.metadata.status == SessionStatus::Error;
+
         crate::agent::lifecycle::overwrite_compact_context(session, compact_context).await;
 
-        session.cache_initialized.store(true, Ordering::Release);
+        session.set_compact_repair_state(if needs_compact_repair {
+            CompactRepairState::Needed
+        } else {
+            CompactRepairState::NotNeeded
+        });
 
-        // Detect incomplete user turn: last non-recovery message is `user` with no assistant response.
-        // This happens after a crash.
-        let has_incomplete_turn = page
-            .items
-            .iter()
-            .rfind(|m| !m.is_recovery_message())
-            .map(|m| m.role == "user")
-            .unwrap_or(false);
+        session.mark_cache_initialized();
 
         log::info!(
-            "Initialized session cache: session={}, messages_loaded={}, incomplete_turn={}",
+            "Initialized session cache: session={}, messages_loaded={}, incomplete_turn={}, compact_repair_state={:?}",
             session_id,
             loaded_count,
-            has_incomplete_turn
+            has_incomplete_turn,
+            session.compact_repair_state()
         );
     } else {
         return Err(format!("Session not found: {}", session_id));
@@ -66,12 +77,52 @@ pub async fn ensure_cache_initialized(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     session_id: &str,
 ) -> Result<(), String> {
-    let sessions = active_sessions.read().await;
-    if let Some(session) = sessions.get(session_id) {
-        if !session.cache_initialized.load(Ordering::Acquire) {
-            drop(sessions); // Release read lock before calling init
-            init_session_with_messages(active_sessions, session_id).await?;
+    loop {
+        let sessions = active_sessions.read().await;
+        if let Some(session) = sessions.get(session_id) {
+            match session.try_claim_cache_initialization() {
+                CacheInitializationClaim::Ready => {}
+                CacheInitializationClaim::Claimed => {
+                    drop(sessions); // Release read lock before calling init
+                    if let Err(error) =
+                        init_session_with_messages(active_sessions, session_id).await
+                    {
+                        let sessions = active_sessions.read().await;
+                        if let Some(session) = sessions.get(session_id) {
+                            session.reset_cache_initialization();
+                        }
+                        return Err(error);
+                    }
+                }
+                CacheInitializationClaim::InProgress => {
+                    drop(sessions);
+                    let state = loop {
+                        let sessions = active_sessions.read().await;
+                        let state = sessions
+                            .get(session_id)
+                            .map(|session| session.cache_initialization_state());
+                        drop(sessions);
+
+                        match state {
+                            Some(crate::agent::state::CacheInitializationState::Initializing) => {
+                                sleep(Duration::from_millis(10)).await;
+                            }
+                            other => break other,
+                        }
+                    };
+
+                    match state {
+                        Some(crate::agent::state::CacheInitializationState::Ready) | None => {}
+                        Some(crate::agent::state::CacheInitializationState::Uninitialized) => {
+                            continue;
+                        }
+                        Some(crate::agent::state::CacheInitializationState::Initializing) => {
+                            unreachable!("initializing state should be handled by the wait loop")
+                        }
+                    }
+                }
+            }
         }
+        return Ok(());
     }
-    Ok(())
 }

--- a/src-tauri/src/agent/lifecycle/creation.rs
+++ b/src-tauri/src/agent/lifecycle/creation.rs
@@ -5,7 +5,7 @@ use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::settings_repository::SettingsRepository;
 use crate::repositories::{SessionMetadata, SessionStatus};
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU8};
 use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
@@ -226,7 +226,9 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
                 cancel_pending: Arc::new(AtomicBool::new(false)),
                 pending_execution: None,
                 messages: Arc::new(RwLock::new(Vec::new())),
-                cache_initialized: Arc::new(AtomicBool::new(false)),
+                cache_state: Arc::new(AtomicU8::new(
+                    crate::agent::state::CacheInitializationState::Uninitialized as u8,
+                )),
                 last_synced_at: Arc::new(RwLock::new(None)),
                 repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
                 pending_events: Arc::new(RwLock::new(
@@ -235,6 +237,9 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
                 pending_approvals: Arc::new(RwLock::new(std::collections::HashMap::new())),
                 context_registry,
                 compact_context: Arc::new(RwLock::new(compact_context_record)),
+                compact_repair_state: Arc::new(AtomicU8::new(
+                    crate::agent::state::CompactRepairState::NotNeeded as u8,
+                )),
                 compaction: crate::agent::state::CompactionRuntimeState::new(),
                 expected_response_id: Arc::new(RwLock::new(None)),
                 cached_stable_prompt: Arc::new(RwLock::new(None)),

--- a/src-tauri/src/agent/lifecycle/management.rs
+++ b/src-tauri/src/agent/lifecycle/management.rs
@@ -8,7 +8,7 @@ use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::{SessionMetadata, SessionStatus};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU8};
 use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
@@ -127,7 +127,9 @@ pub async fn resume_session(
                 cancel_pending: Arc::new(AtomicBool::new(false)),
                 pending_execution: None,
                 messages: Arc::new(RwLock::new(Vec::new())),
-                cache_initialized: Arc::new(AtomicBool::new(false)),
+                cache_state: Arc::new(AtomicU8::new(
+                    crate::agent::state::CacheInitializationState::Uninitialized as u8,
+                )),
                 last_synced_at: Arc::new(RwLock::new(None)),
                 repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
                 pending_events: Arc::new(RwLock::new(
@@ -136,6 +138,9 @@ pub async fn resume_session(
                 pending_approvals: Arc::new(RwLock::new(std::collections::HashMap::new())),
                 context_registry: Arc::new(crate::agent::context::registry::ContextRegistry::new()),
                 compact_context: Arc::new(RwLock::new(compact_context_record)),
+                compact_repair_state: Arc::new(AtomicU8::new(
+                    crate::agent::state::CompactRepairState::NotNeeded as u8,
+                )),
                 compaction: crate::agent::state::CompactionRuntimeState::new(),
                 expected_response_id: Arc::new(RwLock::new(None)),
                 cached_stable_prompt: Arc::new(RwLock::new(None)),

--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -7,7 +7,7 @@ use crate::repositories::message_repository::MessageRepository as MessageReposit
 use crate::repositories::session_repository::SessionRepository;
 use crate::repositories::SessionStatus;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU8};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
@@ -21,13 +21,19 @@ use super::management::update_session_status_with_dispatcher;
 async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
     let message_repo = crate::state::get_message_repository();
 
-    // Load messages for the session (up to MAX_CACHED_MESSAGES)
-    let page = message_repo
-        .get_page(session_id, 1, MAX_CACHED_MESSAGES as u64)
+    // Inspect the most recent messages because unresolved tool calls only matter
+    // near the active tail after crash recovery.
+    let recent_slice = message_repo
+        .get_recent_slice(session_id, MAX_CACHED_MESSAGES as u64)
         .await
-        .map_err(|e| format!("Failed to load messages for tombstone check: {}", e))?;
+        .map_err(|e| {
+            format!(
+                "Failed to load messages for session {} during tombstone check: {}",
+                session_id, e
+            )
+        })?;
 
-    let messages = page.items;
+    let messages = recent_slice.items;
 
     // Collect all resolved tool_call_ids (role="tool" messages with a tool_call_id)
     let resolved_ids: HashSet<String> = messages
@@ -117,13 +123,18 @@ fn build_recovered_session(
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),
-        cache_initialized: Arc::new(AtomicBool::new(false)),
+        cache_state: Arc::new(AtomicU8::new(
+            crate::agent::state::CacheInitializationState::Uninitialized as u8,
+        )),
         last_synced_at: Arc::new(RwLock::new(None)),
         repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
         pending_events: Arc::new(RwLock::new(crate::agent::state::PendingEventManager::new())),
         pending_approvals: Arc::new(RwLock::new(std::collections::HashMap::new())),
         context_registry,
         compact_context: Arc::new(RwLock::new(None)),
+        compact_repair_state: Arc::new(AtomicU8::new(
+            crate::agent::state::CompactRepairState::NotNeeded as u8,
+        )),
         compaction: crate::agent::state::CompactionRuntimeState::new(),
         expected_response_id: Arc::new(RwLock::new(None)),
         cached_stable_prompt: Arc::new(RwLock::new(None)),

--- a/src-tauri/src/agent/llm/completion/request/orchestration.rs
+++ b/src-tauri/src/agent/llm/completion/request/orchestration.rs
@@ -84,6 +84,42 @@ pub async fn request_llm_completion(
     let system_prompt_tokens = token_counts.system_prompt_tokens;
     let tools_tokens = token_counts.tools_tokens;
     let raw_messages = normalized_messages.clone();
+    let compaction_parent_request = Some(CompactionParentRequest {
+        model: snapshot.model.clone(),
+        provider: snapshot.provider.clone(),
+        system_prompt: system_prompt.clone(),
+        session_context: session_context.clone(),
+        available_tools: available_tools.clone(),
+    });
+
+    store_last_completion_request(active_sessions, &session_id, &compaction_parent_request).await;
+
+    if uses_compaction_strategy(&context_settings.context_strategy)
+        && claim_compact_repair_attempt(active_sessions, &session_id).await
+    {
+        match trigger_preflight_compaction_for_messages_or_error(
+            active_sessions,
+            app_handle,
+            &session_id,
+            &snapshot.session_name,
+            &normalized_messages,
+            compaction_parent_request.clone(),
+        )
+        .await
+        {
+            Ok(true) => {
+                log::info!(
+                    "Triggered compact repair before completion request for session {}",
+                    session_id
+                );
+                return Ok(());
+            }
+            Ok(false) => {
+                reset_compact_repair_attempt(active_sessions, &session_id).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
 
     // 8. Inject Compact Summary
     let (messages_with_summary, compact_summary_injected) = inject_compact_summary(
@@ -104,16 +140,6 @@ pub async fn request_llm_completion(
     // 9. Select Final Messages
     let final_messages =
         select_final_messages(messages_with_summary, &snapshot.provider, &context_settings);
-
-    let compaction_parent_request = Some(CompactionParentRequest {
-        model: snapshot.model.clone(),
-        provider: snapshot.provider.clone(),
-        system_prompt: system_prompt.clone(),
-        session_context: session_context.clone(),
-        available_tools: available_tools.clone(),
-    });
-
-    store_last_completion_request(active_sessions, &session_id, &compaction_parent_request).await;
 
     // 10. Check empty messages
     match check_empty_messages(
@@ -515,6 +541,27 @@ async fn store_last_completion_request(
     if let Some(session) = active.get(session_id) {
         let mut last_completion_request = session.last_completion_request.write().await;
         *last_completion_request = request.clone();
+    }
+}
+
+async fn claim_compact_repair_attempt(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+) -> bool {
+    let active = active_sessions.read().await;
+    active
+        .get(session_id)
+        .map(|session| session.claim_compact_repair_attempt())
+        .unwrap_or(false)
+}
+
+async fn reset_compact_repair_attempt(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+) {
+    let active = active_sessions.read().await;
+    if let Some(session) = active.get(session_id) {
+        session.set_compact_repair_state(crate::agent::state::CompactRepairState::Needed);
     }
 }
 

--- a/src-tauri/src/agent/session_manager/compact.rs
+++ b/src-tauri/src/agent/session_manager/compact.rs
@@ -313,6 +313,7 @@ pub async fn save_compact_context(
         if let Some(session) = active.get(session_id) {
             let mut compact = session.compact_context.write().await;
             *compact = Some(record.clone());
+            session.set_compact_repair_state(crate::agent::state::CompactRepairState::NotNeeded);
         }
     }
 

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -5,7 +5,7 @@ use crate::agent::types::ToolCall;
 use crate::models::chat::Message;
 use crate::repositories::{CompactContextRecord, SessionMetadata};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::oneshot;
@@ -201,6 +201,49 @@ pub enum CompactionResumeAction {
     RunDeferred(DeferredWorkflowStep),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CacheInitializationState {
+    Uninitialized = 0,
+    Initializing = 1,
+    Ready = 2,
+}
+
+impl CacheInitializationState {
+    fn from_raw(value: u8) -> Self {
+        match value {
+            1 => Self::Initializing,
+            2 => Self::Ready,
+            _ => Self::Uninitialized,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheInitializationClaim {
+    Claimed,
+    InProgress,
+    Ready,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CompactRepairState {
+    NotNeeded = 0,
+    Needed = 1,
+    Attempted = 2,
+}
+
+impl CompactRepairState {
+    fn from_raw(value: u8) -> Self {
+        match value {
+            1 => Self::Needed,
+            2 => Self::Attempted,
+            _ => Self::NotNeeded,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CompactionRuntimeState {
     /// Closed runtime phase model for active compaction work.
@@ -352,8 +395,8 @@ pub struct AgentSession {
     /// Thread-safe: Arc allows shared ownership, RwLock allows concurrent reads
     pub messages: Arc<RwLock<Vec<Message>>>,
 
-    /// Flag indicating if cache has been initialized from DB
-    pub cache_initialized: Arc<AtomicBool>,
+    /// Explicit cache lifecycle state, used to prevent double initialization races.
+    pub cache_state: Arc<AtomicU8>,
 
     /// Last DB sync timestamp (for debugging/monitoring)
     pub last_synced_at: Arc<RwLock<Option<SystemTime>>>,
@@ -377,6 +420,9 @@ pub struct AgentSession {
     /// Compact context for the session (SP17)
     pub compact_context: Arc<RwLock<Option<CompactContextRecord>>>,
 
+    /// Explicit repair lifecycle state for rebuilding lost compact summaries.
+    pub compact_repair_state: Arc<AtomicU8>,
+
     /// Transient runtime-only compaction orchestration state.
     pub compaction: CompactionRuntimeState,
 
@@ -393,6 +439,62 @@ pub struct AgentSession {
     /// Exact prompt-layout fields from the latest emitted completion request.
     /// Reused by compaction so the summarization call preserves provider cache prefixes.
     pub last_completion_request: Arc<RwLock<Option<CompactionParentRequest>>>,
+}
+
+impl AgentSession {
+    pub fn cache_initialization_state(&self) -> CacheInitializationState {
+        CacheInitializationState::from_raw(self.cache_state.load(Ordering::Acquire))
+    }
+
+    pub fn try_claim_cache_initialization(&self) -> CacheInitializationClaim {
+        match self.cache_state.compare_exchange(
+            CacheInitializationState::Uninitialized as u8,
+            CacheInitializationState::Initializing as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => CacheInitializationClaim::Claimed,
+            Err(current) => match CacheInitializationState::from_raw(current) {
+                CacheInitializationState::Uninitialized => {
+                    unreachable!("compare_exchange cannot fail while leaving state uninitialized")
+                }
+                CacheInitializationState::Initializing => CacheInitializationClaim::InProgress,
+                CacheInitializationState::Ready => CacheInitializationClaim::Ready,
+            },
+        }
+    }
+
+    pub fn mark_cache_initialized(&self) {
+        self.cache_state
+            .store(CacheInitializationState::Ready as u8, Ordering::Release);
+    }
+
+    pub fn reset_cache_initialization(&self) {
+        self.cache_state.store(
+            CacheInitializationState::Uninitialized as u8,
+            Ordering::Release,
+        );
+    }
+
+    pub fn compact_repair_state(&self) -> CompactRepairState {
+        CompactRepairState::from_raw(self.compact_repair_state.load(Ordering::Acquire))
+    }
+
+    pub fn set_compact_repair_state(&self, state: CompactRepairState) {
+        self.compact_repair_state
+            .store(state as u8, Ordering::Release);
+    }
+
+    pub fn claim_compact_repair_attempt(&self) -> bool {
+        self.compact_repair_state
+            .compare_exchange(
+                CompactRepairState::Needed as u8,
+                CompactRepairState::Attempted as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp/builtin/attachments/server.rs
+++ b/src-tauri/src/mcp/builtin/attachments/server.rs
@@ -247,6 +247,8 @@ impl AttachmentsServer {
                 "- {} available, 5 tools\n",
                 Self::format_file_count(total_count)
             ),
+            "- This service shows indexed attachments only. Workspace-only files and inline media do not appear here.\n".to_string(),
+            "- If a referenced file is missing here, it was likely kept in the workspace instead; use workspace tools for text-readable files.\n".to_string(),
         ];
 
         if !recent_files.is_empty() {

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
@@ -334,11 +334,14 @@ impl WorkspaceServer {
 mod tests {
     use super::*;
     use crate::agent::context::registry::ContextRegistry;
-    use crate::agent::state::{AgentSession, CompactionRuntimeState, PendingEventManager};
+    use crate::agent::state::{
+        AgentSession, CacheInitializationState, CompactRepairState, CompactionRuntimeState,
+        PendingEventManager,
+    };
     use crate::repositories::{SessionMetadata, SessionStatus};
     use crate::session::SessionManager;
     use std::collections::HashMap;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, AtomicU8};
     use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::sync::RwLock;
@@ -387,13 +390,14 @@ mod tests {
             cancel_pending: Arc::new(AtomicBool::new(false)),
             pending_execution: None,
             messages: Arc::new(RwLock::new(Vec::new())),
-            cache_initialized: Arc::new(AtomicBool::new(true)),
+            cache_state: Arc::new(AtomicU8::new(CacheInitializationState::Ready as u8)),
             last_synced_at: Arc::new(RwLock::new(None)),
             repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
             pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
             pending_approvals: Arc::new(RwLock::new(HashMap::new())),
             context_registry: Arc::new(ContextRegistry::new()),
             compact_context: Arc::new(RwLock::new(None)),
+            compact_repair_state: Arc::new(AtomicU8::new(CompactRepairState::NotNeeded as u8)),
             compaction: CompactionRuntimeState::new(),
             expected_response_id: Arc::new(RwLock::new(None)),
             cached_stable_prompt: Arc::new(RwLock::new(None)),

--- a/src-tauri/tests/compact_error_recovery_tests.rs
+++ b/src-tauri/tests/compact_error_recovery_tests.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU8};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -15,8 +15,8 @@ use tauri_mcp_agent_lib::agent::llm::types::{
 };
 use tauri_mcp_agent_lib::agent::session_bus::SessionBus;
 use tauri_mcp_agent_lib::agent::state::{
-    AgentSession, CompactionKind, CompactionPhase, DeferredWorkflowStep, InFlightCompaction,
-    PendingEventManager,
+    AgentSession, CacheInitializationState, CompactRepairState, CompactionKind, CompactionPhase,
+    DeferredWorkflowStep, InFlightCompaction, PendingEventManager,
 };
 use tauri_mcp_agent_lib::repositories::{
     InMemorySessionRepository, SessionMetadata, SessionRepository, SessionStatus,
@@ -126,13 +126,14 @@ fn build_agent_session(
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),
-        cache_initialized: Arc::new(AtomicBool::new(true)),
+        cache_state: Arc::new(AtomicU8::new(CacheInitializationState::Ready as u8)),
         last_synced_at: Arc::new(RwLock::new(Some(SystemTime::now()))),
         repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
         pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
         pending_approvals: Arc::new(RwLock::new(HashMap::new())),
         context_registry: Arc::new(ContextRegistry::new()),
         compact_context: Arc::new(RwLock::new(None)),
+        compact_repair_state: Arc::new(AtomicU8::new(CompactRepairState::NotNeeded as u8)),
         compaction: tauri_mcp_agent_lib::agent::state::CompactionRuntimeState::with_test_state(
             CompactionPhase::InFlight(InFlightCompaction {
                 kind,
@@ -159,9 +160,11 @@ async fn preflight_compact_failure_transitions_workflow_to_error() {
         .expect("session upsert should succeed");
     let session_repo: Arc<dyn SessionRepository> = repo.clone();
 
+    let session = build_agent_session(metadata.clone(), true);
+    session.set_compact_repair_state(CompactRepairState::Attempted);
     let active_sessions = Arc::new(RwLock::new(HashMap::from([(
         session_id.to_string(),
-        build_agent_session(metadata.clone(), true),
+        session,
     )])));
     let dispatcher = RecordingDispatcher::default();
     let error = AgentRuntimeError::new(AgentRuntimeErrorType::RateLimitError, "LLM rate limit hit");
@@ -186,6 +189,7 @@ async fn preflight_compact_failure_transitions_workflow_to_error() {
     let active = active_sessions.read().await;
     let session = active.get(session_id).expect("active session should exist");
     assert_eq!(session.metadata.status, SessionStatus::Error);
+    assert_eq!(session.compact_repair_state(), CompactRepairState::Needed);
     let snapshot = session.compaction.snapshot().await;
     assert!(matches!(snapshot.phase, CompactionPhase::Idle));
     assert_eq!(snapshot.last_compacted_tail_id, None);
@@ -236,9 +240,11 @@ async fn manual_compact_failure_clears_flags_without_failing_workflow() {
         .expect("session upsert should succeed");
     let session_repo: Arc<dyn SessionRepository> = repo.clone();
 
+    let session = build_agent_session(metadata.clone(), false);
+    session.set_compact_repair_state(CompactRepairState::Attempted);
     let active_sessions = Arc::new(RwLock::new(HashMap::from([(
         session_id.to_string(),
-        build_agent_session(metadata.clone(), false),
+        session,
     )])));
     let dispatcher = RecordingDispatcher::default();
 
@@ -262,6 +268,7 @@ async fn manual_compact_failure_clears_flags_without_failing_workflow() {
     let active = active_sessions.read().await;
     let session = active.get(session_id).expect("active session should exist");
     assert_eq!(session.metadata.status, SessionStatus::Busy);
+    assert_eq!(session.compact_repair_state(), CompactRepairState::Needed);
     let snapshot = session.compaction.snapshot().await;
     assert!(matches!(snapshot.phase, CompactionPhase::Idle));
     assert_eq!(snapshot.last_compacted_tail_id, None);

--- a/src-tauri/tests/session_cache_recent_slice_regression_tests.rs
+++ b/src-tauri/tests/session_cache_recent_slice_regression_tests.rs
@@ -19,6 +19,7 @@ use tauri_mcp_agent_lib::repositories::{
     SessionRepository, SessionStatus, SqliteCompactContextRepository, SqliteMessageRepository,
     SqliteSessionRepository,
 };
+use tauri_mcp_agent_lib::utils::sqlite::format_sqlite_url;
 use tauri_mcp_agent_lib::{set_compact_context_repository, set_message_repository};
 use tokio::sync::{Mutex, OnceCell, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -37,7 +38,7 @@ fn test_db_url() -> &'static str {
             "libragent_session_cache_recent_slice_regression_{}.db",
             uuid::Uuid::new_v4()
         ));
-        format!("sqlite://{}?mode=rwc", db_path.display())
+        format!("{}?mode=rwc", format_sqlite_url(&db_path.to_string_lossy()))
     })
 }
 

--- a/src-tauri/tests/session_cache_recent_slice_regression_tests.rs
+++ b/src-tauri/tests/session_cache_recent_slice_regression_tests.rs
@@ -1,0 +1,282 @@
+mod common;
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU8};
+use std::sync::{Arc, OnceLock};
+
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::MigratorTrait;
+use tauri_mcp_agent_lib::agent::context::registry::ContextRegistry;
+use tauri_mcp_agent_lib::agent::lifecycle::init_session_with_messages;
+use tauri_mcp_agent_lib::agent::state::{
+    AgentSession, CacheInitializationState, CompactRepairState, CompactionRuntimeState,
+    PendingEventManager,
+};
+use tauri_mcp_agent_lib::migration::Migrator;
+use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::repositories::{
+    CompactContextRecord, CompactContextRepository, MessageRepository, SessionMetadata,
+    SessionRepository, SessionStatus, SqliteCompactContextRepository, SqliteMessageRepository,
+    SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::{set_compact_context_repository, set_message_repository};
+use tokio::sync::{Mutex, OnceCell, RwLock};
+use tokio_util::sync::CancellationToken;
+
+static TEST_DB_URL: OnceLock<String> = OnceLock::new();
+static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+static TEST_DB_ROOT: OnceCell<DatabaseConnection> = OnceCell::const_new();
+
+fn test_mutex() -> &'static Mutex<()> {
+    TEST_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+fn test_db_url() -> &'static str {
+    TEST_DB_URL.get_or_init(|| {
+        let db_path = std::env::temp_dir().join(format!(
+            "libragent_session_cache_recent_slice_regression_{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        format!("sqlite://{}?mode=rwc", db_path.display())
+    })
+}
+
+async fn connect_test_db() -> DatabaseConnection {
+    common::register_sqlite_vec();
+    let mut options = ConnectOptions::new(test_db_url().to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Failed to connect test database")
+}
+
+async fn ensure_test_db_root() -> DatabaseConnection {
+    TEST_DB_ROOT
+        .get_or_init(|| async {
+            let db = connect_test_db().await;
+            Migrator::up(&db, None)
+                .await
+                .expect("Migrations should run");
+            set_message_repository(SqliteMessageRepository::new(db.clone()));
+            set_compact_context_repository(SqliteCompactContextRepository::new(db.clone()));
+            db
+        })
+        .await
+        .clone()
+}
+
+async fn test_db() -> DatabaseConnection {
+    ensure_test_db_root().await;
+    connect_test_db().await
+}
+
+fn build_session_metadata(session_id: &str) -> SessionMetadata {
+    let now = chrono::Utc::now().timestamp_millis();
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Session cache recent slice regression".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-5.4".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        unsafe_mode: false,
+        workspace_override: None,
+    }
+}
+
+fn build_agent_session(metadata: SessionMetadata) -> AgentSession {
+    AgentSession {
+        metadata,
+        is_running: false,
+        active_permit: None,
+        status_transition: Arc::new(RwLock::new(None)),
+        transition_lock: Arc::new(tokio::sync::Mutex::new(())),
+        cancellation_token: CancellationToken::new(),
+        yolo_mode: Arc::new(AtomicBool::new(false)),
+        unsafe_mode: Arc::new(AtomicBool::new(false)),
+        cancel_pending: Arc::new(AtomicBool::new(false)),
+        pending_execution: None,
+        messages: Arc::new(RwLock::new(Vec::new())),
+        cache_state: Arc::new(AtomicU8::new(
+            tauri_mcp_agent_lib::agent::state::CacheInitializationState::Uninitialized as u8,
+        )),
+        last_synced_at: Arc::new(RwLock::new(None)),
+        repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
+        pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
+        pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+        context_registry: Arc::new(ContextRegistry::new()),
+        compact_context: Arc::new(RwLock::new(None)),
+        compact_repair_state: Arc::new(AtomicU8::new(
+            tauri_mcp_agent_lib::agent::state::CompactRepairState::NotNeeded as u8,
+        )),
+        compaction: CompactionRuntimeState::new(),
+        expected_response_id: Arc::new(RwLock::new(None)),
+        cached_stable_prompt: Arc::new(RwLock::new(None)),
+        last_completion_request: Arc::new(RwLock::new(None)),
+    }
+}
+
+fn build_message(session_id: &str, index: usize) -> Message {
+    let created_at = 1_712_345_678_000_i64 + index as i64;
+    Message {
+        id: format!("msg-{index:04}"),
+        session_id: session_id.to_string(),
+        role: if index % 2 == 0 {
+            "assistant".to_string()
+        } else {
+            "user".to_string()
+        },
+        content: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        created_at,
+        updated_at: created_at,
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn init_session_cache_loads_recent_messages_so_compact_boundaries_survive_resume() {
+    let _guard = test_mutex().lock().await;
+    let db = test_db().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let local_message_repo = SqliteMessageRepository::new(db.clone());
+    let local_compact_repo = SqliteCompactContextRepository::new(db.clone());
+
+    let session_id = format!("session-cache-recent-{}", uuid::Uuid::new_v4());
+    let metadata = build_session_metadata(&session_id);
+    session_repo
+        .upsert_session(&metadata)
+        .await
+        .expect("session should be created");
+
+    for index in 1..=1105 {
+        local_message_repo
+            .insert(&build_message(&session_id, index))
+            .await
+            .expect("message insert should succeed");
+    }
+
+    let compact_record = CompactContextRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        session_id: session_id.clone(),
+        from_id: "msg-0001".to_string(),
+        to_id: "msg-1050".to_string(),
+        summary: "Persisted summary".to_string(),
+        created_at: chrono::Utc::now().timestamp_millis(),
+    };
+    local_compact_repo
+        .upsert(&compact_record)
+        .await
+        .expect("compact context should be stored");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::from([(
+        session_id.clone(),
+        build_agent_session(metadata),
+    )])));
+
+    init_session_with_messages(&active_sessions, &session_id)
+        .await
+        .expect("cache init should succeed");
+
+    let sessions = active_sessions.read().await;
+    let session = sessions
+        .get(&session_id)
+        .expect("active session should remain present");
+    let loaded_messages = session.messages.read().await.clone();
+    let loaded_ids: Vec<String> = loaded_messages
+        .iter()
+        .map(|message| message.id.clone())
+        .collect();
+
+    assert_eq!(loaded_messages.len(), 1000);
+    assert_eq!(loaded_ids.first().map(String::as_str), Some("msg-0106"));
+    assert_eq!(loaded_ids.last().map(String::as_str), Some("msg-1105"));
+    assert!(loaded_ids.iter().any(|id| id == "msg-1050"));
+    assert!(!loaded_ids.iter().any(|id| id == "msg-0001"));
+    assert_eq!(
+        session.cache_initialization_state(),
+        CacheInitializationState::Ready
+    );
+
+    let loaded_compact_context = session.compact_context.read().await.clone();
+    assert_eq!(
+        loaded_compact_context
+            .as_ref()
+            .map(|record| record.to_id.as_str()),
+        Some("msg-1050")
+    );
+    assert_eq!(
+        session.compact_repair_state(),
+        CompactRepairState::NotNeeded
+    );
+}
+
+#[tokio::test]
+async fn init_session_cache_arms_compact_repair_only_for_errored_long_sessions_missing_summary() {
+    let _guard = test_mutex().lock().await;
+    let db = test_db().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let local_message_repo = SqliteMessageRepository::new(db.clone());
+
+    let session_id = format!("session-cache-repair-{}", uuid::Uuid::new_v4());
+    let mut metadata = build_session_metadata(&session_id);
+    metadata.status = SessionStatus::Error;
+    session_repo
+        .upsert_session(&metadata)
+        .await
+        .expect("session should be created");
+
+    for index in 1..=1105 {
+        local_message_repo
+            .insert(&build_message(&session_id, index))
+            .await
+            .expect("message insert should succeed");
+    }
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::from([(
+        session_id.clone(),
+        build_agent_session(metadata),
+    )])));
+
+    init_session_with_messages(&active_sessions, &session_id)
+        .await
+        .expect("cache init should succeed");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions
+            .get(&session_id)
+            .expect("active session should remain present");
+        assert_eq!(session.compact_repair_state(), CompactRepairState::Needed);
+        assert!(session.compact_context.read().await.is_none());
+    }
+}

--- a/src-tauri/tests/workflow_restart_state_tests.rs
+++ b/src-tauri/tests/workflow_restart_state_tests.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -56,13 +56,18 @@ fn build_agent_session(metadata: SessionMetadata) -> AgentSession {
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),
-        cache_initialized: Arc::new(AtomicBool::new(true)),
+        cache_state: Arc::new(AtomicU8::new(
+            tauri_mcp_agent_lib::agent::state::CacheInitializationState::Ready as u8,
+        )),
         last_synced_at: Arc::new(RwLock::new(Some(SystemTime::now()))),
         repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
         pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
         pending_approvals: Arc::new(RwLock::new(HashMap::new())),
         context_registry: Arc::new(ContextRegistry::new()),
         compact_context: Arc::new(RwLock::new(None)),
+        compact_repair_state: Arc::new(AtomicU8::new(
+            tauri_mcp_agent_lib::agent::state::CompactRepairState::NotNeeded as u8,
+        )),
         compaction: CompactionRuntimeState::new(),
         expected_response_id: Arc::new(RwLock::new(None)),
         cached_stable_prompt: Arc::new(RwLock::new(None)),

--- a/src/features/agent/lib/resource-attachment-operations.ts
+++ b/src/features/agent/lib/resource-attachment-operations.ts
@@ -4,7 +4,7 @@ import { getWorkspaceDir } from '@/lib/backend/workspace';
 import { workspacePathToFileUrl } from '@/lib/file-url';
 import { getMimeTypeFromFilename } from '@/lib/mime-utils';
 import { saveAgentFile } from '@/features/agent/api/agent-backend';
-import type { AttachmentReference } from '@/models/chat';
+import type { AttachmentAgentAccess, AttachmentReference } from '@/models/chat';
 import {
   convertToBlobUrl,
   extractFilenameFromUrl,
@@ -18,11 +18,75 @@ const TEXT_EXTENSIONS =
 const SUPPORTED_EXTENSIONS =
   /\.(txt|md|markdown|json|jsonc|json5|yaml|yml|toml|js|jsx|ts|tsx|mjs|cjs|py|rb|rs|go|java|c|cpp|h|hpp|css|scss|less|html|htm|svg|sh|bash|zsh|fish|ps1|sql|graphql|csv|log|xml|proto|pdf|docx|xlsx)$/i;
 
+const BINARY_WORKSPACE_EXTENSIONS = /\.(pdf|docx|xlsx)$/i;
+
 function isTextFile(filename: string, mimeType: string): boolean {
   return (
     /^text\/|\/(json|xml|javascript|typescript)/.test(mimeType) ||
     TEXT_EXTENSIONS.test(filename)
   );
+}
+
+function classifyWorkspaceAccessMode(
+  filename: string,
+  mimeType: string,
+): 'workspace-text' | 'workspace-binary' {
+  if (isTextFile(filename, mimeType)) {
+    return 'workspace-text';
+  }
+
+  if (
+    BINARY_WORKSPACE_EXTENSIONS.test(filename) ||
+    /^(image|audio|video)\//.test(mimeType)
+  ) {
+    return 'workspace-binary';
+  }
+
+  return 'workspace-binary';
+}
+
+function buildIndexedAgentAccess(): AttachmentAgentAccess {
+  return {
+    mode: 'indexed',
+    reason: 'indexed',
+    note: 'Indexed in the attachments store. Use attachments tools such as list/read/search instead of guessing via workspace tools.',
+  };
+}
+
+function buildInlineAgentAccess(): AttachmentAgentAccess {
+  return {
+    mode: 'inline-media',
+    reason: 'inline_media',
+    note: 'Inline media attachment. The model should use the media payload already attached to the message, not attachments or workspace text tools.',
+  };
+}
+
+function buildWorkspaceOnlyAgentAccess(
+  filename: string,
+  mimeType: string,
+  reason: 'unsupported_extension' | 'processing_failed',
+): AttachmentAgentAccess {
+  const mode = classifyWorkspaceAccessMode(filename, mimeType);
+
+  if (mode === 'workspace-text') {
+    return {
+      mode,
+      reason,
+      note:
+        reason === 'processing_failed'
+          ? 'Stored in the workspace because normal attachment processing failed. Do not use attachments tools for this file; use workspace__readFile if you need the text content.'
+          : 'Stored in the workspace only. It is not indexed in the attachments store, so attachments tools will not find it. Use workspace__readFile for text inspection.',
+    };
+  }
+
+  return {
+    mode,
+    reason,
+    note:
+      reason === 'processing_failed'
+        ? 'Stored in the workspace because normal attachment processing failed. It is a binary/non-text artifact, so attachments tools will not find it and workspace__readFile is not the right tool.'
+        : 'Stored in the workspace only because this binary/media type is not indexed in the attachments store. attachments tools will not find it, and workspace__readFile should not be used on it.',
+  };
 }
 
 interface AddAgentAttachmentArgs {
@@ -213,6 +277,7 @@ async function toInlineAttachment(
     lineCount: 0,
     preview: filename,
     uploadedAt: new Date().toISOString(),
+    agentAccess: buildInlineAgentAccess(),
     inlineContent: {
       type: inlineType,
       data: fallbackBase64Data,
@@ -228,6 +293,9 @@ export function toWorkspaceOnlyAttachment(
   mimeType: string,
   fileSize: number,
   workspacePath?: string,
+  reason:
+    | 'unsupported_extension'
+    | 'processing_failed' = 'unsupported_extension',
 ): AttachmentReference {
   logger.info(
     'File type not supported by Attachments, saving to workspace only',
@@ -246,6 +314,7 @@ export function toWorkspaceOnlyAttachment(
     preview: filename,
     uploadedAt: new Date().toISOString(),
     workspacePath,
+    agentAccess: buildWorkspaceOnlyAgentAccess(filename, mimeType, reason),
   };
 }
 
@@ -313,6 +382,7 @@ async function commitAttachmentToStore(
     chunkCount: result.chunkCount,
     lastAccessedAt: new Date().toISOString(),
     workspacePath: resolvedWorkspacePath,
+    agentAccess: buildIndexedAgentAccess(),
   };
 }
 
@@ -379,6 +449,7 @@ export async function addAgentAttachment({
           source.actualMimeType,
           source.fileSize,
           source.workspacePath,
+          'processing_failed',
         );
       }
     }
@@ -390,6 +461,7 @@ export async function addAgentAttachment({
         source.actualMimeType,
         source.fileSize,
         source.workspacePath,
+        'unsupported_extension',
       );
     }
 
@@ -417,6 +489,7 @@ export async function addAgentAttachment({
         source.actualMimeType,
         source.fileSize,
         source.workspacePath,
+        'processing_failed',
       );
     }
   } finally {

--- a/src/features/agent/lib/resource-attachment-operations.ts
+++ b/src/features/agent/lib/resource-attachment-operations.ts
@@ -49,7 +49,7 @@ function buildIndexedAgentAccess(): AttachmentAgentAccess {
   return {
     mode: 'indexed',
     reason: 'indexed',
-    note: 'Indexed in the attachments store. Use attachments tools such as list/read/search instead of guessing via workspace tools.',
+    note: 'Indexed in the attachments store. Use attachments__list, attachments__read, and attachments__search instead of guessing via workspace tools.',
   };
 }
 

--- a/src/features/settings/components/DangerZoneSettings.tsx
+++ b/src/features/settings/components/DangerZoneSettings.tsx
@@ -231,7 +231,7 @@ export function DangerZoneSettings({
                         });
                       }}
                       disabled={isResetting || !isFactoryResetConfirmed}
-                      className="bg-destructive text-white hover:bg-destructive/90"
+                      className="bg-destructive text-white hover:bg-destructive/90 dark:bg-destructive/60"
                     >
                       {isResetting && (
                         <LoadingSpinner size="sm" className="mr-2" />

--- a/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/features/settings/tabs/GeneralTab.tsx
@@ -321,7 +321,7 @@ function GeneralTabComponent({
                   onChange={(e) =>
                     onDisplaySettingsChange('showTokenSpeed', e.target.checked)
                   }
-                  className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  className="w-4 h-4 rounded border-input text-primary focus:ring-primary"
                 />
                 <span className="text-muted-foreground font-medium">
                   {t('settings.display.showTokenSpeed', 'Show Token Speed')}
@@ -343,7 +343,7 @@ function GeneralTabComponent({
                   onChange={(e) =>
                     onDisplaySettingsChange('compactMetrics', e.target.checked)
                   }
-                  className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  className="w-4 h-4 rounded border-input text-primary focus:ring-primary"
                 />
                 <span className="text-muted-foreground font-medium">
                   {t('settings.display.compactMetrics', 'Compact Metrics')}

--- a/src/lib/__tests__/message-preprocessor.test.ts
+++ b/src/lib/__tests__/message-preprocessor.test.ts
@@ -91,10 +91,12 @@ describe('message-preprocessor', () => {
       expect(text).toContain('"filename": "test.txt"');
       expect(text).toContain('"mode": "indexed"');
       expect(text).toContain(
-        'read(contentId: "content-1", fromLine: 1, toLine: 200)',
+        'attachments__read(contentId: "content-1", fromLine: 1, toLine: 200)',
       );
-      expect(text).toContain('search(query: "your search query")');
-      expect(text).toContain('list()');
+      expect(text).toContain(
+        'attachments__search(query: "your search query")',
+      );
+      expect(text).toContain('attachments__list()');
     });
 
     it('logs the effective default for includeLatestMediaPayload', async () => {

--- a/src/lib/__tests__/message-preprocessor.test.ts
+++ b/src/lib/__tests__/message-preprocessor.test.ts
@@ -89,6 +89,7 @@ describe('message-preprocessor', () => {
 
       expect(text).toContain('<attachment_0>');
       expect(text).toContain('"filename": "test.txt"');
+      expect(text).toContain('"mode": "indexed"');
       expect(text).toContain(
         'read(contentId: "content-1", fromLine: 1, toLine: 200)',
       );
@@ -148,10 +149,8 @@ describe('message-preprocessor', () => {
       const text = (processed.content[1] as MCPTextContent).text;
 
       expect(text).toContain('workspace__readFile(path: "/path/to/file.txt")');
-      expect(text).toContain('list()');
-      expect(text).toContain(
-        'read(contentId: <id from list>, fromLine: 1, toLine: 200)',
-      );
+      expect(text).toContain('"mode": "workspace-text"');
+      expect(text).toContain('attachments tools: do not use them for this file');
     });
 
     it('should append attachment hints for metadata-only files', async () => {
@@ -176,7 +175,31 @@ describe('message-preprocessor', () => {
       const text = (processed.content[1] as MCPTextContent).text;
 
       expect(text).toContain('File metadata only');
-      expect(text).toContain('list()');
+      expect(text).toContain('"mode": "metadata-only"');
+    });
+
+    it('marks workspace-only binary attachments as not readable through text tools', async () => {
+      const message = createMessage({
+        attachments: [
+          {
+            sessionId: 'session-1',
+            workspacePath: '/path/to/video.mp4',
+            filename: 'video.mp4',
+            mimeType: 'video/mp4',
+            size: 1024,
+            lineCount: 0,
+            preview: 'video.mp4',
+            uploadedAt: new Date().toISOString(),
+            status: 'workspace-only',
+          },
+        ],
+      });
+
+      const processed = await prepareMessageForLLM(message);
+      const text = (processed.content[1] as MCPTextContent).text;
+
+      expect(text).toContain('"mode": "workspace-binary"');
+      expect(text).toContain('workspace__readFile: do not use it; this is binary/non-text');
     });
 
     it('should handle multiple attachments', async () => {
@@ -553,6 +576,11 @@ describe('message-preprocessor', () => {
       ) as MCPTextContent[];
       expect(
         olderTextBlocks.some((c) => c.text.includes('<historical_media_0>')),
+      ).toBe(true);
+      expect(
+        olderTextBlocks.some((c) =>
+          c.text.includes('Do not call attachments tools or workspace__readFile'),
+        ),
       ).toBe(true);
 
       const latestImageBlocks = processedLatest.content.filter(

--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -2,7 +2,7 @@ import { Message } from '@/models/chat';
 import type { MCPContent } from '@/lib/mcp/protocol/content';
 import { getLogger } from './logger';
 import { stringToMCPContentArray } from './utils';
-import type { AttachmentReference } from '@/models/chat';
+import type { AttachmentAgentAccess, AttachmentReference } from '@/models/chat';
 import { readLocalFileAsBase64 } from '@/lib/backend/workspace';
 
 const logger = getLogger('message-preprocessor');
@@ -31,17 +31,132 @@ function truncateText(value: string, maxLength: number): string {
 function createAttachmentHintPayload(
   attachment: AttachmentReference,
 ): AttachmentReference {
-  if (
+  const preview =
     typeof attachment.preview === 'string' &&
     attachment.preview.length > ATTACHMENT_PREVIEW_CHAR_LIMIT
+      ? truncateText(attachment.preview, ATTACHMENT_PREVIEW_CHAR_LIMIT)
+      : attachment.preview;
+
+  return {
+    ...attachment,
+    preview,
+    agentAccess: deriveAttachmentAgentAccess(attachment),
+  };
+}
+
+function isWorkspaceTextReadable(attachment: AttachmentReference): boolean {
+  if (
+    /^text\/|\/(json|xml|javascript|typescript)/.test(attachment.mimeType) ||
+    /\.(txt|md|markdown|json|jsonc|json5|yaml|yml|toml|js|jsx|ts|tsx|mjs|cjs|py|rb|rs|go|java|c|cpp|h|hpp|css|scss|less|html|htm|svg|sh|bash|zsh|fish|ps1|sql|graphql|csv|log|xml|proto)$/i.test(
+      attachment.filename,
+    )
   ) {
+    return true;
+  }
+
+  return false;
+}
+
+function deriveAttachmentAgentAccess(
+  attachment: AttachmentReference,
+): AttachmentAgentAccess {
+  if (attachment.agentAccess) {
+    return attachment.agentAccess;
+  }
+
+  if (attachment.contentId || attachment.status === 'committed') {
     return {
-      ...attachment,
-      preview: truncateText(attachment.preview, ATTACHMENT_PREVIEW_CHAR_LIMIT),
+      mode: 'indexed',
+      reason: 'indexed',
+      note: 'Indexed in the attachments store. Use attachments tools such as list/read/search.',
     };
   }
 
-  return attachment;
+  if (attachment.status === 'inline' || attachment.inlineContent) {
+    return {
+      mode: 'inline-media',
+      reason: 'inline_media',
+      note: 'Inline media attachment. Use the media payload already present in the message instead of attachments or workspace text tools.',
+    };
+  }
+
+  if (attachment.workspacePath) {
+    return isWorkspaceTextReadable(attachment)
+      ? {
+          mode: 'workspace-text',
+          reason: 'workspace_only',
+          note: 'Workspace-only attachment. attachments tools will not find it; use workspace__readFile if you need the text content.',
+        }
+      : {
+          mode: 'workspace-binary',
+          reason: 'workspace_only',
+          note: 'Workspace-only binary/media attachment. attachments tools will not find it, and workspace__readFile is not appropriate.',
+        };
+  }
+
+  return {
+    mode: 'metadata-only',
+    reason: 'metadata_only',
+    note: 'Only metadata is available. Do not assume this attachment is readable until the storage mode is clarified.',
+  };
+}
+
+function buildAttachmentGuidanceLines(
+  attachment: AttachmentReference,
+  access: AttachmentAgentAccess,
+): string[] {
+  const lines = [
+    'Agent guidance:',
+    `- Access mode: ${access.mode}`,
+    `- Reason: ${access.reason}`,
+    `- ${access.note}`,
+  ];
+
+  if (attachment.workspacePath) {
+    lines.push(`- Workspace path: ${attachment.workspacePath}`);
+  }
+
+  switch (access.mode) {
+    case 'indexed':
+      if (attachment.contentId) {
+        lines.push(
+          '- Valid tools: attachments list/read/search',
+          `- Read full content: read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
+          '- Search indexed content: search(query: "your search query")',
+          '- List indexed attachments: list()',
+        );
+      }
+      break;
+    case 'workspace-text':
+      if (attachment.workspacePath) {
+        lines.push(
+          '- attachments tools: do not use them for this file',
+          `- Read text via workspace: workspace__readFile(path: "${attachment.workspacePath}")`,
+        );
+      }
+      break;
+    case 'workspace-binary':
+      lines.push(
+        '- attachments tools: do not use them for this file',
+        '- workspace__readFile: do not use it; this is binary/non-text',
+        '- Refer to the file by filename/path or use a media/specialized tool if one exists',
+      );
+      break;
+    case 'inline-media':
+      lines.push(
+        '- The media payload is already part of the message content',
+        '- Do not call attachments tools or workspace__readFile for this attachment',
+      );
+      break;
+    case 'metadata-only':
+      lines.push(
+        '- File metadata only — do not guess a read path',
+        '- Clarify storage mode before attempting tool calls',
+      );
+      break;
+  }
+
+  return lines;
 }
 
 function estimateTextTokens(text: string): number {
@@ -164,6 +279,7 @@ function summarizeInlineAttachment(
   index: number,
 ): string {
   const source = attachment.inlineContent;
+  const access = deriveAttachmentAgentAccess(attachment);
   return buildHistoricalMediaSummary(index, {
     kind: source?.type ?? 'unknown',
     filename: attachment.filename,
@@ -172,6 +288,8 @@ function summarizeInlineAttachment(
     uploadedAt: attachment.uploadedAt,
     uri: source?.uri,
     hasInlineBytes: typeof source?.data === 'string' && source.data.length > 0,
+    agentAccess: access,
+    note: 'Inline media history item. Do not call attachments tools or workspace__readFile for it.',
   });
 }
 
@@ -188,6 +306,7 @@ function summarizeHistoricalMediaItem(
     mimeType: item.mimeType ?? source?.mimeType,
     uri,
     embeddedBytes: rawData ? estimateBase64Bytes(rawData) : undefined,
+    note: 'Historical media item. Do not call attachments tools or workspace__readFile for it.',
   });
 }
 
@@ -436,23 +555,15 @@ export async function prepareMessageForLLM(
     // Build text hint blocks for workspace/committed attachments
     const attachmentHintBlocks = textAttachments.map((attachment, i) => {
       const safeAttachment = createAttachmentHintPayload(attachment);
-      const accessHints = attachment.contentId
-        ? `To read the full content of this file, use:
-- read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)
-- For keyword search: search(query: "your search query")
-- For file list: list()`
-        : attachment.workspacePath
-          ? `This file is in your workspace (may not be indexed in content store yet):
-- To read it via workspace: workspace__readFile(path: "${attachment.workspacePath}")
-- To check if it has been indexed: list()
-- If listed, use read(contentId: <id from list>, fromLine: 1, toLine: 200)`
-          : `File metadata only — use list() to find available files`;
+      const access = deriveAttachmentAgentAccess(safeAttachment);
+      const guidance = buildAttachmentGuidanceLines(
+        safeAttachment,
+        access,
+      ).join('\n');
 
       return `<attachment_${i}>
 ${JSON.stringify(safeAttachment, null, 2)}
-<!--
-${accessHints}
--->
+${guidance}
 </attachment_${i}>`;
     });
 

--- a/src/lib/message-preprocessor.ts
+++ b/src/lib/message-preprocessor.ts
@@ -68,7 +68,7 @@ function deriveAttachmentAgentAccess(
     return {
       mode: 'indexed',
       reason: 'indexed',
-      note: 'Indexed in the attachments store. Use attachments tools such as list/read/search.',
+      note: 'Indexed in the attachments store. Use attachments tools such as attachments__list, attachments__read, and attachments__search.',
     };
   }
 
@@ -120,10 +120,10 @@ function buildAttachmentGuidanceLines(
     case 'indexed':
       if (attachment.contentId) {
         lines.push(
-          '- Valid tools: attachments list/read/search',
-          `- Read full content: read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
-          '- Search indexed content: search(query: "your search query")',
-          '- List indexed attachments: list()',
+          '- Valid tools: attachments__list, attachments__read, attachments__search',
+          `- Read full content: attachments__read(contentId: "${attachment.contentId}", fromLine: 1, toLine: 200)`,
+          '- Search indexed content: attachments__search(query: "your search query")',
+          '- List indexed attachments: attachments__list()',
         );
       }
       break;

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -28,6 +28,23 @@ export interface UIResource {
   blob?: string; // base64-encoded content when used
 }
 
+export interface AttachmentAgentAccess {
+  mode:
+    | 'indexed'
+    | 'workspace-text'
+    | 'workspace-binary'
+    | 'inline-media'
+    | 'metadata-only';
+  reason:
+    | 'indexed'
+    | 'workspace_only'
+    | 'unsupported_extension'
+    | 'processing_failed'
+    | 'inline_media'
+    | 'metadata_only';
+  note: string;
+}
+
 // MCP file attachment reference type
 export interface AttachmentReference {
   sessionId: string; // MCP file store ID (same as session ID)
@@ -43,6 +60,12 @@ export interface AttachmentReference {
   workspacePath?: string; // File path where it's saved in the workspace
   // Explicit state tracking (replaces brittle contentId prefix checking)
   status: 'pending' | 'committed' | 'workspace-only' | 'inline' | 'processing'; // File upload/storage status
+  /**
+   * AI-facing access guidance for this attachment.
+   * This is intentionally separate from lifecycle status so prompts can tell the
+   * model which tool family is valid without guessing from contentId/workspacePath.
+   */
+  agentAccess?: AttachmentAgentAccess;
   pendingId?: string; // Temporary ID for pending files (before commit)
   // For pending files only - used during upload process
   originalUrl?: string; // Original URL or blob URL

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,37 @@ import viteConfig from './vite.config';
 // Call the function to get the config object
 const viteConfigObject = viteConfig({ command: 'serve', mode: 'test' });
 
+function parsePositiveIntEnv(name: string): number | undefined {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseBooleanEnv(name: string): boolean | undefined {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return undefined;
+  }
+
+  if (rawValue === 'true') {
+    return true;
+  }
+
+  if (rawValue === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+
+const maxWorkers = parsePositiveIntEnv('VITEST_MAX_WORKERS');
+const minWorkers = parsePositiveIntEnv('VITEST_MIN_WORKERS');
+const fileParallelism = parseBooleanEnv('VITEST_FILE_PARALLELISM');
+
 export default mergeConfig(
   viteConfigObject,
   defineConfig({
@@ -14,6 +45,9 @@ export default mergeConfig(
       setupFiles: './src/test/setup.ts',
       css: true,
       exclude: [...configDefaults.exclude, 'aur/**', '.worktrees/**'],
+      ...(maxWorkers ? { maxWorkers } : {}),
+      ...(minWorkers ? { minWorkers } : {}),
+      ...(fileParallelism !== undefined ? { fileParallelism } : {}),
     },
   }),
 );


### PR DESCRIPTION
## Summary
- fix session cache initialization so recent slices preserve compaction boundaries on resume
- add explicit cache/repair state transitions and re-arm repair after compaction failures
- keep full refactor validation while applying adaptive resource caps and add regression coverage

## Validation
- cargo test --test compact_error_recovery_tests --test session_cache_recent_slice_regression_tests --test workflow_restart_state_tests
- pnpm refactor:validate