### PR TITLE
fix(compaction): stabilize checkpoint fallback

### DIFF
--- a/src-tauri/src/agent/llm/completion/compaction/selection.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/selection.rs
@@ -125,6 +125,18 @@ fn retained_tail_has_orphan_tool_messages(messages: &[Message], split_idx: usize
     })
 }
 
+fn find_next_ownership_safe_split(
+    messages: &[Message],
+    delta_start_idx: usize,
+    split_idx: usize,
+) -> Option<usize> {
+    let starting_split_idx = split_idx.max(delta_start_idx.saturating_add(1));
+
+    (starting_split_idx..=messages.len()).find(|candidate_split_idx| {
+        !retained_tail_has_orphan_tool_messages(messages, *candidate_split_idx)
+    })
+}
+
 pub(super) fn build_checkpoint_backoff_split_candidates(
     messages: &[Message],
     compact_context_record: Option<&CompactContextRecord>,
@@ -189,10 +201,20 @@ fn find_prompt_checkpoint_compactable_end_exclusive(
                     .is_some_and(|value| value > compaction_window_start)
             })
             .unwrap_or(latest_checkpoint_relative_idx);
-        return Some(delta_start_idx + preserve_relative_idx);
+        if preserve_relative_idx > 0 {
+            return find_next_ownership_safe_split(
+                messages,
+                delta_start_idx,
+                delta_start_idx + preserve_relative_idx,
+            );
+        }
     }
 
