### PR TITLE
fix(workspace): resolve sudo password input timeout and align pending…

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/code_execution/normalization.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/normalization.rs
@@ -80,8 +80,140 @@ pub fn normalize_shell_command(raw_command: &str) -> String {
             normalized = fix_consecutive_quotes(&normalized);
         }
 
+        // 4. Inject -S flag for sudo commands to read from stdin in non-interactive/non-PTY shells
+        normalized = inject_sudo_stdin_flag(&normalized);
+
         normalized
     }
+}
+
+/// Inject -S flag for sudo commands to read from stdin in non-interactive/non-PTY shells
+#[cfg(not(windows))]
+pub fn inject_sudo_stdin_flag(command: &str) -> String {
+    let mut result = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+    let chars: Vec<char> = command.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if in_single_quote {
+            if chars[i] == '\'' {
+                in_single_quote = false;
+            }
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if in_double_quote {
+            if escaped {
+                escaped = false;
+            } else if chars[i] == '\\' {
+                escaped = true;
+            } else if chars[i] == '"' {
+                in_double_quote = false;
+            }
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if chars[i] == '\\' {
+            escaped = true;
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if chars[i] == '\'' {
+            in_single_quote = true;
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if chars[i] == '"' {
+            in_double_quote = true;
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        // Check for 'sudo' word outside of quotes
+        if chars[i..].starts_with(&['s', 'u', 'd', 'o']) {
+            // Check word boundaries for 'sudo'
+            let is_start_boundary = i == 0 || {
+                let prev = chars[i - 1];
+                prev.is_whitespace()
+                    || prev == ';'
+                    || prev == '&'
+                    || prev == '|'
+                    || prev == '('
+                    || prev == ')'
+                    || prev == '{'
+                    || prev == '}'
+            };
+
+            let has_space_after = i + 4 < chars.len() && chars[i + 4].is_whitespace();
+            let is_end_boundary = i + 4 == chars.len() || has_space_after;
+
+            if is_start_boundary && is_end_boundary {
+                result.push_str("sudo");
+                i += 4;
+
+                // Check if it's already followed by -S or --stdin
+                let mut next_idx = i;
+                while next_idx < chars.len() && chars[next_idx].is_whitespace() {
+                    next_idx += 1;
+                }
+
+                let mut already_has_stdin_flag = false;
+                if next_idx < chars.len() {
+                    let rest = &chars[next_idx..];
+                    if rest.starts_with(&['-', 'S']) {
+                        let after_flag = next_idx + 2;
+                        if after_flag == chars.len()
+                            || chars[after_flag].is_whitespace()
+                            || chars[after_flag] == ';'
+                            || chars[after_flag] == '&'
+                            || chars[after_flag] == '|'
+                        {
+                            already_has_stdin_flag = true;
+                        }
+                    } else if rest.starts_with(&['-', '-', 's', 't', 'd', 'i', 'n']) {
+                        let after_flag = next_idx + 7;
+                        if after_flag == chars.len()
+                            || chars[after_flag].is_whitespace()
+                            || chars[after_flag] == ';'
+                            || chars[after_flag] == '&'
+                            || chars[after_flag] == '|'
+                        {
+                            already_has_stdin_flag = true;
+                        }
+                    }
+                }
+
+                if !already_has_stdin_flag {
+                    result.push_str(" -S");
+                }
+                continue;
+            }
+        }
+
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
 }
 
 /// Fix consecutive quotes based on context
@@ -175,6 +307,39 @@ mod tests {
 
         // Trailing backslash (should be preserved)
         assert_eq!(normalize_shell_command("echo hello \\"), "echo hello \\");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_inject_sudo_stdin_flag() {
+        assert_eq!(
+            inject_sudo_stdin_flag("sudo apt update"),
+            "sudo -S apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("sudo -S apt update"),
+            "sudo -S apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("sudo --stdin apt update"),
+            "sudo --stdin apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("sudo -u root apt update"),
+            "sudo -S -u root apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("echo 'sudo apt update'"),
+            "echo 'sudo apt update'"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("cd /tmp && sudo apt update"),
+            "cd /tmp && sudo -S apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("  sudo   apt update"),
+            "  sudo -S   apt update"
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/normalization.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/normalization.rs
@@ -161,6 +161,7 @@ pub fn inject_sudo_stdin_flag(command: &str) -> String {
                     || prev == ')'
                     || prev == '{'
                     || prev == '}'
+                    || prev == '`'
             };
 
             let has_space_after = i + 4 < chars.len() && chars[i + 4].is_whitespace();
@@ -339,6 +340,10 @@ mod tests {
         assert_eq!(
             inject_sudo_stdin_flag("  sudo   apt update"),
             "  sudo -S   apt update"
+        );
+        assert_eq!(
+            inject_sudo_stdin_flag("`sudo apt update`"),
+            "`sudo -S apt update`"
         );
     }
 

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -175,9 +175,10 @@ impl PendingExecutions {
     pub fn cleanup_expired(&self, ttl_seconds: u64) {
         let mut map = self.0.lock().unwrap();
         let now = chrono::Utc::now();
+        let ttl_limit = i64::try_from(ttl_seconds).unwrap_or(i64::MAX);
         map.retain(|_, exec| {
             let age = now.signed_duration_since(exec.created_at);
-            age.num_seconds() < ttl_seconds as i64
+            age.num_seconds() < ttl_limit
         });
     }
 }

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -170,6 +170,16 @@ impl PendingExecutions {
     pub fn count(&self) -> usize {
         self.0.lock().unwrap().len()
     }
+
+    /// Cleanup expired pending executions
+    pub fn cleanup_expired(&self, ttl_seconds: u64) {
+        let mut map = self.0.lock().unwrap();
+        let now = chrono::Utc::now();
+        map.retain(|_, exec| {
+            let age = now.signed_duration_since(exec.created_at);
+            age.num_seconds() < ttl_seconds as i64
+        });
+    }
 }
 
 #[derive(Debug)]
@@ -881,6 +891,9 @@ mod tests {
             run_mode: "sync".to_string(),
             timeout: 30,
             created_at: now - chrono::Duration::minutes(15),
+            prompt: "prompt".to_string(),
+            input_type: InteractiveShellInputType::Text,
+            response_tx: None,
         });
 
         // Add one new entry
@@ -892,6 +905,9 @@ mod tests {
             run_mode: "sync".to_string(),
             timeout: 30,
             created_at: now,
+            prompt: "prompt".to_string(),
+            input_type: InteractiveShellInputType::Text,
+            response_tx: None,
         });
 
         assert_eq!(pending.count(), 2);

--- a/src-tauri/src/search/message_index.rs
+++ b/src-tauri/src/search/message_index.rs
@@ -347,6 +347,7 @@ mod tests {
             source: None,
             error: None,
             usage: None,
+            prompt_tokens: None,
         };
 
         let doc = MessageDocument::from(model);

--- a/src/features/agent/components/AgentChatHeader.tsx
+++ b/src/features/agent/components/AgentChatHeader.tsx
@@ -4,9 +4,10 @@ import {
   useAgentSessionActions,
   useAgentSessionState,
 } from '@/context/AgentSessionContext';
+import { useAgentSessionListActions } from '@/context/AgentSessionListContext';
 import { useAgentPlanning } from '@/context/AgentPlanningContext';
 import { useAgentWorkspace } from '@/context/AgentWorkspaceContext';
-import { useAgentChat } from '@/context/AgentChatContext';
+import { useAgentChatState } from '@/context/AgentChatContext';
 import { SessionFilesPopover } from '@/components/shared/SessionFilesPopover';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,16 +25,9 @@ interface AgentChatHeaderProps {
   assistantName?: string;
 }
 
-export function AgentChatHeader({
-  children,
-  assistantName,
-}: AgentChatHeaderProps) {
+function CopyMessagesButton() {
   const { t } = useTranslation();
-  const { session } = useAgentSessionState();
-  const { renameSession } = useAgentSessionActions();
-  const { showPlanningPanel, togglePlanningPanel } = useAgentPlanning();
-  const { showWorkspacePanel, toggleWorkspacePanel } = useAgentWorkspace();
-  const { messages } = useAgentChat();
+  const { messages } = useAgentChatState();
   const [isCopying, setIsCopying] = useState(false);
   const { copyToClipboard } = useClipboard();
 
@@ -52,7 +46,46 @@ export function AgentChatHeader({
   };
 
   return (
-    <AgentSessionHeader onRenameSession={renameSession}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleCopyMessages}
+          disabled={isCopying}
+          aria-label={t('agent.header.copyAria')}
+          className="h-6 px-2"
+        >
+          {isCopying ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{t('agent.header.copyTooltip')}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function AgentChatHeader({
+  children,
+  assistantName,
+}: AgentChatHeaderProps) {
+  const { t } = useTranslation();
+  const { session } = useAgentSessionState();
+  const { renameSession } = useAgentSessionActions();
+  const { toggleBookmark } = useAgentSessionListActions();
+  const { showPlanningPanel, togglePlanningPanel } = useAgentPlanning();
+  const { showWorkspacePanel, toggleWorkspacePanel } = useAgentWorkspace();
+
+  return (
+    <AgentSessionHeader
+      onRenameSession={renameSession}
+      isBookmarked={session?.isBookmarked}
+      onToggleBookmark={() => session?.id && toggleBookmark(session.id)}
+    >
       <div className="flex items-center justify-between w-full">
         <div className="flex items-center">
           {children}
@@ -62,26 +95,7 @@ export function AgentChatHeader({
         </div>
 
         <div className="flex items-center gap-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleCopyMessages}
-                disabled={isCopying}
-                aria-label={t('agent.header.copyAria')}
-                className="h-6 px-2"
-              >
-                {isCopying ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('agent.header.copyTooltip')}</TooltipContent>
-          </Tooltip>
+          <CopyMessagesButton />
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/features/agent/components/AgentSessionHeader.tsx
+++ b/src/features/agent/components/AgentSessionHeader.tsx
@@ -3,15 +3,29 @@ import { useOptionalAgentSessionState } from '@/context/AgentSessionContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
-import { Check, Loader2, Pencil, X } from 'lucide-react';
+import {
+  Check,
+  Loader2,
+  Pencil,
+  X,
+  Bookmark,
+  BookmarkCheck,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface AgentSessionHeaderProps {
   children?: React.ReactNode;
   assistantName?: string;
   sessionName?: string;
   sessionType?: string;
+  isBookmarked?: boolean;
+  onToggleBookmark?: () => void;
   assistantNameClassName?: string;
   sessionNameClassName?: string;
   onRenameSession?: (name: string) => Promise<void>;
@@ -22,6 +36,8 @@ export default function AgentSessionHeader({
   assistantName,
   sessionName,
   sessionType = 'Agent',
+  isBookmarked,
+  onToggleBookmark,
   assistantNameClassName,
   sessionNameClassName,
   onRenameSession,
@@ -44,6 +60,44 @@ export default function AgentSessionHeader({
     session?.assistant?.name ??
     t('agent.header.defaultAssistant', 'Agent');
   const canEditSessionName = Boolean(session?.id && onRenameSession);
+
+  const renderSessionTypeOrBookmark = () => {
+    if (isBookmarked !== undefined && onToggleBookmark) {
+      const tooltipLabel = isBookmarked
+        ? t('sessionHistory.actions.unbookmarkAria', 'Remove bookmark')
+        : t('sessionHistory.actions.bookmarkAria', 'Bookmark session');
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0"
+              onClick={onToggleBookmark}
+              aria-label={tooltipLabel}
+            >
+              {isBookmarked ? (
+                <BookmarkCheck className="h-3.5 w-3.5 text-warning" />
+              ) : (
+                <Bookmark className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{tooltipLabel}</TooltipContent>
+        </Tooltip>
+      );
+    }
+    if (sessionType) {
+      return (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          ({sessionType})
+        </span>
+      );
+    }
+    return null;
+  };
 
   useEffect(() => {
     if (!isEditingSessionName) {
@@ -182,9 +236,7 @@ export default function AgentSessionHeader({
               >
                 <X className="h-4 w-4" />
               </Button>
-              <span className="shrink-0 text-xs text-muted-foreground">
-                ({sessionType})
-              </span>
+              {renderSessionTypeOrBookmark()}
             </div>
           ) : (
             <>
@@ -197,9 +249,7 @@ export default function AgentSessionHeader({
               >
                 {resolvedSessionName}
               </span>
-              <span className="shrink-0 text-xs text-muted-foreground">
-                ({sessionType})
-              </span>
+              {renderSessionTypeOrBookmark()}
               {canEditSessionName && (
                 <Button
                   type="button"

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
This pull request introduces improvements to shell command normalization and enhances the management of pending executions in the workspace module. The most significant changes are the automatic injection of the `-S` flag for `sudo` commands to support non-interactive shells, and the addition of a cleanup method for expired pending executions. Comprehensive tests have been added to ensure the correctness of these features.

**Shell Command Normalization:**

* Added logic to `normalize_shell_command` and implemented `inject_sudo_stdin_flag` to automatically insert the `-S` flag for `sudo` commands, ensuring they can read passwords from stdin in non-interactive or non-PTY shells. This avoids issues when running such commands programmatically.
* Added tests for `inject_sudo_stdin_flag` to verify correct handling of various `sudo` command patterns, including quoted cases and commands that already include `-S` or `--stdin`.

**Pending Executions Management:**

* Added a `cleanup_expired` method to `PendingExecutions` to remove entries older than a specified TTL, improving resource management.
* Updated tests for pending executions to include required fields (`prompt`, `input_type`, `response_tx`) in test data, ensuring tests reflect the current struct definition. [[1]](diffhunk://#diff-3a089eb5a381dc6ea9c0cae3cd284f8bd475f11da8764b92fd80cba8ff4fbcc2R894-R896) [[2]](diffhunk://#diff-3a089eb5a381dc6ea9c0cae3cd284f8bd475f11da8764b92fd80cba8ff4fbcc2R908-R910)

**Other Minor Changes:**

* Added an optional `prompt_tokens` field to the test model in `message_index.rs` to align with the latest struct definition.