### PR TITLE
refactor(compaction): split trigger.rs into focused sub-modules

### DIFF
--- a/.github/skills/email-integration/SKILL.md
+++ b/.github/skills/email-integration/SKILL.md
@@ -61,6 +61,7 @@ python scripts/setup_account.py --reset
 ```
 
 The script will:
+
 1. Prompt for email address (visible)
 2. Auto-detect server settings from domain (see `references/server-profiles.md`)
 3. Prompt for password using `getpass()` — **input is hidden**
@@ -125,6 +126,7 @@ python scripts/email_client.py --action search_email --query "<IMAP search strin
 ```
 
 Query construction examples:
+
 - "김철수한테 온 거" → `--query "FROM 김철수"`
 - "지난주 메일" → `--query "SINCE 26-May-2026"`
 - "프로젝트 관련" → `--query "SUBJECT 프로젝트"`
@@ -161,13 +163,13 @@ For bulk operations (e.g. "스팸함 비워"), confirm count with user before pr
 
 ## Error Handling
 
-| Error | Cause | Action |
-|---|---|---|
+| Error                  | Cause                                 | Action                                                          |
+| ---------------------- | ------------------------------------- | --------------------------------------------------------------- |
 | Auth failed (IMAP 535) | Wrong password or App Password needed | Run `setup_account.py --reset`, guide user to App Password docs |
-| Connection refused | Wrong host/port | Check `references/server-profiles.md`, offer to re-run setup |
-| Config not found | First run or deleted | Run `setup_account.py` |
-| SSL error | Port mismatch | Suggest switching 993↔143 or 587↔465 |
-| Send failed (SMTP 550) | Recipient rejected | Confirm address with user |
+| Connection refused     | Wrong host/port                       | Check `references/server-profiles.md`, offer to re-run setup    |
+| Config not found       | First run or deleted                  | Run `setup_account.py`                                          |
+| SSL error              | Port mismatch                         | Suggest switching 993↔143 or 587↔465                          |
+| Send failed (SMTP 550) | Recipient rejected                    | Confirm address with user                                       |
 
 Always provide the next concrete step, never just report the error.
 

--- a/.github/skills/email-integration/references/request-patterns.md
+++ b/.github/skills/email-integration/references/request-patterns.md
@@ -9,15 +9,15 @@ Use this reference to determine the correct `--action` and arguments.
 
 **Patterns that trigger this action:**
 
-| User says | Command |
-| --- | --- |
-| "메일 보여줘" | `--action read_inbox --limit 10 --filter unread` |
-| "받은 편지함" | `--action read_inbox --limit 10 --filter unread` |
-| "안 읽은 메일" | `--action read_inbox --filter unread` |
-| "오늘 온 메일" | `--action read_inbox --filter today` |
-| "최근 메일 20개" | `--action read_inbox --limit 20 --filter all` |
-| "전체 메일 목록" | `--action read_inbox --limit 20 --filter all` |
-| "Check my email" | `--action read_inbox --limit 10 --filter unread` |
+| User says          | Command                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "메일 보여줘"      | `--action read_inbox --limit 10 --filter unread`                                                                                                       |
+| "받은 편지함"      | `--action read_inbox --limit 10 --filter unread`                                                                                                       |
+| "안 읽은 메일"     | `--action read_inbox --filter unread`                                                                                                                  |
+| "오늘 온 메일"     | `--action read_inbox --filter today`                                                                                                                   |
+| "최근 메일 20개"   | `--action read_inbox --limit 20 --filter all`                                                                                                          |
+| "전체 메일 목록"   | `--action read_inbox --limit 20 --filter all`                                                                                                          |
+| "Check my email"   | `--action read_inbox --limit 10 --filter unread`                                                                                                       |
 | "다음 10개 보여줘" | Re-run `--action read_inbox --limit 20 --filter all`, explain that offset pagination is not built in, and present items 11-20 from the expanded result |
 
 **Default:** `--limit 10 --filter unread`
@@ -28,13 +28,13 @@ Use this reference to determine the correct `--action` and arguments.
 
 **Patterns that trigger this action:**
 
-| User says | Command |
-| --- | --- |
-| "1번 메일 열어줘" | `--action read_email --uid <uid from list item #1>` |
-| "이 메일 내용 보여줘" | `--action read_email --uid <last referenced uid>` |
-| "두 번째 메일 읽어줘" | `--action read_email --uid <uid from list item #2>` |
-| "방금 온 메일 내용이 뭐야?" | `--action read_email --uid <uid of most recent>` |
-| "Open email from 김철수" | Search first, then read the matching UID |
+| User says                   | Command                                             |
+| --------------------------- | --------------------------------------------------- |
+| "1번 메일 열어줘"           | `--action read_email --uid <uid from list item #1>` |
+| "이 메일 내용 보여줘"       | `--action read_email --uid <last referenced uid>`   |
+| "두 번째 메일 읽어줘"       | `--action read_email --uid <uid from list item #2>` |
+| "방금 온 메일 내용이 뭐야?" | `--action read_email --uid <uid of most recent>`    |
+| "Open email from 김철수"    | Search first, then read the matching UID            |
 
 **Note:** Always use the UID from a prior `read_inbox` or `search_email` response.
 Never guess UIDs. If the user refers to an email by number, map to the `uid` field
@@ -46,19 +46,20 @@ from the numbered list shown to the user.
 
 **Patterns that trigger this action:**
 
-| User says | Approach |
-| --- | --- |
-| "김철수한테 메일 보내줘" | Ask for subject/body if not provided, then send |
-| "이 메일에 답장 써줘" | Use `--reply-to-uid`, prepend "Re:" to subject |
-| "회의 일정 잡는 메일 써줘" | Draft full body based on context, confirm before sending |
-| "박 팀장한테 보고서 보냈다고 해줘" | Draft short message, confirm recipient address, send |
-| "Forward this to HR" | Read original, compose new message with original body quoted |
+| User says                          | Approach                                                     |
+| ---------------------------------- | ------------------------------------------------------------ |
+| "김철수한테 메일 보내줘"           | Ask for subject/body if not provided, then send              |
+| "이 메일에 답장 써줘"              | Use `--reply-to-uid`, prepend "Re:" to subject               |
+| "회의 일정 잡는 메일 써줘"         | Draft full body based on context, confirm before sending     |
+| "박 팀장한테 보고서 보냈다고 해줘" | Draft short message, confirm recipient address, send         |
+| "Forward this to HR"               | Read original, compose new message with original body quoted |
 
 **Draft confirmation rule:**
 If the user does not provide a full body, draft the email content yourself,
 show it to the user for approval ("이 내용으로 발송할까요?"), then send after confirmation.
 
 **Example composed command:**
