### PR TITLE
Add anchored editFiles diff preview

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
@@ -1,7 +1,276 @@
+use super::super::utils::{compute_anchor, initial_prefix_hash_state};
 use super::types::{EditAction, PreparedFileEdit};
 use crate::mcp::builtin::error_guidance::SuccessHint;
 use crate::mcp::types::MCPResult;
 use serde_json::json;
+
+const MAX_DIFF_PREVIEW_LINES: usize = 50;
+const DIFF_CONTEXT_LINES: usize = 1;
+
+#[derive(Clone)]
+struct AnchoredLine {
+    line_number: usize,
+    content: String,
+    anchor: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DiffPreviewKind {
+    Context,
+    Added,
+    Removed,
+}
+
+#[derive(Clone)]
+struct DiffPreviewLine {
+    kind: DiffPreviewKind,
+    content: String,
+    line_number: usize,
+    anchor: Option<String>,
+}
+
+impl DiffPreviewLine {
+    fn render_hashline(&self) -> String {
+        match self.anchor.as_deref() {
+            Some(anchor) => format!("{}:{}|{}", self.line_number, anchor, self.content),
+            None => format!("{}|{}", self.line_number, self.content),
+        }
+    }
+
+    fn render(&self) -> String {
+        match self.kind {
+            DiffPreviewKind::Context => format!("  {}", self.render_hashline()),
+            DiffPreviewKind::Added => format!("+ {}", self.render_hashline()),
+            DiffPreviewKind::Removed => format!("- {}", self.render_hashline()),
+        }
+    }
+}
+
+fn build_anchored_lines(content: &str) -> Vec<AnchoredLine> {
+    let mut prefix_state = initial_prefix_hash_state();
+
+    content
+        .lines()
+        .enumerate()
+        .map(|(idx, line)| AnchoredLine {
+            line_number: idx + 1,
+            content: line.to_string(),
+            anchor: compute_anchor(line, &mut prefix_state),
+        })
+        .collect()
+}
+
+fn push_context_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+    lines.push(DiffPreviewLine {
+        kind: DiffPreviewKind::Context,
+        content: line.content.clone(),
+        line_number: line.line_number,
+        anchor: Some(line.anchor.clone()),
+    });
+}
+
+fn push_added_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+    lines.push(DiffPreviewLine {
+        kind: DiffPreviewKind::Added,
+        content: line.content.clone(),
+        line_number: line.line_number,
+        anchor: Some(line.anchor.clone()),
+    });
+}
+
+fn push_removed_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+    lines.push(DiffPreviewLine {
+        kind: DiffPreviewKind::Removed,
+        content: line.content.clone(),
+        line_number: line.line_number,
+        anchor: Some(line.anchor.clone()),
+    });
+}
+
+fn build_preview_lines(
+    batch: &PreparedFileEdit,
+    original_lines: &[AnchoredLine],
+    new_lines: &[AnchoredLine],
+) -> Vec<DiffPreviewLine> {
+    let mut preview_lines = Vec::new();
+    let mut sorted_edits = batch.edits.clone();
+    sorted_edits.sort_by_key(|edit| edit.start_line);
+
+    let mut current_old_idx = 0usize;
+    let mut current_new_idx = 0usize;
+    let mut line_delta = 0i64;
+
+    for edit in sorted_edits {
+        let original_line_count = match edit.action {
+            EditAction::InsertAfter => 0usize,
+            EditAction::Delete | EditAction::Replace => edit.end_line - edit.start_line + 1,
+        };
+        let replacement_line_count = edit.replacement_line_count();
+        let old_start_idx = match edit.action {
+            EditAction::InsertAfter => edit.start_line,
+            EditAction::Delete | EditAction::Replace => edit.start_line.saturating_sub(1),
+        }
+        .min(original_lines.len());
+        let old_end_idx = match edit.action {
+            EditAction::InsertAfter => old_start_idx,
+            EditAction::Delete | EditAction::Replace => edit.end_line.min(original_lines.len()),
+        };
+        let mapped_new_start = match edit.action {
+            EditAction::InsertAfter => edit.start_line as i64 + line_delta,
+            EditAction::Delete | EditAction::Replace => edit.start_line as i64 - 1 + line_delta,
+        };
+        let new_start_idx = if mapped_new_start <= 0 {
+            0
+        } else {
+            mapped_new_start as usize
+        }
+        .min(new_lines.len());
+        let new_end_idx = (new_start_idx + replacement_line_count).min(new_lines.len());
+
+        while current_old_idx < old_start_idx && current_new_idx < new_start_idx {
+            push_context_line(&mut preview_lines, &new_lines[current_new_idx]);
+            current_old_idx += 1;
+            current_new_idx += 1;
+        }
+
+        let original_slice = &original_lines[old_start_idx..old_end_idx];
+        let new_slice = &new_lines[new_start_idx..new_end_idx];
+        let slices_match = original_slice.len() == new_slice.len()
+            && original_slice
+                .iter()
+                .zip(new_slice.iter())
+                .all(|(original_line, new_line)| original_line.content == new_line.content);
+
+        if slices_match {
+            for new_line in new_slice {
+                push_context_line(&mut preview_lines, new_line);
+            }
+        } else {
+            for original_line in original_slice {
+                push_removed_line(&mut preview_lines, original_line);
+            }
+            for new_line in new_slice {
+                push_added_line(&mut preview_lines, new_line);
+            }
+        }
+
+        current_old_idx = old_end_idx;
+        current_new_idx = new_end_idx;
+        line_delta += replacement_line_count as i64 - original_line_count as i64;
+    }
+
+    while current_old_idx < original_lines.len() && current_new_idx < new_lines.len() {
+        push_context_line(&mut preview_lines, &new_lines[current_new_idx]);
+        current_old_idx += 1;
+        current_new_idx += 1;
+    }
+
+    preview_lines
+}
+
+fn build_preview_ranges(preview_lines: &[DiffPreviewLine]) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+
+    for changed_idx in preview_lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| (line.kind != DiffPreviewKind::Context).then_some(idx))
+    {
+        let start = changed_idx.saturating_sub(DIFF_CONTEXT_LINES);
+        let end = (changed_idx + DIFF_CONTEXT_LINES + 1).min(preview_lines.len());
+
+        if let Some((_, last_end)) = ranges.last_mut() {
+            if start <= *last_end {
+                *last_end = (*last_end).max(end);
+                continue;
+            }
+        }
+
+        ranges.push((start, end));
+    }
+
+    ranges
+}
+
+/// Generate a git-style diff preview with anchor annotations for changed lines.
+fn build_diff_with_anchors(batch: &PreparedFileEdit) -> String {
+    let original_lines = build_anchored_lines(&batch.original_content);
+    let new_lines = build_anchored_lines(&batch.new_content);
+    let preview_lines = build_preview_lines(batch, &original_lines, &new_lines);
+    let preview_ranges = build_preview_ranges(&preview_lines);
+
+    if preview_ranges.is_empty() {
+        return "  (no line-level changes to preview)".to_string();
+    }
+
+    let total_selected_lines: usize = preview_ranges
+        .iter()
+        .map(|(start, end)| end.saturating_sub(*start))
+        .sum();
+    let mut rendered_lines: Vec<(String, bool)> = Vec::new();
+    let mut emitted_lines = 0usize;
+    let mut emitted_selected_lines = 0usize;
+    let mut previous_end = 0usize;
+    let mut truncated = false;
+
+    'ranges: for (range_index, (start, end)) in preview_ranges.iter().enumerate() {
+        if range_index > 0 {
+            let omitted_count = start.saturating_sub(previous_end);
+            if omitted_count > 0 {
+                if emitted_lines >= MAX_DIFF_PREVIEW_LINES {
+                    truncated = true;
+                    break;
+                }
+
+                rendered_lines.push((
+                    format!("  ... {} unchanged line(s) omitted", omitted_count),
+                    false,
+                ));
+                emitted_lines += 1;
+            }
+        }
+
+        for preview_line in &preview_lines[*start..*end] {
+            if emitted_lines >= MAX_DIFF_PREVIEW_LINES {
+                truncated = true;
+                break 'ranges;
+            }
+
+            rendered_lines.push((preview_line.render(), true));
+            emitted_lines += 1;
+            emitted_selected_lines += 1;
+        }
+
+        previous_end = *end;
+    }
+
+    if truncated {
+        let mut remaining_selected_lines =
+            total_selected_lines.saturating_sub(emitted_selected_lines);
+        if remaining_selected_lines > 0 {
+            if rendered_lines.len() >= MAX_DIFF_PREVIEW_LINES {
+                if let Some((_, was_selected_line)) = rendered_lines.pop() {
+                    if was_selected_line {
+                        remaining_selected_lines += 1;
+                    }
+                }
+            }
+            rendered_lines.push((
+                format!(
+                    "  ... {} more diff line(s) omitted",
+                    remaining_selected_lines
+                ),
+                false,
+            ));
+        }
+    }
+
+    rendered_lines
+        .into_iter()
+        .map(|(line, _)| line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) -> MCPResult {
     let mut file_sections = Vec::new();
@@ -45,10 +314,11 @@ pub(super) fn build_edit_files_success(prepared_batches: &[PreparedFileEdit]) ->
                 batch.new_hash_sections.join("\n...\n")
             )
         };