-    Some(delta_start_idx + latest_checkpoint_relative_idx + 1)
+    find_next_ownership_safe_split(
+        messages,
+        delta_start_idx,
+        delta_start_idx + latest_checkpoint_relative_idx + 1,
+    )
 }
 
 pub fn has_prompt_checkpoint_compaction_target(

--- a/src-tauri/src/agent/llm/completion/mod.rs
+++ b/src-tauri/src/agent/llm/completion/mod.rs
@@ -9,10 +9,10 @@ pub use compaction::{
     build_compaction_request_payload_for_testing, build_overflow_recovery_compaction_messages,
     derive_tail_recompaction_recovery_plan_for_testing,
     find_preflight_compactable_end_exclusive_for_testing, fit_compaction_request_messages_to_limit,
-    inspect_compaction_payload, preview_preflight_compaction_selection,
-    should_skip_same_tail_compaction, trigger_manual_compaction_for_session,
-    trigger_preflight_compaction_for_session, CompactionPayloadDiagnostics,
-    CompactionPayloadMessageDiagnostic, CompactionPreservationHints,
+    has_prompt_checkpoint_compaction_target, inspect_compaction_payload,
+    preview_preflight_compaction_selection, should_skip_same_tail_compaction,
+    trigger_manual_compaction_for_session, trigger_preflight_compaction_for_session,
+    CompactionPayloadDiagnostics, CompactionPayloadMessageDiagnostic, CompactionPreservationHints,
     CompactionRequestPayloadPreview, CompactionSelectionPreview, TailRecompactionRecoveryPlan,
 };
 pub use context::{

--- a/src-tauri/tests/llm_context_tests.rs
+++ b/src-tauri/tests/llm_context_tests.rs
@@ -11,7 +11,8 @@ use tauri_mcp_agent_lib::agent::llm::completion::{
     build_overflow_recovery_compaction_messages,
     derive_tail_recompaction_recovery_plan_for_testing,
     find_preflight_compactable_end_exclusive_for_testing, fit_compaction_request_messages_to_limit,
-    inspect_compaction_payload, merge_consecutive_user_messages, normalize_request_messages,
+    has_prompt_checkpoint_compaction_target, inspect_compaction_payload,
+    merge_consecutive_user_messages, normalize_request_messages,
     preview_preflight_compaction_selection, resolve_context_management_settings,
     resolve_preserved_calibration_ratio, should_skip_same_tail_compaction,
     uses_compaction_strategy,
@@ -585,6 +586,129 @@ fn test_preflight_compactable_end_respects_effective_budget_after_output_reserve
 
     assert_eq!(full_budget_end, 4);
     assert_eq!(reserve_adjusted_end, 1);
+}
+
+#[test]
+fn test_preflight_compactable_end_falls_back_to_latest_checkpoint_when_overflow_window_starts_before_first_checkpoint(
+) {
+    let messages = vec![
+        TestMessageBuilder::new("m0", "user")
+            .text("checkpoint 0")
+            .prompt_tokens(27_195)
+            .build(),
+        TestMessageBuilder::new("m1", "assistant")
+            .text("checkpoint 1")
+            .prompt_tokens(34_492)
+            .build(),
+        TestMessageBuilder::new("m2", "user")
+            .text("checkpoint 2")
+            .prompt_tokens(35_271)
+            .build(),
+        TestMessageBuilder::new("m3", "tool")
+            .text("latest checkpoint")
+            .prompt_tokens(127_783)
+            .build(),
+        TestMessageBuilder::new("m4", "assistant")
+            .text("post-checkpoint assistant")
+            .build(),
+        TestMessageBuilder::new("m5", "user")
+            .text("latest request")
+            .source(MessageSource::Ui)
+            .build(),
+    ];
+
+    let compactable_end_exclusive =
+        find_preflight_compactable_end_exclusive_for_testing(&messages, None, Some(127_165));
+
+    assert_eq!(compactable_end_exclusive, 4);
+}
+
+#[test]
+fn test_prompt_checkpoint_compaction_target_survives_degenerate_near_overflow_window() {
+    let messages = vec![
+        TestMessageBuilder::new("m0", "user")
+            .text("checkpoint 0")
+            .prompt_tokens(27_195)
+            .build(),
+        TestMessageBuilder::new("m1", "assistant")
+            .text("checkpoint 1")
+            .prompt_tokens(34_492)
+            .build(),
+        TestMessageBuilder::new("m2", "user")
+            .text("checkpoint 2")
+            .prompt_tokens(35_271)
+            .build(),
+        TestMessageBuilder::new("m3", "tool")
+            .text("latest checkpoint")
+            .prompt_tokens(127_783)
+            .build(),
+        TestMessageBuilder::new("m4", "assistant")
+            .text("post-checkpoint assistant")
+            .build(),
+        TestMessageBuilder::new("m5", "user")
+            .text("latest request")
+            .source(MessageSource::Ui)
+            .build(),
+    ];
+
+    assert!(has_prompt_checkpoint_compaction_target(
+        &messages, None, 127_165
+    ));
+}
+
+#[test]
+fn test_preflight_compactable_end_advances_past_tool_result_when_checkpoint_fallback_would_orphan_tail(
+) {
+    let mut latest_checkpoint_owner = TestMessageBuilder::new("m1", "assistant")
+        .text("assistant tool owner checkpoint")
+        .prompt_tokens(127_783)
+        .build();
+    latest_checkpoint_owner.tool_calls = Some(vec![AgentToolCall {
+        id: "call_compaction_1".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "workspace__readFile".to_string(),
+            arguments: "{\"path\":\"notes.txt\"}".to_string(),
+        },
+    }]);
+    let mut tool_result = TestMessageBuilder::new("m2", "tool")
+        .text("tool result")
+        .build();
+    tool_result.tool_call_id = Some("call_compaction_1".to_string());
+
+    let messages = vec![
+        TestMessageBuilder::new("m0", "assistant")
+            .text("older compact summary")
+            .source(MessageSource::CompactSummary)
+            .build(),
+        latest_checkpoint_owner,
+        tool_result,
+        TestMessageBuilder::new("m3", "user")
+            .text("latest request")
+            .source(MessageSource::Ui)
+            .build(),
+    ];
+    let compact_record = CompactContextRecord {
+        id: "compact-1".to_string(),
+        session_id: TEST_SESSION_ID.to_string(),
+        to_id: "m0".to_string(),
+        condensed_count: Some(1),
+        summary: "Existing summary".to_string(),
+        created_at: 123,
+    };
+
+    let compactable_end_exclusive = find_preflight_compactable_end_exclusive_for_testing(
+        &messages,
+        Some(&compact_record),
+        Some(127_165),
+    );
+
+    assert_eq!(compactable_end_exclusive, 3);
+    assert!(has_prompt_checkpoint_compaction_target(
+        &messages,
+        Some(&compact_record),
+        127_165
+    ));
 }
 
 #[test]


### PR DESCRIPTION
This pull request enhances the logic around selecting safe split points for prompt checkpoint compaction, ensuring that tool messages are not orphaned during the process. It introduces a helper function to find ownership-safe splits, updates the main compaction selection logic to use this function, and adds new tests to cover edge cases involving tool messages and checkpoint fallback behavior.

**Compaction logic improvements:**

* Added `find_next_ownership_safe_split` to identify the next valid split index that does not orphan tool messages in `selection.rs`.
* Updated `find_prompt_checkpoint_compactable_end_exclusive` to use the new helper, ensuring fallback splits do not orphan tool messages and improving robustness in edge cases.

**API and test coverage:**

* Exposed `has_prompt_checkpoint_compaction_target` in the public API for use in tests and other modules [[1]](diffhunk://#diff-73dafb46ba704d033405206c3f9054f60c2668fc519ed82ea26f4a76766c6680L12-R15) [[2]](diffhunk://#diff-265c2cc34df794f84eab74e9000ff69e274695aa66832960c2eb7f1ddb7add8cL14-R15).
* Added comprehensive tests in `llm_context_tests.rs` to verify correct handling of checkpoint fallback, tool message ownership, and edge cases where the overflow window interacts with checkpoints.