+
 ```
 python email_client.py --action send_email \
   --to "chulsoo.kim@corp.com" \
@@ -72,31 +73,31 @@ python email_client.py --action send_email \
 
 **Patterns that trigger this action:**
 
-| User says | IMAP query |
-| --- | --- |
-| "김철수한테 온 거 찾아줘" | `FROM "김철수"` |
-| "boss@corp.com에서 온 메일" | `FROM "boss@corp.com"` |
-| "프로젝트 관련 메일" | `SUBJECT "프로젝트"` |
-| "지난주 메일" | `SINCE 26-May-2026` |
-| "5월에 온 메일" | `SINCE 01-May-2026 BEFORE 01-Jun-2026` |
-| "안 읽은 메일 중 긴급" | `UNSEEN SUBJECT "긴급"` |
-| "첨부파일 있는 메일" | `BODY "Content-Disposition: attachment"` (best effort) |
-| "계약서 관련" | `TEXT "계약서"` |
+| User says                   | IMAP query                                             |
+| --------------------------- | ------------------------------------------------------ |
+| "김철수한테 온 거 찾아줘"   | `FROM "김철수"`                                        |
+| "boss@corp.com에서 온 메일" | `FROM "boss@corp.com"`                                 |
+| "프로젝트 관련 메일"        | `SUBJECT "프로젝트"`                                   |
+| "지난주 메일"               | `SINCE 26-May-2026`                                    |
+| "5월에 온 메일"             | `SINCE 01-May-2026 BEFORE 01-Jun-2026`                 |
+| "안 읽은 메일 중 긴급"      | `UNSEEN SUBJECT "긴급"`                                |
+| "첨부파일 있는 메일"        | `BODY "Content-Disposition: attachment"` (best effort) |
+| "계약서 관련"               | `TEXT "계약서"`                                        |
 
 **IMAP search operator reference:**
 
-| Operator | Meaning |
-| --- | --- |
-| `FROM "x"` | Sender contains x |
-| `TO "x"` | Recipient contains x |
-| `SUBJECT "x"` | Subject contains x |
-| `TEXT "x"` | Body or header contains x |
-| `UNSEEN` | Unread messages |
-| `SEEN` | Read messages |
-| `SINCE dd-Mon-yyyy` | On or after date |
-| `BEFORE dd-Mon-yyyy` | Before date |
-| `ON dd-Mon-yyyy` | Exactly on date |
-| `FLAGGED` | Starred / flagged |
+| Operator             | Meaning                   |
+| -------------------- | ------------------------- |
+| `FROM "x"`           | Sender contains x         |
+| `TO "x"`             | Recipient contains x      |
+| `SUBJECT "x"`        | Subject contains x        |
+| `TEXT "x"`           | Body or header contains x |
+| `UNSEEN`             | Unread messages           |
+| `SEEN`               | Read messages             |
+| `SINCE dd-Mon-yyyy`  | On or after date          |
+| `BEFORE dd-Mon-yyyy` | Before date               |
+| `ON dd-Mon-yyyy`     | Exactly on date           |
+| `FLAGGED`            | Starred / flagged         |
 
 Combine operators with a space (implicit AND):
 `FROM "boss" SINCE 01-May-2026 UNSEEN`
@@ -107,28 +108,29 @@ Combine operators with a space (implicit AND):
 
 **Patterns that trigger this action:**
 
-| User says | Command |
-| --- | --- |
-| "읽음 처리해줘" | `--action manage_email --uid <uid> --op mark_read` |
-| "안 읽음으로 바꿔줘" | `--action manage_email --uid <uid> --op mark_unread` |
-| "이 메일 삭제해줘" | `--action manage_email --uid <uid> --op delete` |
-| "스팸함으로 이동" | `--action manage_email --uid <uid> --op move --folder Spam` |
-| "보관함으로 이동" | `--action manage_email --uid <uid> --op move --folder Archive` |
-| "중요 폴더로" | `--action manage_email --uid <uid> --op move --folder Important` |
+| User says            | Command                                                          |
+| -------------------- | ---------------------------------------------------------------- |
+| "읽음 처리해줘"      | `--action manage_email --uid <uid> --op mark_read`               |
+| "안 읽음으로 바꿔줘" | `--action manage_email --uid <uid> --op mark_unread`             |
+| "이 메일 삭제해줘"   | `--action manage_email --uid <uid> --op delete`                  |
+| "스팸함으로 이동"    | `--action manage_email --uid <uid> --op move --folder Spam`      |
+| "보관함으로 이동"    | `--action manage_email --uid <uid> --op move --folder Archive`   |
+| "중요 폴더로"        | `--action manage_email --uid <uid> --op move --folder Important` |
 
 **Bulk operations (e.g. "스팸함 비워"):**
+
 1. Search the target folder: `--action search_email --query "ALL"`
 2. Show count to user: "스팸함에 37개 있습니다. 모두 삭제할까요?"
 3. After confirmation, loop through UIDs with `--op delete`
 
 **Common folder names** (vary by server):
 
-| Folder type | Gmail | Outlook | Naver |
-| --- | --- | --- | --- |
-| Spam | `[Gmail]/Spam` | `Junk Email` | `스팸메일함` |
-| Archive | `[Gmail]/All Mail` | `Archive` | `보관함` |
-| Sent | `[Gmail]/Sent Mail` | `Sent Items` | `보낸메일함` |
-| Trash | `[Gmail]/Trash` | `Deleted Items` | `휴지통` |
+| Folder type | Gmail               | Outlook         | Naver        |
+| ----------- | ------------------- | --------------- | ------------ |
+| Spam        | `[Gmail]/Spam`      | `Junk Email`    | `스팸메일함` |
+| Archive     | `[Gmail]/All Mail`  | `Archive`       | `보관함`     |
+| Sent        | `[Gmail]/Sent Mail` | `Sent Items`    | `보낸메일함` |
+| Trash       | `[Gmail]/Trash`     | `Deleted Items` | `휴지통`     |
 
 If folder move fails, try listing folders first (IMAP `LIST "" "*"` — not exposed as a
 standalone action, but can be added if needed).
@@ -137,10 +139,10 @@ standalone action, but can be added if needed).
 
 ## Ambiguous requests — how to resolve
 
-| Situation | Resolution |
-| --- | --- |
-| User says "메일 확인해줘" with no context | Default to `read_inbox --filter unread --limit 10` |
-| User refers to "그 메일" without specifying | Ask: "어떤 메일을 말씀하시는 건가요? 목록에서 번호를 알려주세요." |
-| User asks to "forward" | Read original → compose new with quoted body → confirm → send |
-| User wants to reply but gives no body | Draft reply based on original content and context, confirm before send |
-| User asks "몇 개나 왔어?" | Run `read_inbox --filter all` and report `total` + `unread` counts only |
+| Situation                                   | Resolution                                                              |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| User says "메일 확인해줘" with no context   | Default to `read_inbox --filter unread --limit 10`                      |
+| User refers to "그 메일" without specifying | Ask: "어떤 메일을 말씀하시는 건가요? 목록에서 번호를 알려주세요."       |
+| User asks to "forward"                      | Read original → compose new with quoted body → confirm → send           |
+| User wants to reply but gives no body       | Draft reply based on original content and context, confirm before send  |
+| User asks "몇 개나 왔어?"                   | Run `read_inbox --filter all` and report `total` + `unread` counts only |

--- a/.github/skills/email-integration/references/server-profiles.md
+++ b/.github/skills/email-integration/references/server-profiles.md
@@ -7,10 +7,10 @@ When a domain matches, these settings are applied as defaults (user can override
 
 ## Gmail (`gmail.com`, `googlemail.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value            |
+| --------- | ---------------- |
 | IMAP host | `imap.gmail.com` |
-| IMAP port | `993` (SSL) |
+| IMAP port | `993` (SSL)      |
 | SMTP host | `smtp.gmail.com` |
 | SMTP port | `587` (STARTTLS) |
 
@@ -28,12 +28,12 @@ Gmail Settings → See all settings → Forwarding and POP/IMAP → Enable IMAP
 
 ## Outlook / Hotmail (`outlook.com`, `hotmail.com`, `live.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value                   |
+| --------- | ----------------------- |
 | IMAP host | `outlook.office365.com` |
