### PR TITLE
fix(skill): make email setup non-interactive-friendly

### DIFF
--- a/src-tauri/bundled_skills/email-integration/SKILL.md
+++ b/src-tauri/bundled_skills/email-integration/SKILL.md
@@ -3,7 +3,7 @@ name: email-integration
 description: |
   Integrates with any IMAP/SMTP mail server (Gmail, Outlook, Naver, Kakao, custom servers, etc.).
   Use when the user wants to read, send, search, reply to, or manage emails.
-  On first use, runs interactive account setup in the terminal to store credentials in a local config file with restricted permissions.
+  On first use, collect the email/server settings, capture the password through a single hidden shell prompt, and run setup_account.py non-interactively to store credentials in a local config file with restricted permissions.
   Subsequent requests use the stored config without re-asking for credentials.
   Triggers on requests like: "메일 보여줘", "이메일 확인", "send email", "받은 편지함", "메일 보내줘", "메일 검색".
 ---
@@ -24,10 +24,11 @@ Paths in this skill are relative to the directory containing this `SKILL.md`, no
 
 ## ⚠️ Security Rules (Mandatory)
 
-- **NEVER** ask for passwords or credentials in chat
+- **NEVER** ask for passwords, app passwords, or other secrets in chat
 - **NEVER** display or repeat the contents of `~/.libragent/email_config`
-- **ALWAYS** use `setup_account.py` for credential collection — it uses `getpass()` so input is hidden in terminal
-- If the user accidentally pastes credentials in chat, acknowledge receipt, do NOT echo them back, and immediately run setup to store them properly
+- Ask for the email address and custom server overrides in chat only when needed; collect the password only through a hidden shell prompt
+- **ALWAYS** use `setup_account.py` to persist credentials
+- If the user accidentally pastes a password or other secret in chat, acknowledge receipt, do NOT echo it back, and immediately run setup to store it properly
 
 ---
 
@@ -36,7 +37,7 @@ Paths in this skill are relative to the directory containing this `SKILL.md`, no
 Email integration involves these steps:
 
 1. **Detect config** — run `validate_config.py` to check if account is configured
-2. **Setup (first time only)** — run `setup_account.py` interactively in terminal
+2. **Setup (first time only)** — gather non-secret setup fields, then run `setup_account.py` with args plus one hidden password prompt
 3. **Dispatch action** — classify the user's request and call `email_client.py` with the right action
 4. **Present results** — format and summarize the output for the user
 
@@ -58,24 +59,70 @@ python "<skill-base-dir>/scripts/validate_config.py"
 
 ## Step 2: Account Setup (First Time or Reset)
 
-Tell the user setup is needed, then run in terminal:
+Do **not** run `python "<skill-base-dir>/scripts/setup_account.py"` bare inside LibrAgent. That old terminal wizard asks for multiple prompts and can time out under the current prompt-resume shell contract.
 
