### PR TITLE
Handle stale scheduled task workspace overrides

### DIFF
--- a/src-tauri/src/scheduled/runner.rs
+++ b/src-tauri/src/scheduled/runner.rs
@@ -18,7 +18,9 @@ use uuid::Uuid;
 use crate::agent::{AgentConfig, AgentSessionManager};
 use crate::mcp::types::MCPContent;
 use crate::models::chat::{Message, MessageSource};
-use crate::repositories::{AssistantRepository, ScheduledTaskRepository, SessionRepository};
+use crate::repositories::{
+    AssistantRepository, ScheduledTaskRepository, SessionRepository, UpdateScheduledTaskParams,
+};
 use crate::scheduled::ScheduleTimezone;
 use crate::services::WorkspaceService;
 use crate::state::{
@@ -68,12 +70,56 @@ pub async fn resolve_task_session_resolution(
     Ok(TaskSessionResolution::Create(session_id.to_string()))
 }
 
-async fn sync_task_workspace_override(
+fn is_stale_workspace_override_error(error: &str) -> bool {
+    error.starts_with("Path does not exist:") || error.starts_with("Path is not a directory:")
+}
+
+pub async fn sync_task_workspace_override(
+    repo: &dyn ScheduledTaskRepository,
+    task_id: &str,
+    task_name: &str,
     session_id: &str,
     workspace_override: Option<&str>,
 ) -> Result<(), String> {
     if let Some(path) = workspace_override {
-        WorkspaceService::set_override(session_id, path.to_string()).await
+        match WorkspaceService::set_override(session_id, path.to_string()).await {
+            Ok(()) => Ok(()),
+            Err(error) if is_stale_workspace_override_error(&error) => {
+                log::warn!(
+                    "⏰ Scheduled task '{}' ({}) references stale workspace override '{}'; \
+                     clearing override and falling back to the default workspace.",
+                    task_name,
+                    task_id,
+                    path
+                );
+                WorkspaceService::cancel_override(session_id).await?;
+                repo.update_scheduled_task(
+                    task_id,
+                    UpdateScheduledTaskParams {
+                        name: None,
+                        cron_expression: None,
+                        schedule_timezone: None,
+                        assistant_id: None,
+                        group_id: None,
+                        group_name: None,
+                        message: None,
+                        yolo_mode: None,
+                        workspace_override: Some(None),
+                        enabled: None,
+                        next_run_at: None,
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    format!(
+                        "Failed to clear stale workspace override for scheduled task {}: {}",
+                        task_id, e
+                    )
+                })?;
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     } else {
         WorkspaceService::cancel_override(session_id).await
     }
@@ -219,7 +265,15 @@ async fn execute_task(
     }
 
     // ── 4. Synchronize workspace override before injecting the task message ───
-    sync_task_workspace_override(&session_id, task.workspace_override.as_deref()).await?;
+    let repo = get_scheduled_task_repository();
+    sync_task_workspace_override(
+        repo,
+        &task.id,
+        &task.name,
+        &session_id,
+        task.workspace_override.as_deref(),
+    )
+    .await?;
 
     // ── 5. Inject message and trigger workflow ────────────────────────────────
     let now_ts = chrono::Utc::now().timestamp_millis();
@@ -258,7 +312,6 @@ async fn execute_task(
         now_ms,
         &task.schedule_timezone,
     )?;
-    let repo = get_scheduled_task_repository();
     let new_session_id = is_new_session.then_some(session_id);
     repo.record_run(&task.id, new_session_id, now_ms, next_run_at)
         .await

--- a/src-tauri/src/scheduled/runner.rs
+++ b/src-tauri/src/scheduled/runner.rs
@@ -8,6 +8,7 @@
 //!  5. Record the run and compute the next fire time
 
 use std::collections::HashSet;
+use std::path::Path;
 use std::str::FromStr;
 
 use chrono::TimeZone;
@@ -70,8 +71,8 @@ pub async fn resolve_task_session_resolution(
     Ok(TaskSessionResolution::Create(session_id.to_string()))
 }
 
-fn is_stale_workspace_override_error(error: &str) -> bool {
-    error.starts_with("Path does not exist:") || error.starts_with("Path is not a directory:")
+fn is_stale_workspace_override(path: &str) -> bool {
+    !Path::new(path).is_dir()
 }
 
 pub async fn sync_task_workspace_override(
@@ -82,43 +83,41 @@ pub async fn sync_task_workspace_override(
     workspace_override: Option<&str>,
 ) -> Result<(), String> {
     if let Some(path) = workspace_override {
-        match WorkspaceService::set_override(session_id, path.to_string()).await {
-            Ok(()) => Ok(()),
-            Err(error) if is_stale_workspace_override_error(&error) => {
-                log::warn!(
-                    "⏰ Scheduled task '{}' ({}) references stale workspace override '{}'; \
-                     clearing override and falling back to the default workspace.",
-                    task_name,
-                    task_id,
-                    path
-                );
-                WorkspaceService::cancel_override(session_id).await?;
-                repo.update_scheduled_task(
-                    task_id,
-                    UpdateScheduledTaskParams {
-                        name: None,
-                        cron_expression: None,
-                        schedule_timezone: None,
-                        assistant_id: None,
-                        group_id: None,
-                        group_name: None,
-                        message: None,
-                        yolo_mode: None,
-                        workspace_override: Some(None),
-                        enabled: None,
-                        next_run_at: None,
-                    },
+        if is_stale_workspace_override(path) {
+            log::warn!(
+                "⏰ Scheduled task '{}' ({}) references stale workspace override '{}'; \
+                 clearing override and falling back to the default workspace.",
+                task_name,
+                task_id,
+                path
+            );
+            WorkspaceService::cancel_override(session_id).await?;
+            repo.update_scheduled_task(
+                task_id,
+                UpdateScheduledTaskParams {
+                    name: None,
+                    cron_expression: None,
+                    schedule_timezone: None,
+                    assistant_id: None,
+                    group_id: None,
+                    group_name: None,
+                    message: None,
+                    yolo_mode: None,
+                    workspace_override: Some(None),
+                    enabled: None,
+                    next_run_at: None,
+                },
+            )
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to clear stale workspace override for scheduled task {}: {}",
+                    task_id, e
                 )
-                .await
-                .map_err(|e| {
-                    format!(
-                        "Failed to clear stale workspace override for scheduled task {}: {}",
-                        task_id, e
-                    )
-                })?;
-                Ok(())
-            }
-            Err(error) => Err(error),
+            })?;
+            Ok(())
+        } else {
+            WorkspaceService::set_override(session_id, path.to_string()).await
         }
     } else {
         WorkspaceService::cancel_override(session_id).await

--- a/src-tauri/tests/scheduled_task_workspace_override_tests.rs
+++ b/src-tauri/tests/scheduled_task_workspace_override_tests.rs
@@ -6,7 +6,7 @@ use tauri_mcp_agent_lib::repositories::{
 };
 use tauri_mcp_agent_lib::scheduled::runner::sync_task_workspace_override;
 use tauri_mcp_agent_lib::services::scheduled_task_service::{
-    CreateScheduledTaskInput, ScheduledTaskService,
+    CreateScheduledTaskInput, ScheduledTaskGovernanceSettings, ScheduledTaskService,
 };
 use tauri_mcp_agent_lib::set_session_repository;
 
@@ -56,7 +56,7 @@ async fn sync_task_workspace_override_clears_stale_scheduled_override() {
     let missing_workspace = temp_dir.path().join("missing-workspace");
     let missing_workspace_str = missing_workspace.to_string_lossy().to_string();
 
-    let task = ScheduledTaskService::create_scheduled_task(
+    let task = ScheduledTaskService::create_scheduled_task_with_governance(
         &scheduled_repo,
         CreateScheduledTaskInput {
             name: "Nightly report".to_string(),
@@ -70,6 +70,7 @@ async fn sync_task_workspace_override_clears_stale_scheduled_override() {
             created_by_session_id: Some(session_id.to_string()),
             workspace_override: Some(missing_workspace_str.clone()),
         },
+        &ScheduledTaskGovernanceSettings::default(),
     )
     .await
     .expect("scheduled task should be created");

--- a/src-tauri/tests/scheduled_task_workspace_override_tests.rs
+++ b/src-tauri/tests/scheduled_task_workspace_override_tests.rs
@@ -1,0 +1,94 @@
+mod common;
+
+use tauri_mcp_agent_lib::repositories::{
+    ScheduledTaskRepository, SessionMetadata, SessionRepository, SessionStatus,
+    SqliteScheduledTaskRepository, SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::scheduled::runner::sync_task_workspace_override;
+use tauri_mcp_agent_lib::services::scheduled_task_service::{
+    CreateScheduledTaskInput, ScheduledTaskService,
+};
+use tauri_mcp_agent_lib::set_session_repository;
+
+fn make_session(session_id: &str) -> SessionMetadata {
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Scheduled Task Session".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-4.1".to_string(),
+        provider: "openai".to_string(),
+        agent_config: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: 1,
+        updated_at: 1,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        yolo_mode: false,
+        unsafe_mode: false,
+        workspace_override: None,
+    }
+}
+
+#[tokio::test]
+async fn sync_task_workspace_override_clears_stale_scheduled_override() {
+    let db = common::setup_test_db_with_migrations().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    set_session_repository(session_repo.clone());
+    let scheduled_repo = SqliteScheduledTaskRepository::new(db);
+
+    let session_id = "scheduled-stale-workspace-session";
+    session_repo
+        .upsert_session(&make_session(session_id))
+        .await
+        .expect("session should be persisted");
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let missing_workspace = temp_dir.path().join("missing-workspace");
+    let missing_workspace_str = missing_workspace.to_string_lossy().to_string();
+
+    let task = ScheduledTaskService::create_scheduled_task(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Nightly report".to_string(),
+            cron_expression: "0 9 * * *".to_string(),
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Generate report".to_string(),
+            yolo_mode: false,
+            created_by_session_id: Some(session_id.to_string()),
+            workspace_override: Some(missing_workspace_str.clone()),
+        },
+    )
+    .await
+    .expect("scheduled task should be created");
+
+    sync_task_workspace_override(
+        &scheduled_repo,
+        &task.id,
+        &task.name,
+        session_id,
+        task.workspace_override.as_deref(),
+    )
+    .await
+    .expect("stale override should be cleared instead of failing");
+
+    let updated = scheduled_repo
+        .get_scheduled_task(&task.id)
+        .await
+        .expect("task lookup should succeed")
+        .expect("task should still exist");
+
+    assert_eq!(updated.workspace_override, None);
+}


### PR DESCRIPTION
## Summary
- clear stale scheduled task workspace overrides instead of failing the run
- fall back to the session default workspace when the stored override path no longer exists
- add an integration test covering stale scheduled workspace cleanup

## Testing
- pnpm rust:test -- --test scheduled_task_workspace_override_tests