### PR TITLE
Add terminal checkSession follow-up guidance

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -422,7 +422,14 @@ pub fn build_terminal_check_session_result_from_messages(
             }),
         ]
     } else {
-        vec![]
+        vec![json!({
+            "toolName": "messageToSession",
+            "reason": "Request the child session for more detail, file contents, or full output.",
+            "args": {
+                "sessionId": session_id,
+                "message": "Please share the complete output or file contents."
+            }
+        })]
     };
     let message = if is_abnormal {
         format!(
@@ -436,8 +443,8 @@ pub fn build_terminal_check_session_result_from_messages(
         )
     } else {
         format!(
-            "Session {} is terminal ({}).\n\nResult:\n{}",
-            session_id, status, assistant_text
+            "Session {} is terminal ({}).\n\nResult:\n{}\n\nIf you need more detail, use messageToSession(\"{}\", message=\"Please share the complete output or file contents.\") to ask the child session for the full result.",
+            session_id, status, assistant_text, session_id
         )
     };
     let hint = SuccessHint::new(message.clone(), vec![]);
@@ -469,6 +476,8 @@ pub fn build_terminal_check_session_result_from_messages(
             Value::String(default_session_recovery_message(status)),
         );
     }
+    // Always include hasMoreDetail hint so UI can show a "view more" action
+    response_data.insert("hasMoreDetail".to_string(), Value::Bool(true));
 
     hint.to_mcp_result_with_data(Some(Value::Object(response_data)))
 }

--- a/src-tauri/tests/check_session_terminal_result_tests.rs
+++ b/src-tauri/tests/check_session_terminal_result_tests.rs
@@ -41,9 +41,17 @@ fn terminal_check_session_result_includes_final_answer_without_waiting() {
         .structured_content
         .as_ref()
         .expect("structured content expected");
+    let next_actions = structured
+        .get("nextActions")
+        .and_then(|value| value.as_array())
+        .expect("nextActions array expected");
+    let follow_up_action = next_actions
+        .first()
+        .expect("messageToSession follow-up expected");
 
     assert!(text.contains("Session session-terminal-123 is terminal (idle)."));
     assert!(text.contains("All subtasks completed successfully."));
+    assert!(text.contains("If you need more detail, use messageToSession"));
     assert_eq!(
         structured
             .get("responseStatus")
@@ -61,6 +69,32 @@ fn terminal_check_session_result_includes_final_answer_without_waiting() {
     assert_eq!(
         structured.get("result").and_then(|value| value.as_str()),
         Some("All subtasks completed successfully.")
+    );
+    assert_eq!(
+        follow_up_action
+            .get("toolName")
+            .and_then(|value| value.as_str()),
+        Some("messageToSession")
+    );
+    assert_eq!(
+        follow_up_action
+            .get("reason")
+            .and_then(|value| value.as_str()),
+        Some("Request the child session for more detail, file contents, or full output.")
+    );
+    assert_eq!(
+        follow_up_action
+            .get("args")
+            .and_then(|value| value.get("sessionId"))
+            .and_then(|value| value.as_str()),
+        Some("session-terminal-123")
+    );
+    assert_eq!(
+        follow_up_action
+            .get("args")
+            .and_then(|value| value.get("message"))
+            .and_then(|value| value.as_str()),
+        Some("Please share the complete output or file contents.")
     );
 }
 


### PR DESCRIPTION
## Summary
- add messageToSession follow-up guidance to terminal checkSession success responses
- expose the same follow-up in structured nextActions for agent consumers
- cover the terminal-success path with targeted Rust integration assertions

Closes #1336