### PR TITLE
⚡ Bolt: Add lazy loading to images

### DIFF
--- a/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/MediaContentRenderer.tsx
@@ -269,10 +269,13 @@ export function ImageContentRenderer({
         </Tooltip>
       </div>
 
+      {/* ⚡ Bolt: Added lazy loading and async decoding to prevent blocking main thread and eager loading offscreen images */}
       <img
         key={itemKey}
         src={imageSrc}
         alt={t('agent.mediaRenderer.imageAlt')}
+        loading="lazy"
+        decoding="async"
         className="h-auto max-w-full rounded-lg border border-border/10 shadow-sm"
       />
     </div>

--- a/src/features/mcp-servers/components/RecommendedPresets.tsx
+++ b/src/features/mcp-servers/components/RecommendedPresets.tsx
@@ -190,9 +190,12 @@ export const RecommendedPresets: React.FC<RecommendedPresetsProps> = ({
             <div className="flex items-center gap-2 min-w-0">
               <div className="w-6 h-6 rounded overflow-hidden flex-shrink-0 border border-border/50">
                 {preset.logo ? (
+                  /* ⚡ Bolt: Added lazy loading and async decoding to improve scroll performance for long lists */
                   <img
                     src={preset.logo}
                     alt={preset.name}
+                    loading="lazy"
+                    decoding="async"
                     className="w-full h-full object-contain"
                     onError={(e) => {
                       (e.currentTarget as HTMLImageElement).style.display =

--- a/src/features/mcp-servers/components/ServerCard.tsx
+++ b/src/features/mcp-servers/components/ServerCard.tsx
@@ -53,9 +53,12 @@ export const ServerCard = React.memo(
             {/* Server logo */}
             <div className="w-8 h-8 rounded-md overflow-hidden flex-shrink-0 mt-0.5 border border-border/50">
               {server.metadata?.logo ? (
+                /* ⚡ Bolt: Added lazy loading and async decoding to prevent eager loading of background images */
                 <img
                   src={server.metadata.logo}
                   alt={serverName}
+                  loading="lazy"
+                  decoding="async"
                   className="w-full h-full object-contain"
                   onError={(e) => {
                     (e.currentTarget as HTMLImageElement).style.display =


### PR DESCRIPTION
💡 What: Added `loading="lazy"` and `decoding="async"` to images rendered across the application.
   
🎯 Why: Images below the fold or in background tabs were being eagerly loaded and decoded synchronously on the main thread, causing unnecessary network usage and layout blocking during initial render.
   
📊 Impact: Faster initial load time, less initial network overhead, and prevents main thread blocking on large images.
   
🔬 Measurement: Verify using network panel that images are only loaded when they enter the viewport, and main thread is less blocked during render.

---
*PR created automatically by Jules for task [5392845497504883237](https://jules.google.com/task/5392845497504883237) started by @fritzprix*