### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Path traversal in `FileExportService::create_zip_export` where `package_name` is directly interpolated into a path passed to `temp_dir.path().join()`.
 **Learning:** `Path::join` allows directory traversal if the right-hand side contains relative components like `..`, potentially escaping intended directories (e.g., `temp_dir`). This can be exploited to overwrite arbitrary files when creating zip exports.
 **Prevention:** Sanitize variables from external input used in path constructions, even for temporary filenames. Replace non-alphanumeric characters with safe alternatives like underscores.
+## 2024-05-18 - Path Traversal in MCP Workspace Export
+**Vulnerability:** The MCP tool `export_operations.rs` constructed the output `zip_filename` using the unsanitized `name_param` from user input, allowing potential path traversal (e.g. `../../../malicious_name.zip`).
+**Learning:** Even if the input is parsed via JSON, if it's used directly in path constructions without sanitization, it poses a path traversal risk.
+**Prevention:** Always sanitize user-provided filename inputs (e.g., using `sanitize_package_name` or replacing non-alphanumeric chars) before incorporating them into file paths.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,7 +6,7 @@
 **Vulnerability:** Path traversal in `FileExportService::create_zip_export` where `package_name` is directly interpolated into a path passed to `temp_dir.path().join()`.
 **Learning:** `Path::join` allows directory traversal if the right-hand side contains relative components like `..`, potentially escaping intended directories (e.g., `temp_dir`). This can be exploited to overwrite arbitrary files when creating zip exports.
 **Prevention:** Sanitize variables from external input used in path constructions, even for temporary filenames. Replace non-alphanumeric characters with safe alternatives like underscores.
-## 2024-05-18 - Path Traversal in MCP Workspace Export
-**Vulnerability:** The MCP tool `export_operations.rs` constructed the output `zip_filename` using the unsanitized `name_param` from user input, allowing potential path traversal (e.g. `../../../malicious_name.zip`).
+## 2026-06-02 - Path Traversal in MCP Workspace Export
+**Vulnerability:** The MCP tool `export_operations.rs` constructed the output `zip_filename` using the unsanitized `name_param` from user input, allowing potential path traversal (e.g., if `name_param` contained `../..` such as `../../../malicious_name`, it would generate `../../../malicious_name_{timestamp}.zip` and escape the export directory).
 **Learning:** Even if the input is parsed via JSON, if it's used directly in path constructions without sanitization, it poses a path traversal risk.
 **Prevention:** Always sanitize user-provided filename inputs (e.g., using `sanitize_package_name` or replacing non-alphanumeric chars) before incorporating them into file paths.

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -172,7 +172,10 @@ impl WorkspaceServer {
 
         // === ZIP PACKAGE EXPORT ===
         let package_name = name_param.unwrap_or_else(|| "workspace_export".to_string());
-        let safe_package_name = crate::services::file_export_service::FileExportService::sanitize_package_name(&package_name);
+        let safe_package_name =
+            crate::services::file_export_service::FileExportService::sanitize_package_name(
+                &package_name,
+            );
         let zip_filename = format!("{safe_package_name}_{timestamp}.zip");
         let zip_path = exports_dir.join("packages").join(&zip_filename);
 

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -172,7 +172,8 @@ impl WorkspaceServer {
 
         // === ZIP PACKAGE EXPORT ===
         let package_name = name_param.unwrap_or_else(|| "workspace_export".to_string());
-        let zip_filename = format!("{package_name}_{timestamp}.zip");
+        let safe_package_name = crate::services::file_export_service::FileExportService::sanitize_package_name(&package_name);
+        let zip_filename = format!("{safe_package_name}_{timestamp}.zip");
         let zip_path = exports_dir.join("packages").join(&zip_filename);
 
         let mut missing_files = Vec::new();

--- a/src-tauri/src/search/message_index.rs
+++ b/src-tauri/src/search/message_index.rs
@@ -347,6 +347,7 @@ mod tests {
             source: None,
             error: None,
             usage: None,
+            prompt_tokens: None,
         };
 
         let doc = MessageDocument::from(model);

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The workspace export tool directly used the user-provided `name` parameter to construct the zip file path without sanitization, leading to a path traversal vulnerability.
🎯 Impact: An attacker could potentially create zip files outside the designated `.libragent/exports/packages` directory by supplying a name like `../../../malicious_name`.
🔧 Fix: Sanitized the `package_name` using `FileExportService::sanitize_package_name` to strip out dangerous characters before path construction.
✅ Verification: Verified locally by running `cargo test` and checking that the `package_name` is sanitized.

---
*PR created automatically by Jules for task [7497457400511518231](https://jules.google.com/task/7497457400511518231) started by @fritzprix*