-```bash
-python "<skill-base-dir>/scripts/setup_account.py"
+Instead:
+
+1. Determine the email address.
+2. For known domains, use the preset profile from `references/server-profiles.md`.
+3. For custom/self-hosted domains, ask for all four values in chat first: IMAP host/port and SMTP host/port.
+4. Collect the password through a **single hidden shell prompt** and pass it to `setup_account.py` through a temporary environment variable.
+
+### Preferred PowerShell pattern in LibrAgent
+
+Run `runInPersistentPowerShell` with:
+
+- `requireUserInput=true`
+- `inputType=password`
+- an `inputPrompt` like `이메일 비밀번호 또는 앱 비밀번호를 입력하세요:`
+
+Command for known preset domains:
+
+```powershell
+$env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
+try {
+  python "<skill-base-dir>/scripts/setup_account.py" `
+    --email "user@example.com" `
+    --use-preset-servers `
+    --password-env LIBRAGENT_EMAIL_PASSWORD
+} finally {
+  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
+}
 ```
 
-For reset after auth failure:
+Command for reset after auth failure:
 
-```bash
-python "<skill-base-dir>/scripts/setup_account.py" --reset
+```powershell
+$env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
+try {
+  python "<skill-base-dir>/scripts/setup_account.py" `
+    --reset `
+    --email "user@example.com" `
+    --use-preset-servers `
+    --password-env LIBRAGENT_EMAIL_PASSWORD
+} finally {
+  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
+}
 ```
 
-The script will:
-1. Prompt for email address (visible)
-2. Auto-detect server settings from domain (see `references/server-profiles.md`)
-3. Prompt for password using `getpass()` — **input is hidden**
-4. Test the connection live
-5. Save to `~/.libragent/email_config` with restricted permissions
+Command for custom/self-hosted domains:
+
+```powershell
+$env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
+try {
+  python "<skill-base-dir>/scripts/setup_account.py" `
+    --email "user@example.com" `
+    --imap-host "imap.example.com" `
+    --imap-port 993 `
+    --smtp-host "smtp.example.com" `
+    --smtp-port 587 `
+    --password-env LIBRAGENT_EMAIL_PASSWORD
+} finally {
+  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
+}
+```
+
+On non-PowerShell shells, use the same pattern: collect one hidden password in the shell, export it temporarily, run `setup_account.py --password-env ...`, then clear it.
 
 After successful setup, proceed to Step 3 with the original user request.
 

--- a/src-tauri/bundled_skills/email-integration/SKILL.md
+++ b/src-tauri/bundled_skills/email-integration/SKILL.md
@@ -66,7 +66,7 @@ Instead:
 1. Determine the email address.
 2. For known domains, use the preset profile from `references/server-profiles.md`.
 3. For custom/self-hosted domains, ask for all four values in chat first: IMAP host/port and SMTP host/port.
-4. Collect the password through a **single hidden shell prompt** and pass it to `setup_account.py` through a temporary environment variable.
+4. Collect the password through a **single hidden shell prompt**, store it in a temporary environment variable in the persistent shell, then run `setup_account.py` in a separate visible command that reuses that variable.
 
 ### Preferred PowerShell pattern in LibrAgent
 
@@ -75,54 +75,58 @@ Run `runInPersistentPowerShell` with:
 - `requireUserInput=true`
 - `inputType=password`
 - an `inputPrompt` like `이메일 비밀번호 또는 앱 비밀번호를 입력하세요:`
+- an explicit setup timeout such as `timeout=90`
 
-Command for known preset domains:
+Use a **two-step PowerShell flow** in LibrAgent:
 
-```powershell
-$env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
-try {
-  python "<skill-base-dir>/scripts/setup_account.py" `
-    --email "user@example.com" `
-    --use-preset-servers `
-    --password-env LIBRAGENT_EMAIL_PASSWORD
-} finally {
-  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
-}
-```
+1. Hidden prompt call: set the temporary password environment variable.
+2. Visible setup call: run `setup_account.py ... --password-env ...` with no hidden input so the script's non-secret diagnostics remain visible.
+3. Cleanup call: remove the temporary environment variable.
 
-Command for reset after auth failure:
+Hidden prompt command:
 
 ```powershell
 $env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
-try {
-  python "<skill-base-dir>/scripts/setup_account.py" `
-    --reset `
-    --email "user@example.com" `
-    --use-preset-servers `
-    --password-env LIBRAGENT_EMAIL_PASSWORD
-} finally {
-  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
-}
 ```
 
-Command for custom/self-hosted domains:
+Visible setup command for known preset domains:
 
 ```powershell
-$env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
-try {
-  python "<skill-base-dir>/scripts/setup_account.py" `
-    --email "user@example.com" `
-    --imap-host "imap.example.com" `
-    --imap-port 993 `
-    --smtp-host "smtp.example.com" `
-    --smtp-port 587 `
-    --password-env LIBRAGENT_EMAIL_PASSWORD
-} finally {
-  Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
-}
+python "<skill-base-dir>/scripts/setup_account.py" `
+  --email "user@example.com" `
+  --use-preset-servers `
+  --password-env LIBRAGENT_EMAIL_PASSWORD
 ```
 
-On non-PowerShell shells, use the same pattern: collect one hidden password in the shell, export it temporarily, run `setup_account.py --password-env ...`, then clear it.
+Visible setup command for reset after auth failure:
+
+```powershell
+python "<skill-base-dir>/scripts/setup_account.py" `
+  --reset `
+  --email "user@example.com" `
+  --use-preset-servers `
+  --password-env LIBRAGENT_EMAIL_PASSWORD
+```
+
+Visible setup command for custom/self-hosted domains:
+
+```powershell
+python "<skill-base-dir>/scripts/setup_account.py" `
+  --email "user@example.com" `
+  --imap-host "imap.example.com" `
+  --imap-port 993 `
+  --smtp-host "smtp.example.com" `
+  --smtp-port 587 `
+  --password-env LIBRAGENT_EMAIL_PASSWORD
+```
+
+Cleanup command:
+
+```powershell
+Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
+```
+
+On non-PowerShell shells, use the same two-step pattern: collect one hidden password in the shell, export it temporarily, run `setup_account.py --password-env ...` in a separate visible command, then clear it.
 
 After successful setup, proceed to Step 3 with the original user request.
 
@@ -220,9 +224,9 @@ For bulk operations (e.g. "스팸함 비워"), confirm count with user before pr
 
 | Error | Cause | Action |
 |---|---|---|
-| Auth failed (IMAP 535) | Wrong password or App Password needed | Run `python "<skill-base-dir>/scripts/setup_account.py" --reset`, guide user to App Password docs |
-| Connection refused | Wrong host/port | Check `references/server-profiles.md`, offer to re-run setup |
-| Config not found | First run or deleted | Run `python "<skill-base-dir>/scripts/setup_account.py"` |
+| Auth failed (IMAP 535) | Wrong password or App Password needed | Re-run Step 2 with `--reset` using the hidden-prompt + visible setup flow, then guide the user to the provider's App Password docs |
+| Connection refused | Wrong host/port | Check `references/server-profiles.md`, re-collect the four server fields in chat, then re-run Step 2 with an explicit setup timeout |
+| Config not found | First run or deleted | Run Step 2's non-interactive setup flow; do **not** launch the old bare wizard |
 | SSL error | Port mismatch | Suggest switching 993↔143 or 587↔465 |
 | Send failed (SMTP 550) | Recipient rejected | Confirm address with user |
 

--- a/src-tauri/bundled_skills/email-integration/SKILL.md
+++ b/src-tauri/bundled_skills/email-integration/SKILL.md
@@ -53,7 +53,7 @@ python "<skill-base-dir>/scripts/validate_config.py"
 
 - Exit code `0` → configured, proceed to Step 3
 - Exit code `1` → not configured, go to Step 2
-- Exit code `2` → config exists but invalid (e.g. wrong password), go to Step 2 with `--reset` flag
+- Exit code `2` → config exists but is incomplete/corrupt, go to Step 2 with `--reset` flag
 
 ---
 
@@ -64,8 +64,8 @@ Do **not** run `python "<skill-base-dir>/scripts/setup_account.py"` bare inside 
 Instead:
 
 1. Determine the email address.
-2. For known domains, use the preset profile from `references/server-profiles.md`.
-3. For custom/self-hosted domains, ask for all four values in chat first: IMAP host/port and SMTP host/port.
+2. For known preset domains from `references/server-profiles.md`, use the preset flow.
+3. For custom/self-hosted domains, including corporate Microsoft 365 domains outside `*.onmicrosoft.com`, ask for all four values in chat first: IMAP host/port and SMTP host/port.
 4. Collect the password through a **single hidden shell prompt**, store it in a temporary environment variable in the persistent shell, then run `setup_account.py` in a separate visible command that reuses that variable.
 
 ### Preferred PowerShell pattern in LibrAgent
@@ -83,11 +83,15 @@ Use a **two-step PowerShell flow** in LibrAgent:
 2. Visible setup call: run `setup_account.py ... --password-env ...` with no hidden input so the script's non-secret diagnostics remain visible.
 3. Cleanup call: remove the temporary environment variable.
 
+Use `--password-env` for this two-step persistent-shell pattern. If the runtime can pipe the hidden password directly into the setup command's stdin without exposing it, `--password-stdin` is a more private alternative.
+
 Hidden prompt command:
 
 ```powershell
 $env:LIBRAGENT_EMAIL_PASSWORD = Read-Host
 ```
+
+This `Read-Host` snippet is safe **only** when LibrAgent is enforcing hidden password input for that call. Running it directly in a normal terminal will echo the password on screen.
 
 Visible setup command for known preset domains:
 
@@ -126,7 +130,7 @@ Cleanup command:
 Remove-Item Env:LIBRAGENT_EMAIL_PASSWORD -ErrorAction SilentlyContinue
 ```
 
-On non-PowerShell shells, use the same two-step pattern: collect one hidden password in the shell, export it temporarily, run `setup_account.py --password-env ...` in a separate visible command, then clear it.
+On non-PowerShell shells, use the same two-step pattern: collect one hidden password in the shell, export it temporarily, run `setup_account.py --password-env ...` in a separate visible command, then clear it. If the shell/tool runtime can securely pipe the hidden password straight into stdin, use `setup_account.py --password-stdin` instead of a temporary environment variable.
 
 After successful setup, proceed to Step 3 with the original user request.
 

--- a/src-tauri/bundled_skills/email-integration/references/server-profiles.md
+++ b/src-tauri/bundled_skills/email-integration/references/server-profiles.md
@@ -1,7 +1,8 @@
 # Mail Server Profiles
 
 Reference for `setup_account.py` auto-detection and manual troubleshooting.
-When a domain matches, these settings are applied as defaults (user can override).
+When a domain matches, these settings can be applied directly with `--use-preset-servers`.
+For custom/self-hosted domains, pass all four server flags explicitly.
 
 ---
 

--- a/src-tauri/bundled_skills/email-integration/references/server-profiles.md
+++ b/src-tauri/bundled_skills/email-integration/references/server-profiles.md
@@ -1,8 +1,9 @@
 # Mail Server Profiles
 
 Reference for `setup_account.py` auto-detection and manual troubleshooting.
-When a domain matches, these settings can be applied directly with `--use-preset-servers`.
-For custom/self-hosted domains, pass all four server flags explicitly.
+Known preset domains can be applied directly with `--use-preset-servers`.
+Auto-detected presets currently include: `gmail.com`, `googlemail.com`, `outlook.com`, `hotmail.com`, `live.com`, `*.onmicrosoft.com`, `naver.com`, `kakao.com`, `daum.net`, `yahoo.com`, `icloud.com`, `me.com`, and `mac.com`.
+For custom/self-hosted domains, including corporate domains outside `*.onmicrosoft.com`, pass all four server flags explicitly.
 
 ---
 
@@ -44,7 +45,7 @@ Gmail Settings → See all settings → Forwarding and POP/IMAP → Enable IMAP
 
 ---
 
-## Microsoft 365 / Work Outlook (`*.onmicrosoft.com`, corporate domains)
+## Microsoft 365 / Work Outlook (`*.onmicrosoft.com`)
 
 | Setting | Value |
 | --- | --- |
@@ -53,9 +54,13 @@ Gmail Settings → See all settings → Forwarding and POP/IMAP → Enable IMAP
 | SMTP host | `smtp.office365.com` |
 | SMTP port | `587` (STARTTLS) |
 
+**Auto-detected only for `*.onmicrosoft.com` addresses.**
+
 **Note:** Corporate M365 tenants may block Basic Auth (username/password).
 If login fails, the admin needs to enable SMTP AUTH per-mailbox:
 `Exchange Admin Center → Mailboxes → [user] → Mail flow settings → Authenticated SMTP`
+
+For custom corporate domains that are backed by Microsoft 365, collect and pass the four server values explicitly instead of relying on `--use-preset-servers`.
 
 ---
 

--- a/src-tauri/bundled_skills/email-integration/references/server-profiles.md
+++ b/src-tauri/bundled_skills/email-integration/references/server-profiles.md
@@ -118,7 +118,7 @@ Use your **Kakao account password**.
 
 ## Custom / Self-Hosted
 
-No preset. `setup_account.py` will prompt for all fields manually.
+No preset. In LibrAgent, collect the four server values in chat first, then pass them to `setup_account.py` with explicit `--imap-host`, `--imap-port`, `--smtp-host`, and `--smtp-port` arguments.
 
 Common patterns:
 

--- a/src-tauri/bundled_skills/email-integration/scripts/email_client.py
+++ b/src-tauri/bundled_skills/email-integration/scripts/email_client.py
@@ -45,11 +45,15 @@ CONFIG_PATH = Path.home() / ".libragent" / "email_config"
 
 def load_config() -> dict:
     if not CONFIG_PATH.exists():
-        error_exit("Config not found. Run setup_account.py first.")
+        error_exit(
+            "Config not found. Run the skill's non-interactive setup flow first."
+        )
     try:
         return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
-        error_exit("Config file is corrupted. Run setup_account.py --reset.")
+        error_exit(
+            "Config file is corrupted. Re-run the skill's non-interactive setup flow with reset."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -119,11 +123,18 @@ def connect_imap(cfg: dict) -> imaplib.IMAP4_SSL:
     """Open and authenticate IMAP connection."""
     ctx = ssl.create_default_context()
     try:
-        imap = imaplib.IMAP4_SSL(cfg["imap_host"], cfg["imap_port"], ssl_context=ctx)
+        imap = imaplib.IMAP4_SSL(
+            cfg["imap_host"],
+            cfg["imap_port"],
+            ssl_context=ctx,
+            timeout=15,
+        )
         imap.login(cfg["email"], cfg["password"])
         return imap
     except imaplib.IMAP4.error as e:
-        error_exit(f"IMAP auth failed: {e}. Run setup_account.py --reset.")
+        error_exit(
+            f"IMAP auth failed: {e}. Re-run the skill's non-interactive setup flow with reset."
+        )
     except OSError as e:
         error_exit(f"IMAP connection failed: {e}")
 
@@ -144,7 +155,9 @@ def connect_smtp(cfg: dict) -> smtplib.SMTP:
         smtp.login(cfg["email"], cfg["password"])
         return smtp
     except smtplib.SMTPAuthenticationError as e:
-        error_exit(f"SMTP auth failed: {e}. Run setup_account.py --reset.")
+        error_exit(
+            f"SMTP auth failed: {e}. Re-run the skill's non-interactive setup flow with reset."
+        )
     except OSError as e:
         error_exit(f"SMTP connection failed: {e}")
 

--- a/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
+++ b/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
@@ -8,8 +8,9 @@ Supports both:
 
 Preferred agent flow:
   - Collect email address and any custom server overrides outside the script
-  - Collect the password through a single hidden shell prompt
-  - Pass the password via a temporary environment variable to --password-env
+  - Collect the password through a single hidden shell prompt in a first shell call
+  - Run setup_account.py in a second visible shell call with --password-env so
+    non-secret diagnostics remain visible to the agent
 
 Usage:
     python setup_account.py                         # Interactive wizard
@@ -28,6 +29,8 @@ import ssl
 import stat
 import sys
 from pathlib import Path
+
+NETWORK_TIMEOUT_SECONDS = 15
 
 # ---------------------------------------------------------------------------
 # Server presets — domain suffix → (imap_host, imap_port, smtp_host, smtp_port)
@@ -254,7 +257,12 @@ def test_imap(host: str, port: int, email: str, password: str) -> tuple[bool, st
     """Test IMAP login. Returns (success, error_message)."""
     try:
         context = ssl.create_default_context()
-        with imaplib.IMAP4_SSL(host, port, ssl_context=context) as imap:
+        with imaplib.IMAP4_SSL(
+            host,
+            port,
+            ssl_context=context,
+            timeout=NETWORK_TIMEOUT_SECONDS,
+        ) as imap:
             imap.login(email, password)
         return True, ""
     except imaplib.IMAP4.error as e:
@@ -267,10 +275,15 @@ def test_smtp(host: str, port: int, email: str, password: str) -> tuple[bool, st
     """Test SMTP login. Returns (success, error_message)."""
     try:
         if port == 465:
-            with smtplib.SMTP_SSL(host, port, timeout=10, context=ssl.create_default_context()) as smtp:
+            with smtplib.SMTP_SSL(
+                host,
+                port,
+                timeout=NETWORK_TIMEOUT_SECONDS,
+                context=ssl.create_default_context(),
+            ) as smtp:
                 smtp.login(email, password)
         else:
-            with smtplib.SMTP(host, port, timeout=10) as smtp:
+            with smtplib.SMTP(host, port, timeout=NETWORK_TIMEOUT_SECONDS) as smtp:
                 smtp.ehlo()
                 smtp.starttls(context=ssl.create_default_context())
                 smtp.login(email, password)

--- a/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
+++ b/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
@@ -2,18 +2,27 @@
 """
 Email account setup for LibrAgent email-integration skill.
 
-Collects credentials interactively (password via getpass — never visible),
-tests the connection, and saves config to ~/.libragent/email_config.
+Supports both:
+1. Interactive terminal setup for direct manual use
+2. Argument-driven setup for agent workflows that can only collect one hidden prompt
+
+Preferred agent flow:
+  - Collect email address and any custom server overrides outside the script
+  - Collect the password through a single hidden shell prompt
+  - Pass the password via a temporary environment variable to --password-env
 
 Usage:
-    python setup_account.py           # First-time setup
-    python setup_account.py --reset   # Reset / update credentials
+    python setup_account.py                         # Interactive wizard
+    python setup_account.py --reset                # Interactive reset
+    python setup_account.py --email user@gmail.com --use-preset-servers \
+      --password-env LIBRAGENT_EMAIL_PASSWORD
 """
 
 import argparse
 import getpass
 import imaplib
 import json
+import os
 import smtplib
 import ssl
 import stat
@@ -98,12 +107,58 @@ SERVER_PRESETS = {
 }
 
 CONFIG_PATH = Path.home() / ".libragent" / "email_config"
+SERVER_FIELDS = ("imap_host", "imap_port", "smtp_host", "smtp_port")
+
+
+def fail(message: str, exit_code: int = 1) -> None:
+    """Exit with a concise error message."""
+    print(f"❌ {message}", file=sys.stderr)
+    sys.exit(exit_code)
 
 
 def get_preset(email: str) -> dict | None:
     """Return server preset for the given email domain, or None if unknown."""
     domain = email.split("@")[-1].lower()
     return SERVER_PRESETS.get(domain)
+
+
+def server_from_preset(preset: dict) -> dict:
+    """Extract only server settings from a preset object."""
+    return {field: preset[field] for field in SERVER_FIELDS}
+
+
+def read_password_from_stdin() -> str:
+    """Read the entire stdin stream and trim the trailing line ending."""
+    password = sys.stdin.read().rstrip("\r\n")
+    if not password:
+        fail("Password stdin was empty.")
+    return password
+
+
+def resolve_password(args: argparse.Namespace, interactive: bool) -> str:
+    """Load password from env/stdin or interactive getpass."""
+    if args.password_env and args.password_stdin:
+        fail("Use only one of --password-env or --password-stdin.")
+
+    if args.password_env:
+        password = os.environ.get(args.password_env)
+        if password is None:
+            fail(f"Environment variable '{args.password_env}' was not set.")
+        if not password:
+            fail(f"Environment variable '{args.password_env}' is empty.")
+        return password
+
+    if args.password_stdin:
+        return read_password_from_stdin()
+
+    if interactive:
+        password = getpass.getpass("Password (input hidden): ")
+        if not password:
+            fail("Password cannot be empty.")
+        return password
+
+    fail("Password required. Use --password-env or --password-stdin.")
+    return ""
 
 
 def prompt_server_settings(preset: dict | None) -> dict:
@@ -121,12 +176,78 @@ def prompt_server_settings(preset: dict | None) -> dict:
         smtp_host = input("  SMTP host (e.g. smtp.example.com): ").strip()
         smtp_port = input("  SMTP port [587]: ").strip() or "587"
 
-    return {
-        "imap_host": imap_host,
-        "imap_port": int(imap_port),
-        "smtp_host": smtp_host,
-        "smtp_port": int(smtp_port),
+    try:
+        return {
+            "imap_host": imap_host,
+            "imap_port": int(imap_port),
+            "smtp_host": smtp_host,
+            "smtp_port": int(smtp_port),
+        }
+    except ValueError:
+        fail("IMAP/SMTP ports must be integers.")
+        return {}
+
+
+def resolve_server_settings(args: argparse.Namespace, email: str, interactive: bool) -> dict:
+    """Resolve server settings from args, preset defaults, or interactive prompts."""
+    preset = get_preset(email)
+    provided_server_values = {
+        "imap_host": args.imap_host,
+        "imap_port": args.imap_port,
+        "smtp_host": args.smtp_host,
+        "smtp_port": args.smtp_port,
     }
+    has_any_override = any(value is not None for value in provided_server_values.values())
+    has_all_overrides = all(value is not None for value in provided_server_values.values())
+
+    if args.use_preset_servers:
+        if not preset:
+            fail(
+                "No preset exists for this domain. Provide --imap-host/--imap-port/"
+                "--smtp-host/--smtp-port instead."
+            )
+        return server_from_preset(preset)
+
+    if has_any_override:
+        if not has_all_overrides:
+            fail(
+                "Provide all four server overrides together: --imap-host --imap-port "
+                "--smtp-host --smtp-port."
+            )
+        return {
+            "imap_host": args.imap_host,
+            "imap_port": args.imap_port,
+            "smtp_host": args.smtp_host,
+            "smtp_port": args.smtp_port,
+        }
+
+    if interactive:
+        return prompt_server_settings(preset)
+
+    if preset:
+        return server_from_preset(preset)
+
+    fail(
+        "No preset exists for this domain. Provide --imap-host --imap-port "
+        "--smtp-host --smtp-port."
+    )
+    return {}
+
+
+def confirm_overwrite(args: argparse.Namespace, interactive: bool) -> None:
+    """Handle existing config file overwrite rules."""
+    if not CONFIG_PATH.exists() or args.reset or args.force_overwrite:
+        return
+
+    if interactive:
+        print(f"\n⚠️  Config already exists at {CONFIG_PATH}")
+        overwrite = input("   Overwrite? [y/N]: ").strip().lower()
+        if overwrite == "y":
+            return
+        print("   Setup cancelled.")
+        sys.exit(0)
+
+    fail("Config already exists. Re-run with --reset or --force-overwrite.")
 
 
 def test_imap(host: str, port: int, email: str, password: str) -> tuple[bool, str]:
@@ -163,47 +284,39 @@ def test_smtp(host: str, port: int, email: str, password: str) -> tuple[bool, st
 def save_config(config: dict) -> None:
     """Save config JSON with restricted permissions (600)."""
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONFIG_PATH.write_text(json.dumps(config, indent=2), encoding="utf-8")
-    # chmod 600 — owner read/write only
+    CONFIG_PATH.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
     CONFIG_PATH.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
-def run_setup(reset: bool = False) -> None:
-    if CONFIG_PATH.exists() and not reset:
-        print(f"\n⚠️  Config already exists at {CONFIG_PATH}")
-        overwrite = input("   Overwrite? [y/N]: ").strip().lower()
-        if overwrite != "y":
-            print("   Setup cancelled.")
-            sys.exit(0)
+def run_setup(args: argparse.Namespace) -> None:
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    confirm_overwrite(args, interactive)
 
     print("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     print("  LibrAgent Email Integration Setup")
     print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     print()
 
-    # 1. Email address
-    email = input("Email address: ").strip()
-    if "@" not in email:
-        print("❌ Invalid email address.")
-        sys.exit(1)
+    if args.email:
+        email = args.email.strip()
+    elif interactive:
+        email = input("Email address: ").strip()
+    else:
+        fail("Email address required. Provide --email.")
 
-    # 2. Show auth note if preset exists
+    if "@" not in email:
+        fail("Invalid email address.")
+
     preset = get_preset(email)
     if preset and preset.get("auth_note"):
         print()
         print(f"  ℹ️  {preset['auth_note']}")
 
-    # 3. Server settings
-    server = prompt_server_settings(preset)
+    server = resolve_server_settings(args, email, interactive)
 
-    # 4. Password (hidden)
     print()
-    password = getpass.getpass("Password (input hidden): ")
-    if not password:
-        print("❌ Password cannot be empty.")
-        sys.exit(1)
+    password = resolve_password(args, interactive)
 
-    # 5. Test IMAP
     print()
     print(f"  Testing IMAP connection to {server['imap_host']}:{server['imap_port']} ...")
     ok, err = test_imap(server["imap_host"], server["imap_port"], email, password)
@@ -211,16 +324,24 @@ def run_setup(reset: bool = False) -> None:
         print(f"  ❌ IMAP test failed: {err}")
         print()
         print("  Troubleshooting:")
-        print("  - Gmail/Yahoo: Did you use an App Password?")
+        print("  - Gmail/Yahoo/iCloud: Did you use an App Password?")
         print("  - Naver: Is IMAP enabled in mail settings?")
-        print("  - Outlook: Is IMAP enabled in account settings?")
-        retry = input("\n  Try different settings? [y/N]: ").strip().lower()
-        if retry == "y":
-            run_setup(reset=True)
+        print("  - Outlook/M365: Is IMAP or SMTP AUTH enabled in account settings?")
+        if interactive:
+            retry = input("\n  Try different settings? [y/N]: ").strip().lower()
+            if retry == "y":
+                rerun_args = argparse.Namespace(**vars(args))
+                rerun_args.reset = True
+                rerun_args.use_preset_servers = False
+                rerun_args.imap_host = None
+                rerun_args.imap_port = None
+                rerun_args.smtp_host = None
+                rerun_args.smtp_port = None
+                run_setup(rerun_args)
+                return
         sys.exit(1)
     print("  ✓ IMAP OK")
 
-    # 6. Test SMTP
     print(f"  Testing SMTP connection to {server['smtp_host']}:{server['smtp_port']} ...")
     ok, err = test_smtp(server["smtp_host"], server["smtp_port"], email, password)
     if not ok:
@@ -229,12 +350,11 @@ def run_setup(reset: bool = False) -> None:
     else:
         print("  ✓ SMTP OK")
 
-    # 7. Save
     config = {
         "email": email,
         "password": password,
         **server,
-        "smtp_use_tls": server["smtp_port"] != 465,  # 465 uses SSL directly
+        "smtp_use_tls": server["smtp_port"] != 465,
     }
     save_config(config)
 
@@ -244,11 +364,37 @@ def run_setup(reset: bool = False) -> None:
     print()
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Create CLI parser."""
     parser = argparse.ArgumentParser(description="LibrAgent email account setup")
     parser.add_argument("--reset", action="store_true", help="Reset existing configuration")
+    parser.add_argument("--force-overwrite", action="store_true", help="Overwrite existing config without prompt")
+    parser.add_argument("--email", help="Email address to configure")
+    parser.add_argument(
+        "--use-preset-servers",
+        action="store_true",
+        help="Use the known preset for the email domain without prompting for IMAP/SMTP fields",
+    )
+    parser.add_argument("--imap-host", help="Override IMAP host")
+    parser.add_argument("--imap-port", type=int, help="Override IMAP port")
+    parser.add_argument("--smtp-host", help="Override SMTP host")
+    parser.add_argument("--smtp-port", type=int, help="Override SMTP port")
+    parser.add_argument(
+        "--password-env",
+        help="Read the password from the named environment variable",
+    )
+    parser.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the password from stdin",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
-    run_setup(reset=args.reset)
+    run_setup(args)
 
 
 if __name__ == "__main__":

--- a/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
+++ b/src-tauri/bundled_skills/email-integration/scripts/setup_account.py
@@ -73,6 +73,23 @@ SERVER_PRESETS = {
         "smtp_port": 587,
         "auth_note": "Same as Outlook — enable IMAP in settings first.",
     },
+    "live.com": {
+        "imap_host": "outlook.office365.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.office365.com",
+        "smtp_port": 587,
+        "auth_note": "Same as Outlook — enable IMAP in settings first.",
+    },
+    "onmicrosoft.com": {
+        "imap_host": "outlook.office365.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.office365.com",
+        "smtp_port": 587,
+        "auth_note": (
+            "Microsoft 365 may require IMAP or SMTP AUTH to be enabled by the tenant admin.\n"
+            "Custom corporate domains are not auto-detected; use explicit server flags for those."
+        ),
+    },
     "naver.com": {
         "imap_host": "imap.naver.com",
         "imap_port": 993,
@@ -107,6 +124,36 @@ SERVER_PRESETS = {
             "Generate one at: https://login.yahoo.com/account/security"
         ),
     },
+    "icloud.com": {
+        "imap_host": "imap.mail.me.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.mail.me.com",
+        "smtp_port": 587,
+        "auth_note": (
+            "iCloud Mail requires an app-specific password.\n"
+            "Generate one at: https://appleid.apple.com"
+        ),
+    },
+    "me.com": {
+        "imap_host": "imap.mail.me.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.mail.me.com",
+        "smtp_port": 587,
+        "auth_note": (
+            "iCloud Mail requires an app-specific password.\n"
+            "Generate one at: https://appleid.apple.com"
+        ),
+    },
+    "mac.com": {
+        "imap_host": "imap.mail.me.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.mail.me.com",
+        "smtp_port": 587,
+        "auth_note": (
+            "iCloud Mail requires an app-specific password.\n"
+            "Generate one at: https://appleid.apple.com"
+        ),
+    },
 }
 
 CONFIG_PATH = Path.home() / ".libragent" / "email_config"
@@ -122,7 +169,14 @@ def fail(message: str, exit_code: int = 1) -> None:
 def get_preset(email: str) -> dict | None:
     """Return server preset for the given email domain, or None if unknown."""
     domain = email.split("@")[-1].lower()
-    return SERVER_PRESETS.get(domain)
+    preset = SERVER_PRESETS.get(domain)
+    if preset:
+        return preset
+
+    if domain.endswith(".onmicrosoft.com"):
+        return SERVER_PRESETS["onmicrosoft.com"]
+
+    return None
 
 
 def server_from_preset(preset: dict) -> dict:

--- a/src-tauri/bundled_skills/email-integration/scripts/validate_config.py
+++ b/src-tauri/bundled_skills/email-integration/scripts/validate_config.py
@@ -24,7 +24,7 @@ def main() -> None:
     if not CONFIG_PATH.exists():
         print(json.dumps({
             "status": "missing",
-            "message": "No config found. Run setup_account.py to configure.",
+            "message": "No config found. Run the skill's Step 2 non-interactive setup flow to configure email, server fields, and password.",
             "action": "setup",
         }))
         sys.exit(1)


### PR DESCRIPTION
## Summary\n- refactor bundled email-integration setup to support argument-driven configuration\n- collect the password through a single hidden shell prompt via temporary env vars\n- update the bundled skill docs to avoid the old multi-step terminal wizard inside LibrAgent\n\n## Validation\n- python src-tauri\\bundled_skills\\email-integration\\scripts\\setup_account.py --help\n- PYTHONUTF8=1 python .github\\skills\\skill-creator\\scripts\\quick_validate.py src-tauri\\bundled_skills\\email-integration