### PR TITLE
🎨 Palette: Remove redundant action verbs from BaseBubble aria-label

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Redundant ARIA Toggle Labels
+**Learning:** Screen readers natively announce the expanded or collapsed state of elements with the `aria-expanded` attribute. Including action words like "Toggle" in the `aria-label` creates redundant and overly verbose announcements.
+**Action:** For toggle buttons and accordions using `aria-expanded`, set the `aria-label` to simply describe the content (e.g., the `title`) without action verbs.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-24 - Redundant ARIA Toggle Labels
+## 2026-05-24 - Redundant ARIA Toggle Labels
 **Learning:** Screen readers natively announce the expanded or collapsed state of elements with the `aria-expanded` attribute. Including action words like "Toggle" in the `aria-label` creates redundant and overly verbose announcements.
 **Action:** For toggle buttons and accordions using `aria-expanded`, set the `aria-label` to simply describe the content (e.g., the `title`) without action verbs.

--- a/src/components/ui/BaseBubble.tsx
+++ b/src/components/ui/BaseBubble.tsx
@@ -60,10 +60,7 @@ export const BaseBubble: React.FC<BaseBubbleProps> = ({
             onClick={() => setIsExpanded(!isExpanded)}
             aria-expanded={isExpanded}
             aria-controls={contentId}
-            aria-label={
-              toggleAriaLabel ||
-              t('baseBubble.toggle', { title, defaultValue: `Toggle ${title}` })
-            }
+            aria-label={toggleAriaLabel || title}
             className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors rounded-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
           >
             {isExpanded ? (


### PR DESCRIPTION
💡 What: Removed the 'Toggle' action verb from the BaseBubble toggle button's aria-label.
🎯 Why: Screen readers natively announce the expanded/collapsed state via the aria-expanded attribute. Including 'Toggle' makes the announcement overly verbose and redundant.
📸 Before/After: N/A (Non-visual change)
♿ Accessibility: Improved screen reader clarity by avoiding redundant state announcements.

---
*PR created automatically by Jules for task [6090148260877392056](https://jules.google.com/task/6090148260877392056) started by @fritzprix*