+        let diff_section = build_diff_with_anchors(batch);
 
         file_sections.push(format!(
-            "File: '{}'\nChanges:\n{}\nSummary: {}{}",
-            batch.path, edit_summary, diff_summary, anchors_section
+            "File: '{}'\nChanges:\n{}\nSummary: {}\n\nDiff:\n```diff\n{}\n```{}",
+            batch.path, edit_summary, diff_summary, diff_section, anchors_section
         ));
     }
 

--- a/src-tauri/tests/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/workspace_hash_anchor_tests.rs
@@ -27,6 +27,16 @@ fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> Works
     WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
 }
 
+fn extract_anchor(hashlines: &str, line_index: usize) -> String {
+    hashlines
+        .lines()
+        .nth(line_index)
+        .and_then(|line| line.split('|').next())
+        .and_then(|prefix| prefix.split(':').nth(1))
+        .expect("anchor")
+        .to_string()
+}
+
 #[test]
 fn anchored_line_format_uses_single_opaque_anchor() {
     let rendered = format_as_hashlines("alpha\nbeta");
@@ -450,6 +460,215 @@ async fn edit_files_delete_only_response_does_not_claim_new_anchors_exist() {
     assert!(
         !text.contains("Anchors above are current for the edited ranges"),
         "delete-only success must not claim that new anchors are available: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_files_success_response_includes_diff_block_with_anchor_annotations() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-success-diff-anchors";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+
+    let original_hashlines = format_as_hashlines("alpha\nbeta\n");
+    let first_anchor = extract_anchor(&original_hashlines, 0);
+    let new_hashlines = format_as_hashlines("ALPHA\nbeta\n");
+    let new_first_anchor = extract_anchor(&new_hashlines, 0);
+    let new_second_anchor = extract_anchor(&new_hashlines, 1);
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "sample.txt",
+                        "op": "replace",
+                        "startLine": 1,
+                        "startAnchor": first_anchor,
+                        "content": "ALPHA"
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit batch should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Diff:\n```diff"),
+        "success response should include a diff block: {text}"
+    );
+    assert!(
+        text.contains(&format!("- 1:{first_anchor}|alpha")),
+        "diff should annotate removed lines with their original anchor: {text}"
+    );
+    assert!(
+        text.contains(&format!("+ 1:{new_first_anchor}|ALPHA")),
+        "diff should annotate added lines with their new anchor: {text}"
+    );
+    assert!(
+        text.contains(&format!("  2:{new_second_anchor}|beta")),
+        "diff should render context lines in readFile hashline format: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_files_delete_only_response_includes_diff_block() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-delete-only-diff";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\ngamma\n")
+        .expect("write sample file");
+
+    let original_hashlines = format_as_hashlines("alpha\nbeta\ngamma\n");
+    let second_anchor = extract_anchor(&original_hashlines, 1);
+    let new_hashlines = format_as_hashlines("alpha\ngamma\n");
+    let alpha_anchor = extract_anchor(&new_hashlines, 0);
+    let gamma_anchor = extract_anchor(&new_hashlines, 1);
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "sample.txt",
+                        "op": "delete",
+                        "startLine": 2,
+                        "startAnchor": second_anchor,
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("edit batch should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("Diff:\n```diff"),
+        "delete-only success should still include a diff block: {text}"
+    );
+    assert!(
+        text.contains(&format!("- 2:{second_anchor}|beta")),
+        "delete-only diff should annotate the removed line with its original anchor: {text}"
+    );
+    assert!(
+        text.contains(&format!("  1:{alpha_anchor}|alpha"))
+            && text.contains(&format!("  2:{gamma_anchor}|gamma")),
+        "delete-only diff should keep surrounding context lines: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_files_diff_preview_truncates_large_changes() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-diff-preview-truncation";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    let original_content = (1..=220)
+        .map(|idx| format!("old-{idx:03}-{}", "x".repeat(480)))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    let updated_content = (1..=220)
+        .map(|idx| format!("new-{idx:03}-{}", "y".repeat(480)))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    std::fs::write(workspace_dir.join("sample.txt"), &original_content).expect("write sample file");
+
+    let original_hashlines = format_as_hashlines(&original_content);
+    let start_anchor = extract_anchor(&original_hashlines, 0);
+    let end_anchor = extract_anchor(&original_hashlines, 219);
+
+    let result = server
+        .handle_edit_files(
+            json!({
+                "edits": [
+                    {
+                        "path": "sample.txt",
+                        "op": "replace",
+                        "startLine": 1,
+                        "endLine": 220,
+                        "startAnchor": start_anchor,
+                        "endAnchor": end_anchor,
+                        "content": updated_content,
+                    }
+                ]
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("large edit batch should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("more diff line(s) omitted"),
+        "large diffs should be truncated instead of dumping the full file: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_files_diff_preview_omitted_count_ignores_gap_markers() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-files-diff-preview-gap-marker-count";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    let target_lines = [2usize, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52];
+    let original_content = (1..=60)
+        .map(|idx| format!("line-{idx:02}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    std::fs::write(workspace_dir.join("sample.txt"), &original_content).expect("write sample file");
+
+    let original_hashlines = format_as_hashlines(&original_content);
+    let anchor_lines: Vec<&str> = original_hashlines.lines().collect();
+    let edits = target_lines
+        .iter()
+        .map(|line_number| {
+            let start_anchor = anchor_lines[line_number - 1]
+                .split('|')
+                .next()
+                .and_then(|prefix| prefix.split(':').nth(1))
+                .expect("start anchor");
+
+            json!({
+                "path": "sample.txt",
+                "op": "replace",
+                "startLine": line_number,
+                "startAnchor": start_anchor,
+                "content": format!("updated-{line_number:02}"),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let result = server
+        .handle_edit_files(json!({ "edits": edits }), Some(session_id.to_string()))
+        .await
+        .expect("edit batch should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("  ... 4 more diff line(s) omitted"),
+        "truncation should count only omitted diff lines, not omitted-gap markers: {text}"
+    );
+    assert!(
+        !text.contains("  ... 5 more diff line(s) omitted"),
+        "gap markers must not inflate omitted diff line counts: {text}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add an inline diff preview to successful editFiles responses
- format diff lines with readFile-style hashlines so line/anchor parsing stays consistent
- cover replace, delete-only, truncation, and omitted-count edge cases in workspace hash anchor tests