### PR TITLE
Refine session history bookmarks and sorting

### DIFF
--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -31,7 +31,6 @@ interface SessionCardProps {
   session: AgentSession;
   onResume: (sessionId: string) => void;
   onDelete: (sessionId: string) => void;
-  nestingLevel?: number;
   lineageHint?: string;
   selectedLineageId?: string | null;
   onLineageSelect?: (lineageId: string) => void;
@@ -61,7 +60,6 @@ export function SessionCard({
   session,
   onResume,
   onDelete,
-  nestingLevel = 0,
   lineageHint,
   selectedLineageId = null,
   onLineageSelect,
@@ -231,7 +229,6 @@ export function SessionCard({
       aria-label={t('sessionHistory.card.ariaLabel', 'Session: {{name}}', {
         name: sessionNameFallback,
       })}
-      data-nesting-level={nestingLevel}
     >
       <div
         className={cn(

--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -219,10 +219,6 @@ export function SessionCard({
     updatedAtLabel,
     createdAtLabel,
   ].filter((value): value is string => Boolean(value));
-  const contentIndentStyle =
-    nestingLevel > 0
-      ? { paddingLeft: `${Math.min(nestingLevel, 4) * 14}px` }
-      : undefined;
 
   return (
     <article
@@ -235,6 +231,7 @@ export function SessionCard({
       aria-label={t('sessionHistory.card.ariaLabel', 'Session: {{name}}', {
         name: sessionNameFallback,
       })}
+      data-nesting-level={nestingLevel}
     >
       <div
         className={cn(
@@ -243,7 +240,7 @@ export function SessionCard({
         )}
         aria-hidden="true"
       />
-      <div className="space-y-2.5" style={contentIndentStyle}>
+      <div className="space-y-2.5">
         <div className="grid grid-cols-[auto,minmax(0,1fr),auto] items-start gap-2">
           <div className="pt-0.5">
             {hasExpandableChildren ? (

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -27,6 +27,8 @@ import {
   BookmarkCheck,
   Clock3,
   StarOff,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react';
 import {
   buildChildrenMap,
@@ -37,7 +39,10 @@ import {
   type SessionStatusCounts,
 } from '@/lib/session-utils';
 import { formatRelativeTime } from '@/lib/date-utils';
-import { sortSessionsByLatestActivity } from '@/lib/session-metadata';
+import {
+  getLatestSessionActivityTimestamp,
+  sortSessionsByLatestActivity,
+} from '@/lib/session-metadata';
 import type { AgentSession } from '@/models/agent';
 import { SessionCard } from './SessionCard';
 
@@ -61,6 +66,8 @@ interface SessionHistoryPanelProps {
   searchPlaceholder?: string;
   emptyStateTitle?: string;
   emptyStateSubtitle?: string;
+  initialSortKey?: SessionSortKey;
+  initialSortDirection?: SessionSortDirection;
 }
 
 interface SessionHistoryRow {
@@ -73,6 +80,8 @@ interface SessionHistoryRow {
 }
 
 type SessionHistoryTranslate = ReturnType<typeof useTranslation>['t'];
+type SessionSortKey = 'updatedAt' | 'createdAt' | 'name';
+type SessionSortDirection = 'asc' | 'desc';
 
 function findScrollParent(element: HTMLElement | null): HTMLElement | null {
   let current = element?.parentElement ?? null;
@@ -98,25 +107,89 @@ interface BookmarkedSessionTileProps {
 const HISTORY_CONTENT_RAIL_CLASS = 'mx-auto w-full max-w-4xl';
 const HISTORY_SECTION_CLASS =
   'rounded-xl border bg-card/80 p-4 shadow-sm shadow-black/5';
+const BOOKMARK_PREVIEW_LIMIT = 6;
+const sessionSortValues: SessionSortKey[] = ['updatedAt', 'createdAt', 'name'];
 
-function BookmarkedSessionTile({
+function getSessionDisplayName(
+  session: AgentSession,
+  t: SessionHistoryTranslate,
+): string {
+  return (
+    session.name ||
+    t('sessionHistory.card.fallbackName', 'Session {{id}}', {
+      id: session.id.slice(0, 8),
+    })
+  );
+}
+
+function isSessionSortKey(value: string): value is SessionSortKey {
+  return sessionSortValues.includes(value as SessionSortKey);
+}
+
+function getSessionSortTimestamp(
+  session: AgentSession,
+  sortKey: Extract<SessionSortKey, 'updatedAt' | 'createdAt'>,
+): number {
+  if (sortKey === 'updatedAt') {
+    return getLatestSessionActivityTimestamp(session);
+  }
+
+  return session.createdAt.getTime();
+}
+
+function compareSessionsBySort(
+  left: AgentSession,
+  right: AgentSession,
+  sortKey: SessionSortKey,
+  sortDirection: SessionSortDirection,
+  t: SessionHistoryTranslate,
+): number {
+  let comparison = 0;
+
+  if (sortKey === 'name') {
+    comparison = getSessionDisplayName(left, t).localeCompare(
+      getSessionDisplayName(right, t),
+      undefined,
+      {
+        numeric: true,
+        sensitivity: 'base',
+      },
+    );
+  } else {
+    comparison =
+      getSessionSortTimestamp(left, sortKey) -
+      getSessionSortTimestamp(right, sortKey);
+  }
+
+  if (comparison === 0) {
+    return 0;
+  }
+
+  return sortDirection === 'asc' ? comparison : -comparison;
+}
+
+function compareSessionsByLatestActivityDesc(
+  left: AgentSession,
+  right: AgentSession,
+): number {
+  return (
+    getSessionSortTimestamp(right, 'updatedAt') -
+    getSessionSortTimestamp(left, 'updatedAt')
+  );
+}
+
+function BookmarkedSessionRow({
   session,
   onResume,
   onToggleBookmark,
   t,
 }: BookmarkedSessionTileProps) {
-  const shortcutLabel =
-    session.name ||
-    t('sessionHistory.card.fallbackName', 'Session {{id}}', {
-      id: session.id.slice(0, 8),
-    });
+  const shortcutLabel = getSessionDisplayName(session, t);
   const latestActivity =
-    formatRelativeTime(session.updatedAt ?? session.createdAt, new Date()) ||
-    t('sessionHistory.card.justNow', 'just now');
-  const statusLabel = t(
-    `sessionHistory.status.${session.status}`,
-    session.status,
-  );
+    formatRelativeTime(
+      new Date(getLatestSessionActivityTimestamp(session)),
+      new Date(),
+    ) || t('sessionHistory.card.justNow', 'just now');
   const secondaryLabel =
     session.assistant?.name ||
     (session.provider && session.model
@@ -127,67 +200,48 @@ function BookmarkedSessionTile({
         ));
 
   return (
-    <article className="rounded-xl border bg-background/80 p-3 shadow-sm shadow-black/5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start gap-2">
-            <h3 className="min-w-0 flex-1 truncate text-sm font-semibold leading-5 text-foreground">
-              {shortcutLabel}
-            </h3>
-            <Badge
-              variant="secondary"
-              className="h-5 shrink-0 px-1.5 text-[10px]"
-            >
-              {statusLabel}
-            </Badge>
+    <div className="flex items-center gap-2 rounded-lg border bg-background/80 px-3 py-2 shadow-sm shadow-black/5">
+      <Button
+        type="button"
+        variant="ghost"
+        className="-my-1 h-auto min-w-0 flex-1 justify-start px-2 py-1"
+        onClick={() => onResume(session.id)}
+        aria-label={t(
+          'sessionHistory.bookmarkedSection.resumeAria',
+          'Open bookmarked session {{name}}',
+          { name: shortcutLabel },
+        )}
+      >
+        <div className="min-w-0 flex-1 text-left">
+          <div className="truncate text-sm font-semibold leading-5 text-foreground">
+            {shortcutLabel}
           </div>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            {secondaryLabel}
-          </p>
+          <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="truncate">{secondaryLabel}</span>
+            <span aria-hidden="true">•</span>
+            <Clock3 className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">
+              {t('sessionHistory.bookmarkedSection.lastUsed', 'Used {{time}}', {
+                time: latestActivity,
+              })}
+            </span>
+          </div>
         </div>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7 shrink-0"
-          onClick={() => onToggleBookmark?.(session.id)}
-          aria-label={t(
-            'sessionHistory.actions.unbookmarkAria',
-            'Remove bookmark',
-          )}
-        >
-          <StarOff className="h-4 w-4" aria-hidden="true" />
-        </Button>
-      </div>
-
-      <div className="mt-3 flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
-          <Clock3 className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">
-            {t('sessionHistory.bookmarkedSection.lastUsed', 'Used {{time}}', {
-              time: latestActivity,
-            })}
-          </span>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 shrink-0 px-2"
-          onClick={() => onResume(session.id)}
-          aria-label={t(
-            'sessionHistory.bookmarkedSection.resumeAria',
-            'Open bookmarked session {{name}}',
-            { name: shortcutLabel },
-          )}
-        >
-          <BookmarkCheck className="h-4 w-4 text-warning" />
-          <span>
-            {t('sessionHistory.bookmarkedSection.open', 'Open session')}
-          </span>
-        </Button>
-      </div>
-    </article>
+      </Button>
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className="h-8 w-8 shrink-0"
+        onClick={() => onToggleBookmark?.(session.id)}
+        aria-label={t(
+          'sessionHistory.actions.unbookmarkAria',
+          'Remove bookmark',
+        )}
+      >
+        <StarOff className="h-4 w-4" aria-hidden="true" />
+      </Button>
+    </div>
   );
 }
 
@@ -232,14 +286,22 @@ export function SessionHistoryPanel({
   searchPlaceholder,
   emptyStateTitle,
   emptyStateSubtitle,
+  initialSortKey = 'updatedAt',
+  initialSortDirection = 'desc',
 }: SessionHistoryPanelProps) {
   const { t } = useTranslation('common');
   const rootRef = useRef<HTMLDivElement | null>(null);
   const scrollParentRef = useRef<HTMLElement | null>(null);
   const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const historyControlsRef = useRef<HTMLDivElement | null>(null);
   const [selectedLineageId, setSelectedLineageId] = useState<string | null>(
     null,
   );
+  const [showBookmarkedOnly, setShowBookmarkedOnly] = useState(false);
+  const [activeSortKey, setActiveSortKey] =
+    useState<SessionSortKey>(initialSortKey);
+  const [activeSortDirection, setActiveSortDirection] =
+    useState<SessionSortDirection>(initialSortDirection);
   const [manuallyExpandedSessionIds, setManuallyExpandedSessionIds] = useState<
     Set<string>
   >(() => new Set());
@@ -270,7 +332,9 @@ export function SessionHistoryPanel({
     searchQuery !== deferredSearchQuery || sessions !== deferredSessions;
 
   const filtersActive =
-    activeStatusFilter !== 'all' || deferredSearchQuery.trim().length > 0;
+    activeStatusFilter !== 'all' ||
+    deferredSearchQuery.trim().length > 0 ||
+    showBookmarkedOnly;
 
   useEffect(() => {
     if (!selectedLineageId) {
@@ -287,7 +351,14 @@ export function SessionHistoryPanel({
 
   useEffect(() => {
     setCollapsedAutoExpandedSessionIds(new Set());
-  }, [activeStatusFilter, deferredSearchQuery, selectedLineageId]);
+  }, [
+    activeSortDirection,
+    activeSortKey,
+    activeStatusFilter,
+    deferredSearchQuery,
+    selectedLineageId,
+    showBookmarkedOnly,
+  ]);
 
   useLayoutEffect(() => {
     scrollParentRef.current = findScrollParent(rootRef.current);
@@ -300,7 +371,10 @@ export function SessionHistoryPanel({
       ),
     [deferredSessions],
   );
-  const featuredBookmarkedSessions = bookmarkedSessions.slice(0, 5);
+  const featuredBookmarkedSessions = bookmarkedSessions.slice(
+    0,
+    BOOKMARK_PREVIEW_LIMIT,
+  );
   const remainingBookmarkedCount = Math.max(
     bookmarkedSessions.length - featuredBookmarkedSessions.length,
     0,
@@ -328,15 +402,18 @@ export function SessionHistoryPanel({
           (session) => session.lineageId === selectedLineageId,
         )
       : deferredSessions;
+    const bookmarkedScopeSessions = showBookmarkedOnly
+      ? lineageSessions.filter((session) => session.isBookmarked === true)
+      : lineageSessions;
     const nextStatusCounts = {
-      all: lineageSessions.length,
+      all: bookmarkedScopeSessions.length,
       busy: 0,
       idle: 0,
       paused: 0,
       error: 0,
     };
 
-    lineageSessions.forEach((session) => {
+    bookmarkedScopeSessions.forEach((session) => {
       if (
         Object.prototype.hasOwnProperty.call(nextStatusCounts, session.status)
       ) {
@@ -344,7 +421,7 @@ export function SessionHistoryPanel({
       }
     });
 
-    let filteredSessions = lineageSessions;
+    let filteredSessions = bookmarkedScopeSessions;
 
     if (activeStatusFilter !== 'all') {
       filteredSessions = filteredSessions.filter(
@@ -355,9 +432,28 @@ export function SessionHistoryPanel({
     const matchedSessions = [
       ...filterSessions(filteredSessions, deferredSearchQuery),
     ].sort((a, b) => {
+      const sortDiff = compareSessionsBySort(
+        a,
+        b,
+        activeSortKey,
+        activeSortDirection,
+        t,
+      );
+      if (sortDiff !== 0) {
+        return sortDiff;
+      }
+
       const statusDiff =
         (statusPriority[a.status] ?? 999) - (statusPriority[b.status] ?? 999);
-      if (statusDiff !== 0) return statusDiff;
+      if (statusDiff !== 0) {
+        return statusDiff;
+      }
+
+      const latestActivityDiff = compareSessionsByLatestActivityDesc(a, b);
+      if (latestActivityDiff !== 0) {
+        return latestActivityDiff;
+      }
+
       return b.createdAt.getTime() - a.createdAt.getTime();
     });
 
@@ -509,13 +605,15 @@ export function SessionHistoryPanel({
 
     return {
       autoExpandedAncestorIds: nextAutoExpandedAncestorIds,
-      baseSessions: lineageSessions,
+      baseSessions: bookmarkedScopeSessions,
       displayRows: rows,
       matchedSessionCount: matchedSessions.length,
       statusCounts: nextStatusCounts,
     };
   }, [
     activeStatusFilter,
+    activeSortDirection,
+    activeSortKey,
     collapsedAutoExpandedSessionIds,
     descendantStatusCounts,
     deferredSearchQuery,
@@ -523,6 +621,7 @@ export function SessionHistoryPanel({
     filtersActive,
     manuallyExpandedSessionIds,
     selectedLineageId,
+    showBookmarkedOnly,
     t,
   ]);
 
@@ -569,6 +668,25 @@ export function SessionHistoryPanel({
     paused: `${t('sessionHistory.tabs.paused', 'Paused')} (${statusCounts.paused})`,
     error: `${t('sessionHistory.tabs.error', 'Error')} (${statusCounts.error})`,
   };
+  const sortLabelByValue: Record<SessionSortKey, string> = {
+    updatedAt: t('sessionHistory.sort.updatedAt', 'Recent activity'),
+    createdAt: t('sessionHistory.sort.createdAt', 'Created'),
+    name: t('sessionHistory.sort.name', 'Name'),
+  };
+  const handleBrowseBookmarkedHistory = useCallback(() => {
+    setShowBookmarkedOnly(true);
+    window.requestAnimationFrame(() => {
+      historyControlsRef.current?.scrollIntoView?.({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+  }, []);
+  const sortDirectionToggleLabel =
+    activeSortDirection === 'asc'
+      ? t('sessionHistory.sort.descending', 'Sort descending')
+      : t('sessionHistory.sort.ascending', 'Sort ascending');
+
   const handleEndReached = useCallback(() => {
     if (!hasMoreSessions || isLoadingMoreSessions) {
       return;
@@ -744,60 +862,79 @@ export function SessionHistoryPanel({
         </Button>
       </div>
 
-      {!selectedLineageId && bookmarkedSessions.length > 0 && (
-        <section
-          id="bookmarked-sessions"
-          className={cn(
-            HISTORY_CONTENT_RAIL_CLASS,
-            HISTORY_SECTION_CLASS,
-            'mb-4',
-          )}
-        >
-          <div className="flex flex-wrap items-end justify-between gap-3">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <BookmarkCheck className="h-4 w-4 text-warning" />
-                <h2 className="text-sm font-semibold text-foreground">
-                  {t(
-                    'sessionHistory.bookmarkedSection.heading',
-                    'Bookmarked Sessions',
-                  )}
-                </h2>
-                <Badge variant="secondary">{bookmarkedSessions.length}</Badge>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {t(
-                  'sessionHistory.bookmarkedSection.description',
-                  'Pinned sessions stay here for quick access while the full history remains below.',
-                )}
-              </p>
-            </div>
-            {remainingBookmarkedCount > 0 && (
-              <Badge variant="outline" className="h-6 px-2">
-                {t(
-                  'sessionHistory.bookmarkedSection.more',
-                  '+{{count}} more in history',
-                  { count: remainingBookmarkedCount },
-                )}
-              </Badge>
+      {!selectedLineageId &&
+        !showBookmarkedOnly &&
+        bookmarkedSessions.length > 0 && (
+          <section
+            id="bookmarked-sessions"
+            className={cn(
+              HISTORY_CONTENT_RAIL_CLASS,
+              HISTORY_SECTION_CLASS,
+              'mb-4',
             )}
-          </div>
+          >
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <BookmarkCheck className="h-4 w-4 text-warning" />
+                  <h2 className="text-sm font-semibold text-foreground">
+                    {t(
+                      'sessionHistory.bookmarkedSection.heading',
+                      'Bookmarked Sessions',
+                    )}
+                  </h2>
+                  <Badge variant="secondary">{bookmarkedSessions.length}</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t(
+                    'sessionHistory.bookmarkedSection.description',
+                    'Pinned sessions stay here for quick access while the full history remains below.',
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {remainingBookmarkedCount > 0 && (
+                  <Badge variant="outline" className="h-6 px-2">
+                    {t(
+                      'sessionHistory.bookmarkedSection.more',
+                      '+{{count}} more bookmarked',
+                      { count: remainingBookmarkedCount },
+                    )}
+                  </Badge>
+                )}
+                {remainingBookmarkedCount > 0 && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleBrowseBookmarkedHistory}
+                  >
+                    {t(
+                      'sessionHistory.bookmarkedSection.browseAll',
+                      'Browse all bookmarked',
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
 
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            {featuredBookmarkedSessions.map((session) => (
-              <BookmarkedSessionTile
-                key={session.id}
-                session={session}
-                onResume={onResume}
-                onToggleBookmark={onToggleBookmark}
-                t={t}
-              />
-            ))}
-          </div>
-        </section>
-      )}
+            <div className="mt-3 flex flex-col gap-2" role="list">
+              {featuredBookmarkedSessions.map((session) => (
+                <div key={session.id} role="listitem">
+                  <BookmarkedSessionRow
+                    session={session}
+                    onResume={onResume}
+                    onToggleBookmark={onToggleBookmark}
+                    t={t}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
       <div
+        ref={historyControlsRef}
         className={cn(
           HISTORY_CONTENT_RAIL_CLASS,
           HISTORY_SECTION_CLASS,
@@ -827,10 +964,68 @@ export function SessionHistoryPanel({
             )}
           </div>
 
-          <div className="flex items-center gap-2 md:w-56 md:shrink-0">
-            <span className="text-xs font-medium text-muted-foreground">
-              {t('sessionHistory.statusFilter.label', 'Status')}
-            </span>
+          <div className="flex flex-wrap items-center gap-2 md:justify-end">
+            <Button
+              type="button"
+              size="sm"
+              variant={showBookmarkedOnly ? 'secondary' : 'outline'}
+              className="shrink-0"
+              aria-pressed={showBookmarkedOnly}
+              onClick={() =>
+                setShowBookmarkedOnly((previousState) => !previousState)
+              }
+            >
+              <BookmarkCheck className="mr-2 h-4 w-4" />
+              {t('sessionHistory.tabs.bookmarked', 'Bookmarked')} (
+              {bookmarkedSessions.length})
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-2 md:w-64 md:shrink-0">
+            <Select
+              value={activeSortKey}
+              onValueChange={(value) => {
+                if (isSessionSortKey(value)) {
+                  setActiveSortKey(value);
+                }
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-full"
+                aria-label={t('sessionHistory.sort.label', 'Sort sessions')}
+              >
+                <SelectValue>{sortLabelByValue[activeSortKey]}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {sessionSortValues.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {sortLabelByValue[value]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={() =>
+                setActiveSortDirection((previousState) =>
+                  previousState === 'asc' ? 'desc' : 'asc',
+                )
+              }
+              aria-label={sortDirectionToggleLabel}
+            >
+              {activeSortDirection === 'asc' ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+
+          <div className="md:w-56 md:shrink-0">
             <Select
               value={activeStatusFilter}
               onValueChange={(value) => {
@@ -860,26 +1055,48 @@ export function SessionHistoryPanel({
         </div>
       </div>
 
-      {selectedLineageId && (
+      {(selectedLineageId || showBookmarkedOnly) && (
         <div
           className={cn(
             HISTORY_CONTENT_RAIL_CLASS,
-            'mt-3 flex items-center gap-2 text-xs text-muted-foreground',
+            'mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground',
           )}
         >
-          <span>
-            {t('sessionHistory.focusedLineage', 'Focused lineage: {{id}}', {
-              id: selectedLineageId.slice(0, 8),
-            })}
-          </span>
-          <Button
-            variant="link"
-            size="sm"
-            className="h-auto p-0"
-            onClick={() => setSelectedLineageId(null)}
-          >
-            {t('sessionHistory.showAllLineages', 'Show all lineages')}
-          </Button>
+          {selectedLineageId && (
+            <>
+              <span>
+                {t('sessionHistory.focusedLineage', 'Focused lineage: {{id}}', {
+                  id: selectedLineageId.slice(0, 8),
+                })}
+              </span>
+              <Button
+                variant="link"
+                size="sm"
+                className="h-auto p-0"
+                onClick={() => setSelectedLineageId(null)}
+              >
+                {t('sessionHistory.showAllLineages', 'Show all lineages')}
+              </Button>
+            </>
+          )}
+          {showBookmarkedOnly && (
+            <>
+              <span>
+                {t(
+                  'sessionHistory.bookmarkFilter.focused',
+                  'Showing bookmarked sessions',
+                )}
+              </span>
+              <Button
+                variant="link"
+                size="sm"
+                className="h-auto p-0"
+                onClick={() => setShowBookmarkedOnly(false)}
+              >
+                {t('sessionHistory.bookmarkFilter.clear', 'Show all sessions')}
+              </Button>
+            </>
+          )}
         </div>
       )}
 
@@ -945,6 +1162,26 @@ export function SessionHistoryPanel({
                     className="mt-2"
                   >
                     {t('sessionHistory.clearSearch', 'Clear search')}
+                  </Button>
+                </>
+              ) : showBookmarkedOnly ? (
+                <>
+                  <p className="text-sm">
+                    {t(
+                      'sessionHistory.bookmarkFilter.empty',
+                      'No bookmarked sessions yet',
+                    )}
+                  </p>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setShowBookmarkedOnly(false)}
+                    className="mt-2"
+                  >
+                    {t(
+                      'sessionHistory.bookmarkFilter.clear',
+                      'Show all sessions',
+                    )}
                   </Button>
                 </>
               ) : (

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -108,6 +108,8 @@ const HISTORY_CONTENT_RAIL_CLASS = 'mx-auto w-full max-w-4xl';
 const HISTORY_SECTION_CLASS =
   'rounded-xl border bg-card/80 p-4 shadow-sm shadow-black/5';
 const BOOKMARK_PREVIEW_LIMIT = 6;
+const TREE_INDENT_PX = 18;
+const MAX_TREE_INDENT_LEVEL = 8;
 const sessionSortValues: SessionSortKey[] = ['updatedAt', 'createdAt', 'name'];
 
 function getSessionDisplayName(
@@ -762,32 +764,53 @@ export function SessionHistoryPanel({
       hasExpandableChildren,
       isExpanded,
       descendantStatusCounts: rowDescendantStatusCounts,
-    }: SessionHistoryRow) => (
-      <div key={session.id} role="listitem">
-        <div className="pb-4">
-          <SessionCard
-            session={session}
-            onResume={onResume}
-            onDelete={onDelete}
-            onDeleteOnly={onDeleteOnly}
-            onToggleBookmark={onToggleBookmark}
-            nestingLevel={nestingLevel}
-            lineageHint={lineageHint}
-            selectedLineageId={selectedLineageId}
-            descendantCount={descendantCounts.get(session.id) ?? 0}
-            descendantStatusCounts={rowDescendantStatusCounts}
-            hasExpandableChildren={hasExpandableChildren}
-            isExpanded={isExpanded}
-            onToggleExpand={handleToggleExpand}
-            onLineageSelect={(lineageId) =>
-              setSelectedLineageId((prev) =>
-                prev === lineageId ? null : lineageId,
-              )
-            }
-          />
+    }: SessionHistoryRow) => {
+      const indentationPx =
+        nestingLevel > 0
+          ? Math.min(nestingLevel, MAX_TREE_INDENT_LEVEL) * TREE_INDENT_PX
+          : 0;
+
+      return (
+        <div
+          key={session.id}
+          role="listitem"
+          style={
+            indentationPx > 0
+              ? { paddingLeft: `${indentationPx}px` }
+              : undefined
+          }
+        >
+          <div
+            className={cn(
+              'pb-4',
+              nestingLevel > 0 &&
+                'border-l border-border/50 pl-3 dark:border-border/60',
+            )}
+          >
+            <SessionCard
+              session={session}
+              onResume={onResume}
+              onDelete={onDelete}
+              onDeleteOnly={onDeleteOnly}
+              onToggleBookmark={onToggleBookmark}
+              nestingLevel={nestingLevel}
+              lineageHint={lineageHint}
+              selectedLineageId={selectedLineageId}
+              descendantCount={descendantCounts.get(session.id) ?? 0}
+              descendantStatusCounts={rowDescendantStatusCounts}
+              hasExpandableChildren={hasExpandableChildren}
+              isExpanded={isExpanded}
+              onToggleExpand={handleToggleExpand}
+              onLineageSelect={(lineageId) =>
+                setSelectedLineageId((prev) =>
+                  prev === lineageId ? null : lineageId,
+                )
+              }
+            />
+          </div>
         </div>
-      </div>
-    ),
+      );
+    },
     [
       descendantCounts,
       handleToggleExpand,

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -793,7 +793,6 @@ export function SessionHistoryPanel({
               onDelete={onDelete}
               onDeleteOnly={onDeleteOnly}
               onToggleBookmark={onToggleBookmark}
-              nestingLevel={nestingLevel}
               lineageHint={lineageHint}
               selectedLineageId={selectedLineageId}
               descendantCount={descendantCounts.get(session.id) ?? 0}

--- a/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
+++ b/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
@@ -202,6 +202,32 @@ describe('SessionHistoryPanel', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('applies row-level indentation for expanded child sessions', () => {
+    const sessions: AgentSession[] = [
+      createSession('root', 'Root'),
+      createSession('child', 'Child', { parentSessionId: 'root' }),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+    const rootRow = screen.getByTestId('session-card-root').closest('[role="listitem"]');
+    const childRow = screen.getByTestId('session-card-child').closest('[role="listitem"]');
+
+    expect(rootRow).not.toHaveStyle({ paddingLeft: '18px' });
+    expect(childRow).toHaveStyle({ paddingLeft: '18px' });
+    expect(childRow?.firstElementChild).toHaveClass('border-l', 'pl-3');
+  });
+
   it('sorts root sessions by latest activity descending by default', () => {
     const sessions: AgentSession[] = [
       createSession('older', 'Older Session', {

--- a/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
+++ b/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
@@ -59,6 +59,18 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false;
+}
+
+if (!HTMLElement.prototype.setPointerCapture) {
+  HTMLElement.prototype.setPointerCapture = () => {};
+}
+
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = () => {};
+}
+
 let animationFrameQueue: FrameRequestCallback[] = [];
 
 global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -130,6 +142,12 @@ function mockElementRect(
   });
 }
 
+function getRenderedSessionIds(): string[] {
+  return screen
+    .getAllByTestId(/^session-card-/)
+    .map((element) => element.getAttribute('data-testid')?.replace('session-card-', '') ?? '');
+}
+
 describe('SessionHistoryPanel', () => {
   beforeEach(() => {
     animationFrameQueue = [];
@@ -182,6 +200,106 @@ describe('SessionHistoryPanel', () => {
     expect(
       screen.queryByTestId('session-card-grandchild'),
     ).not.toBeInTheDocument();
+  });
+
+  it('sorts root sessions by latest activity descending by default', () => {
+    const sessions: AgentSession[] = [
+      createSession('older', 'Older Session', {
+        updatedAt: new Date('2026-03-18T00:00:00Z'),
+      }),
+      createSession('newest', 'Newest Session', {
+        updatedAt: new Date('2026-03-21T00:00:00Z'),
+      }),
+      createSession('middle', 'Middle Session', {
+        updatedAt: new Date('2026-03-20T00:00:00Z'),
+      }),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    expect(getRenderedSessionIds()).toEqual(['newest', 'middle', 'older']);
+  });
+
+  it('prioritizes lastMessageAt over updatedAt for latest activity sorting', () => {
+    const sessions: AgentSession[] = [
+      createSession('metadata-only', 'Metadata Only', {
+        updatedAt: new Date('2026-03-21T00:00:00Z'),
+      }),
+      createSession('recent-message', 'Recent Message', {
+        updatedAt: new Date('2026-03-20T00:00:00Z'),
+        lastMessageAt: new Date('2026-03-22T00:00:00Z'),
+      }),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    expect(getRenderedSessionIds()).toEqual(['recent-message', 'metadata-only']);
+  });
+
+  it('toggles the session sort direction', () => {
+    const sessions: AgentSession[] = [
+      createSession('older', 'Older Session', {
+        updatedAt: new Date('2026-03-18T00:00:00Z'),
+      }),
+      createSession('newest', 'Newest Session', {
+        updatedAt: new Date('2026-03-21T00:00:00Z'),
+      }),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sort ascending' }));
+
+    expect(getRenderedSessionIds()).toEqual(['older', 'newest']);
+    expect(
+      screen.getByRole('button', { name: 'Sort descending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts sessions by name when the sort key changes', () => {
+    const sessions: AgentSession[] = [
+      createSession('zebra', 'Zebra'),
+      createSession('apple', 'Apple'),
+      createSession('mango', 'Mango'),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+        initialSortKey="name"
+        initialSortDirection="asc"
+      />,
+    );
+
+    expect(getRenderedSessionIds()).toEqual(['apple', 'mango', 'zebra']);
   });
 
   it('renders the session list with list semantics', () => {
@@ -381,6 +499,7 @@ describe('SessionHistoryPanel', () => {
       createSession('s4', 'Session 4', { isBookmarked: true }),
       createSession('s5', 'Session 5', { isBookmarked: true }),
       createSession('s6', 'Session 6', { isBookmarked: true }),
+      createSession('s7', 'Session 7', { isBookmarked: true }),
     ];
 
     render(
@@ -393,7 +512,75 @@ describe('SessionHistoryPanel', () => {
       />,
     );
 
-    expect(screen.getByText('+1 more in history')).toBeInTheDocument();
+    expect(screen.getByText('+1 more bookmarked')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Browse all bookmarked' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts bookmarked preview sessions by latest message activity', () => {
+    const sessions: AgentSession[] = [
+      createSession('metadata-bookmark', 'Metadata Bookmark', {
+        isBookmarked: true,
+        updatedAt: new Date('2026-03-21T00:00:00Z'),
+      }),
+      createSession('message-bookmark', 'Message Bookmark', {
+        isBookmarked: true,
+        updatedAt: new Date('2026-03-20T00:00:00Z'),
+        lastMessageAt: new Date('2026-03-22T00:00:00Z'),
+      }),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    const bookmarkedButtons = screen.getAllByRole('button', {
+      name: /Open bookmarked session /,
+    });
+
+    expect(bookmarkedButtons[0]).toHaveAccessibleName(
+      'Open bookmarked session Message Bookmark',
+    );
+    expect(bookmarkedButtons[1]).toHaveAccessibleName(
+      'Open bookmarked session Metadata Bookmark',
+    );
+  });
+
+  it('can focus the main history list on bookmarked sessions', () => {
+    const sessions: AgentSession[] = [
+      createSession('root', 'Root'),
+      createSession('bookmarked-child', 'Bookmarked Child', {
+        parentSessionId: 'root',
+        isBookmarked: true,
+      }),
+      createSession('other-root', 'Other Root'),
+    ];
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bookmarked (1)' }));
+
+    expect(screen.getByText('Showing bookmarked sessions')).toBeInTheDocument();
+    expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('session-card-bookmarked-child'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('session-card-other-root')).not.toBeInTheDocument();
   });
 
   it('resets collapsed auto-expanded lineage state when the filter context changes', () => {

--- a/src/lib/session-metadata.ts
+++ b/src/lib/session-metadata.ts
@@ -279,12 +279,24 @@ export function mapSessionMetadataToAgentSession(
   };
 }
 
+export function getLatestSessionActivityTimestamp(
+  session: AgentSession,
+): number {
+  return (
+    session.lastMessageAt?.getTime() ??
+    session.updatedAt?.getTime() ??
+    session.createdAt.getTime()
+  );
+}
+
 export function sortSessionsByLatestActivity(
   sessions: AgentSession[],
 ): AgentSession[] {
-  return sessions.slice().sort((a, b) => {
-    const timeA = a.updatedAt?.getTime() || a.createdAt.getTime();
-    const timeB = b.updatedAt?.getTime() || b.createdAt.getTime();
-    return timeB - timeA;
-  });
+  return sessions
+    .slice()
+    .sort(
+      (left, right) =>
+        getLatestSessionActivityTimestamp(right) -
+        getLatestSessionActivityTimestamp(left),
+    );
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -180,7 +180,8 @@
       "open": "Sitzung öffnen",
       "lastUsed": "Verwendet {{time}}",
       "defaultMeta": "Für den Schnellzugriff gespeichert",
-      "more": "+{{count}} weitere im Verlauf"
+      "more": "+{{count}} weitere Favoriten",
+      "browseAll": "Alle Favoriten anzeigen"
     },
     "toasts": {
       "deleted": "Sitzung gelöscht",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "Status",
       "all": "Alle Status"
+    },
+    "bookmarkFilter": {
+      "focused": "Favoriten-Sitzungen werden angezeigt",
+      "clear": "Alle Sitzungen anzeigen",
+      "empty": "Noch keine Favoriten-Sitzungen"
+    },
+    "sort": {
+      "label": "Sitzungen sortieren",
+      "updatedAt": "Neueste Aktivität",
+      "createdAt": "Erstellt",
+      "name": "Name",
+      "ascending": "Aufsteigend sortieren",
+      "descending": "Absteigend sortieren"
     },
     "lineageHint": {
       "child": "↳ Kind von {{parentName}}",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -180,7 +180,8 @@
       "open": "Open session",
       "lastUsed": "Used {{time}}",
       "defaultMeta": "Saved for quick access",
-      "more": "+{{count}} more in history"
+      "more": "+{{count}} more bookmarked",
+      "browseAll": "Browse all bookmarked"
     },
     "toasts": {
       "deleted": "Session deleted",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "Status",
       "all": "All statuses"
+    },
+    "bookmarkFilter": {
+      "focused": "Showing bookmarked sessions",
+      "clear": "Show all sessions",
+      "empty": "No bookmarked sessions yet"
+    },
+    "sort": {
+      "label": "Sort sessions",
+      "updatedAt": "Recent activity",
+      "createdAt": "Created",
+      "name": "Name",
+      "ascending": "Sort ascending",
+      "descending": "Sort descending"
     },
     "lineageHint": {
       "child": "↳ Child of {{parentName}}",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -180,7 +180,8 @@
       "open": "Abrir sesión",
       "lastUsed": "Usada {{time}}",
       "defaultMeta": "Guardada para acceso rápido",
-      "more": "+{{count}} más en el historial"
+      "more": "+{{count}} favoritos más",
+      "browseAll": "Ver todos los favoritos"
     },
     "toasts": {
       "deleted": "Sesión eliminada",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "Estado",
       "all": "Todos los estados"
+    },
+    "bookmarkFilter": {
+      "focused": "Mostrando sesiones favoritas",
+      "clear": "Mostrar todas las sesiones",
+      "empty": "Todavía no hay sesiones favoritas"
+    },
+    "sort": {
+      "label": "Ordenar sesiones",
+      "updatedAt": "Actividad reciente",
+      "createdAt": "Fecha de creación",
+      "name": "Nombre",
+      "ascending": "Orden ascendente",
+      "descending": "Orden descendente"
     },
     "lineageHint": {
       "child": "↳ Hijo de {{parentName}}",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -180,7 +180,8 @@
       "open": "Ouvrir la session",
       "lastUsed": "Utilisée {{time}}",
       "defaultMeta": "Enregistrée pour un accès rapide",
-      "more": "+{{count}} de plus dans l'historique"
+      "more": "+{{count}} autres favoris",
+      "browseAll": "Parcourir tous les favoris"
     },
     "toasts": {
       "deleted": "Session supprimée",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "Statut",
       "all": "Tous les statuts"
+    },
+    "bookmarkFilter": {
+      "focused": "Affichage des sessions favorites",
+      "clear": "Afficher toutes les sessions",
+      "empty": "Aucune session favorite pour le moment"
+    },
+    "sort": {
+      "label": "Trier les sessions",
+      "updatedAt": "Activité récente",
+      "createdAt": "Création",
+      "name": "Nom",
+      "ascending": "Trier par ordre croissant",
+      "descending": "Trier par ordre décroissant"
     },
     "lineageHint": {
       "child": "↳ Enfant de {{parentName}}",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -179,7 +179,8 @@
       "open": "セッションを開く",
       "lastUsed": "{{time}} に使用",
       "defaultMeta": "すぐ戻れるよう保存済み",
-      "more": "履歴にさらに {{count}} 件"
+      "more": "さらに {{count}} 件のブックマーク",
+      "browseAll": "すべてのブックマークを表示"
     },
     "toasts": {
       "deleted": "セッションを削除しました",
@@ -263,6 +264,19 @@
     "statusFilter": {
       "all": "すべてのステータス",
       "label": "ステータス"
+    },
+    "bookmarkFilter": {
+      "focused": "ブックマークしたセッションを表示中",
+      "clear": "すべてのセッションを表示",
+      "empty": "ブックマークしたセッションはまだありません"
+    },
+    "sort": {
+      "label": "セッションを並び替え",
+      "updatedAt": "最新のアクティビティ",
+      "createdAt": "作成日",
+      "name": "名前",
+      "ascending": "昇順で並び替え",
+      "descending": "降順で並び替え"
     }
   },
   "settings": {

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -180,7 +180,8 @@
       "open": "세션 열기",
       "lastUsed": "{{time}} 사용",
       "defaultMeta": "빠르게 다시 열 수 있도록 저장됨",
-      "more": "기록에 {{count}}개 더 있음"
+      "more": "북마크 {{count}}개 더",
+      "browseAll": "모든 북마크 탐색"
     },
     "toasts": {
       "deleted": "세션이 삭제되었습니다",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "상태",
       "all": "모든 상태"
+    },
+    "bookmarkFilter": {
+      "focused": "북마크한 세션만 표시 중",
+      "clear": "모든 세션 보기",
+      "empty": "북마크한 세션이 없습니다"
+    },
+    "sort": {
+      "label": "세션 정렬",
+      "updatedAt": "최신 활동",
+      "createdAt": "생성일",
+      "name": "이름",
+      "ascending": "오름차순 정렬",
+      "descending": "내림차순 정렬"
     },
     "lineageHint": {
       "child": "↳ {{parentName}}의 하위 세션",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -180,7 +180,8 @@
       "open": "Abrir sessão",
       "lastUsed": "Usada {{time}}",
       "defaultMeta": "Salva para acesso rápido",
-      "more": "+{{count}} mais no histórico"
+      "more": "+{{count}} favoritos a mais",
+      "browseAll": "Ver todos os favoritos"
     },
     "toasts": {
       "deleted": "Sessão excluída",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "Status",
       "all": "Todos os status"
+    },
+    "bookmarkFilter": {
+      "focused": "Mostrando sessões favoritas",
+      "clear": "Mostrar todas as sessões",
+      "empty": "Ainda não há sessões favoritas"
+    },
+    "sort": {
+      "label": "Ordenar sessões",
+      "updatedAt": "Atividade recente",
+      "createdAt": "Criadas em",
+      "name": "Nome",
+      "ascending": "Ordenar em ordem crescente",
+      "descending": "Ordenar em ordem decrescente"
     },
     "lineageHint": {
       "child": "↳ Filho de {{parentName}}",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -180,7 +180,8 @@
       "open": "打开会话",
       "lastUsed": "最近使用于 {{time}}",
       "defaultMeta": "已保存，方便快速返回",
-      "more": "历史记录中还有 {{count}} 个"
+      "more": "还有 {{count}} 个书签",
+      "browseAll": "查看全部书签"
     },
     "toasts": {
       "deleted": "会话已删除",
@@ -197,6 +198,19 @@
     "statusFilter": {
       "label": "状态",
       "all": "所有状态"
+    },
+    "bookmarkFilter": {
+      "focused": "正在显示已加书签的会话",
+      "clear": "显示所有会话",
+      "empty": "还没有已加书签的会话"
+    },
+    "sort": {
+      "label": "排序会话",
+      "updatedAt": "最近活动",
+      "createdAt": "创建时间",
+      "name": "名称",
+      "ascending": "按升序排序",
+      "descending": "按降序排序"
     },
     "lineageHint": {
       "child": "↳ {{parentName}} 的子级",


### PR DESCRIPTION
## Summary
- convert bookmarked sessions into a compact quick-access list with bookmark-only browsing
- add session sorting controls for recent activity, created time, and name
- use last message timestamps for latest-activity ordering across previews and history

## Validation
- pnpm lint
- pnpm vitest run src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx