### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in workspace export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Path traversal in `FileExportService::create_zip_export` where `package_name` is directly interpolated into a path passed to `temp_dir.path().join()`.
 **Learning:** `Path::join` allows directory traversal if the right-hand side contains relative components like `..`, potentially escaping intended directories (e.g., `temp_dir`). This can be exploited to overwrite arbitrary files when creating zip exports.
 **Prevention:** Sanitize variables from external input used in path constructions, even for temporary filenames. Replace non-alphanumeric characters with safe alternatives like underscores.
+## 2024-05-31 - Path Traversal in MCP Workspace Export Package Name
+**Vulnerability:** Path traversal vulnerability in `export_operations.rs` where the `name` parameter from the MCP request is directly used to construct the ZIP export filename (`{package_name}_{timestamp}.zip`).
+**Learning:** External user input, even when used only for a portion of a filename, can contain path traversal characters (like `../`) that alter the final resolved path when used with `Path::join`, potentially allowing files to be written outside the intended directory.
+**Prevention:** Always sanitize user-provided filename inputs (e.g., using `sanitize_package_name` to remove or replace non-alphanumeric characters) before interpolating them into paths.

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -171,9 +171,10 @@ impl WorkspaceServer {
         }
 
         // === ZIP PACKAGE EXPORT ===
-        let package_name = crate::services::file_export_service::FileExportService::sanitize_package_name(
-            &name_param.unwrap_or_else(|| "workspace_export".to_string()),
-        );
+        let package_name =
+            crate::services::file_export_service::FileExportService::sanitize_package_name(
+                &name_param.unwrap_or_else(|| "workspace_export".to_string()),
+            );
         let zip_filename = format!("{package_name}_{timestamp}.zip");
         let zip_path = exports_dir.join("packages").join(&zip_filename);
 

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -171,7 +171,9 @@ impl WorkspaceServer {
         }
 
         // === ZIP PACKAGE EXPORT ===
-        let package_name = name_param.unwrap_or_else(|| "workspace_export".to_string());
+        let package_name = crate::services::file_export_service::FileExportService::sanitize_package_name(
+            &name_param.unwrap_or_else(|| "workspace_export".to_string()),
+        );
         let zip_filename = format!("{package_name}_{timestamp}.zip");
         let zip_path = exports_dir.join("packages").join(&zip_filename);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `name` parameter in the workspace export operation is used without sanitization to construct the zip package filename, allowing path traversal characters (like `../`) to manipulate the output path.
🎯 Impact: An attacker could write the exported zip package outside the intended `.libragent/exports/packages` directory, potentially overwriting sensitive files on the system.
🔧 Fix: Sanitized the `package_name` using `FileExportService::sanitize_package_name` before interpolating it into the zip filename.
✅ Verification: Tests passing, code reviewed, manual review confirms safe path constructions.

---
*PR created automatically by Jules for task [13949229092951120377](https://jules.google.com/task/13949229092951120377) started by @fritzprix*