### PR TITLE
Add default Sonner close buttons

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from 'next-themes';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({
@@ -9,6 +10,7 @@ const Toaster = ({
 }: ToasterProps) => {
   // Prefer resolvedTheme so the toaster receives the actual theme being used
   const { resolvedTheme } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <Sonner
@@ -16,7 +18,7 @@ const Toaster = ({
       theme={(resolvedTheme ?? 'system') as ToasterProps['theme']}
       className="toaster group"
       toastOptions={{
-        closeButtonAriaLabel: 'Dismiss notification',
+        closeButtonAriaLabel: t('common.close', 'Close'),
         ...toastOptions,
       }}
       style={

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -2,14 +2,23 @@ import { useTheme } from 'next-themes';
 import React from 'react';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = ({
+  closeButton = true,
+  toastOptions,
+  ...props
+}: ToasterProps) => {
   // Prefer resolvedTheme so the toaster receives the actual theme being used
   const { resolvedTheme } = useTheme();
 
   return (
     <Sonner
+      closeButton={closeButton}
       theme={(resolvedTheme ?? 'system') as ToasterProps['theme']}
       className="toaster group"
+      toastOptions={{
+        closeButtonAriaLabel: 'Dismiss notification',
+        ...toastOptions,
+      }}
       style={
         {
           '--normal-bg': 'var(--popover)',


### PR DESCRIPTION
## Summary
- enable Sonner close buttons by default in the shared toaster wrapper
- provide a default dismiss aria label via toastOptions
- keep the change scoped to the shared wrapper without altering individual toast flows

## Validation
- pnpm refactor:validate