### PR TITLE
Refine session history layout and rename flow

### DIFF
--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -27,7 +27,7 @@ pub use session_commands::{
     agent_init_session_with_messages, agent_list_attention_sessions, agent_list_sessions,
     agent_mark_session_viewed, agent_open_session, agent_resume_session, agent_set_execution_mode,
     agent_set_unsafe_mode, agent_set_yolo_mode, agent_toggle_session_bookmark,
-    agent_update_session_config,
+    agent_update_session_config, agent_update_session_name,
 };
 pub use ui_actions::agent_execute_ui_tauri_action;
 pub use workflow_commands::{

--- a/src-tauri/src/commands/agent_commands/session_commands.rs
+++ b/src-tauri/src/commands/agent_commands/session_commands.rs
@@ -304,6 +304,36 @@ pub async fn agent_toggle_session_bookmark(
         .map_err(|e| format!("Failed to toggle bookmark: {}", e))
 }
 
+/// Update the user-visible session title.
+#[command]
+pub async fn agent_update_session_name(
+    manager: State<'_, AgentSessionManager>,
+    session_id: String,
+    name: String,
+) -> Result<(), String> {
+    let trimmed_name = name.trim();
+    if trimmed_name.is_empty() {
+        return Err("Session title cannot be empty".to_string());
+    }
+
+    let normalized_name = trimmed_name.to_string();
+    let repo = get_session_repository();
+    repo.update_name(&session_id, normalized_name.clone())
+        .await
+        .map_err(|e| format!("Failed to update session title: {}", e))?;
+
+    let active_sessions = manager.active_sessions_arc();
+    let mut active = active_sessions.write().await;
+    if let Some(session) = active.get_mut(&session_id) {
+        session.metadata.name = Some(normalized_name);
+    }
+    drop(active);
+
+    crate::agent::tauri_events::emit_resource_updated("session", "update", Some(session_id));
+
+    Ok(())
+}
+
 /// Mark a session as viewed at the current time.
 #[command]
 pub async fn agent_mark_session_viewed(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,7 +43,7 @@ use commands::agent_commands::{
     agent_respond_channel_permission, agent_respond_tool_approval, agent_resume_session,
     agent_resume_workflow, agent_send_message, agent_set_execution_mode, agent_set_unsafe_mode,
     agent_set_yolo_mode, agent_terminate_workflow, agent_toggle_session_bookmark,
-    agent_update_session_config,
+    agent_update_session_config, agent_update_session_name,
 };
 use commands::assistant_crud_commands::{
     batch_upsert_assistants, create_assistant, delete_assistant, get_assistant,
@@ -269,6 +269,7 @@ pub fn run() {
                 agent_update_session_config,
                 agent_create_session_with_initial_message,
                 agent_toggle_session_bookmark,
+                agent_update_session_name,
                 agent_mark_session_viewed,
                 agent_set_yolo_mode,
                 agent_set_unsafe_mode,

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -150,6 +150,20 @@ impl SessionRepository for InMemorySessionRepository {
         Ok(())
     }
 
+    async fn update_name(&self, session_id: &str, name: String) -> Result<(), DbError> {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.name = Some(name);
+            log::debug!("InMemory: Updated session name for {}", session_id);
+        } else {
+            log::debug!(
+                "InMemory: Name update for non-existent session {} (idempotent skip)",
+                session_id
+            );
+        }
+        Ok(())
+    }
+
     /// Get all sessions stored in memory
     ///
     /// Returns sessions in arbitrary order (HashMap iteration order).

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -217,6 +217,9 @@ pub trait SessionRepository: Send + Sync {
         agent_config: Option<String>,
     ) -> Result<(), DbError>;
 
+    /// Update the user-visible session title without affecting activity ordering.
+    async fn update_name(&self, session_id: &str, name: String) -> Result<(), DbError>;
+
     /// Get all sessions
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError>;
 
@@ -418,6 +421,15 @@ impl SessionRepository for SqliteSessionRepository {
         active_model.update(&self.db).await?;
 
         Ok(())
+    }
+
+    async fn update_name(&self, session_id: &str, name: String) -> Result<(), DbError> {
+        self.apply_partial_update(session::ActiveModel {
+            id: Set(session_id.to_string()),
+            name: Set(Some(name)),
+            ..Default::default()
+        })
+        .await
     }
 
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {

--- a/src-tauri/tests/session_repository_tests.rs
+++ b/src-tauri/tests/session_repository_tests.rs
@@ -232,6 +232,29 @@ async fn toggle_bookmark_persists_boolean_value() {
 }
 
 #[tokio::test]
+async fn update_name_persists_title_without_touching_updated_at() {
+    let repo = setup_repo().await;
+    let session = build_session("test-rename", 42_000);
+
+    repo.upsert_session(&session)
+        .await
+        .expect("session should insert");
+
+    repo.update_name("test-rename", "Renamed Session".to_string())
+        .await
+        .expect("title update should persist");
+
+    let retrieved = repo
+        .get_session("test-rename")
+        .await
+        .expect("lookup should succeed")
+        .expect("session should exist");
+
+    assert_eq!(retrieved.name.as_deref(), Some("Renamed Session"));
+    assert_eq!(retrieved.updated_at, session.updated_at);
+}
+
+#[tokio::test]
 async fn get_session_coalesces_legacy_execution_flags() {
     let db = common::setup_test_db_with_migrations().await;
     let repo = SqliteSessionRepository::new(db.clone());

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   BrainCircuit,
   History,
+  BookmarkCheck,
   Network,
   Settings,
   Users,
@@ -27,6 +28,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '../ui/sidebar';
+import { Badge } from '../ui/badge';
 import { useAgentSessionListState } from '@/context/AgentSessionListContext';
 import { useUpdateContext } from '@/context/UpdateContext';
 import { buildChildrenMap } from '@/lib/session-utils';
@@ -69,6 +71,10 @@ export default function AppSidebar() {
   const hasUpdate = updateStatus === 'available';
 
   const { sessions } = useAgentSessionListState();
+  const bookmarkedCount = useMemo(
+    () => sessions.filter((session) => session.isBookmarked === true).length,
+    [sessions],
+  );
 
   /** Show up to 5 recent sessions with lightweight hierarchy cues. */
   const recentSessions = useMemo(() => {
@@ -178,6 +184,36 @@ export default function AppSidebar() {
                   >
                     <History className="shrink-0" />
                     <span>{t('sidebar.history')}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={
+                    location.pathname.startsWith('/history') &&
+                    location.hash === '#bookmarked-sessions'
+                  }
+                  tooltip={t('sidebar.bookmarked', 'Bookmarked')}
+                >
+                  <Link
+                    to="/history#bookmarked-sessions"
+                    className="flex w-full items-center justify-between gap-2"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <BookmarkCheck className="shrink-0" />
+                      <span className="truncate">
+                        {t('sidebar.bookmarked', 'Bookmarked')}
+                      </span>
+                    </div>
+                    {!isCollapsed && bookmarkedCount > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="h-5 shrink-0 px-1.5"
+                      >
+                        {bookmarkedCount}
+                      </Badge>
+                    )}
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -334,6 +370,9 @@ export default function AppSidebar() {
                           {session.name ||
                             `${t('sidebar.session')} ${session.id.slice(0, 8)}`}
                         </span>
+                        {session.isBookmarked && (
+                          <BookmarkCheck className="h-3.5 w-3.5 shrink-0 text-warning" />
+                        )}
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -70,7 +70,7 @@ export default function AppSidebar() {
   const { status: updateStatus } = useUpdateContext();
   const hasUpdate = updateStatus === 'available';
 
-  const { sessions } = useAgentSessionListState();
+  const { sessions, hasMoreSessions } = useAgentSessionListState();
   const bookmarkedCount = useMemo(
     () => sessions.filter((session) => session.isBookmarked === true).length,
     [sessions],
@@ -206,14 +206,16 @@ export default function AppSidebar() {
                         {t('sidebar.bookmarked', 'Bookmarked')}
                       </span>
                     </div>
-                    {!isCollapsed && bookmarkedCount > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="h-5 shrink-0 px-1.5"
-                      >
-                        {bookmarkedCount}
-                      </Badge>
-                    )}
+                    {!isCollapsed &&
+                      bookmarkedCount > 0 &&
+                      !hasMoreSessions && (
+                        <Badge
+                          variant="secondary"
+                          className="h-5 shrink-0 px-1.5"
+                        >
+                          {bookmarkedCount}
+                        </Badge>
+                      )}
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/context/AgentSessionContext.tsx
+++ b/src/context/AgentSessionContext.tsx
@@ -28,7 +28,7 @@ export function AgentSessionProvider({
   children,
   sessionId,
 }: AgentSessionProviderProps) {
-  const { markSessionViewed, clearPendingApproval } =
+  const { markSessionViewed, clearPendingApproval, renameSession } =
     useAgentSessionListActions();
   const { refreshCompactedRange } = useLLMService();
   const stateProps = useAgentSessionStateLogic();
@@ -59,6 +59,7 @@ export function AgentSessionProvider({
   const customActions = useAgentSessionActionsLogic(sessionId, stateProps, {
     acknowledgeSessionAttention,
     clearPendingApproval,
+    renameSessionInList: renameSession,
   });
 
   const stateValue: AgentSessionStateContextValue = useMemo(

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -105,6 +105,11 @@ interface AgentSessionListActionsContextValue {
   toggleBookmark: (sessionId: string) => Promise<void>;
 
   /**
+   * Update the user-visible title on a session.
+   */
+  renameSession: (sessionId: string, name: string) => Promise<void>;
+
+  /**
    * Persist that the user viewed a session and clear unread state locally.
    */
   markSessionViewed: (sessionId: string, viewedAt?: Date) => Promise<void>;
@@ -556,6 +561,58 @@ export function AgentSessionListProvider({
     [applySessionUpdate, mutateSessions, sessions],
   );
 
+  const renameSession = useCallback(
+    async (sessionId: string, name: string) => {
+      const normalizedName = name.trim();
+      if (!normalizedName) {
+        throw new Error('Session title cannot be empty');
+      }
+
+      const currentSession =
+        sessionsRef.current.find((session) => session.id === sessionId) ??
+        notificationSessionsRef.current.find(
+          (session) => session.id === sessionId,
+        );
+      const previousName = currentSession?.name;
+
+      if (previousName === normalizedName) {
+        return;
+      }
+
+      mutateSessions(
+        (previousSessions) =>
+          previousSessions.map((session) =>
+            session.id === sessionId
+              ? { ...session, name: normalizedName }
+              : session,
+          ),
+        {
+          notificationUpdater: (previousNotifications) =>
+            previousNotifications.map((session) =>
+              session.id === sessionId
+                ? { ...session, name: normalizedName }
+                : session,
+            ),
+        },
+      );
+
+      try {
+        await safeInvoke<void>('agent_update_session_name', {
+          sessionId,
+          name: normalizedName,
+        });
+      } catch (err) {
+        logger.error('Failed to rename session', err);
+        applySessionUpdate(sessionId, (session) => ({
+          ...session,
+          name: previousName,
+        }));
+        throw err;
+      }
+    },
+    [applySessionUpdate, mutateSessions],
+  );
+
   const markSessionViewed = useCallback(
     async (sessionId: string, viewedAt = new Date()) => {
       await safeInvoke<void>('agent_mark_session_viewed', {
@@ -659,6 +716,7 @@ export function AgentSessionListProvider({
       deleteSession,
       deleteSessionOnly,
       toggleBookmark,
+      renameSession,
       markSessionViewed,
       clearPendingApproval,
     }),
@@ -669,6 +727,7 @@ export function AgentSessionListProvider({
       deleteSession,
       deleteSessionOnly,
       toggleBookmark,
+      renameSession,
       markSessionViewed,
       clearPendingApproval,
     ],

--- a/src/context/__tests__/AgentSessionContext-actions.test.tsx
+++ b/src/context/__tests__/AgentSessionContext-actions.test.tsx
@@ -1,4 +1,4 @@
-import { TEST_SESSION_ID, createDefaultWrapper, mockMarkSessionViewed, mockRefreshCompactedRange, listenMock, openAgentSessionMock, safeInvokeMock, createOpenSessionResponse, mockClearPendingApproval } from "./agent-session-test-utils";
+import { TEST_SESSION_ID, createDefaultWrapper, mockMarkSessionViewed, mockRefreshCompactedRange, listenMock, openAgentSessionMock, safeInvokeMock, createOpenSessionResponse, mockClearPendingApproval, mockRenameSession } from "./agent-session-test-utils";
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
@@ -13,6 +13,7 @@ describe('AgentSessionContext – User Actions', () => {
     vi.clearAllMocks();
     mockMarkSessionViewed.mockResolvedValue(undefined);
     mockRefreshCompactedRange.mockResolvedValue(undefined);
+    mockRenameSession.mockResolvedValue(undefined);
     listenMock.mockResolvedValue(mockUnlisten);
     openAgentSessionMock.mockResolvedValue(
       createOpenSessionResponse(TEST_SESSION_ID, {
@@ -169,5 +170,30 @@ describe('AgentSessionContext – User Actions', () => {
             expect(result.current.state.executionMode).toBe('unsafe');
             expect(result.current.state.yoloModeEnabled).toBe(false);
             expect(result.current.state.unsafeModeEnabled).toBe(true);
+        });
+
+        it('updates local session title and persists it through the list action', async () => {
+            const { result } = renderHook(
+                () => ({
+                    state: useAgentSessionState(),
+                    actions: useAgentSessionActions(),
+                }),
+                { wrapper: defaultWrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.state.isSessionLoading).toBe(false);
+                expect(result.current.state.session?.name).toBe('Test Session');
+            });
+
+            await act(async () => {
+                await result.current.actions.renameSession('  Renamed Session  ');
+            });
+
+            expect(mockRenameSession).toHaveBeenCalledWith(
+                TEST_SESSION_ID,
+                'Renamed Session',
+            );
+            expect(result.current.state.session?.name).toBe('Renamed Session');
         });
 });

--- a/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
+++ b/src/context/__tests__/AgentSessionListContext-bookmark.test.tsx
@@ -200,3 +200,80 @@ describe('AgentSessionListContext – toggleBookmark', () => {
         expect(toggleCall?.args.bookmarked).toBe(true);
     });
 });
+
+describe('AgentSessionListContext – renameSession', () => {
+    const makeSession = (id: string, name: string) => ({
+        id,
+        name,
+        status: 'idle' as const,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        isBookmarked: false,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        __resetAgentSessionListStartupCacheForTests();
+        (listen as ReturnType<typeof vi.fn>).mockResolvedValue(vi.fn());
+    });
+
+    it('renames a session optimistically and sends the trimmed title to IPC', async () => {
+        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({
+                    items: [makeSession('s1', 'Original Title')],
+                    nextCursor: undefined,
+                });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
+            if (cmd === 'agent_update_session_name') return Promise.resolve(undefined);
+            return Promise.reject(new Error(`Unexpected cmd: ${cmd}`));
+        });
+
+        const { result } = renderHook(
+            () => ({ state: useAgentSessionListState(), actions: useAgentSessionListActions() }),
+            { wrapper: TestWrapper },
+        );
+
+        await waitFor(() => expect(result.current.state.sessions).toHaveLength(1));
+
+        await act(async () => {
+            await result.current.actions.renameSession('s1', '  Renamed Title  ');
+        });
+
+        expect(result.current.state.sessions[0].name).toBe('Renamed Title');
+        expect(safeInvoke).toHaveBeenCalledWith('agent_update_session_name', {
+            sessionId: 's1',
+            name: 'Renamed Title',
+        });
+    });
+
+    it('reverts the optimistic title update when IPC fails', async () => {
+        (safeInvoke as ReturnType<typeof vi.fn>).mockImplementation((cmd) => {
+            if (cmd === 'agent_list_sessions') {
+                return Promise.resolve({
+                    items: [makeSession('s1', 'Original Title')],
+                    nextCursor: undefined,
+                });
+            }
+            if (cmd === 'agent_list_attention_sessions') return Promise.resolve([]);
+            if (cmd === 'agent_update_session_name') {
+                return Promise.reject(new Error('rename failed'));
+            }
+            return Promise.reject(new Error(`Unexpected cmd: ${cmd}`));
+        });
+
+        const { result } = renderHook(
+            () => ({ state: useAgentSessionListState(), actions: useAgentSessionListActions() }),
+            { wrapper: TestWrapper },
+        );
+
+        await waitFor(() => expect(result.current.state.sessions).toHaveLength(1));
+
+        await act(async () => {
+            await result.current.actions.renameSession('s1', 'Renamed Title').catch(() => {/* expected */});
+        });
+
+        expect(result.current.state.sessions[0].name).toBe('Original Title');
+    });
+});

--- a/src/context/__tests__/agent-session-test-utils.tsx
+++ b/src/context/__tests__/agent-session-test-utils.tsx
@@ -11,6 +11,7 @@ import type { Message } from '@/models/chat';
 
 export const mockMarkSessionViewed = vi.fn();
 export const mockClearPendingApproval = vi.fn();
+export const mockRenameSession = vi.fn();
 export const mockRefreshCompactedRange = vi.fn();
 export const listenMock = listen as ReturnType<typeof vi.fn>;
 export const safeInvokeMock = safeInvoke as ReturnType<typeof vi.fn>;
@@ -44,6 +45,7 @@ vi.mock('../AgentSessionListContext', () => ({
   useAgentSessionListActions: () => ({
     markSessionViewed: mockMarkSessionViewed,
     clearPendingApproval: mockClearPendingApproval,
+    renameSession: mockRenameSession,
   }),
 }));
 

--- a/src/context/agent-session/types.ts
+++ b/src/context/agent-session/types.ts
@@ -123,4 +123,5 @@ export interface AgentSessionActionsContextValue {
   toggleYoloMode: () => void;
   toggleUnsafeMode: () => void;
   updateSessionConfig: (model: string, provider: string) => void;
+  renameSession: (name: string) => Promise<void>;
 }

--- a/src/context/agent-session/useAgentSessionActions.ts
+++ b/src/context/agent-session/useAgentSessionActions.ts
@@ -15,6 +15,7 @@ export function useAgentSessionActionsLogic(
   externalActions: {
     acknowledgeSessionAttention: (viewedAt?: Date) => Promise<void>;
     clearPendingApproval: (sessionId: string, toolCallId: string) => void;
+    renameSessionInList: (sessionId: string, name: string) => Promise<void>;
   },
 ) {
   const { state, setters } = stateProps;
@@ -237,6 +238,42 @@ export function useAgentSessionActionsLogic(
     [setters],
   );
 
+  const renameSession = useCallback(
+    async (name: string) => {
+      if (!state.session) {
+        throw new Error('No active session initialized');
+      }
+
+      const normalizedName = name.trim();
+      if (!normalizedName) {
+        throw new Error('Session title cannot be empty');
+      }
+
+      const previousName = state.session.name;
+      if (previousName === normalizedName) {
+        return;
+      }
+
+      setters.setSession((prev) =>
+        prev ? { ...prev, name: normalizedName } : prev,
+      );
+
+      try {
+        await externalActions.renameSessionInList(
+          state.session.id,
+          normalizedName,
+        );
+      } catch (err) {
+        setters.setSession((prev) =>
+          prev ? { ...prev, name: previousName } : prev,
+        );
+        logger.error('Failed to rename session', err);
+        throw err;
+      }
+    },
+    [externalActions, setters, state.session],
+  );
+
   return {
     sendMessage,
     stopSession,
@@ -247,5 +284,6 @@ export function useAgentSessionActionsLogic(
     toggleYoloMode,
     toggleUnsafeMode,
     updateSessionConfig,
+    renameSession,
   };
 }

--- a/src/features/agent/components/AgentChatHeader.tsx
+++ b/src/features/agent/components/AgentChatHeader.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import AgentSessionHeader from './AgentSessionHeader';
-import { useAgentSessionState } from '@/context/AgentSessionContext';
+import {
+  useAgentSessionActions,
+  useAgentSessionState,
+} from '@/context/AgentSessionContext';
 import { useAgentPlanning } from '@/context/AgentPlanningContext';
 import { useAgentWorkspace } from '@/context/AgentWorkspaceContext';
 import { useAgentChat } from '@/context/AgentChatContext';
@@ -27,6 +30,7 @@ export function AgentChatHeader({
 }: AgentChatHeaderProps) {
   const { t } = useTranslation();
   const { session } = useAgentSessionState();
+  const { renameSession } = useAgentSessionActions();
   const { showPlanningPanel, togglePlanningPanel } = useAgentPlanning();
   const { showWorkspacePanel, toggleWorkspacePanel } = useAgentWorkspace();
   const { messages } = useAgentChat();
@@ -48,7 +52,7 @@ export function AgentChatHeader({
   };
 
   return (
-    <AgentSessionHeader>
+    <AgentSessionHeader onRenameSession={renameSession}>
       <div className="flex items-center justify-between w-full">
         <div className="flex items-center">
           {children}

--- a/src/features/agent/components/AgentSessionHeader.tsx
+++ b/src/features/agent/components/AgentSessionHeader.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useOptionalAgentSessionState } from '@/context/AgentSessionContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
+import { Check, Loader2, Pencil, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
 interface AgentSessionHeaderProps {
   children?: React.ReactNode;
@@ -9,6 +14,7 @@ interface AgentSessionHeaderProps {
   sessionType?: string;
   assistantNameClassName?: string;
   sessionNameClassName?: string;
+  onRenameSession?: (name: string) => Promise<void>;
 }
 
 export default function AgentSessionHeader({
@@ -18,15 +24,97 @@ export default function AgentSessionHeader({
   sessionType = 'Agent',
   assistantNameClassName,
   sessionNameClassName,
+  onRenameSession,
 }: AgentSessionHeaderProps) {
+  const { t } = useTranslation('common');
   const optionalSessionState = useOptionalAgentSessionState();
   const session = optionalSessionState?.session;
+  const [isEditingSessionName, setIsEditingSessionName] = useState(false);
+  const [draftSessionName, setDraftSessionName] = useState('');
+  const [isSavingSessionName, setIsSavingSessionName] = useState(false);
+  const sessionNameInputRef = useRef<HTMLInputElement | null>(null);
 
   // Fallback display if session is not yet loaded
   const resolvedSessionName =
-    sessionName ?? session?.name ?? 'Untitled Session';
+    sessionName ??
+    session?.name ??
+    t('agent.header.untitledSession', 'Untitled Session');
   const resolvedAssistantName =
-    assistantName ?? session?.assistant?.name ?? 'Agent';
+    assistantName ??
+    session?.assistant?.name ??
+    t('agent.header.defaultAssistant', 'Agent');
+  const canEditSessionName = Boolean(session?.id && onRenameSession);
+
+  useEffect(() => {
+    if (!isEditingSessionName) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      sessionNameInputRef.current?.focus();
+      sessionNameInputRef.current?.select();
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [isEditingSessionName]);
+
+  const handleStartEditing = () => {
+    setDraftSessionName(resolvedSessionName);
+    setIsEditingSessionName(true);
+  };
+
+  const handleCancelEditing = () => {
+    setDraftSessionName(resolvedSessionName);
+    setIsEditingSessionName(false);
+    setIsSavingSessionName(false);
+  };
+
+  const handleSaveSessionName = async () => {
+    if (!onRenameSession) {
+      return;
+    }
+
+    const normalizedName = draftSessionName.trim();
+    if (!normalizedName) {
+      toast.error(
+        t('agent.header.renameEmptyError', 'Session title cannot be empty'),
+      );
+      return;
+    }
+
+    if (normalizedName === resolvedSessionName) {
+      handleCancelEditing();
+      return;
+    }
+
+    setIsSavingSessionName(true);
+    try {
+      await onRenameSession(normalizedName);
+      toast.success(t('agent.header.renameSuccess', 'Session title updated'));
+      setIsEditingSessionName(false);
+    } catch {
+      toast.error(
+        t('agent.header.renameError', 'Failed to update session title'),
+      );
+    } finally {
+      setIsSavingSessionName(false);
+    }
+  };
+
+  const handleSessionNameKeyDown = async (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      await handleSaveSessionName();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      handleCancelEditing();
+    }
+  };
 
   return (
     <div>
@@ -46,17 +134,86 @@ export default function AgentSessionHeader({
         </div>
         <div className="flex min-w-0 items-center gap-2">
           <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-            Session
+            {t('agent.header.sessionLabel', 'Session')}
           </span>
-          <span
-            className={cn(
-              'max-w-xs truncate text-sm font-medium text-foreground/90',
-              sessionNameClassName,
-            )}
-            title={resolvedSessionName}
-          >
-            {resolvedSessionName} ({sessionType})
-          </span>
+          {isEditingSessionName ? (
+            <div className="flex min-w-0 items-center gap-2">
+              <Input
+                ref={sessionNameInputRef}
+                value={draftSessionName}
+                onChange={(event) => setDraftSessionName(event.target.value)}
+                onKeyDown={handleSessionNameKeyDown}
+                disabled={isSavingSessionName}
+                className="h-8 w-[16rem] max-w-[50vw]"
+                aria-label={t(
+                  'agent.header.renameInputAria',
+                  'Edit session title',
+                )}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => void handleSaveSessionName()}
+                disabled={isSavingSessionName}
+                aria-label={t(
+                  'agent.header.renameSaveAria',
+                  'Save session title',
+                )}
+              >
+                {isSavingSessionName ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Check className="h-4 w-4" />
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={handleCancelEditing}
+                disabled={isSavingSessionName}
+                aria-label={t(
+                  'agent.header.renameCancelAria',
+                  'Cancel editing session title',
+                )}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                ({sessionType})
+              </span>
+            </div>
+          ) : (
+            <>
+              <span
+                className={cn(
+                  'max-w-xs truncate text-sm font-medium text-foreground/90',
+                  sessionNameClassName,
+                )}
+                title={resolvedSessionName}
+              >
+                {resolvedSessionName}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                ({sessionType})
+              </span>
+              {canEditSessionName && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0"
+                  onClick={handleStartEditing}
+                  aria-label={t('agent.header.renameAria', 'Rename session')}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </>
+          )}
         </div>
       </div>
 

--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -356,7 +356,11 @@ export function SessionCard({
                 size="sm"
                 variant={isSelectedLineage ? 'default' : 'outline'}
                 className="h-5 px-1.5 text-[10px]"
-                onClick={() => onLineageSelect?.(session.lineageId)}
+                onClick={() => {
+                  if (session.lineageId) {
+                    onLineageSelect?.(session.lineageId);
+                  }
+                }}
                 aria-label={t(
                   'sessionHistory.card.lineageFilterAria',
                   'Filter by lineage {{id}}',

--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -194,14 +194,44 @@ export function SessionCard({
     t('sessionHistory.card.fallbackName', 'Session {{id}}', {
       id: session.id.slice(0, 8),
     });
+  const createdAtLabel = t(
+    'sessionHistory.card.createdAt',
+    'Created {{time}}',
+    {
+      time:
+        formatRelativeTime(session.createdAt, new Date()) ||
+        t('sessionHistory.card.justNow', 'just now'),
+    },
+  );
+  const updatedAtLabel = session.updatedAt
+    ? t('sessionHistory.card.updatedAt', 'Updated {{time}}', {
+        time:
+          formatRelativeTime(session.updatedAt, new Date()) ||
+          t('sessionHistory.card.justNow', 'just now'),
+      })
+    : null;
+  const summaryParts = [
+    session.assistant?.name,
+    session.model && session.provider
+      ? `${t('sessionHistory.card.model', 'Model:')} ${session.provider}/${session.model}`
+      : null,
+    lineageHint,
+    updatedAtLabel,
+    createdAtLabel,
+  ].filter((value): value is string => Boolean(value));
+  const contentIndentStyle =
+    nestingLevel > 0
+      ? { paddingLeft: `${Math.min(nestingLevel, 4) * 14}px` }
+      : undefined;
 
   return (
     <article
       className={cn(
-        'relative overflow-hidden rounded-xl border p-4 transition',
+        'relative overflow-hidden rounded-xl border px-3 py-2.5 transition',
         statusConfig.cardClassName,
+        session.isBookmarked &&
+          'ring-1 ring-warning/25 shadow-sm shadow-warning/10',
       )}
-      style={{ marginLeft: `${nestingLevel * 16}px` }}
       aria-label={t('sessionHistory.card.ariaLabel', 'Session: {{name}}', {
         name: sessionNameFallback,
       })}
@@ -213,15 +243,15 @@ export function SessionCard({
         )}
         aria-hidden="true"
       />
-      <div className="flex items-start justify-between mb-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
+      <div className="space-y-2.5" style={contentIndentStyle}>
+        <div className="grid grid-cols-[auto,minmax(0,1fr),auto] items-start gap-2">
+          <div className="pt-0.5">
             {hasExpandableChildren ? (
               <Button
                 type="button"
                 size="icon"
                 variant="ghost"
-                className="h-7 w-7 shrink-0"
+                className="h-6 w-6 shrink-0"
                 onClick={() => onToggleExpand?.(session.id)}
                 aria-label={
                   isExpanded
@@ -238,18 +268,38 @@ export function SessionCard({
                 }
               >
                 {isExpanded ? (
-                  <ChevronDown className="w-4 h-4" aria-hidden="true" />
+                  <ChevronDown className="h-4 w-4" aria-hidden="true" />
                 ) : (
-                  <ChevronRight className="w-4 h-4" aria-hidden="true" />
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
                 )}
               </Button>
             ) : (
-              <span className="w-7 shrink-0" aria-hidden="true" />
+              <span className="w-6 shrink-0" aria-hidden="true" />
             )}
-            <h3 className="font-semibold truncate">{sessionNameFallback}</h3>
+          </div>
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-semibold leading-5">
+              {sessionNameFallback}
+            </h3>
+            {summaryParts.length > 0 && (
+              <p className="mt-1 truncate text-xs text-muted-foreground">
+                {summaryParts.join(' · ')}
+              </p>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {session.isBookmarked && (
+              <Badge
+                variant="secondary"
+                className="h-5 border-warning/20 bg-warning/10 px-1.5 text-[10px] text-warning-foreground"
+              >
+                <BookmarkCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                {t('sessionHistory.card.bookmarkedBadge', 'Bookmarked')}
+              </Badge>
+            )}
             <Badge
               variant={statusConfig.variant}
-              className={statusConfig.className}
+              className={cn('h-5 px-1.5 text-[10px]', statusConfig.className)}
               role="status"
               aria-label={t(
                 'sessionHistory.card.statusAriaLabel',
@@ -258,41 +308,43 @@ export function SessionCard({
               )}
             >
               {statusConfig.icon === 'active' && (
-                <Circle className="w-3 h-3 fill-current" />
+                <Circle className="h-3 w-3 fill-current" />
               )}
               {statusConfig.icon === 'idle' && (
-                <Circle className="w-3 h-3 fill-current" />
+                <Circle className="h-3 w-3 fill-current" />
               )}
-              {statusConfig.icon === 'paused' && <Pause className="w-3 h-3" />}
-              {statusConfig.icon === 'error' && <XCircle className="w-3 h-3" />}
+              {statusConfig.icon === 'paused' && <Pause className="h-3 w-3" />}
+              {statusConfig.icon === 'error' && <XCircle className="h-3 w-3" />}
               {statusConfig.icon === 'unknown' && (
-                <Circle className="w-3 h-3 fill-current" />
+                <Circle className="h-3 w-3 fill-current" />
               )}
               {statusConfig.badge}
             </Badge>
           </div>
-          {session.assistant?.name && (
-            <p className="text-xs text-muted-foreground">
-              {session.assistant.name}
-            </p>
-          )}
         </div>
-      </div>
 
-      <div className="text-xs text-muted-foreground space-y-1">
-        {(depthLabel || shortParentId || shortLineageId) && (
-          <div className="flex flex-wrap items-center gap-1">
-            <Badge variant="secondary">{relationBadge}</Badge>
-            {depthLabel && <Badge variant="outline">{depthLabel}</Badge>}
+        {(depthLabel ||
+          shortParentId ||
+          shortLineageId ||
+          (descendantStatusCounts && descendantCount > 0)) && (
+          <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+            <Badge variant="secondary" className="h-5 px-1.5 text-[10px]">
+              {relationBadge}
+            </Badge>
+            {depthLabel && (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+                {depthLabel}
+              </Badge>
+            )}
             {descendantCount > 0 && (
-              <Badge variant="outline">
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t('sessionHistory.card.descendants', '{{count}} descendants', {
                   count: descendantCount,
                 })}
               </Badge>
             )}
             {shortParentId && (
-              <Badge variant="outline">
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t('sessionHistory.card.parentBadge', 'Parent: {{id}}', {
                   id: shortParentId,
                 })}
@@ -304,7 +356,7 @@ export function SessionCard({
                 size="sm"
                 variant={isSelectedLineage ? 'default' : 'outline'}
                 className="h-5 px-1.5 text-[10px]"
-                onClick={() => onLineageSelect?.(session.lineageId!)}
+                onClick={() => onLineageSelect?.(session.lineageId)}
                 aria-label={t(
                   'sessionHistory.card.lineageFilterAria',
                   'Filter by lineage {{id}}',
@@ -316,26 +368,22 @@ export function SessionCard({
                 })}
               </Button>
             )}
-          </div>
-        )}
-        {descendantStatusCounts && descendantCount > 0 && (
-          <div className="flex flex-wrap items-center gap-1">
-            {descendantStatusCounts.busy > 0 && (
-              <Badge variant="outline">
+            {descendantStatusCounts?.busy ? (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t('sessionHistory.card.descendantBusy', 'Busy: {{count}}', {
                   count: descendantStatusCounts.busy,
                 })}
               </Badge>
-            )}
-            {descendantStatusCounts.idle > 0 && (
-              <Badge variant="outline">
+            ) : null}
+            {descendantStatusCounts?.idle ? (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t('sessionHistory.card.descendantIdle', 'Idle: {{count}}', {
                   count: descendantStatusCounts.idle,
                 })}
               </Badge>
-            )}
-            {descendantStatusCounts.paused > 0 && (
-              <Badge variant="outline">
+            ) : null}
+            {descendantStatusCounts?.paused ? (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t(
                   'sessionHistory.card.descendantPaused',
                   'Paused: {{count}}',
@@ -344,212 +392,179 @@ export function SessionCard({
                   },
                 )}
               </Badge>
-            )}
-            {descendantStatusCounts.error > 0 && (
-              <Badge variant="outline">
+            ) : null}
+            {descendantStatusCounts?.error ? (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                 {t('sessionHistory.card.descendantError', 'Error: {{count}}', {
                   count: descendantStatusCounts.error,
                 })}
               </Badge>
-            )}
+            ) : null}
           </div>
         )}
-        {lineageHint && <div>{lineageHint}</div>}
-        {session.model && session.provider && (
-          <div className="flex items-center gap-1">
-            <span className="font-medium">
-              {t('sessionHistory.card.model', 'Model:')}
-            </span>
-            <span>
-              {session.provider}/{session.model}
-            </span>
-          </div>
-        )}
-        <div>
-          {t('sessionHistory.card.createdAt', 'Created {{time}}', {
-            time:
-              formatRelativeTime(session.createdAt, new Date()) ||
-              t('sessionHistory.card.justNow', 'just now'),
-          })}
-        </div>
-        {session.updatedAt && (
-          <div>
-            {t('sessionHistory.card.updatedAt', 'Updated {{time}}', {
-              time:
-                formatRelativeTime(session.updatedAt, new Date()) ||
-                t('sessionHistory.card.justNow', 'just now'),
-            })}
-          </div>
-        )}
-      </div>
 
-      <div
-        className="flex gap-2 mt-3"
-        role="group"
-        aria-label={t('sessionHistory.actions.groupAria', 'Session actions')}
-      >
-        {!showConfirm ? (
-          <>
-            <Button
-              size="sm"
-              variant={isActive ? 'default' : 'outline'}
-              onClick={() => onResume(session.id)}
-              className="flex-1"
-              aria-label={
-                isViewOnly
+        <div
+          className="flex items-center gap-2"
+          role="group"
+          aria-label={t('sessionHistory.actions.groupAria', 'Session actions')}
+        >
+          <Button
+            size="sm"
+            variant={isActive ? 'default' : 'outline'}
+            onClick={() => onResume(session.id)}
+            className="h-8 min-w-[7.5rem] flex-1 justify-center sm:flex-none"
+            aria-label={
+              isViewOnly
+                ? t(
+                    'sessionHistory.actions.viewAria',
+                    'View session {{name}}',
+                    {
+                      name: sessionNameFallback,
+                    },
+                  )
+                : isPaused
                   ? t(
-                      'sessionHistory.actions.viewAria',
-                      'View session {{name}}',
+                      'sessionHistory.actions.resumeAria',
+                      'Resume session {{name}}',
                       { name: sessionNameFallback },
                     )
-                  : isPaused
-                    ? t(
-                        'sessionHistory.actions.resumeAria',
-                        'Resume session {{name}}',
-                        { name: sessionNameFallback },
-                      )
-                    : t(
-                        'sessionHistory.actions.continueAria',
-                        'Continue session {{name}}',
-                        { name: sessionNameFallback },
-                      )
-              }
-            >
-              {isViewOnly ? (
-                <>
-                  <Eye className="w-3 h-3 mr-1" aria-hidden="true" />
-                  {t('sessionHistory.actions.view', 'View')}
-                </>
-              ) : isPaused ? (
-                <>
-                  <Play className="w-3 h-3 mr-1" aria-hidden="true" />
-                  {t('sessionHistory.actions.resume', 'Resume')}
-                </>
-              ) : (
-                <>
-                  <Play className="w-3 h-3 mr-1" aria-hidden="true" />
-                  {t('sessionHistory.actions.continue', 'Continue')}
-                </>
-              )}
-            </Button>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => onToggleBookmark?.(session.id)}
-                  aria-label={
-                    session.isBookmarked
-                      ? t(
-                          'sessionHistory.actions.unbookmarkAria',
-                          'Remove bookmark',
-                        )
-                      : t(
-                          'sessionHistory.actions.bookmarkAria',
-                          'Bookmark session',
-                        )
-                  }
-                  className={session.isBookmarked ? 'text-yellow-500' : ''}
-                >
-                  {session.isBookmarked ? (
-                    <BookmarkCheck className="w-3 h-3" aria-hidden="true" />
-                  ) : (
-                    <Bookmark className="w-3 h-3" aria-hidden="true" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {session.isBookmarked
-                  ? t('sessionHistory.actions.unbookmark', 'Remove bookmark')
-                  : t('sessionHistory.actions.bookmark', 'Bookmark')}
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={handleDelete}
-                  disabled={isDeleting}
-                  aria-label={t(
-                    'sessionHistory.actions.deleteAria',
-                    'Delete session {{name}}',
-                    { name: sessionNameFallback },
-                  )}
-                >
-                  <Trash2 className="w-3 h-3" aria-hidden="true" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('sessionHistory.actions.deleteTooltip', 'Delete session')}
-              </TooltipContent>
-            </Tooltip>
-          </>
-        ) : (
-          <>
-            {descendantCount > 0 ? (
+                  : t(
+                      'sessionHistory.actions.continueAria',
+                      'Continue session {{name}}',
+                      { name: sessionNameFallback },
+                    )
+            }
+          >
+            {isViewOnly ? (
               <>
-                <div className="flex w-full gap-2">
-                  <div className="flex flex-col flex-1 gap-0.5">
+                <Eye className="mr-1 h-3 w-3" aria-hidden="true" />
+                {t('sessionHistory.actions.view', 'View')}
+              </>
+            ) : (
+              <>
+                <Play className="mr-1 h-3 w-3" aria-hidden="true" />
+                {isPaused
+                  ? t('sessionHistory.actions.resume', 'Resume')
+                  : t('sessionHistory.actions.continue', 'Continue')}
+              </>
+            )}
+          </Button>
+          <Button
+            size="sm"
+            variant={session.isBookmarked ? 'secondary' : 'outline'}
+            onClick={() => onToggleBookmark?.(session.id)}
+            aria-label={
+              session.isBookmarked
+                ? t('sessionHistory.actions.unbookmarkAria', 'Remove bookmark')
+                : t('sessionHistory.actions.bookmarkAria', 'Bookmark session')
+            }
+            className={cn(
+              'h-8 shrink-0 px-2.5',
+              session.isBookmarked &&
+                'border-warning/20 bg-warning/10 text-warning-foreground hover:bg-warning/20',
+            )}
+          >
+            {session.isBookmarked ? (
+              <BookmarkCheck className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Bookmark className="h-4 w-4" aria-hidden="true" />
+            )}
+            <span>
+              {session.isBookmarked
+                ? t('sessionHistory.actions.bookmarked', 'Bookmarked')
+                : t('sessionHistory.actions.bookmark', 'Bookmark')}
+            </span>
+          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="h-8 w-8 shrink-0"
+                aria-label={t(
+                  'sessionHistory.actions.deleteAria',
+                  'Delete session {{name}}',
+                  { name: sessionNameFallback },
+                )}
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t('sessionHistory.actions.deleteTooltip', 'Delete session')}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {showConfirm && (
+        <div className="absolute inset-0 z-10 flex items-end rounded-xl bg-background/95 p-3 backdrop-blur-sm">
+          <div className="w-full rounded-lg border bg-card p-3 shadow-lg">
+            <div className="mb-2 text-sm font-medium text-foreground">
+              {t('sessionHistory.actions.confirmDelete', 'Confirm Delete')}
+            </div>
+            {descendantCount > 0 ? (
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                    className="w-full"
+                    aria-busy={isDeleting}
+                    aria-label={t(
+                      'sessionHistory.actions.deleteAllAria',
+                      'Delete this session and all subagent sessions',
+                    )}
+                  >
+                    {isDeleting
+                      ? t('sessionHistory.actions.deleting', 'Deleting...')
+                      : t('sessionHistory.actions.deleteAll', 'Delete all')}
+                  </Button>
+                  <p className="text-center text-xs text-destructive">
+                    {t(
+                      'sessionHistory.card.subagentsCount',
+                      '+{{count}} subagent',
+                      {
+                        count: descendantCount,
+                      },
+                    )}
+                  </p>
+                </div>
+                {onDeleteOnly && (
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
                     <Button
                       size="sm"
-                      variant="destructive"
-                      onClick={handleDelete}
+                      variant="outline"
+                      onClick={handleDeleteOnly}
                       disabled={isDeleting}
                       className="w-full"
-                      aria-busy={isDeleting}
                       aria-label={t(
-                        'sessionHistory.actions.deleteAllAria',
-                        'Delete this session and all subagent sessions',
+                        'sessionHistory.actions.deleteOnlyThisAria',
+                        'Delete only this session',
                       )}
                     >
-                      {isDeleting
-                        ? t('sessionHistory.actions.deleting', 'Deleting...')
-                        : t('sessionHistory.actions.deleteAll', 'Delete all')}
-                    </Button>
-                    <p className="text-xs text-destructive text-center">
                       {t(
-                        'sessionHistory.card.subagentsCount',
-                        '+{{count}} subagent',
-                        { count: descendantCount },
+                        'sessionHistory.actions.deleteOnlyThis',
+                        'Delete only this',
                       )}
+                    </Button>
+                    <p className="text-center text-xs text-muted-foreground">
+                      {t('sessionHistory.card.subagentsKept', 'Subagents kept')}
                     </p>
                   </div>
-                  {onDeleteOnly && (
-                    <div className="flex flex-col flex-1 gap-0.5">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={handleDeleteOnly}
-                        disabled={isDeleting}
-                        className="w-full"
-                        aria-label={t(
-                          'sessionHistory.actions.deleteOnlyThisAria',
-                          'Delete only this session',
-                        )}
-                      >
-                        {t(
-                          'sessionHistory.actions.deleteOnlyThis',
-                          'Delete only this',
-                        )}
-                      </Button>
-                      <p className="text-xs text-muted-foreground text-center">
-                        {t(
-                          'sessionHistory.card.subagentsKept',
-                          'Subagents kept',
-                        )}
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </>
+                )}
+              </div>
             ) : (
               <Button
                 size="sm"
                 variant="destructive"
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="flex-1"
+                className="w-full"
                 aria-busy={isDeleting}
                 aria-label={t(
                   'sessionHistory.actions.confirmDeleteAria',
@@ -566,6 +581,7 @@ export function SessionCard({
               variant="outline"
               onClick={handleCancelDelete}
               disabled={isDeleting}
+              className="mt-2 w-full"
               aria-label={t(
                 'sessionHistory.actions.cancelDeletionAria',
                 'Cancel deletion',
@@ -573,9 +589,9 @@ export function SessionCard({
             >
               {t('sessionHistory.actions.cancel', 'Cancel')}
             </Button>
-          </>
-        )}
-      </div>
+          </div>
+        </div>
+      )}
     </article>
   );
 }

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -8,10 +8,25 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { RefreshCw, Search, History, X, Bookmark } from 'lucide-react';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  RefreshCw,
+  Search,
+  History,
+  X,
+  BookmarkCheck,
+  Clock3,
+  StarOff,
+} from 'lucide-react';
 import {
   Virtuoso,
   type Components,
@@ -26,6 +41,8 @@ import {
   type SessionStatus,
   type SessionStatusCounts,
 } from '@/lib/session-utils';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { sortSessionsByLatestActivity } from '@/lib/session-metadata';
 import type { AgentSession } from '@/models/agent';
 import { SessionCard } from './SessionCard';
 
@@ -34,10 +51,8 @@ interface SessionHistoryPanelProps {
   isLoading: boolean;
   hasMoreSessions: boolean;
   isLoadingMoreSessions: boolean;
-  activeTab: string;
   activeStatusFilter: 'all' | SessionStatus;
   searchQuery: string;
-  onActiveTabChange: (value: string) => void;
   onActiveStatusFilterChange: (value: 'all' | SessionStatus) => void;
   onSearchQueryChange: (value: string) => void;
   onRefresh: () => void;
@@ -60,6 +75,111 @@ interface SessionHistoryRow {
   hasExpandableChildren: boolean;
   isExpanded: boolean;
   descendantStatusCounts?: SessionStatusCounts;
+}
+
+type SessionHistoryTranslate = ReturnType<typeof useTranslation>['t'];
+
+interface BookmarkedSessionTileProps {
+  session: AgentSession;
+  onResume: (sessionId: string) => void;
+  onToggleBookmark?: (sessionId: string) => void;
+  t: SessionHistoryTranslate;
+}
+
+const HISTORY_CONTENT_RAIL_CLASS = 'mx-auto w-full max-w-4xl';
+const HISTORY_SECTION_CLASS =
+  'rounded-xl border bg-card/80 p-4 shadow-sm shadow-black/5';
+
+function BookmarkedSessionTile({
+  session,
+  onResume,
+  onToggleBookmark,
+  t,
+}: BookmarkedSessionTileProps) {
+  const shortcutLabel =
+    session.name ||
+    t('sessionHistory.card.fallbackName', 'Session {{id}}', {
+      id: session.id.slice(0, 8),
+    });
+  const latestActivity =
+    formatRelativeTime(session.updatedAt ?? session.createdAt, new Date()) ||
+    t('sessionHistory.card.justNow', 'just now');
+  const statusLabel = t(
+    `sessionHistory.status.${session.status}`,
+    session.status,
+  );
+  const secondaryLabel =
+    session.assistant?.name ||
+    (session.provider && session.model
+      ? `${session.provider}/${session.model}`
+      : t(
+          'sessionHistory.bookmarkedSection.defaultMeta',
+          'Saved for quick access',
+        ));
+
+  return (
+    <article className="rounded-xl border bg-background/80 p-3 shadow-sm shadow-black/5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            <h3 className="min-w-0 flex-1 truncate text-sm font-semibold leading-5 text-foreground">
+              {shortcutLabel}
+            </h3>
+            <Badge
+              variant="secondary"
+              className="h-5 shrink-0 px-1.5 text-[10px]"
+            >
+              {statusLabel}
+            </Badge>
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {secondaryLabel}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 shrink-0"
+          onClick={() => onToggleBookmark?.(session.id)}
+          aria-label={t(
+            'sessionHistory.actions.unbookmarkAria',
+            'Remove bookmark',
+          )}
+        >
+          <StarOff className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+          <Clock3 className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">
+            {t('sessionHistory.bookmarkedSection.lastUsed', 'Used {{time}}', {
+              time: latestActivity,
+            })}
+          </span>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 px-2"
+          onClick={() => onResume(session.id)}
+          aria-label={t(
+            'sessionHistory.bookmarkedSection.resumeAria',
+            'Open bookmarked session {{name}}',
+            { name: shortcutLabel },
+          )}
+        >
+          <BookmarkCheck className="h-4 w-4 text-warning" />
+          <span>
+            {t('sessionHistory.bookmarkedSection.open', 'Open session')}
+          </span>
+        </Button>
+      </div>
+    </article>
+  );
 }
 
 const sessionHistoryVirtuosoComponents: Components<SessionHistoryRow> = {
@@ -97,15 +217,27 @@ const statusPriority: Record<string, number> = {
   error: 4,
 };
 
+const statusFilterValues: Array<'all' | SessionStatus> = [
+  'all',
+  'busy',
+  'idle',
+  'paused',
+  'error',
+];
+
+function isSessionStatusFilterValue(
+  value: string,
+): value is 'all' | SessionStatus {
+  return statusFilterValues.includes(value as 'all' | SessionStatus);
+}
+
 export function SessionHistoryPanel({
   sessions,
   isLoading,
   hasMoreSessions,
   isLoadingMoreSessions,
-  activeTab,
   activeStatusFilter,
   searchQuery,
-  onActiveTabChange,
   onActiveStatusFilterChange,
   onSearchQueryChange,
   onRefresh,
@@ -154,9 +286,7 @@ export function SessionHistoryPanel({
     searchQuery !== deferredSearchQuery || sessions !== deferredSessions;
 
   const filtersActive =
-    activeTab === 'bookmarked' ||
-    activeStatusFilter !== 'all' ||
-    deferredSearchQuery.trim().length > 0;
+    activeStatusFilter !== 'all' || deferredSearchQuery.trim().length > 0;
 
   useEffect(() => {
     if (!selectedLineageId) {
@@ -173,7 +303,20 @@ export function SessionHistoryPanel({
 
   useEffect(() => {
     setCollapsedAutoExpandedSessionIds(new Set());
-  }, [activeStatusFilter, activeTab, deferredSearchQuery, selectedLineageId]);
+  }, [activeStatusFilter, deferredSearchQuery, selectedLineageId]);
+
+  const bookmarkedSessions = useMemo(
+    () =>
+      sortSessionsByLatestActivity(
+        deferredSessions.filter((session) => session.isBookmarked === true),
+      ),
+    [deferredSessions],
+  );
+  const featuredBookmarkedSessions = bookmarkedSessions.slice(0, 5);
+  const remainingBookmarkedCount = Math.max(
+    bookmarkedSessions.length - featuredBookmarkedSessions.length,
+    0,
+  );
 
   const descendantCounts = useMemo(
     () => buildDescendantCounts(sessions),
@@ -188,7 +331,6 @@ export function SessionHistoryPanel({
   const {
     autoExpandedAncestorIds,
     baseSessions,
-    bookmarkedCount,
     displayRows,
     matchedSessionCount,
     statusCounts,
@@ -205,7 +347,6 @@ export function SessionHistoryPanel({
       paused: 0,
       error: 0,
     };
-    let nextBookmarkedCount = 0;
 
     lineageSessions.forEach((session) => {
       if (
@@ -213,15 +354,9 @@ export function SessionHistoryPanel({
       ) {
         nextStatusCounts[session.status as keyof typeof nextStatusCounts]++;
       }
-      if (session.isBookmarked) {
-        nextBookmarkedCount++;
-      }
     });
 
-    let filteredSessions =
-      activeTab === 'bookmarked'
-        ? lineageSessions.filter((session) => session.isBookmarked === true)
-        : lineageSessions;
+    let filteredSessions = lineageSessions;
 
     if (activeStatusFilter !== 'all') {
       filteredSessions = filteredSessions.filter(
@@ -387,14 +522,12 @@ export function SessionHistoryPanel({
     return {
       autoExpandedAncestorIds: nextAutoExpandedAncestorIds,
       baseSessions: lineageSessions,
-      bookmarkedCount: nextBookmarkedCount,
       displayRows: rows,
       matchedSessionCount: matchedSessions.length,
       statusCounts: nextStatusCounts,
     };
   }, [
     activeStatusFilter,
-    activeTab,
     collapsedAutoExpandedSessionIds,
     descendantStatusCounts,
     deferredSearchQuery,
@@ -441,295 +574,343 @@ export function SessionHistoryPanel({
     ],
   );
 
+  const statusFilterLabelByValue: Record<'all' | SessionStatus, string> = {
+    all: t('sessionHistory.statusFilter.all', 'All statuses'),
+    busy: `${t('sessionHistory.tabs.busy', 'Busy')} (${statusCounts.busy})`,
+    idle: `${t('sessionHistory.tabs.idle', 'Idle')} (${statusCounts.idle})`,
+    paused: `${t('sessionHistory.tabs.paused', 'Paused')} (${statusCounts.paused})`,
+    error: `${t('sessionHistory.tabs.error', 'Error')} (${statusCounts.error})`,
+  };
+
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background p-6">
-      <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center justify-center p-2.5 bg-primary/10 text-primary rounded-xl">
-              <History size={28} />
-            </div>
-            <div>
-              <h1
-                className="text-2xl text-foreground font-semibold tracking-tight"
-                id="session-heading"
-              >
-                {defaultHeading}
-              </h1>
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {defaultDescription} (
+    <div className="flex min-h-full flex-col bg-background p-6">
+      <div
+        className={cn(
+          HISTORY_CONTENT_RAIL_CLASS,
+          'mb-8 flex items-center justify-between gap-3',
+        )}
+      >
+        <div className="flex items-center gap-4">
+          <div className="rounded-xl bg-primary/10 p-2.5 text-primary">
+            <History size={28} />
+          </div>
+          <div>
+            <h1
+              className="text-2xl font-semibold tracking-tight text-foreground"
+              id="session-heading"
+            >
+              {defaultHeading}
+            </h1>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {defaultDescription} (
+              {t(
+                'sessionHistory.loadedCountSummary',
+                '{{count}} loaded sessions',
+                {
+                  count: baseSessions.length,
+                },
+              )}
+              {hasMoreSessions
+                ? `, ${t('sessionHistory.moreAvailable', 'more available')}`
+                : ''}
+              {filtersActive
+                ? `, ${t(
+                    'sessionHistory.matchCountSummary',
+                    '{{count}} matching filters',
+                    { count: matchedSessionCount },
+                  )}`
+                : ''}
+              )
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onRefresh}
+          disabled={isLoading}
+          aria-label={t('sessionHistory.refreshAria', 'Refresh sessions')}
+          className="h-9 w-9"
+        >
+          <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+        </Button>
+      </div>
+
+      {!selectedLineageId && bookmarkedSessions.length > 0 && (
+        <section
+          id="bookmarked-sessions"
+          className={cn(
+            HISTORY_CONTENT_RAIL_CLASS,
+            HISTORY_SECTION_CLASS,
+            'mb-4',
+          )}
+        >
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <BookmarkCheck className="h-4 w-4 text-warning" />
+                <h2 className="text-sm font-semibold text-foreground">
+                  {t(
+                    'sessionHistory.bookmarkedSection.heading',
+                    'Bookmarked Sessions',
+                  )}
+                </h2>
+                <Badge variant="secondary">{bookmarkedSessions.length}</Badge>
+              </div>
+              <p className="text-xs text-muted-foreground">
                 {t(
-                  'sessionHistory.loadedCountSummary',
-                  '{{count}} loaded sessions',
-                  { count: baseSessions.length },
+                  'sessionHistory.bookmarkedSection.description',
+                  'Pinned sessions stay here for quick access while the full history remains below.',
                 )}
-                {hasMoreSessions
-                  ? `, ${t('sessionHistory.moreAvailable', 'more available')}`
-                  : ''}
-                {filtersActive
-                  ? `, ${t(
-                      'sessionHistory.matchCountSummary',
-                      '{{count}} matching filters',
-                      { count: matchedSessionCount },
-                    )}`
-                  : ''}
-                )
+              </p>
+            </div>
+            {remainingBookmarkedCount > 0 && (
+              <Badge variant="outline" className="h-6 px-2">
+                {t(
+                  'sessionHistory.bookmarkedSection.more',
+                  '+{{count}} more in history',
+                  { count: remainingBookmarkedCount },
+                )}
+              </Badge>
+            )}
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            {featuredBookmarkedSessions.map((session) => (
+              <BookmarkedSessionTile
+                key={session.id}
+                session={session}
+                onResume={onResume}
+                onToggleBookmark={onToggleBookmark}
+                t={t}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <div
+        className={cn(
+          HISTORY_CONTENT_RAIL_CLASS,
+          HISTORY_SECTION_CLASS,
+          'mb-4 flex flex-col gap-3',
+        )}
+      >
+        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder={defaultSearchPlaceholder}
+              value={searchQuery}
+              onChange={(event) => onSearchQueryChange(event.target.value)}
+              className="pl-10 pr-10"
+              aria-label={t('sessionHistory.searchAria', 'Search sessions')}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => onSearchQueryChange('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 transform rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={t('sessionHistory.clearSearchAria', 'Clear search')}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 md:w-56 md:shrink-0">
+            <span className="text-xs font-medium text-muted-foreground">
+              {t('sessionHistory.statusFilter.label', 'Status')}
+            </span>
+            <Select
+              value={activeStatusFilter}
+              onValueChange={(value) => {
+                if (isSessionStatusFilterValue(value)) {
+                  onActiveStatusFilterChange(value);
+                }
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-full"
+                aria-label={t('sessionHistory.statusFilter.label', 'Status')}
+              >
+                <SelectValue>
+                  {statusFilterLabelByValue[activeStatusFilter]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {statusFilterValues.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {statusFilterLabelByValue[value]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      {selectedLineageId && (
+        <div
+          className={cn(
+            HISTORY_CONTENT_RAIL_CLASS,
+            'mt-3 flex items-center gap-2 text-xs text-muted-foreground',
+          )}
+        >
+          <span>
+            {t('sessionHistory.focusedLineage', 'Focused lineage: {{id}}', {
+              id: selectedLineageId.slice(0, 8),
+            })}
+          </span>
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0"
+            onClick={() => setSelectedLineageId(null)}
+          >
+            {t('sessionHistory.showAllLineages', 'Show all lineages')}
+          </Button>
+        </div>
+      )}
+
+      <div
+        className={cn(
+          HISTORY_CONTENT_RAIL_CLASS,
+          'mt-6 min-h-[18rem] transition-opacity duration-200',
+          isPending ? 'opacity-50' : 'opacity-100',
+        )}
+        aria-busy={isPending}
+      >
+        {isPending && (
+          <div className="sr-only" aria-live="polite">
+            {t('sessionHistory.filteringStatus', 'Filtering sessions...')}
+          </div>
+        )}
+        {isLoading && sessions.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center text-muted-foreground">
+              <RefreshCw className="mx-auto mb-2 h-8 w-8 animate-spin" />
+              <p className="text-sm">
+                {t('sessionHistory.loading', 'Loading sessions...')}
               </p>
             </div>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onRefresh}
-            disabled={isLoading}
-            aria-label={t('sessionHistory.refreshAria', 'Refresh sessions')}
-            className="h-9 w-9"
-          >
-            <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
-          </Button>
-        </div>
-
-        <Tabs
-          defaultValue="all"
-          value={activeTab}
-          onValueChange={onActiveTabChange}
-          className="mb-4 w-full shrink-0"
-        >
-          <TabsList className="w-full justify-start overflow-x-auto">
-            <TabsTrigger value="all" className="flex-1">
-              {t('sessionHistory.tabs.all', 'All')} ({statusCounts.all})
-            </TabsTrigger>
-            <TabsTrigger value="bookmarked" className="flex-1">
-              <Bookmark className="mr-1.5 h-3.5 w-3.5" />
-              {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} (
-              {bookmarkedCount})
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-
-        <div className="mb-4 flex shrink-0 flex-wrap items-center gap-2">
-          <span className="text-xs font-medium text-muted-foreground">
-            {t('sessionHistory.statusFilter.label', 'Status')}
-          </span>
-          <Button
-            variant={activeStatusFilter === 'all' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => onActiveStatusFilterChange('all')}
-            aria-pressed={activeStatusFilter === 'all'}
-          >
-            {t('sessionHistory.statusFilter.all', 'All statuses')}
-          </Button>
-          <Button
-            variant={activeStatusFilter === 'busy' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => onActiveStatusFilterChange('busy')}
-            aria-pressed={activeStatusFilter === 'busy'}
-          >
-            {t('sessionHistory.tabs.busy', 'Busy')} ({statusCounts.busy})
-          </Button>
-          <Button
-            variant={activeStatusFilter === 'idle' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => onActiveStatusFilterChange('idle')}
-            aria-pressed={activeStatusFilter === 'idle'}
-          >
-            {t('sessionHistory.tabs.idle', 'Idle')} ({statusCounts.idle})
-          </Button>
-          <Button
-            variant={activeStatusFilter === 'paused' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => onActiveStatusFilterChange('paused')}
-            aria-pressed={activeStatusFilter === 'paused'}
-          >
-            {t('sessionHistory.tabs.paused', 'Paused')} ({statusCounts.paused})
-          </Button>
-          <Button
-            variant={activeStatusFilter === 'error' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => onActiveStatusFilterChange('error')}
-            aria-pressed={activeStatusFilter === 'error'}
-          >
-            {t('sessionHistory.tabs.error', 'Error')} ({statusCounts.error})
-          </Button>
-        </div>
-
-        <div className="relative shrink-0">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-          <Input
-            type="text"
-            placeholder={defaultSearchPlaceholder}
-            value={searchQuery}
-            onChange={(event) => onSearchQueryChange(event.target.value)}
-            className="pl-10 pr-10"
-            aria-label={t('sessionHistory.searchAria', 'Search sessions')}
-          />
-          {searchQuery && (
-            <button
-              type="button"
-              onClick={() => onSearchQueryChange('')}
-              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-sm"
-              aria-label={t('sessionHistory.clearSearchAria', 'Clear search')}
-            >
-              <X className="h-4 w-4" />
-            </button>
-          )}
-        </div>
-        {selectedLineageId && (
-          <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
-            <span>
-              {t('sessionHistory.focusedLineage', 'Focused lineage: {{id}}', {
-                id: selectedLineageId.slice(0, 8),
-              })}
-            </span>
-            <Button
-              variant="link"
-              size="sm"
-              className="h-auto p-0"
-              onClick={() => setSelectedLineageId(null)}
-            >
-              {t('sessionHistory.showAllLineages', 'Show all lineages')}
-            </Button>
-          </div>
-        )}
-
-        {/* Content */}
-        <div
-          className={cn(
-            'mt-6 flex min-h-0 flex-1 flex-col transition-opacity duration-200',
-            isPending ? 'opacity-50' : 'opacity-100',
-          )}
-          aria-busy={isPending}
-        >
-          {isPending && (
-            <div className="sr-only" aria-live="polite">
-              {t('sessionHistory.filteringStatus', 'Filtering sessions...')}
-            </div>
-          )}
-          {isLoading && sessions.length === 0 ? (
-            <div className="flex items-center justify-center h-full">
-              <div className="text-center text-muted-foreground">
-                <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-2" />
-                <p className="text-sm">
-                  {t('sessionHistory.loading', 'Loading sessions...')}
-                </p>
-              </div>
-            </div>
-          ) : displayRows.length === 0 ? (
-            <div className="flex items-center justify-center h-full">
-              <div className="text-center text-muted-foreground">
-                {selectedLineageId ? (
-                  <>
-                    <p className="text-sm">
-                      {t(
-                        'sessionHistory.noSessionsInLineage',
-                        'No sessions visible in lineage {{id}}',
-                        { id: selectedLineageId.slice(0, 8) },
-                      )}
-                    </p>
-                    <Button
-                      variant="link"
-                      size="sm"
-                      onClick={() => setSelectedLineageId(null)}
-                      className="mt-2"
-                    >
-                      {t(
-                        'sessionHistory.clearLineageFocus',
-                        'Clear lineage focus',
-                      )}
-                    </Button>
-                  </>
-                ) : searchQuery.trim() ? (
-                  <>
-                    <p className="text-sm">
-                      {t(
-                        'sessionHistory.noSessionsMatching',
-                        'No sessions found matching "{{query}}"',
-                        { query: searchQuery },
-                      )}
-                    </p>
-                    <Button
-                      variant="link"
-                      size="sm"
-                      onClick={() => onSearchQueryChange('')}
-                      className="mt-2"
-                    >
-                      {t('sessionHistory.clearSearch', 'Clear search')}
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-sm">{defaultEmptyTitle}</p>
-                    <p className="text-xs mt-2">{defaultEmptySubtitle}</p>
-                  </>
-                )}
-              </div>
-            </div>
-          ) : (
-            <Virtuoso
-              className="min-h-0 flex-1 max-w-2xl pr-2 pb-4"
-              style={{ height: '100%' }}
-              data={displayRows}
-              overscan={400}
-              computeItemKey={(_index, row) => row.session.id}
-              components={{
-                ...sessionHistoryVirtuosoComponents,
-                Footer: () =>
-                  hasMoreSessions ? (
-                    <div className="flex justify-center py-4">
-                      <Button
-                        variant="outline"
-                        onClick={onLoadMore}
-                        disabled={isLoadingMoreSessions}
-                      >
-                        <RefreshCw
-                          className={cn(
-                            'mr-2 h-4 w-4',
-                            isLoadingMoreSessions && 'animate-spin',
-                          )}
-                        />
-                        {isLoadingMoreSessions
-                          ? t('sessionHistory.loadingMore', 'Loading more...')
-                          : t('sessionHistory.loadMore', 'Load more')}
-                      </Button>
-                    </div>
-                  ) : null,
-              }}
-              itemContent={(
-                _index,
-                {
-                  session,
-                  nestingLevel,
-                  lineageHint,
-                  hasExpandableChildren,
-                  isExpanded,
-                  descendantStatusCounts: rowDescendantStatusCounts,
-                },
-              ) => (
-                <SessionCard
-                  session={session}
-                  onResume={onResume}
-                  onDelete={onDelete}
-                  onDeleteOnly={onDeleteOnly}
-                  onToggleBookmark={onToggleBookmark}
-                  nestingLevel={nestingLevel}
-                  lineageHint={lineageHint}
-                  selectedLineageId={selectedLineageId}
-                  descendantCount={descendantCounts.get(session.id) ?? 0}
-                  descendantStatusCounts={rowDescendantStatusCounts}
-                  hasExpandableChildren={hasExpandableChildren}
-                  isExpanded={isExpanded}
-                  onToggleExpand={handleToggleExpand}
-                  onLineageSelect={(lineageId) =>
-                    setSelectedLineageId((prev) =>
-                      prev === lineageId ? null : lineageId,
-                    )
-                  }
-                />
+        ) : displayRows.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center text-muted-foreground">
+              {selectedLineageId ? (
+                <>
+                  <p className="text-sm">
+                    {t(
+                      'sessionHistory.noSessionsInLineage',
+                      'No sessions visible in lineage {{id}}',
+                      { id: selectedLineageId.slice(0, 8) },
+                    )}
+                  </p>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setSelectedLineageId(null)}
+                    className="mt-2"
+                  >
+                    {t(
+                      'sessionHistory.clearLineageFocus',
+                      'Clear lineage focus',
+                    )}
+                  </Button>
+                </>
+              ) : searchQuery.trim() ? (
+                <>
+                  <p className="text-sm">
+                    {t(
+                      'sessionHistory.noSessionsMatching',
+                      'No sessions found matching "{{query}}"',
+                      { query: searchQuery },
+                    )}
+                  </p>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => onSearchQueryChange('')}
+                    className="mt-2"
+                  >
+                    {t('sessionHistory.clearSearch', 'Clear search')}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm">{defaultEmptyTitle}</p>
+                  <p className="mt-2 text-xs">{defaultEmptySubtitle}</p>
+                </>
               )}
-            />
-          )}
-        </div>
+            </div>
+          </div>
+        ) : (
+          <Virtuoso
+            useWindowScroll
+            className="w-full pb-4"
+            data={displayRows}
+            overscan={400}
+            computeItemKey={(_index, row) => row.session.id}
+            components={{
+              ...sessionHistoryVirtuosoComponents,
+              Footer: () =>
+                hasMoreSessions ? (
+                  <div className="flex justify-center py-4">
+                    <Button
+                      variant="outline"
+                      onClick={onLoadMore}
+                      disabled={isLoadingMoreSessions}
+                    >
+                      <RefreshCw
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          isLoadingMoreSessions && 'animate-spin',
+                        )}
+                      />
+                      {isLoadingMoreSessions
+                        ? t('sessionHistory.loadingMore', 'Loading more...')
+                        : t('sessionHistory.loadMore', 'Load more')}
+                    </Button>
+                  </div>
+                ) : null,
+            }}
+            itemContent={(
+              _index,
+              {
+                session,
+                nestingLevel,
+                lineageHint,
+                hasExpandableChildren,
+                isExpanded,
+                descendantStatusCounts: rowDescendantStatusCounts,
+              },
+            ) => (
+              <SessionCard
+                session={session}
+                onResume={onResume}
+                onDelete={onDelete}
+                onDeleteOnly={onDeleteOnly}
+                onToggleBookmark={onToggleBookmark}
+                nestingLevel={nestingLevel}
+                lineageHint={lineageHint}
+                selectedLineageId={selectedLineageId}
+                descendantCount={descendantCounts.get(session.id) ?? 0}
+                descendantStatusCounts={rowDescendantStatusCounts}
+                hasExpandableChildren={hasExpandableChildren}
+                isExpanded={isExpanded}
+                onToggleExpand={handleToggleExpand}
+                onLineageSelect={(lineageId) =>
+                  setSelectedLineageId((prev) =>
+                    prev === lineageId ? null : lineageId,
+                  )
+                }
+              />
+            )}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/features/agent/components/__tests__/SessionCard.test.tsx
+++ b/src/features/agent/components/__tests__/SessionCard.test.tsx
@@ -86,4 +86,24 @@ describe('SessionCard', () => {
     // const visibleTooltip = tooltipElements.find(el => el.checkVisibility?.());
     // expect(visibleTooltip).toBeInTheDocument();
   });
+
+  it('shows visible bookmark state affordances for bookmarked sessions', () => {
+    const onResume = vi.fn();
+    const onDelete = vi.fn();
+    const onToggleBookmark = vi.fn();
+
+    render(
+      <SessionCard
+        session={{ ...mockSession, isBookmarked: true }}
+        onResume={onResume}
+        onDelete={onDelete}
+        onToggleBookmark={onToggleBookmark}
+      />,
+    );
+
+    expect(screen.getAllByText('Bookmarked').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /Remove bookmark/i }));
+    expect(onToggleBookmark).toHaveBeenCalledWith('session-123');
+  });
 });

--- a/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
+++ b/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
@@ -18,6 +18,11 @@ vi.mock('react-i18next', () => ({
       if (key === 'sessionHistory.lineageHint.child') {
         return `Child of ${String(options?.parentName ?? '')}`;
       }
+      if (defaultString && options) {
+        return Object.entries(options).reduce((text, [optionKey, value]) => {
+          return text.replace(`{{${optionKey}}}`, String(value));
+        }, defaultString);
+      }
       return defaultString || key;
     },
   }),
@@ -116,7 +121,6 @@ function createSession(
 const defaultProps = {
   hasMoreSessions: false,
   isLoadingMoreSessions: false,
-  onActiveTabChange: () => {},
   onActiveStatusFilterChange: () => {},
   onSearchQueryChange: () => {},
   onRefresh: () => {},
@@ -124,6 +128,7 @@ const defaultProps = {
   onResume: () => {},
   onDelete: () => {},
   onDeleteOnly: () => {},
+  onToggleBookmark: () => {},
 };
 
 describe('SessionHistoryPanel', () => {
@@ -142,7 +147,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
       />,
@@ -164,7 +168,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
       />,
@@ -184,7 +187,6 @@ describe('SessionHistoryPanel', () => {
         sessions={[createSession('root', 'Root')]}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
       />,
@@ -207,7 +209,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery=""
       />,
@@ -235,7 +236,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="error"
         searchQuery=""
       />,
@@ -245,7 +245,7 @@ describe('SessionHistoryPanel', () => {
     expect(screen.getByTestId('session-card-child')).toBeInTheDocument();
   });
 
-  it('keeps lineage roots visible in bookmarked view when only a descendant is bookmarked', () => {
+  it('renders bookmarked sessions in a dedicated top section', () => {
     const sessions: AgentSession[] = [
       createSession('root', 'Root'),
       createSession('child', 'Child', {
@@ -253,29 +253,57 @@ describe('SessionHistoryPanel', () => {
         isBookmarked: true,
       }),
     ];
+    const onResume = vi.fn();
 
     render(
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="bookmarked"
+        onResume={onResume}
         activeStatusFilter="all"
         searchQuery=""
       />,
     );
 
-    expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
-    expect(screen.getByTestId('session-card-child')).toBeInTheDocument();
+    expect(screen.getByText('Bookmarked Sessions')).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open bookmarked session Child' }),
+    );
+    expect(onResume).toHaveBeenCalledWith('child');
   });
 
-  it('allows collapsing an auto-expanded lineage in bookmarked view', () => {
+  it('allows removing a bookmark directly from the top section', () => {
     const sessions: AgentSession[] = [
-      createSession('root', 'Root'),
-      createSession('child', 'Child', {
-        parentSessionId: 'root',
+      createSession('bookmarked', 'Bookmarked Session', { isBookmarked: true }),
+    ];
+    const onToggleBookmark = vi.fn();
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        onToggleBookmark={onToggleBookmark}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove bookmark' }));
+    expect(onToggleBookmark).toHaveBeenCalledWith('bookmarked');
+  });
+
+  it('shows overflow count when bookmarks exceed the featured shortcut cap', () => {
+    const sessions: AgentSession[] = [
+      createSession('s1', 'Session 1', {
         isBookmarked: true,
       }),
+      createSession('s2', 'Session 2', { isBookmarked: true }),
+      createSession('s3', 'Session 3', { isBookmarked: true }),
+      createSession('s4', 'Session 4', { isBookmarked: true }),
+      createSession('s5', 'Session 5', { isBookmarked: true }),
+      createSession('s6', 'Session 6', { isBookmarked: true }),
     ];
 
     render(
@@ -283,16 +311,12 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="bookmarked"
         activeStatusFilter="all"
         searchQuery=""
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
-
-    expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
-    expect(screen.queryByTestId('session-card-child')).not.toBeInTheDocument();
+    expect(screen.getByText('+1 more in history')).toBeInTheDocument();
   });
 
   it('resets collapsed auto-expanded lineage state when the filter context changes', () => {
@@ -311,7 +335,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery="alpha"
       />,
@@ -328,7 +351,6 @@ describe('SessionHistoryPanel', () => {
         sessions={sessions}
         isLoading={false}
         {...defaultProps}
-        activeTab="all"
         activeStatusFilter="all"
         searchQuery="beta"
       />,

--- a/src/features/history/History.tsx
+++ b/src/features/history/History.tsx
@@ -28,7 +28,6 @@ export default function History() {
     deleteSessionOnly,
     toggleBookmark,
   } = useAgentSessionListActions();
-  const [activeTab, setActiveTab] = useState('all');
   const [activeStatusFilter, setActiveStatusFilter] = useState<
     'all' | SessionStatus
   >('all');
@@ -88,16 +87,14 @@ export default function History() {
   }, [loadMoreSessions, t]);
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden text-foreground">
+    <div className="flex min-h-full w-full flex-col text-foreground">
       <SessionHistoryPanel
         sessions={sessions}
         isLoading={isSessionsListLoading}
         hasMoreSessions={hasMoreSessions}
         isLoadingMoreSessions={isLoadingMoreSessions}
-        activeTab={activeTab}
         activeStatusFilter={activeStatusFilter}
         searchQuery={searchQuery}
-        onActiveTabChange={setActiveTab}
         onActiveStatusFilterChange={setActiveStatusFilter}
         onSearchQueryChange={setSearchQuery}
         onRefresh={handleRefreshSessions}

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "Alle Sitzungen anzeigen →",
     "settings": "Einstellungen",
     "history": "Verlauf",
+    "bookmarked": "Lesezeichen",
     "scheduledTasks": "Geplante Aufgaben",
     "session": "Sitzung",
     "knowledge": "Wissen",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "Abstammungsfokus löschen",
     "noSessionsMatching": "Keine Sitzungen für \"{{query}}\" gefunden",
     "clearSearch": "Suche löschen",
+    "bookmarkedSection": {
+      "heading": "Gespeicherte Sitzungen",
+      "description": "Markierte Sitzungen bleiben hier für den Schnellzugriff, während der vollständige Verlauf darunter sichtbar bleibt.",
+      "resumeAria": "Gespeicherte Sitzung {{name}} öffnen",
+      "open": "Sitzung öffnen",
+      "lastUsed": "Verwendet {{time}}",
+      "defaultMeta": "Für den Schnellzugriff gespeichert",
+      "more": "+{{count}} weitere im Verlauf"
+    },
     "toasts": {
       "deleted": "Sitzung gelöscht",
       "deleteFailed": "Sitzung konnte nicht gelöscht werden"
@@ -221,12 +231,18 @@
       "justNow": "gerade eben",
       "subagentsCount_one": "+{{count}} Subagent",
       "subagentsCount_other": "+{{count}} Subagenten",
-      "subagentsKept": "Subagenten behalten"
+      "subagentsKept": "Subagenten behalten",
+      "bookmarkedBadge": "Gespeichert"
     },
     "actions": {
       "view": "Ansehen",
       "continue": "Weiter",
       "resume": "Fortsetzen",
+      "bookmark": "Speichern",
+      "bookmarked": "Gespeichert",
+      "bookmarkAria": "Sitzung speichern",
+      "unbookmark": "Speicherung entfernen",
+      "unbookmarkAria": "Speicherung entfernen",
       "viewAria": "Sitzung {{name}} ansehen",
       "continueAria": "Sitzung {{name}} weiterführen",
       "resumeAria": "Sitzung {{name}} fortsetzen",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -831,7 +831,17 @@
       "toggleWorkspaceAria": "Arbeitsbereich-Dateipanel umschalten",
       "toggleWorkspaceTooltip": "Arbeitsbereich-Dateipanel umschalten",
       "togglePlanningAria": "KI-Planungspanel umschalten",
-      "togglePlanningTooltip": "KI-Planungspanel umschalten"
+      "togglePlanningTooltip": "KI-Planungspanel umschalten",
+      "defaultAssistant": "Agent",
+      "untitledSession": "Unbenannte Sitzung",
+      "sessionLabel": "Sitzung",
+      "renameAria": "Sitzung umbenennen",
+      "renameInputAria": "Sitzungstitel bearbeiten",
+      "renameSaveAria": "Sitzungstitel speichern",
+      "renameCancelAria": "Bearbeiten des Sitzungstitels abbrechen",
+      "renameSuccess": "Sitzungstitel aktualisiert",
+      "renameError": "Sitzungstitel konnte nicht aktualisiert werden",
+      "renameEmptyError": "Der Sitzungstitel darf nicht leer sein"
     },
     "workspace": {
       "loadError": "Verzeichnis konnte nicht geladen werden",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "See all sessions →",
     "settings": "Settings",
     "history": "History",
+    "bookmarked": "Bookmarked",
     "scheduledTasks": "Scheduled Tasks",
     "session": "Session",
     "knowledge": "Knowledge",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "Clear lineage focus",
     "noSessionsMatching": "No sessions found matching \"{{query}}\"",
     "clearSearch": "Clear search",
+    "bookmarkedSection": {
+      "heading": "Bookmarked Sessions",
+      "description": "Pinned sessions stay here for quick access while the full history remains below.",
+      "resumeAria": "Open bookmarked session {{name}}",
+      "open": "Open session",
+      "lastUsed": "Used {{time}}",
+      "defaultMeta": "Saved for quick access",
+      "more": "+{{count}} more in history"
+    },
     "toasts": {
       "deleted": "Session deleted",
       "deleteFailed": "Failed to delete session"
@@ -221,12 +231,18 @@
       "justNow": "just now",
       "subagentsCount_one": "+{{count}} subagent",
       "subagentsCount_other": "+{{count}} subagents",
-      "subagentsKept": "Subagents kept"
+      "subagentsKept": "Subagents kept",
+      "bookmarkedBadge": "Bookmarked"
     },
     "actions": {
       "view": "View",
       "continue": "Continue",
       "resume": "Resume",
+      "bookmark": "Bookmark",
+      "bookmarked": "Bookmarked",
+      "bookmarkAria": "Bookmark session",
+      "unbookmark": "Remove bookmark",
+      "unbookmarkAria": "Remove bookmark",
       "viewAria": "View session {{name}}",
       "continueAria": "Continue session {{name}}",
       "resumeAria": "Resume session {{name}}",
@@ -839,7 +855,17 @@
       "toggleWorkspaceAria": "Toggle Workspace Files Panel",
       "toggleWorkspaceTooltip": "Toggle Workspace Files Panel",
       "togglePlanningAria": "Toggle AI Planning Panel",
-      "togglePlanningTooltip": "Toggle AI Planning Panel"
+      "togglePlanningTooltip": "Toggle AI Planning Panel",
+      "defaultAssistant": "Agent",
+      "untitledSession": "Untitled Session",
+      "sessionLabel": "Session",
+      "renameAria": "Rename session",
+      "renameInputAria": "Edit session title",
+      "renameSaveAria": "Save session title",
+      "renameCancelAria": "Cancel editing session title",
+      "renameSuccess": "Session title updated",
+      "renameError": "Failed to update session title",
+      "renameEmptyError": "Session title cannot be empty"
     },
     "workspace": {
       "loadError": "Failed to load directory",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "Ver todas las sesiones →",
     "settings": "Configuración",
     "history": "Historial",
+    "bookmarked": "Favoritas",
     "scheduledTasks": "Tareas programadas",
     "session": "Sesión",
     "knowledge": "Conocimiento",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "Limpiar enfoque de linaje",
     "noSessionsMatching": "No se encontraron sesiones que coincidan con \"{{query}}\"",
     "clearSearch": "Limpiar búsqueda",
+    "bookmarkedSection": {
+      "heading": "Sesiones favoritas",
+      "description": "Las sesiones fijadas permanecen aquí para acceso rápido mientras el historial completo sigue debajo.",
+      "resumeAria": "Abrir sesión favorita {{name}}",
+      "open": "Abrir sesión",
+      "lastUsed": "Usada {{time}}",
+      "defaultMeta": "Guardada para acceso rápido",
+      "more": "+{{count}} más en el historial"
+    },
     "toasts": {
       "deleted": "Sesión eliminada",
       "deleteFailed": "Error al eliminar la sesión"
@@ -221,12 +231,18 @@
       "justNow": "ahora mismo",
       "subagentsCount_one": "+{{count}} subagente",
       "subagentsCount_other": "+{{count}} subagentes",
-      "subagentsKept": "Subagentes conservados"
+      "subagentsKept": "Subagentes conservados",
+      "bookmarkedBadge": "Favorita"
     },
     "actions": {
       "view": "Ver",
       "continue": "Continuar",
       "resume": "Reanudar",
+      "bookmark": "Guardar",
+      "bookmarked": "Guardada",
+      "bookmarkAria": "Guardar sesión",
+      "unbookmark": "Quitar favorita",
+      "unbookmarkAria": "Quitar favorita",
       "viewAria": "Ver sesión {{name}}",
       "continueAria": "Continuar sesión {{name}}",
       "resumeAria": "Reanudar sesión {{name}}",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -831,7 +831,17 @@
       "toggleWorkspaceAria": "Alternar panel de archivos del espacio de trabajo",
       "toggleWorkspaceTooltip": "Alternar panel de archivos del espacio de trabajo",
       "togglePlanningAria": "Alternar panel de planificación de IA",
-      "togglePlanningTooltip": "Alternar panel de planificación de IA"
+      "togglePlanningTooltip": "Alternar panel de planificación de IA",
+      "defaultAssistant": "Agente",
+      "untitledSession": "Sesión sin título",
+      "sessionLabel": "Sesión",
+      "renameAria": "Renombrar sesión",
+      "renameInputAria": "Editar título de la sesión",
+      "renameSaveAria": "Guardar título de la sesión",
+      "renameCancelAria": "Cancelar edición del título de la sesión",
+      "renameSuccess": "Título de la sesión actualizado",
+      "renameError": "No se pudo actualizar el título de la sesión",
+      "renameEmptyError": "El título de la sesión no puede estar vacío"
     },
     "workspace": {
       "loadError": "Error al cargar el directorio",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "Voir toutes les sessions →",
     "settings": "Paramètres",
     "history": "Historique",
+    "bookmarked": "Favoris",
     "scheduledTasks": "Tâches planifiées",
     "session": "Session",
     "knowledge": "Connaissance",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "Effacer le focus sur la lignée",
     "noSessionsMatching": "Aucune session trouvée pour \"{{query}}\"",
     "clearSearch": "Effacer la recherche",
+    "bookmarkedSection": {
+      "heading": "Sessions favorites",
+      "description": "Les sessions épinglées restent ici pour un accès rapide, tandis que l'historique complet reste disponible en dessous.",
+      "resumeAria": "Ouvrir la session favorite {{name}}",
+      "open": "Ouvrir la session",
+      "lastUsed": "Utilisée {{time}}",
+      "defaultMeta": "Enregistrée pour un accès rapide",
+      "more": "+{{count}} de plus dans l'historique"
+    },
     "toasts": {
       "deleted": "Session supprimée",
       "deleteFailed": "Échec de la suppression de la session"
@@ -221,12 +231,18 @@
       "justNow": "à l'instant",
       "subagentsCount_one": "+{{count}} sous-agent",
       "subagentsCount_other": "+{{count}} sous-agents",
-      "subagentsKept": "Sous-agents conservés"
+      "subagentsKept": "Sous-agents conservés",
+      "bookmarkedBadge": "Favorie"
     },
     "actions": {
       "view": "Voir",
       "continue": "Continuer",
       "resume": "Reprendre",
+      "bookmark": "Enregistrer",
+      "bookmarked": "Enregistrée",
+      "bookmarkAria": "Enregistrer la session",
+      "unbookmark": "Retirer des favoris",
+      "unbookmarkAria": "Retirer des favoris",
       "viewAria": "Voir la session {{name}}",
       "continueAria": "Continuer la session {{name}}",
       "resumeAria": "Reprendre la session {{name}}",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -831,7 +831,17 @@
       "toggleWorkspaceAria": "Basculer le panneau des fichiers de l'espace de travail",
       "toggleWorkspaceTooltip": "Basculer le panneau des fichiers de l'espace de travail",
       "togglePlanningAria": "Basculer le panneau de planification IA",
-      "togglePlanningTooltip": "Basculer le panneau de planification IA"
+      "togglePlanningTooltip": "Basculer le panneau de planification IA",
+      "defaultAssistant": "Agent",
+      "untitledSession": "Session sans titre",
+      "sessionLabel": "Session",
+      "renameAria": "Renommer la session",
+      "renameInputAria": "Modifier le titre de la session",
+      "renameSaveAria": "Enregistrer le titre de la session",
+      "renameCancelAria": "Annuler la modification du titre de la session",
+      "renameSuccess": "Titre de la session mis à jour",
+      "renameError": "Échec de la mise à jour du titre de la session",
+      "renameEmptyError": "Le titre de la session ne peut pas être vide"
     },
     "workspace": {
       "loadError": "Échec du chargement du répertoire",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -148,6 +148,7 @@
     "seeAllSessions": "すべてのセッションを見る →",
     "settings": "設定",
     "history": "履歴",
+    "bookmarked": "ブックマーク",
     "scheduledTasks": "スケジュール済みタスク",
     "session": "セッション",
     "knowledge": "知識",
@@ -171,6 +172,15 @@
     "clearLineageFocus": "系統のフォーカスをクリア",
     "noSessionsMatching": "\"{{query}}\" に一致するセッションは見つかりませんでした",
     "clearSearch": "検索をクリア",
+    "bookmarkedSection": {
+      "heading": "ブックマークしたセッション",
+      "description": "固定したセッションへここからすぐ戻れます。完全な履歴は下にそのまま表示されます。",
+      "resumeAria": "ブックマークしたセッション {{name}} を開く",
+      "open": "セッションを開く",
+      "lastUsed": "{{time}} に使用",
+      "defaultMeta": "すぐ戻れるよう保存済み",
+      "more": "履歴にさらに {{count}} 件"
+    },
     "toasts": {
       "deleted": "セッションを削除しました",
       "deleteFailed": "セッションの削除に失敗しました"
@@ -212,6 +222,7 @@
       "subagentsCount_one": "+{{count}} 個のサブエージェント",
       "subagentsCount_other": "+{{count}} 個のサブエージェント",
       "subagentsKept": "保持されたサブエージェント",
+      "bookmarkedBadge": "ブックマーク済み",
       "descendantBusy": "実行中: {{count}}",
       "descendantError": "エラー: {{count}}",
       "descendantIdle": "待機中: {{count}}",
@@ -222,6 +233,11 @@
       "view": "表示",
       "continue": "続行",
       "resume": "再開",
+      "bookmark": "ブックマーク",
+      "bookmarked": "ブックマーク済み",
+      "bookmarkAria": "セッションをブックマーク",
+      "unbookmark": "ブックマークを解除",
+      "unbookmarkAria": "ブックマークを解除",
       "viewAria": "セッション {{name}} を表示",
       "continueAria": "セッション {{name}} を続行",
       "resumeAria": "セッション {{name}} を再開",
@@ -805,7 +821,17 @@
       "toggleWorkspaceAria": "ワークスペースファイルパネルを切り替え",
       "toggleWorkspaceTooltip": "ワークスペースファイルパネルを切り替え",
       "togglePlanningAria": "AIプランニングパネルを切り替え",
-      "togglePlanningTooltip": "AIプランニングパネルを切り替え"
+      "togglePlanningTooltip": "AIプランニングパネルを切り替え",
+      "defaultAssistant": "エージェント",
+      "untitledSession": "無題のセッション",
+      "sessionLabel": "セッション",
+      "renameAria": "セッション名を変更",
+      "renameInputAria": "セッションタイトルを編集",
+      "renameSaveAria": "セッションタイトルを保存",
+      "renameCancelAria": "セッションタイトルの編集をキャンセル",
+      "renameSuccess": "セッションタイトルを更新しました",
+      "renameError": "セッションタイトルの更新に失敗しました",
+      "renameEmptyError": "セッションタイトルは空にできません"
     },
     "workspace": {
       "loadError": "ディレクトリの読み込みに失敗しました",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "모든 세션 보기 →",
     "settings": "설정",
     "history": "기록",
+    "bookmarked": "북마크",
     "scheduledTasks": "예약된 작업",
     "session": "세션",
     "knowledge": "지식",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "리니지 집중 해제",
     "noSessionsMatching": "\"{{query}}\"와 일치하는 세션이 없습니다",
     "clearSearch": "검색 지우기",
+    "bookmarkedSection": {
+      "heading": "북마크한 세션",
+      "description": "고정한 세션을 여기서 바로 열고, 전체 기록은 아래에서 계속 탐색할 수 있습니다.",
+      "resumeAria": "북마크한 세션 {{name}} 열기",
+      "open": "세션 열기",
+      "lastUsed": "{{time}} 사용",
+      "defaultMeta": "빠르게 다시 열 수 있도록 저장됨",
+      "more": "기록에 {{count}}개 더 있음"
+    },
     "toasts": {
       "deleted": "세션이 삭제되었습니다",
       "deleteFailed": "세션 삭제에 실패했습니다"
@@ -221,12 +231,18 @@
       "justNow": "방금 전",
       "subagentsCount_one": "+{{count}}개의 하위 에이전트",
       "subagentsCount_other": "+{{count}}개의 하위 에이전트",
-      "subagentsKept": "하위 에이전트 유지됨"
+      "subagentsKept": "하위 에이전트 유지됨",
+      "bookmarkedBadge": "북마크됨"
     },
     "actions": {
       "view": "보기",
       "continue": "계속",
       "resume": "재개",
+      "bookmark": "북마크",
+      "bookmarked": "북마크됨",
+      "bookmarkAria": "세션 북마크",
+      "unbookmark": "북마크 해제",
+      "unbookmarkAria": "북마크 해제",
       "viewAria": "세션 {{name}} 보기",
       "continueAria": "세션 {{name}} 계속",
       "resumeAria": "세션 {{name}} 재개",
@@ -840,7 +856,17 @@
       "toggleWorkspaceAria": "워크스페이스 파일 패널 전환",
       "toggleWorkspaceTooltip": "워크스페이스 파일 패널 전환",
       "togglePlanningAria": "AI 계획 패널 전환",
-      "togglePlanningTooltip": "AI 계획 패널 전환"
+      "togglePlanningTooltip": "AI 계획 패널 전환",
+      "defaultAssistant": "에이전트",
+      "untitledSession": "제목 없는 세션",
+      "sessionLabel": "세션",
+      "renameAria": "세션 이름 변경",
+      "renameInputAria": "세션 제목 편집",
+      "renameSaveAria": "세션 제목 저장",
+      "renameCancelAria": "세션 제목 편집 취소",
+      "renameSuccess": "세션 제목이 업데이트되었습니다",
+      "renameError": "세션 제목 업데이트에 실패했습니다",
+      "renameEmptyError": "세션 제목은 비워 둘 수 없습니다"
     },
     "workspace": {
       "loadError": "디렉토리 로드에 실패했습니다",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "Ver todas as sessões →",
     "settings": "Configurações",
     "history": "Histórico",
+    "bookmarked": "Favoritas",
     "scheduledTasks": "Tarefas Agendadas",
     "session": "Sessão",
     "knowledge": "Conhecimento",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "Limpar foco na linhagem",
     "noSessionsMatching": "Nenhuma sessão encontrada para \"{{query}}\"",
     "clearSearch": "Limpar pesquisa",
+    "bookmarkedSection": {
+      "heading": "Sessões favoritas",
+      "description": "As sessões marcadas ficam aqui para acesso rápido, enquanto o histórico completo continua logo abaixo.",
+      "resumeAria": "Abrir sessão favorita {{name}}",
+      "open": "Abrir sessão",
+      "lastUsed": "Usada {{time}}",
+      "defaultMeta": "Salva para acesso rápido",
+      "more": "+{{count}} mais no histórico"
+    },
     "toasts": {
       "deleted": "Sessão excluída",
       "deleteFailed": "Falha ao excluir sessão"
@@ -221,12 +231,18 @@
       "justNow": "agora mesmo",
       "subagentsCount_one": "+{{count}} subagente",
       "subagentsCount_other": "+{{count}} subagentes",
-      "subagentsKept": "Subagentes mantidos"
+      "subagentsKept": "Subagentes mantidos",
+      "bookmarkedBadge": "Favorita"
     },
     "actions": {
       "view": "Ver",
       "continue": "Continuar",
       "resume": "Retomar",
+      "bookmark": "Salvar",
+      "bookmarked": "Salva",
+      "bookmarkAria": "Salvar sessão",
+      "unbookmark": "Remover favorita",
+      "unbookmarkAria": "Remover favorita",
       "viewAria": "Ver sessão {{name}}",
       "continueAria": "Continuar sessão {{name}}",
       "resumeAria": "Retomar sessão {{name}}",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -831,7 +831,17 @@
       "toggleWorkspaceAria": "Alternar Painel de Arquivos do Espaço de Trabalho",
       "toggleWorkspaceTooltip": "Alternar Painel de Arquivos do Espaço de Trabalho",
       "togglePlanningAria": "Alternar Painel de Planejamento de IA",
-      "togglePlanningTooltip": "Alternar Painel de Planejamento de IA"
+      "togglePlanningTooltip": "Alternar Painel de Planejamento de IA",
+      "defaultAssistant": "Agente",
+      "untitledSession": "Sessão sem título",
+      "sessionLabel": "Sessão",
+      "renameAria": "Renomear sessão",
+      "renameInputAria": "Editar título da sessão",
+      "renameSaveAria": "Salvar título da sessão",
+      "renameCancelAria": "Cancelar edição do título da sessão",
+      "renameSuccess": "Título da sessão atualizado",
+      "renameError": "Falha ao atualizar o título da sessão",
+      "renameEmptyError": "O título da sessão não pode ficar vazio"
     },
     "workspace": {
       "loadError": "Falha ao carregar diretório",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -149,6 +149,7 @@
     "seeAllSessions": "查看全部会话 →",
     "settings": "设置",
     "history": "历史记录",
+    "bookmarked": "已收藏",
     "scheduledTasks": "计划任务",
     "session": "会话",
     "knowledge": "知识",
@@ -172,6 +173,15 @@
     "clearLineageFocus": "清除血统聚焦",
     "noSessionsMatching": "未找到匹配 \"{{query}}\" 的会话",
     "clearSearch": "清除搜索",
+    "bookmarkedSection": {
+      "heading": "已收藏的会话",
+      "description": "置顶的会话会显示在这里，方便快速返回；完整历史记录仍保留在下方。",
+      "resumeAria": "打开已收藏的会话 {{name}}",
+      "open": "打开会话",
+      "lastUsed": "最近使用于 {{time}}",
+      "defaultMeta": "已保存，方便快速返回",
+      "more": "历史记录中还有 {{count}} 个"
+    },
     "toasts": {
       "deleted": "会话已删除",
       "deleteFailed": "删除会话失败"
@@ -221,12 +231,18 @@
       "justNow": "刚刚",
       "subagentsCount_one": "+{{count}} 个子代理",
       "subagentsCount_other": "+{{count}} 个子代理",
-      "subagentsKept": "保留子代理"
+      "subagentsKept": "保留子代理",
+      "bookmarkedBadge": "已收藏"
     },
     "actions": {
       "view": "查看",
       "continue": "继续",
       "resume": "恢复",
+      "bookmark": "收藏",
+      "bookmarked": "已收藏",
+      "bookmarkAria": "收藏会话",
+      "unbookmark": "取消收藏",
+      "unbookmarkAria": "取消收藏",
       "viewAria": "查看会话 {{name}}",
       "continueAria": "继续会话 {{name}}",
       "resumeAria": "恢复会话 {{name}}",
@@ -831,7 +847,17 @@
       "toggleWorkspaceAria": "切换工作区文件面板",
       "toggleWorkspaceTooltip": "切换工作区文件面板",
       "togglePlanningAria": "切换 AI 计划面板",
-      "togglePlanningTooltip": "切换 AI 计划面板"
+      "togglePlanningTooltip": "切换 AI 计划面板",
+      "defaultAssistant": "智能体",
+      "untitledSession": "未命名会话",
+      "sessionLabel": "会话",
+      "renameAria": "重命名会话",
+      "renameInputAria": "编辑会话标题",
+      "renameSaveAria": "保存会话标题",
+      "renameCancelAria": "取消编辑会话标题",
+      "renameSuccess": "会话标题已更新",
+      "renameError": "更新会话标题失败",
+      "renameEmptyError": "会话标题不能为空"
     },
     "workspace": {
       "loadError": "加载目录失败",


### PR DESCRIPTION
## Summary
- add inline session title editing with backend persistence and optimistic frontend updates
- redesign history into a single-rail layout with richer bookmark shortcuts, slimmer session cards, and cleaner status filtering
- add sidebar bookmark affordances plus focused tests and locale updates

## Validation
- focused history/session component tests
- focused session rename context tests
- focused Rust session repository tests