-| IMAP port | `993` (SSL) |
-| SMTP host | `smtp.office365.com` |
-| SMTP port | `587` (STARTTLS) |
+| IMAP port | `993` (SSL)             |
+| SMTP host | `smtp.office365.com`    |
+| SMTP port | `587` (STARTTLS)        |
 
 **Enable IMAP:**
 [Outlook Settings](https://outlook.live.com/mail/options/mail/popimap) → POP and IMAP → IMAP enabled
@@ -45,12 +45,12 @@ Gmail Settings → See all settings → Forwarding and POP/IMAP → Enable IMAP
 
 ## Microsoft 365 / Work Outlook (`*.onmicrosoft.com`, corporate domains)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value                   |
+| --------- | ----------------------- |
 | IMAP host | `outlook.office365.com` |
-| IMAP port | `993` (SSL) |
-| SMTP host | `smtp.office365.com` |
-| SMTP port | `587` (STARTTLS) |
+| IMAP port | `993` (SSL)             |
+| SMTP host | `smtp.office365.com`    |
+| SMTP port | `587` (STARTTLS)        |
 
 **Note:** Corporate M365 tenants may block Basic Auth (username/password).
 If login fails, the admin needs to enable SMTP AUTH per-mailbox:
@@ -60,10 +60,10 @@ If login fails, the admin needs to enable SMTP AUTH per-mailbox:
 
 ## Naver Mail (`naver.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value            |
+| --------- | ---------------- |
 | IMAP host | `imap.naver.com` |
-| IMAP port | `993` (SSL) |
+| IMAP port | `993` (SSL)      |
 | SMTP host | `smtp.naver.com` |
 | SMTP port | `587` (STARTTLS) |
 
@@ -76,12 +76,12 @@ Use your **Naver ID password** (not a separate app password).
 
 ## Daum / Kakao Mail (`daum.net`, `kakao.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value                              |
+| --------- | ---------------------------------- |
 | IMAP host | `imap.daum.net` / `imap.kakao.com` |
-| IMAP port | `993` (SSL) |
+| IMAP port | `993` (SSL)                        |
 | SMTP host | `smtp.daum.net` / `smtp.kakao.com` |
-| SMTP port | `465` (SSL direct) |
+| SMTP port | `465` (SSL direct)                 |
 
 Use your **Kakao account password**.
 
@@ -89,12 +89,12 @@ Use your **Kakao account password**.
 
 ## Yahoo Mail (`yahoo.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value                 |
+| --------- | --------------------- |
 | IMAP host | `imap.mail.yahoo.com` |
-| IMAP port | `993` (SSL) |
+| IMAP port | `993` (SSL)           |
 | SMTP host | `smtp.mail.yahoo.com` |
-| SMTP port | `587` (STARTTLS) |
+| SMTP port | `587` (STARTTLS)      |
 
 **App Password required:**
 [Yahoo Account Security](https://login.yahoo.com/account/security) → Generate app password → Mail
@@ -103,12 +103,12 @@ Use your **Kakao account password**.
 
 ## iCloud Mail (`icloud.com`, `me.com`, `mac.com`)
 
-| Setting | Value |
-| --- | --- |
+| Setting   | Value              |
+| --------- | ------------------ |
 | IMAP host | `imap.mail.me.com` |
-| IMAP port | `993` (SSL) |
+| IMAP port | `993` (SSL)        |
 | SMTP host | `smtp.mail.me.com` |
-| SMTP port | `587` (STARTTLS) |
+| SMTP port | `587` (STARTTLS)   |
 
 **App-specific password required:**
 [Apple ID](https://appleid.apple.com) → Sign-In and Security → App-Specific Passwords
@@ -121,11 +121,11 @@ No preset. `setup_account.py` will prompt for all fields manually.
 
 Common patterns:
 
-| Provider type | Typical IMAP port | Typical SMTP port |
-| --- | --- | --- |
-| SSL (recommended) | `993` | `465` |
-| STARTTLS | `143` | `587` |
-| Legacy (no TLS) | `143` | `25` (avoid) |
+| Provider type     | Typical IMAP port | Typical SMTP port |
+| ----------------- | ----------------- | ----------------- |
+| SSL (recommended) | `993`             | `465`             |
+| STARTTLS          | `143`             | `587`             |
+| Legacy (no TLS)   | `143`             | `25` (avoid)      |
 
 If connecting to port `465` for SMTP, the `smtp_use_tls` flag will be set to `false`
 in the config (direct SSL instead of STARTTLS).
@@ -134,10 +134,10 @@ in the config (direct SSL instead of STARTTLS).
 
 ## Port Quick Reference
 
-| Port | Protocol | Usage |
-| --- | --- | --- |
-| 993 | IMAP over SSL | Standard secure IMAP |
-| 143 | IMAP + STARTTLS | Alternative (less common) |
-| 587 | SMTP + STARTTLS | Standard submission port |
-| 465 | SMTP over SSL | Legacy SSL submission |
-| 25 | SMTP plain | Server-to-server only, avoid |
+| Port | Protocol        | Usage                        |
+| ---- | --------------- | ---------------------------- |
+| 993  | IMAP over SSL   | Standard secure IMAP         |
+| 143  | IMAP + STARTTLS | Alternative (less common)    |
+| 587  | SMTP + STARTTLS | Standard submission port     |
+| 465  | SMTP over SSL   | Legacy SSL submission        |
+| 25   | SMTP plain      | Server-to-server only, avoid |

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ _Important: `bootstrap` is a builtin capability often used alongside these skill
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.7.32"
+version = "0.8.0"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/agent/llm/completion/compaction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction.rs
@@ -1,6 +1,9 @@
+mod diagnostics;
 mod hints;
 mod instruction;
 mod payload;
+mod preparation;
+mod selection;
 mod trigger;
 
 use crate::models::chat::Message;

--- a/src-tauri/src/agent/llm/completion/compaction/diagnostics.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/diagnostics.rs
@@ -1,0 +1,131 @@
+use super::payload::{inspect_compaction_payload, CompactionPayloadDiagnostics};
+use crate::agent::state::CompactionRecoveryPhase;
+use crate::models::chat::Message;
+
+fn format_compaction_payload_messages(diagnostics: &CompactionPayloadDiagnostics) -> String {
+    if diagnostics.messages.is_empty() {
+        return "  - <none>".to_string();
+    }
+
+    diagnostics
+        .messages
+        .iter()
+        .map(|message| {
+            format!(
+                "  - {} | role={} | source={} | flags={} | preview={}",
+                message.id,
+                message.role,
+                message.source,
+                if message.flags.is_empty() {
+                    "-".to_string()
+                } else {
+                    message.flags.join("+")
+                },
+                message.preview
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(super) fn log_compaction_input_diagnostics(
+    session_id: &str,
+    provider_id: &str,
+    recovery_phase: CompactionRecoveryPhase,
+    retry_attempt: u32,
+    base_payload_message_count: usize,
+    request_layout_message_count: usize,
+    selected_messages: &[Message],
+) {
+    let diagnostics = inspect_compaction_payload(selected_messages);
+
+    log::info!(
+        "🧪 Compaction input diagnostics: session={}, provider={}, recovery_phase={:?}, retry_attempt={}, base_payload_message_count={}, request_layout_message_count={}, emitted_message_count={}, body_message_count={}, raw_delta_message_count={}, compact_summary_count={}, compaction_instruction_count={}, scaffolding_count={}, external_request_count={}, assistant_message_count={}, tool_message_count={}, latest_external_request_ids={:?}",
+        session_id,
+        provider_id,
+        recovery_phase,
+        retry_attempt,
+        base_payload_message_count,
+        request_layout_message_count,
+        diagnostics.total_messages,
+        diagnostics.body_message_count,
+        diagnostics.raw_delta_message_count,
+        diagnostics.compact_summary_count,
+        diagnostics.compaction_instruction_count,
+        diagnostics.scaffolding_count,
+        diagnostics.external_request_count,
+        diagnostics.assistant_message_count,
+        diagnostics.tool_message_count,
+        diagnostics.latest_external_request_message_ids
+    );
+
+    if diagnostics.external_request_count == 0 {
+        log::warn!(
+            "⚠️ Compaction input emitted without any external request messages: session={}, provider={}, recovery_phase={:?}, retry_attempt={}",
+            session_id,
+            provider_id,
+            recovery_phase,
+            retry_attempt
+        );
+    }
+
+    if diagnostics.raw_delta_message_count == 1 && diagnostics.external_request_count == 1 {
+        log::warn!(
+            "⚠️ Compaction input collapsed to a single raw delta message around the latest request: session={}, provider={}, recovery_phase={:?}, retry_attempt={}",
+            session_id,
+            provider_id,
+            recovery_phase,
+            retry_attempt
+        );
+    }
+
+    log::debug!(
+        "🧾 Compaction input messages: session={}, provider={}, recovery_phase={:?}, retry_attempt={}, messages=\n{}",
+        session_id,
+        provider_id,
+        recovery_phase,
+        retry_attempt,
+        format_compaction_payload_messages(&diagnostics)
+    );
+}
+
+pub(super) fn log_preflight_split_boundary(
+    session_id: &str,
+    messages: &[Message],
+    split_idx: usize,
+    reason: &str,
+) {
+    let diagnostics =
+        crate::agent::llm::context_selector::inspect_compaction_split_boundary(messages);
+    let first_message_id = messages
+        .first()
+        .map(|message| message.id.as_str())
+        .unwrap_or("?");
+    let last_message_id = messages
+        .last()
+        .map(|message| message.id.as_str())
+        .unwrap_or("?");
+    let first_message_role = messages
+        .first()
+        .map(|message| message.role.as_str())
+        .unwrap_or("?");
+    let last_message_role = messages
+        .last()
+        .map(|message| message.role.as_str())
+        .unwrap_or("?");
+
+    log::warn!(
+        "🧭 Preflight compaction split diagnostics: session={}, reason={}, message_count={}, split_idx={}, first_unresolved_owner_index={:?}, first_unresolved_owner_id={:?}, first_unresolved_tool_call_count={}, first_message_id={}, first_message_role={}, last_message_id={}, last_message_role={}",
+        session_id,
+        reason,
+        messages.len(),
+        split_idx,
+        diagnostics.first_unresolved_owner_index,
+        diagnostics.first_unresolved_owner_id,
+        diagnostics.first_unresolved_tool_call_count,
+        first_message_id,
+        first_message_role,
+        last_message_id,
+        last_message_role
+    );
+}

--- a/src-tauri/src/agent/llm/completion/compaction/preparation.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/preparation.rs
@@ -1,0 +1,353 @@
+use crate::agent::llm::load_context_management_settings;
+use crate::agent::llm::types::{CompactRequest, CompactionParentRequest};
+use crate::agent::state::{AgentSession, CompactionRecoveryPhase};
+use crate::mcp::types::MCPTool;
+use crate::models::chat::Message;
+use crate::repositories::CompactContextRecord;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::diagnostics::log_compaction_input_diagnostics;
+use super::payload::{
+    apply_compaction_retry_budget, build_compaction_request_payload,
+    build_overflow_recovery_compaction_messages, estimate_compaction_non_message_tokens,
+    fit_compaction_request_messages_to_limit, CompactionRequestPayload,
+};
+
+pub(super) const MAX_COMPACTION_BUDGET_RETRY_ATTEMPTS: u32 = 3;
+pub(super) const MAX_COMPACTION_SPLIT_BACKOFF_ATTEMPTS: usize = 3;
+
+pub(super) struct PreparedCompactionRequest {
+    pub compact_event: CompactRequest,
+    pub started_at_ms: i64,
+    pub current_tail_id: Option<String>,
+    pub compacted_delta_count: usize,
+    pub reused_prior_summary: bool,
+}
+
+pub(super) struct PreparedCompactionAttempt {
+    pub prepared: PreparedCompactionRequest,
+    pub recovery_phase: CompactionRecoveryPhase,
+    pub retry_attempt: u32,
+}
+
+#[derive(Clone)]
+pub(super) struct PrepareCompactionRequestInput<'a> {
+    pub session_id: &'a str,
+    pub session_name: &'a str,
+    pub messages: &'a [Message],
+    pub split_idx: usize,
+    pub measured_output_tokens_reserve: usize,
+    pub parent_request: Option<CompactionParentRequest>,
+    pub compact_context_record: Option<CompactContextRecord>,
+    pub started_at_ms: i64,
+    pub resume_completion_after_compact: bool,
+    pub recovery_phase: CompactionRecoveryPhase,
+    pub retry_attempt: u32,
+}
+
+fn advance_compaction_overflow_recovery_step(
+    recovery_phase: CompactionRecoveryPhase,
+    retry_attempt: u32,
+) -> Option<(CompactionRecoveryPhase, u32)> {
+    match recovery_phase {
+        CompactionRecoveryPhase::CacheAligned
+            if retry_attempt < MAX_COMPACTION_BUDGET_RETRY_ATTEMPTS =>
+        {
+            Some((CompactionRecoveryPhase::CacheAligned, retry_attempt + 1))
+        }
+        CompactionRecoveryPhase::CacheAligned => {
+            Some((CompactionRecoveryPhase::OverflowRecovery, 0))
+        }
+        CompactionRecoveryPhase::OverflowRecovery => {
+            Some((CompactionRecoveryPhase::DegradedTools, 0))
+        }
+        CompactionRecoveryPhase::DegradedTools => None,
+    }
+}
+
+pub fn advance_compaction_overflow_recovery_step_for_testing(
+    recovery_phase: CompactionRecoveryPhase,
+    retry_attempt: u32,
+) -> Option<(CompactionRecoveryPhase, u32)> {
+    advance_compaction_overflow_recovery_step(recovery_phase, retry_attempt)
+}
+
+fn degrade_tools_for_overflow_recovery(tools: &[MCPTool]) -> Vec<MCPTool> {
+    tools
+        .iter()
+        .map(|tool| MCPTool {
+            name: tool.name.clone(),
+            title: tool.title.clone(),
+            description: tool.description.clone(),
+            // Overflow recovery is the last-resort fit path. We intentionally keep
+            // only high-signal tool identity/description and drop verbose schemas so
+            // the model still sees what tools exist while the payload stays small
+            // enough to survive the degraded-tools phase.
+            input_schema: crate::mcp::schema::MCPToolInputSchema::default(),
+            output_schema: None,
+            annotations: tool.annotations.clone(),
+        })
+        .collect()
+}
+
+async fn resolve_parent_request(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+    explicit_parent_request: Option<CompactionParentRequest>,
+) -> Option<CompactionParentRequest> {
+    if explicit_parent_request.is_some() {
+        return explicit_parent_request;
+    }
+
+    let request_handle = {
+        let active = active_sessions.read().await;
+        active
+            .get(session_id)
+            .map(|session| session.last_completion_request.clone())
+    }?;
+
+    let request = request_handle.read().await.clone();
+    request
+}
+
+async fn prepare_compaction_request(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    input: PrepareCompactionRequestInput<'_>,
+) -> Result<Option<PreparedCompactionRequest>, String> {
+    let PrepareCompactionRequestInput {
+        session_id,
+        session_name,
+        messages,
+        split_idx,
+        measured_output_tokens_reserve,
+        parent_request,
+        compact_context_record,
+        started_at_ms,
+        resume_completion_after_compact,
+        recovery_phase,
+        retry_attempt,
+    } = input;
+
+    let Some(CompactionRequestPayload {
+        compact_messages: base_compact_messages,
+        to_id,
+        compacted_delta_count,
+        reused_prior_summary,
+    }) = build_compaction_request_payload(
+        session_id,
+        messages,
+        split_idx,
+        compact_context_record.as_ref(),
+        started_at_ms,
+    )
+    else {
+        let compact_record_summary = compact_context_record.as_ref().map(|record| {
+            let compacted_to_idx = messages
+                .iter()
+                .position(|message| message.id == record.to_id);
+            let first_delta_message_idx = compacted_to_idx.map(|idx| idx.saturating_add(1));
+            format!(
+                "to_id={}, compacted_to_idx={:?}, first_delta_message_idx={:?}",
+                record.to_id, compacted_to_idx, first_delta_message_idx
+            )
+        });
+        log::warn!(
+            "⏭️ Preflight compaction payload build returned no-op: session={}, split_idx={}, message_count={}, compact_record={:?}",
+            session_id,
+            split_idx,
+            messages.len(),
+            compact_record_summary
+        );
+        return Ok(None);
+    };
+
+    let settings = load_context_management_settings().await;
+    let safe_input_token_limit =
+        std::cmp::min(settings.max_input_context(), settings.model_max_limit);
+    let base_effective_input_budget =
+        crate::agent::llm::token_utils::calculate_effective_input_budget(
+            safe_input_token_limit,
+            measured_output_tokens_reserve,
+        );
+    let effective_input_token_limit =
+        apply_compaction_retry_budget(base_effective_input_budget, retry_attempt);
+    let resolved_parent_request =
+        resolve_parent_request(active_sessions, session_id, parent_request).await;
+    let request_layout = resolved_parent_request.as_ref().map(|request| {
+        crate::agent::llm::build_request_layout(
+            &request.provider,
+            session_id,
+            request.system_prompt.clone(),
+            request.session_context.clone(),
+            base_compact_messages.clone(),
+        )
+    });
+    let final_compact_messages = request_layout
+        .as_ref()
+        .map(|layout| layout.messages.clone())
+        .unwrap_or_else(|| base_compact_messages.clone());
+    let final_parent_request = match (resolved_parent_request, request_layout.as_ref()) {
+        (Some(mut request), Some(layout)) => {
+            request.system_prompt = layout.system_prompt.clone();
+            Some(request)
+        }
+        (None, Some(_)) => None,
+        (request, None) => request,
+    };
+    let final_parent_request = match (recovery_phase, final_parent_request) {
+        (CompactionRecoveryPhase::DegradedTools, Some(mut request)) => {
+            request.available_tools = request
+                .available_tools
+                .as_ref()
+                .map(|tools| degrade_tools_for_overflow_recovery(tools));
+            Some(request)
+        }
+        (_, request) => request,
+    };
+    let (system_prompt_tokens, tools_tokens) =
+        estimate_compaction_non_message_tokens(final_parent_request.as_ref());
+    let provider_id = final_parent_request
+        .as_ref()
+        .map(|request| request.provider.as_str())
+        .unwrap_or("openai");
+    let compact_messages = match recovery_phase {
+        CompactionRecoveryPhase::CacheAligned => fit_compaction_request_messages_to_limit(
+            &final_compact_messages,
+            provider_id,
+            effective_input_token_limit,
+            system_prompt_tokens,
+            tools_tokens,
+        )?,
+        CompactionRecoveryPhase::OverflowRecovery | CompactionRecoveryPhase::DegradedTools => {
+            build_overflow_recovery_compaction_messages(
+                &final_compact_messages,
+                provider_id,
+                effective_input_token_limit,
+                system_prompt_tokens,
+                tools_tokens,
+            )?
+        }
+    };
+
+    log_compaction_input_diagnostics(
+        session_id,
+        provider_id,
+        recovery_phase,
+        retry_attempt,
+        base_compact_messages.len(),
+        final_compact_messages.len(),
+        &compact_messages,
+    );
+
+    let mut final_compacted_delta_count = compacted_delta_count;
+
+    if !compact_messages.is_empty() {
+        // Count how many delta messages are actually in compact_messages
+        // (excluding the compaction instruction/overlay at the end).
+        let delta_only_count = compact_messages
+            .iter()
+            .filter(|m| {
+                !m.is_compaction_overlay_message()
+                    && !m.is_compact_summary()
+                    && !m.is_request_layout_scaffolding_message()
+            })
+            .count();
+        final_compacted_delta_count = delta_only_count;
+    }
+
+    if final_compacted_delta_count != compacted_delta_count {
+        log::info!(
+            "📐 Compaction payload shrunken, adjusting delta metadata: session={}, compacted_delta_count: {} -> {}",
+            session_id,
+            compacted_delta_count,
+            final_compacted_delta_count
+        );
+    }
+
+    if retry_attempt > 0 {
+        log::warn!(
+            "🔧 Applying compaction retry budget: session={}, retry_attempt={}, safe_input_token_limit={}, measured_output_tokens_reserve={}, base_effective_input_budget={}, effective_input_token_limit={}",
+            session_id,
+            retry_attempt,
+            safe_input_token_limit,
+            measured_output_tokens_reserve,
+            base_effective_input_budget,
+            effective_input_token_limit
+        );
+    }
+    if !matches!(recovery_phase, CompactionRecoveryPhase::CacheAligned) {
+        log::warn!(
+            "🩹 Applying compaction overflow recovery: session={}, recovery_phase={:?}, tools_degraded={}",
+            session_id,
+            recovery_phase,
+            matches!(recovery_phase, CompactionRecoveryPhase::DegradedTools)
+        );
+    }
+
+    Ok(Some(PreparedCompactionRequest {
+        compact_event: CompactRequest {
+            session_id: session_id.to_string(),
+            session_name: session_name.to_string(),
+            messages: compact_messages,
+            to_id,
+            compacted_delta_count: final_compacted_delta_count,
+            parent_request: final_parent_request,
+            resume_completion_after_compact,
+        },
+        started_at_ms,
+        current_tail_id: messages.last().map(|message| message.id.clone()),
+        compacted_delta_count: final_compacted_delta_count,
+        reused_prior_summary,
+    }))
+}
+
+pub(super) async fn prepare_compaction_request_with_recovery_ladder(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    input: PrepareCompactionRequestInput<'_>,
+    initial_recovery_phase: CompactionRecoveryPhase,
+    initial_retry_attempt: u32,
+) -> Result<Option<PreparedCompactionAttempt>, String> {
+    let mut recovery_phase = initial_recovery_phase;
+    let mut retry_attempt = initial_retry_attempt;
+
+    loop {
+        match prepare_compaction_request(
+            active_sessions,
+            PrepareCompactionRequestInput {
+                recovery_phase,
+                retry_attempt,
+                ..input.clone()
+            },
+        )
+        .await
+        {
+            Ok(Some(prepared)) => {
+                return Ok(Some(PreparedCompactionAttempt {
+                    prepared,
+                    recovery_phase,
+                    retry_attempt,
+                }));
+            }
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                let Some((next_recovery_phase, next_retry_attempt)) =
+                    advance_compaction_overflow_recovery_step(recovery_phase, retry_attempt)
+                else {
+                    return Err(error);
+                };
+                log::warn!(
+                    "🪜 Advancing local compaction overflow recovery before emit: session={}, from_phase={:?}, from_retry_attempt={}, to_phase={:?}, to_retry_attempt={}",
+                    input.session_id,
+                    recovery_phase,
+                    retry_attempt,
+                    next_recovery_phase,
+                    next_retry_attempt
+                );
+                recovery_phase = next_recovery_phase;
+                retry_attempt = next_retry_attempt;
+            }
+        }
+    }
+}

--- a/src-tauri/src/agent/llm/completion/compaction/selection.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/selection.rs
@@ -1,0 +1,269 @@
+use crate::models::chat::Message;
+use crate::repositories::CompactContextRecord;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionSelectionPreview {
+    pub compacted_ids: Vec<String>,
+    pub preserved_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailRecompactionRecoveryPlan {
+    pub compacted_to_idx: usize,
+    pub first_delta_message_idx: usize,
+    pub latest_request_start_idx: usize,
+    pub fallback_split_idx: usize,
+}
+
+pub(super) fn build_compaction_selection_preview(
+    messages: &[Message],
+    split_idx: usize,
+) -> CompactionSelectionPreview {
+    let split_idx = split_idx.min(messages.len());
+    CompactionSelectionPreview {
+        compacted_ids: messages[..split_idx]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+        preserved_ids: messages[split_idx..]
+            .iter()
+            .map(|message| message.id.clone())
+            .collect(),
+    }
+}
+
+pub fn preview_preflight_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
+    build_compaction_selection_preview(
+        messages,
+        find_preflight_compactable_end_exclusive(messages, None, None),
+    )
+}
+
+pub(super) fn derive_tail_recompaction_recovery_plan(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    compactable_end_exclusive: usize,
+) -> Option<TailRecompactionRecoveryPlan> {
+    let record = compact_context_record?;
+    let compacted_to_idx = messages
+        .iter()
+        .position(|message| message.id == record.to_id)?;
+    let first_delta_message_idx = compacted_to_idx.saturating_add(1);
+    if first_delta_message_idx < compactable_end_exclusive {
+        return None;
+    }
+
+    let latest_request_start_idx = super::find_latest_external_request_seed_block_start(messages)?;
+    if latest_request_start_idx <= first_delta_message_idx {
+        return None;
+    }
+
+    Some(TailRecompactionRecoveryPlan {
+        compacted_to_idx,
+        first_delta_message_idx,
+        latest_request_start_idx,
+        fallback_split_idx: latest_request_start_idx,
+    })
+}
+
+#[allow(dead_code)]
+pub fn derive_tail_recompaction_recovery_plan_for_testing(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    compactable_end_exclusive: usize,
+) -> Option<TailRecompactionRecoveryPlan> {
+    derive_tail_recompaction_recovery_plan(
+        messages,
+        compact_context_record,
+        compactable_end_exclusive,
+    )
+}
+
+pub(super) fn find_compaction_delta_start_index(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+) -> usize {
+    compact_context_record
+        .and_then(|record| {
+            messages
+                .iter()
+                .position(|message| message.id == record.to_id)
+                .map(|idx| idx.saturating_add(1))
+        })
+        .unwrap_or(0)
+}
+
+fn find_latest_checkpoint_index(messages: &[Message]) -> Option<usize> {
+    messages
+        .iter()
+        .rposition(|message| message.prompt_tokens_value().is_some())
+}
+
+fn retained_tail_has_orphan_tool_messages(messages: &[Message], split_idx: usize) -> bool {
+    use std::collections::HashSet;
+
+    let split_idx = split_idx.min(messages.len());
+    let tail = &messages[split_idx..];
+    let tail_owner_ids = tail
+        .iter()
+        .filter(|message| message.role == "assistant")
+        .flat_map(|message| {
+            message
+                .tool_calls
+                .iter()
+                .flatten()
+                .map(|tool_call| tool_call.id.clone())
+        })
+        .collect::<HashSet<_>>();
+
+    tail.iter().any(|message| {
+        message.role == "tool"
+            && message
+                .tool_call_id
+                .as_ref()
+                .is_some_and(|tool_call_id| !tail_owner_ids.contains(tool_call_id))
+    })
+}
+
+pub(super) fn build_checkpoint_backoff_split_candidates(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    initial_split_idx: usize,
+) -> Vec<usize> {
+    use std::collections::HashSet;
+
+    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
+    let mut seen = HashSet::new();
+    let mut candidates = Vec::new();
+
+    let mut push_candidate = |split_idx: usize| {
+        if split_idx <= delta_start_idx || split_idx > messages.len() {
+            return;
+        }
+        if retained_tail_has_orphan_tool_messages(messages, split_idx) {
+            return;
+        }
+        if seen.insert(split_idx) {
+            candidates.push(split_idx);
+        }
+    };
+
+    push_candidate(initial_split_idx);
+
+    for (idx, message) in messages.iter().enumerate().rev() {
+        if idx < delta_start_idx || message.prompt_tokens_value().is_none() {
+            continue;
+        }
+        push_candidate(idx + 1);
+    }
+
+    candidates
+}
+
+pub fn build_checkpoint_backoff_split_candidates_for_testing(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    initial_split_idx: usize,
+) -> Vec<usize> {
+    build_checkpoint_backoff_split_candidates(messages, compact_context_record, initial_split_idx)
+}
+
+fn find_prompt_checkpoint_compactable_end_exclusive(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    current_context_limit: usize,
+) -> Option<usize> {
+    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
+    let uncompacted_messages = &messages[delta_start_idx..];
+    let latest_checkpoint_relative_idx = find_latest_checkpoint_index(uncompacted_messages)?;
+    let latest_checkpoint = &uncompacted_messages[latest_checkpoint_relative_idx];
+    let latest_prompt_tokens = latest_checkpoint.prompt_tokens_value()?;
+
+    if latest_prompt_tokens > current_context_limit {
+        let compaction_window_start = latest_prompt_tokens.saturating_sub(current_context_limit);
+        let preserve_relative_idx = uncompacted_messages
+            .iter()
+            .position(|message| {
+                message
+                    .prompt_tokens_value()
+                    .is_some_and(|value| value > compaction_window_start)
+            })
+            .unwrap_or(latest_checkpoint_relative_idx);
+        return Some(delta_start_idx + preserve_relative_idx);
+    }
+
+    Some(delta_start_idx + latest_checkpoint_relative_idx + 1)
+}
+
+pub fn has_prompt_checkpoint_compaction_target(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    current_context_limit: usize,
+) -> bool {
+    find_prompt_checkpoint_compactable_end_exclusive(
+        messages,
+        compact_context_record,
+        current_context_limit,
+    )
+    .is_some_and(|compactable_end_exclusive| {
+        compactable_end_exclusive
+            > find_compaction_delta_start_index(messages, compact_context_record)
+    })
+}
+
+pub(super) fn find_preflight_compactable_end_exclusive(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    current_context_limit: Option<usize>,
+) -> usize {
+    if messages.is_empty() {
+        return 0;
+    }
+
+    if let Some(limit) = current_context_limit {
+        if let Some(prompt_checkpoint_end_exclusive) =
+            find_prompt_checkpoint_compactable_end_exclusive(
+                messages,
+                compact_context_record,
+                limit,
+            )
+        {
+            return prompt_checkpoint_end_exclusive;
+        }
+    }
+
+    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
+    let relative_end_exclusive = crate::agent::llm::context_selector::find_compaction_split_index(
+        &messages[delta_start_idx..],
+    );
+    delta_start_idx + relative_end_exclusive
+}
+
+pub fn find_preflight_compactable_end_exclusive_for_testing(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    current_context_limit: Option<usize>,
+) -> usize {
+    find_preflight_compactable_end_exclusive(
+        messages,
+        compact_context_record,
+        current_context_limit,
+    )
+}
+
+pub fn should_skip_same_tail_compaction(
+    messages: &[Message],
+    compact_context_record: Option<&CompactContextRecord>,
+    compactable_end_exclusive: usize,
+) -> bool {
+    let has_compact_summary = messages
+        .first()
+        .map(|message| message.is_compact_summary())
+        .unwrap_or(false);
+
+    if !has_compact_summary {
+        return false;
+    }
+
+    compactable_end_exclusive <= find_compaction_delta_start_index(messages, compact_context_record)
+}

--- a/src-tauri/src/agent/llm/completion/compaction/trigger.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/trigger.rs
@@ -20,8 +20,7 @@ use super::selection::{
     find_preflight_compactable_end_exclusive,
 };
 
-// Re-export public items that compaction.rs imports from this module.
-// This keeps the external API stable without changes to compaction.rs.
+// Re-export public items to keep the external API and downstream imports stable.
 pub use super::preparation::advance_compaction_overflow_recovery_step_for_testing;
 pub use super::selection::{
     build_checkpoint_backoff_split_candidates_for_testing,

--- a/src-tauri/src/agent/llm/completion/compaction/trigger.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/trigger.rs
@@ -1,440 +1,44 @@
 use crate::agent::llm::completion::request::normalize_request_messages;
 use crate::agent::llm::load_context_management_settings;
-use crate::agent::llm::types::{CompactRequest, CompactionParentRequest};
 use crate::agent::state::{
-    AgentSession, CompactionBeginOutcome, CompactionKind, CompactionRecoveryPhase,
-    CompactionReuseOutcome,
+    AgentSession, CompactionBeginOutcome, CompactionKind, CompactionReuseOutcome,
 };
 use crate::agent::tauri_events::{emit_compact_request, emit_compact_started};
-use crate::mcp::types::MCPTool;
 use crate::models::chat::Message;
-use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
 
-use super::payload::{
-    apply_compaction_retry_budget, build_compaction_request_payload,
-    build_overflow_recovery_compaction_messages, estimate_compaction_non_message_tokens,
-    fit_compaction_request_messages_to_limit, inspect_compaction_payload,
-    CompactionPayloadDiagnostics, CompactionRequestPayload,
+use super::diagnostics::log_preflight_split_boundary;
+use super::preparation::{
+    prepare_compaction_request_with_recovery_ladder, PrepareCompactionRequestInput,
+    PreparedCompactionAttempt, MAX_COMPACTION_SPLIT_BACKOFF_ATTEMPTS,
+};
+use super::selection::{
+    build_checkpoint_backoff_split_candidates, derive_tail_recompaction_recovery_plan,
+    find_preflight_compactable_end_exclusive,
 };
 
-async fn resolve_parent_request(
-    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
-    session_id: &str,
-    explicit_parent_request: Option<CompactionParentRequest>,
-) -> Option<CompactionParentRequest> {
-    if explicit_parent_request.is_some() {
-        return explicit_parent_request;
-    }
+// Re-export public items that compaction.rs imports from this module.
+// This keeps the external API stable without changes to compaction.rs.
+pub use super::preparation::advance_compaction_overflow_recovery_step_for_testing;
+pub use super::selection::{
+    build_checkpoint_backoff_split_candidates_for_testing,
+    derive_tail_recompaction_recovery_plan_for_testing,
+    find_preflight_compactable_end_exclusive_for_testing, has_prompt_checkpoint_compaction_target,
+    preview_preflight_compaction_selection, should_skip_same_tail_compaction,
+    CompactionSelectionPreview, TailRecompactionRecoveryPlan,
+};
 
-    let request_handle = {
-        let active = active_sessions.read().await;
-        active
-            .get(session_id)
-            .map(|session| session.last_completion_request.clone())
-    }?;
-
-    let request = request_handle.read().await.clone();
-    request
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompactionSelectionPreview {
-    pub compacted_ids: Vec<String>,
-    pub preserved_ids: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TailRecompactionRecoveryPlan {
-    pub compacted_to_idx: usize,
-    pub first_delta_message_idx: usize,
-    pub latest_request_start_idx: usize,
-    pub fallback_split_idx: usize,
-}
-
-fn build_compaction_selection_preview(
-    messages: &[Message],
-    split_idx: usize,
-) -> CompactionSelectionPreview {
-    let split_idx = split_idx.min(messages.len());
-
-    CompactionSelectionPreview {
-        compacted_ids: messages[..split_idx]
-            .iter()
-            .map(|message| message.id.clone())
-            .collect(),
-        preserved_ids: messages[split_idx..]
-            .iter()
-            .map(|message| message.id.clone())
-            .collect(),
-    }
-}
-
-fn format_compaction_payload_messages(diagnostics: &CompactionPayloadDiagnostics) -> String {
-    if diagnostics.messages.is_empty() {
-        return "  - <none>".to_string();
-    }
-
-    diagnostics
-        .messages
-        .iter()
-        .map(|message| {
-            format!(
-                "  - {} | role={} | source={} | flags={} | preview={}",
-                message.id,
-                message.role,
-                message.source,
-                if message.flags.is_empty() {
-                    "-".to_string()
-                } else {
-                    message.flags.join("+")
-                },
-                message.preview
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn log_compaction_input_diagnostics(
-    session_id: &str,
-    provider_id: &str,
-    recovery_phase: CompactionRecoveryPhase,
-    retry_attempt: u32,
-    base_payload_message_count: usize,
-    request_layout_message_count: usize,
-    selected_messages: &[Message],
-) {
-    let diagnostics = inspect_compaction_payload(selected_messages);
-
-    log::info!(
-        "🧪 Compaction input diagnostics: session={}, provider={}, recovery_phase={:?}, retry_attempt={}, base_payload_message_count={}, request_layout_message_count={}, emitted_message_count={}, body_message_count={}, raw_delta_message_count={}, compact_summary_count={}, compaction_instruction_count={}, scaffolding_count={}, external_request_count={}, assistant_message_count={}, tool_message_count={}, latest_external_request_ids={:?}",
-        session_id,
-        provider_id,
-        recovery_phase,
-        retry_attempt,
-        base_payload_message_count,
-        request_layout_message_count,
-        diagnostics.total_messages,
-        diagnostics.body_message_count,
-        diagnostics.raw_delta_message_count,
-        diagnostics.compact_summary_count,
-        diagnostics.compaction_instruction_count,
-        diagnostics.scaffolding_count,
-        diagnostics.external_request_count,
-        diagnostics.assistant_message_count,
-        diagnostics.tool_message_count,
-        diagnostics.latest_external_request_message_ids
-    );
-
-    if diagnostics.external_request_count == 0 {
-        log::warn!(
-            "⚠️ Compaction input emitted without any external request messages: session={}, provider={}, recovery_phase={:?}, retry_attempt={}",
-            session_id,
-            provider_id,
-            recovery_phase,
-            retry_attempt
-        );
-    }
-
-    if diagnostics.raw_delta_message_count == 1 && diagnostics.external_request_count == 1 {
-        log::warn!(
-            "⚠️ Compaction input collapsed to a single raw delta message around the latest request: session={}, provider={}, recovery_phase={:?}, retry_attempt={}",
-            session_id,
-            provider_id,
-            recovery_phase,
-            retry_attempt
-        );
-    }
-
-    log::debug!(
-        "🧾 Compaction input messages: session={}, provider={}, recovery_phase={:?}, retry_attempt={}, messages=\n{}",
-        session_id,
-        provider_id,
-        recovery_phase,
-        retry_attempt,
-        format_compaction_payload_messages(&diagnostics)
-    );
-}
-
-pub fn preview_preflight_compaction_selection(messages: &[Message]) -> CompactionSelectionPreview {
-    build_compaction_selection_preview(
-        messages,
-        find_preflight_compactable_end_exclusive(messages, None, None),
-    )
-}
-
-fn derive_tail_recompaction_recovery_plan(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    compactable_end_exclusive: usize,
-) -> Option<TailRecompactionRecoveryPlan> {
-    let record = compact_context_record?;
-    let compacted_to_idx = messages
-        .iter()
-        .position(|message| message.id == record.to_id)?;
-    let first_delta_message_idx = compacted_to_idx.saturating_add(1);
-    if first_delta_message_idx < compactable_end_exclusive {
-        return None;
-    }
-
-    let latest_request_start_idx = super::find_latest_external_request_seed_block_start(messages)?;
-    if latest_request_start_idx <= first_delta_message_idx {
-        return None;
-    }
-
-    Some(TailRecompactionRecoveryPlan {
-        compacted_to_idx,
-        first_delta_message_idx,
-        latest_request_start_idx,
-        fallback_split_idx: latest_request_start_idx,
-    })
-}
-
-#[allow(dead_code)]
-pub fn derive_tail_recompaction_recovery_plan_for_testing(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    compactable_end_exclusive: usize,
-) -> Option<TailRecompactionRecoveryPlan> {
-    derive_tail_recompaction_recovery_plan(
-        messages,
-        compact_context_record,
-        compactable_end_exclusive,
-    )
-}
-
-fn find_compaction_delta_start_index(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-) -> usize {
-    compact_context_record
-        .and_then(|record| {
-            messages
-                .iter()
-                .position(|message| message.id == record.to_id)
-                .map(|idx| idx.saturating_add(1))
-        })
-        .unwrap_or(0)
-}
-
-fn find_latest_checkpoint_index(messages: &[Message]) -> Option<usize> {
-    messages
-        .iter()
-        .rposition(|message| message.prompt_tokens_value().is_some())
-}
-
-fn retained_tail_has_orphan_tool_messages(messages: &[Message], split_idx: usize) -> bool {
-    use std::collections::HashSet;
-
-    let split_idx = split_idx.min(messages.len());
-    let tail = &messages[split_idx..];
-    let tail_owner_ids = tail
-        .iter()
-        .filter(|message| message.role == "assistant")
-        .flat_map(|message| {
-            message
-                .tool_calls
-                .iter()
-                .flatten()
-                .map(|tool_call| tool_call.id.clone())
-        })
-        .collect::<HashSet<_>>();
-
-    tail.iter().any(|message| {
-        message.role == "tool"
-            && message
-                .tool_call_id
-                .as_ref()
-                .is_some_and(|tool_call_id| !tail_owner_ids.contains(tool_call_id))
-    })
-}
-
-fn build_checkpoint_backoff_split_candidates(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    initial_split_idx: usize,
-) -> Vec<usize> {
-    use std::collections::HashSet;
-
-    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
-    let mut seen = HashSet::new();
-    let mut candidates = Vec::new();
-
-    let mut push_candidate = |split_idx: usize| {
-        if split_idx <= delta_start_idx || split_idx > messages.len() {
-            return;
-        }
-        if retained_tail_has_orphan_tool_messages(messages, split_idx) {
-            return;
-        }
-        if seen.insert(split_idx) {
-            candidates.push(split_idx);
-        }
-    };
-
-    push_candidate(initial_split_idx);
-
-    for (idx, message) in messages.iter().enumerate().rev() {
-        if idx < delta_start_idx || message.prompt_tokens_value().is_none() {
-            continue;
-        }
-        push_candidate(idx + 1);
-    }
-
-    candidates
-}
-
-fn find_prompt_checkpoint_compactable_end_exclusive(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    current_context_limit: usize,
-) -> Option<usize> {
-    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
-    let uncompacted_messages = &messages[delta_start_idx..];
-    let latest_checkpoint_relative_idx = find_latest_checkpoint_index(uncompacted_messages)?;
-    let latest_checkpoint = &uncompacted_messages[latest_checkpoint_relative_idx];
-    let latest_prompt_tokens = latest_checkpoint.prompt_tokens_value()?;
-
-    if latest_prompt_tokens > current_context_limit {
-        let compaction_window_start = latest_prompt_tokens.saturating_sub(current_context_limit);
-        let preserve_relative_idx = uncompacted_messages
-            .iter()
-            .position(|message| {
-                message
-                    .prompt_tokens_value()
-                    .is_some_and(|value| value > compaction_window_start)
-            })
-            .unwrap_or(latest_checkpoint_relative_idx);
-        return Some(delta_start_idx + preserve_relative_idx);
-    }
-
-    Some(delta_start_idx + latest_checkpoint_relative_idx + 1)
-}
-
-pub fn has_prompt_checkpoint_compaction_target(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    current_context_limit: usize,
-) -> bool {
-    find_prompt_checkpoint_compactable_end_exclusive(
-        messages,
-        compact_context_record,
-        current_context_limit,
-    )
-    .is_some_and(|compactable_end_exclusive| {
-        compactable_end_exclusive
-            > find_compaction_delta_start_index(messages, compact_context_record)
-    })
-}
-
-fn find_preflight_compactable_end_exclusive(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    current_context_limit: Option<usize>,
-) -> usize {
-    if messages.is_empty() {
-        return 0;
-    }
-
-    if let Some(limit) = current_context_limit {
-        if let Some(prompt_checkpoint_end_exclusive) =
-            find_prompt_checkpoint_compactable_end_exclusive(
-                messages,
-                compact_context_record,
-                limit,
-            )
-        {
-            return prompt_checkpoint_end_exclusive;
-        }
-    }
-
-    let delta_start_idx = find_compaction_delta_start_index(messages, compact_context_record);
-    let relative_end_exclusive = crate::agent::llm::context_selector::find_compaction_split_index(
-        &messages[delta_start_idx..],
-    );
-    delta_start_idx + relative_end_exclusive
-}
-
-pub fn find_preflight_compactable_end_exclusive_for_testing(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    current_context_limit: Option<usize>,
-) -> usize {
-    find_preflight_compactable_end_exclusive(
-        messages,
-        compact_context_record,
-        current_context_limit,
-    )
-}
-
-pub fn build_checkpoint_backoff_split_candidates_for_testing(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    initial_split_idx: usize,
-) -> Vec<usize> {
-    build_checkpoint_backoff_split_candidates(messages, compact_context_record, initial_split_idx)
-}
-
-fn log_preflight_split_boundary(
-    session_id: &str,
-    messages: &[Message],
-    split_idx: usize,
-    reason: &str,
-) {
-    let diagnostics =
-        crate::agent::llm::context_selector::inspect_compaction_split_boundary(messages);
-    let first_message_id = messages
-        .first()
-        .map(|message| message.id.as_str())
-        .unwrap_or("?");
-    let last_message_id = messages
-        .last()
-        .map(|message| message.id.as_str())
-        .unwrap_or("?");
-    let first_message_role = messages
-        .first()
-        .map(|message| message.role.as_str())
-        .unwrap_or("?");
-    let last_message_role = messages
-        .last()
-        .map(|message| message.role.as_str())
-        .unwrap_or("?");
-
-    log::warn!(
-        "🧭 Preflight compaction split diagnostics: session={}, reason={}, message_count={}, split_idx={}, first_unresolved_owner_index={:?}, first_unresolved_owner_id={:?}, first_unresolved_tool_call_count={}, first_message_id={}, first_message_role={}, last_message_id={}, last_message_role={}",
-        session_id,
-        reason,
-        messages.len(),
-        split_idx,
-        diagnostics.first_unresolved_owner_index,
-        diagnostics.first_unresolved_owner_id,
-        diagnostics.first_unresolved_tool_call_count,
-        first_message_id,
-        first_message_role,
-        last_message_id,
-        last_message_role
-    );
-}
-
-pub fn should_skip_same_tail_compaction(
-    messages: &[Message],
-    compact_context_record: Option<&CompactContextRecord>,
-    compactable_end_exclusive: usize,
-) -> bool {
-    let has_compact_summary = messages
-        .first()
-        .map(|message| message.is_compact_summary())
-        .unwrap_or(false);
-
-    if !has_compact_summary {
-        return false;
-    }
-
-    compactable_end_exclusive <= find_compaction_delta_start_index(messages, compact_context_record)
+#[derive(Clone)]
+pub(crate) struct PreflightCompactionTriggerInput<'a> {
+    pub session_id: &'a str,
+    pub session_name: &'a str,
+    pub messages: &'a [Message],
+    pub parent_request: Option<crate::agent::llm::types::CompactionParentRequest>,
+    pub measured_output_tokens_reserve: usize,
+    pub resume_completion_after_compact: bool,
 }
 
 fn filter_compaction_history_messages(messages: &[Message]) -> Vec<Message> {
@@ -481,333 +85,6 @@ async fn load_merged_compaction_messages(
     ))
 }
 
-struct PreparedCompactionRequest {
-    compact_event: CompactRequest,
-    started_at_ms: i64,
-    current_tail_id: Option<String>,
-    compacted_delta_count: usize,
-    reused_prior_summary: bool,
-}
-
-struct PreparedCompactionAttempt {
-    prepared: PreparedCompactionRequest,
-    recovery_phase: CompactionRecoveryPhase,
-    retry_attempt: u32,
-}
-
-const MAX_COMPACTION_BUDGET_RETRY_ATTEMPTS: u32 = 3;
-const MAX_COMPACTION_SPLIT_BACKOFF_ATTEMPTS: usize = 3;
-
-fn advance_compaction_overflow_recovery_step(
-    recovery_phase: CompactionRecoveryPhase,
-    retry_attempt: u32,
-) -> Option<(CompactionRecoveryPhase, u32)> {
-    match recovery_phase {
-        CompactionRecoveryPhase::CacheAligned
-            if retry_attempt < MAX_COMPACTION_BUDGET_RETRY_ATTEMPTS =>
-        {
-            Some((CompactionRecoveryPhase::CacheAligned, retry_attempt + 1))
-        }
-        CompactionRecoveryPhase::CacheAligned => {
-            Some((CompactionRecoveryPhase::OverflowRecovery, 0))
-        }
-        CompactionRecoveryPhase::OverflowRecovery => {
-            Some((CompactionRecoveryPhase::DegradedTools, 0))
-        }
-        CompactionRecoveryPhase::DegradedTools => None,
-    }
-}
-
-pub fn advance_compaction_overflow_recovery_step_for_testing(
-    recovery_phase: CompactionRecoveryPhase,
-    retry_attempt: u32,
-) -> Option<(CompactionRecoveryPhase, u32)> {
-    advance_compaction_overflow_recovery_step(recovery_phase, retry_attempt)
-}
-
-#[derive(Clone)]
-struct PrepareCompactionRequestInput<'a> {
-    session_id: &'a str,
-    session_name: &'a str,
-    messages: &'a [Message],
-    split_idx: usize,
-    measured_output_tokens_reserve: usize,
-    parent_request: Option<CompactionParentRequest>,
-    compact_context_record: Option<CompactContextRecord>,
-    started_at_ms: i64,
-    resume_completion_after_compact: bool,
-    recovery_phase: CompactionRecoveryPhase,
-    retry_attempt: u32,
-}
-
-#[derive(Clone)]
-pub(crate) struct PreflightCompactionTriggerInput<'a> {
-    pub session_id: &'a str,
-    pub session_name: &'a str,
-    pub messages: &'a [Message],
-    pub parent_request: Option<CompactionParentRequest>,
-    pub measured_output_tokens_reserve: usize,
-    pub resume_completion_after_compact: bool,
-}
-
-fn degrade_tools_for_overflow_recovery(tools: &[MCPTool]) -> Vec<MCPTool> {
-    tools
-        .iter()
-        .map(|tool| MCPTool {
-            name: tool.name.clone(),
-            title: tool.title.clone(),
-            description: tool.description.clone(),
-            // Overflow recovery is the last-resort fit path. We intentionally keep
-            // only high-signal tool identity/description and drop verbose schemas so
-            // the model still sees what tools exist while the payload stays small
-            // enough to survive the degraded-tools phase.
-            input_schema: crate::mcp::schema::MCPToolInputSchema::default(),
-            output_schema: None,
-            annotations: tool.annotations.clone(),
-        })
-        .collect()
-}
-
-async fn prepare_compaction_request(
-    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
-    input: PrepareCompactionRequestInput<'_>,
-) -> Result<Option<PreparedCompactionRequest>, String> {
-    let PrepareCompactionRequestInput {
-        session_id,
-        session_name,
-        messages,
-        split_idx,
-        measured_output_tokens_reserve,
-        parent_request,
-        compact_context_record,
-        started_at_ms,
-        resume_completion_after_compact,
-        recovery_phase,
-        retry_attempt,
-    } = input;
-
-    let Some(CompactionRequestPayload {
-        compact_messages: base_compact_messages,
-        to_id,
-        compacted_delta_count,
-        reused_prior_summary,
-    }) = build_compaction_request_payload(
-        session_id,
-        messages,
-        split_idx,
-        compact_context_record.as_ref(),
-        started_at_ms,
-    )
-    else {
-        let compact_record_summary = compact_context_record.as_ref().map(|record| {
-            let compacted_to_idx = messages
-                .iter()
-                .position(|message| message.id == record.to_id);
-            let first_delta_message_idx = compacted_to_idx.map(|idx| idx.saturating_add(1));
-            format!(
-                "to_id={}, compacted_to_idx={:?}, first_delta_message_idx={:?}",
-                record.to_id, compacted_to_idx, first_delta_message_idx
-            )
-        });
-        log::warn!(
-            "⏭️ Preflight compaction payload build returned no-op: session={}, split_idx={}, message_count={}, compact_record={:?}",
-            session_id,
-            split_idx,
-            messages.len(),
-            compact_record_summary
-        );
-        return Ok(None);
-    };
-
-    let settings = load_context_management_settings().await;
-    let safe_input_token_limit =
-        std::cmp::min(settings.max_input_context, settings.model_max_limit);
-    let base_effective_input_budget =
-        crate::agent::llm::token_utils::calculate_effective_input_budget(
-            safe_input_token_limit,
-            measured_output_tokens_reserve,
-        );
-    let effective_input_token_limit =
-        apply_compaction_retry_budget(base_effective_input_budget, retry_attempt);
-    let resolved_parent_request =
-        resolve_parent_request(active_sessions, session_id, parent_request).await;
-    let request_layout = resolved_parent_request.as_ref().map(|request| {
-        crate::agent::llm::build_request_layout(
-            &request.provider,
-            session_id,
-            request.system_prompt.clone(),
-            request.session_context.clone(),
-            base_compact_messages.clone(),
-        )
-    });
-    let final_compact_messages = request_layout
-        .as_ref()
-        .map(|layout| layout.messages.clone())
-        .unwrap_or_else(|| base_compact_messages.clone());
-    let final_parent_request = match (resolved_parent_request, request_layout.as_ref()) {
-        (Some(mut request), Some(layout)) => {
-            request.system_prompt = layout.system_prompt.clone();
-            Some(request)
-        }
-        (None, Some(_)) => None,
-        (request, None) => request,
-    };
-    let final_parent_request = match (recovery_phase, final_parent_request) {
-        (CompactionRecoveryPhase::DegradedTools, Some(mut request)) => {
-            request.available_tools = request
-                .available_tools
-                .as_ref()
-                .map(|tools| degrade_tools_for_overflow_recovery(tools));
-            Some(request)
-        }
-        (_, request) => request,
-    };
-    let (system_prompt_tokens, tools_tokens) =
-        estimate_compaction_non_message_tokens(final_parent_request.as_ref());
-    let provider_id = final_parent_request
-        .as_ref()
-        .map(|request| request.provider.as_str())
-        .unwrap_or("openai");
-    let compact_messages = match recovery_phase {
-        CompactionRecoveryPhase::CacheAligned => fit_compaction_request_messages_to_limit(
-            &final_compact_messages,
-            provider_id,
-            effective_input_token_limit,
-            system_prompt_tokens,
-            tools_tokens,
-        )?,
-        CompactionRecoveryPhase::OverflowRecovery | CompactionRecoveryPhase::DegradedTools => {
-            build_overflow_recovery_compaction_messages(
-                &final_compact_messages,
-                provider_id,
-                effective_input_token_limit,
-                system_prompt_tokens,
-                tools_tokens,
-            )?
-        }
-    };
-
-    log_compaction_input_diagnostics(
-        session_id,
-        provider_id,
-        recovery_phase,
-        retry_attempt,
-        base_compact_messages.len(),
-        final_compact_messages.len(),
-        &compact_messages,
-    );
-
-    let mut final_compacted_delta_count = compacted_delta_count;
-
-    if !compact_messages.is_empty() {
-        // Count how many delta messages are actually in compact_messages
-        // (excluding the compaction instruction/overlay at the end).
-        let delta_only_count = compact_messages
-            .iter()
-            .filter(|m| {
-                !m.is_compaction_overlay_message()
-                    && !m.is_compact_summary()
-                    && !m.is_request_layout_scaffolding_message()
-            })
-            .count();
-        final_compacted_delta_count = delta_only_count;
-    }
-
-    if final_compacted_delta_count != compacted_delta_count {
-        log::info!(
-            "📐 Compaction payload shrunken, adjusting delta metadata: session={}, compacted_delta_count: {} -> {}",
-            session_id,
-            compacted_delta_count,
-            final_compacted_delta_count
-        );
-    }
-
-    if retry_attempt > 0 {
-        log::warn!(
-            "🔧 Applying compaction retry budget: session={}, retry_attempt={}, safe_input_token_limit={}, measured_output_tokens_reserve={}, base_effective_input_budget={}, effective_input_token_limit={}",
-            session_id,
-            retry_attempt,
-            safe_input_token_limit,
-            measured_output_tokens_reserve,
-            base_effective_input_budget,
-            effective_input_token_limit
-        );
-    }
-    if !matches!(recovery_phase, CompactionRecoveryPhase::CacheAligned) {
-        log::warn!(
-            "🩹 Applying compaction overflow recovery: session={}, recovery_phase={:?}, tools_degraded={}",
-            session_id,
-            recovery_phase,
-            matches!(recovery_phase, CompactionRecoveryPhase::DegradedTools)
-        );
-    }
-
-    Ok(Some(PreparedCompactionRequest {
-        compact_event: CompactRequest {
-            session_id: session_id.to_string(),
-            session_name: session_name.to_string(),
-            messages: compact_messages,
-            to_id,
-            compacted_delta_count: final_compacted_delta_count,
-            parent_request: final_parent_request,
-            resume_completion_after_compact,
-        },
-        started_at_ms,
-        current_tail_id: messages.last().map(|message| message.id.clone()),
-        compacted_delta_count: final_compacted_delta_count,
-        reused_prior_summary,
-    }))
-}
-
-async fn prepare_compaction_request_with_recovery_ladder(
-    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
-    input: PrepareCompactionRequestInput<'_>,
-    initial_recovery_phase: CompactionRecoveryPhase,
-    initial_retry_attempt: u32,
-) -> Result<Option<PreparedCompactionAttempt>, String> {
-    let mut recovery_phase = initial_recovery_phase;
-    let mut retry_attempt = initial_retry_attempt;
-
-    loop {
-        match prepare_compaction_request(
-            active_sessions,
-            PrepareCompactionRequestInput {
-                recovery_phase,
-                retry_attempt,
-                ..input.clone()
-            },
-        )
-        .await
-        {
-            Ok(Some(prepared)) => {
-                return Ok(Some(PreparedCompactionAttempt {
-                    prepared,
-                    recovery_phase,
-                    retry_attempt,
-                }));
-            }
-            Ok(None) => return Ok(None),
-            Err(error) => {
-                let Some((next_recovery_phase, next_retry_attempt)) =
-                    advance_compaction_overflow_recovery_step(recovery_phase, retry_attempt)
-                else {
-                    return Err(error);
-                };
-                log::warn!(
-                    "🪜 Advancing local compaction overflow recovery before emit: session={}, from_phase={:?}, from_retry_attempt={}, to_phase={:?}, to_retry_attempt={}",
-                    input.session_id,
-                    recovery_phase,
-                    retry_attempt,
-                    next_recovery_phase,
-                    next_retry_attempt
-                );
-                recovery_phase = next_recovery_phase;
-                retry_attempt = next_retry_attempt;
-            }
-        }
-    }
-}
-
 pub(crate) async fn try_trigger_preflight_compaction(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     app_handle: &AppHandle,
@@ -839,7 +116,8 @@ pub(crate) async fn try_trigger_preflight_compaction(
     };
     let compact_context_record = compact_context_handle.read().await.clone();
     let settings = load_context_management_settings().await;
-    let current_context_limit = std::cmp::min(settings.max_input_context, settings.model_max_limit);
+    let current_context_limit =
+        std::cmp::min(settings.max_input_context(), settings.model_max_limit);
     let effective_input_budget = crate::agent::llm::token_utils::calculate_effective_input_budget(
         current_context_limit,
         measured_output_tokens_reserve,
@@ -899,7 +177,7 @@ pub(crate) async fn try_trigger_preflight_compaction(
     }
     let candidate_offset = if matches!(
         initial_recovery_phase,
-        CompactionRecoveryPhase::CacheAligned
+        crate::agent::state::CompactionRecoveryPhase::CacheAligned
     ) {
         usize::min(
             initial_retry_attempt as usize,
@@ -986,7 +264,12 @@ pub(crate) async fn try_trigger_preflight_compaction(
         }
     }
 
-    let Some(prepared_attempt) = prepared_attempt else {
+    let Some(PreparedCompactionAttempt {
+        prepared,
+        recovery_phase,
+        retry_attempt,
+    }) = prepared_attempt
+    else {
         log::info!(
             "⏭️ Preflight compaction skipped (no new delta beyond previous summary): session={}, tail={}, split_idx={}, message_count={}, last_compacted_tail={}",
             session_id,
@@ -997,11 +280,6 @@ pub(crate) async fn try_trigger_preflight_compaction(
         );
         return Ok(false);
     };
-    let PreparedCompactionAttempt {
-        prepared,
-        recovery_phase,
-        retry_attempt,
-    } = prepared_attempt;
 
     let log_to_id = prepared.compact_event.to_id.clone();
     let compact_event = prepared.compact_event.clone();

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.0_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64-setup.exe) · [`LibrAgent_0.8.0_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.0_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.0_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.AppImage) · [`LibrAgent_0.8.0_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent_0.8.0_amd64.deb) · [`LibrAgent-0.8.0-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.0/LibrAgent-0.8.0-1.x86_64.rpm)

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## Summary
Refactored the massive `trigger.rs` file (1,159 lines) in `src-tauri/src/agent/llm/completion/compaction/` into four highly focused modules. This reduces cognitive load, isolates independent logic blocks, and drastically improves codebase maintainability while preserving the identical external public API.

### Changes
1. **`compaction/selection.rs`**: Isolates pure split-index exploration and candidates logic (no async dependencies, no active session access).
2. **`compaction/diagnostics.rs`**: Handles logging, output formatting, and preflight boundary/payload analysis.
3. **`compaction/preparation.rs`**: Orchestrates token calculations, payload scaling, recovery ladders, tool-degradation, and final `CompactRequest` build steps.
4. **`compaction/trigger.rs`**: Rewritten as a thin orchestrator facade that imports submodules, performs the main triggering logic, and re-exports all external API signatures to keep downstream imports stable.
5. **`compaction.rs`**: Declared new submodules under standard Rust module patterns.

### Validation Results
All pipeline validation checks (including type-checking, Clippy, Rust/React tests, formatting, and build verification) successfully passed:
- `pnpm refactor:validate` ✅