### PR TITLE
Fix workspace timeout handoff and wait budget

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
@@ -149,6 +149,13 @@ fn decode_process_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).to_string()
 }
 
+pub async fn read_output_file(file_path: &PathBuf) -> Result<String, String> {
+    let bytes = tokio::fs::read(file_path)
+        .await
+        .map_err(|e| format!("Failed to read output file '{}': {e}", file_path.display()))?;
+    Ok(strip_ansi_escapes(&decode_process_output(&bytes)))
+}
+
 /// Spawn process and stream stdout/stderr to files (common logic for sync/async)
 /// Returns (pid, exit_code, stdout_content, stderr_content)
 /// Respects cancellation token for graceful shutdown

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
@@ -60,7 +60,7 @@ impl WorkspaceServer {
                 .entries
                 .values()
                 .filter(|e| e.session_id == session_id)
-                .filter(|e| matches!(e.status, terminal_manager::ProcessStatus::Running))
+                .filter(|e| terminal_manager::is_active_process_status(&e.status))
                 .count();
 
             if running_count >= MAX_CONCURRENT_PROCESSES {
@@ -220,31 +220,37 @@ impl WorkspaceServer {
                 match result {
                     Ok((pid, exit_code, streaming_handle)) => {
                         entry.pid = pid;
-                        let code = exit_code.unwrap_or(-1);
-                        entry.status = if code == 0 {
-                            terminal_manager::ProcessStatus::Finished
-                        } else {
-                            terminal_manager::ProcessStatus::Failed
-                        };
                         entry.exit_code = exit_code;
-                        entry.finished_at = Some(chrono::Utc::now());
+                        entry.finished_at.get_or_insert_with(chrono::Utc::now);
 
                         // Update file sizes
                         entry.stdout_size = terminal_manager::get_file_size(&stdout_path).await;
                         entry.stderr_size = terminal_manager::get_file_size(&stderr_path).await;
+
+                        if entry.status != terminal_manager::ProcessStatus::Killed {
+                            let code = exit_code.unwrap_or(-1);
+                            entry.status = if code == 0 {
+                                terminal_manager::ProcessStatus::Finished
+                            } else {
+                                terminal_manager::ProcessStatus::Failed
+                            };
+                        }
 
                         // Store streaming handle for real-time access (after entry mutations)
                         reg.streaming_handles
                             .insert(pid_copy.clone(), streaming_handle);
                     }
                     Err(e) => {
-                        entry.status = terminal_manager::ProcessStatus::Failed;
-                        entry.finished_at = Some(chrono::Utc::now());
+                        entry.finished_at.get_or_insert_with(chrono::Utc::now);
                         error!("Process {} execution error: {}", pid_copy, e);
 
                         // Update file sizes even on error
                         entry.stdout_size = terminal_manager::get_file_size(&stdout_path).await;
                         entry.stderr_size = terminal_manager::get_file_size(&stderr_path).await;
+
+                        if entry.status != terminal_manager::ProcessStatus::Killed {
+                            entry.status = terminal_manager::ProcessStatus::Failed;
+                        }
                     }
                 }
             }

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::types::MCPResult;
@@ -43,6 +44,34 @@ impl WorkspaceServer {
 
         // Track execution time
         let execution_start = std::time::Instant::now();
+
+        const MAX_CONCURRENT_PROCESSES: usize = 20;
+        {
+            let registry = self.process_registry.read().await;
+            let active_count = registry
+                .entries
+                .values()
+                .filter(|e| e.session_id == session_id)
+                .filter(|e| terminal_manager::is_active_process_status(&e.status))
+                .count();
+
+            if active_count >= MAX_CONCURRENT_PROCESSES {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidState,
+                    format!(
+                        "Maximum concurrent processes limit reached ({}/{})",
+                        active_count, MAX_CONCURRENT_PROCESSES
+                    ),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Use listProcesses to see active processes".to_string(),
+                    "Use stopProcess to cancel unnecessary processes".to_string(),
+                    "Wait for some processes to finish before starting new ones".to_string(),
+                ])
+                .to_mcp_result());
+            }
+        }
 
         // Generate process ID for sync execution
         let process_id = cuid2::create_id();
@@ -106,10 +135,12 @@ impl WorkspaceServer {
             }
         };
 
-        // Create cancellation token
+        let process_permit = crate::state::get_concurrency_gate()
+            .acquire_active_process()
+            .await?;
         let cancel_token = CancellationToken::new();
+        let completion_notifier = Arc::new(tokio::sync::Notify::new());
 
-        // Register process in registry
         let entry = terminal_manager::ProcessEntry {
             id: process_id.clone(),
             name: None,
@@ -137,71 +168,189 @@ impl WorkspaceServer {
             registry
                 .cancellation_tokens
                 .insert(process_id.clone(), cancel_token.clone());
+            registry
+                .completion_notifiers
+                .insert(process_id.clone(), completion_notifier.clone());
         }
 
-        // Execute command with timeout using common spawn+stream logic
-        let timeout_duration = Duration::from_secs(timeout_secs);
-        let execution_result = tokio::time::timeout(
-            timeout_duration,
-            process::spawn_and_stream_to_files(
+        let registry = self.process_registry.clone();
+        let pid_copy = process_id.clone();
+        let stdout_path_for_task = stdout_path.clone();
+        let stderr_path_for_task = stderr_path.clone();
+
+        tokio::spawn(async move {
+            let _process_permit = process_permit;
+
+            {
+                let mut reg = registry.write().await;
+                if let Some(entry) = reg.entries.get_mut(&pid_copy) {
+                    entry.status = terminal_manager::ProcessStatus::Running;
+                }
+            }
+
+            let result = process::spawn_and_stream_to_files(
                 cmd,
-                stdout_path.clone(),
-                stderr_path.clone(),
-                format!("sync:{process_id}"),
-                cancel_token.clone(),
-            ),
-        )
-        .await;
+                stdout_path_for_task.clone(),
+                stderr_path_for_task.clone(),
+                format!("sync:{pid_copy}"),
+                cancel_token,
+            )
+            .await;
 
-        // Update registry with result
-        let mut reg = self.process_registry.write().await;
+            let mut reg = registry.write().await;
+            if let Some(entry) = reg.entries.get_mut(&pid_copy) {
+                match result {
+                    Ok((pid, exit_code, _, _)) => {
+                        entry.pid = pid;
+                        entry.exit_code = exit_code;
+                        entry.finished_at.get_or_insert_with(chrono::Utc::now);
+                        entry.stdout_size =
+                            terminal_manager::get_file_size(&stdout_path_for_task).await;
+                        entry.stderr_size =
+                            terminal_manager::get_file_size(&stderr_path_for_task).await;
 
-        match execution_result {
-            Ok(Ok((pid, exit_code, stdout, stderr))) => {
-                // Measure duration
+                        if entry.status != terminal_manager::ProcessStatus::Killed {
+                            entry.status = if exit_code.unwrap_or(-1) == 0 {
+                                terminal_manager::ProcessStatus::Finished
+                            } else {
+                                terminal_manager::ProcessStatus::Failed
+                            };
+                        }
+                    }
+                    Err(e) => {
+                        let error_text = format!("Failed to execute isolated shell command: {e}");
+                        let _ = tokio::fs::write(&stderr_path_for_task, format!("{error_text}\n"))
+                            .await;
+
+                        entry.finished_at.get_or_insert_with(chrono::Utc::now);
+                        entry.stdout_size =
+                            terminal_manager::get_file_size(&stdout_path_for_task).await;
+                        entry.stderr_size =
+                            terminal_manager::get_file_size(&stderr_path_for_task).await;
+
+                        if entry.status != terminal_manager::ProcessStatus::Killed {
+                            entry.status = terminal_manager::ProcessStatus::Failed;
+                        }
+
+                        error!("Process {} execution error: {}", pid_copy, e);
+                    }
+                }
+            }
+
+            reg.cancellation_tokens.remove(&pid_copy);
+            let notifier = reg.completion_notifiers.get(&pid_copy).cloned();
+            drop(reg);
+
+            if let Some(notifier) = notifier {
+                notifier.notify_waiters();
+            }
+        });
+
+        let timeout_duration = Duration::from_secs(timeout_secs);
+        let terminal_entry = loop {
+            {
+                let registry = self.process_registry.read().await;
+                let Some(entry) = registry.entries.get(&process_id).cloned() else {
+                    return Ok(guided_error(
+                        ErrorCategory::InternalError,
+                        format!("Process {} disappeared before completion", process_id),
+                        ToolGroup::Workspace,
+                    )
+                    .guidance(vec![
+                        "Retry the command once".to_string(),
+                        "If this persists, inspect workspace tool logs".to_string(),
+                    ])
+                    .to_mcp_result());
+                };
+
+                if terminal_manager::is_terminal_process_status(&entry.status) {
+                    break Some(entry);
+                }
+            }
+
+            let remaining = timeout_duration.saturating_sub(execution_start.elapsed());
+            if remaining.is_zero() {
+                break None;
+            }
+
+            let notifier = {
+                let registry = self.process_registry.read().await;
+                registry.completion_notifiers.get(&process_id).cloned()
+            };
+
+            let wait_slice = remaining.min(Duration::from_millis(100));
+            if let Some(notifier) = notifier {
+                let _ = tokio::time::timeout(wait_slice, notifier.notified()).await;
+            } else {
+                tokio::time::sleep(wait_slice).await;
+            }
+        };
+
+        match terminal_entry {
+            Some(entry) => {
                 let duration_ms = execution_start.elapsed().as_millis() as u64;
+                let stdout_result = process::read_output_file(&stdout_path).await;
+                let stderr_result = process::read_output_file(&stderr_path).await;
+                let actual_exit_code = entry.exit_code.unwrap_or(-1);
+                let success = entry.status == terminal_manager::ProcessStatus::Finished
+                    && actual_exit_code == 0;
 
-                // Update registry entry
-                if let Some(entry) = reg.entries.get_mut(&process_id) {
-                    entry.pid = pid;
-                    entry.exit_code = exit_code;
-                    entry.status = if exit_code.unwrap_or(-1) == 0 {
-                        terminal_manager::ProcessStatus::Finished
-                    } else {
-                        terminal_manager::ProcessStatus::Failed
-                    };
-                    entry.finished_at = Some(chrono::Utc::now());
-                    entry.stdout_size = terminal_manager::get_file_size(&stdout_path).await;
-                    entry.stderr_size = terminal_manager::get_file_size(&stderr_path).await;
+                {
+                    let mut reg = self.process_registry.write().await;
+                    reg.entries.remove(&process_id);
+                    reg.cancellation_tokens.remove(&process_id);
+                    reg.completion_notifiers.remove(&process_id);
+                    reg.streaming_handles.remove(&process_id);
                 }
 
-                // Remove cancellation token
-                reg.cancellation_tokens.remove(&process_id);
-                drop(reg);
-
-                // Cleanup temp directory
                 let _ = tokio::fs::remove_dir_all(&process_tmp_dir).await;
 
-                let success = exit_code.unwrap_or(-1) == 0;
-                let actual_exit_code = exit_code.unwrap_or(-1);
+                let stdout = match stdout_result {
+                    Ok(stdout) => stdout,
+                    Err(error) => {
+                        return Ok(guided_error(
+                            ErrorCategory::OperationFailed,
+                            error,
+                            ToolGroup::Workspace,
+                        )
+                        .guidance(vec![
+                            "Retry the command once".to_string(),
+                            "If this persists, inspect workspace process logs".to_string(),
+                        ])
+                        .to_mcp_result());
+                    }
+                };
+                let stderr = match stderr_result {
+                    Ok(stderr) => stderr,
+                    Err(error) => {
+                        return Ok(guided_error(
+                            ErrorCategory::OperationFailed,
+                            error,
+                            ToolGroup::Workspace,
+                        )
+                        .guidance(vec![
+                            "Retry the command once".to_string(),
+                            "If this persists, inspect workspace process logs".to_string(),
+                        ])
+                        .to_mcp_result());
+                    }
+                };
 
-                // Construct JSON response with enhanced metadata
                 let response = serde_json::json!({
                     "command": command,
                     "exit_code": actual_exit_code,
                     "stdout": stdout,
                     "stderr": stderr,
-                    "status": if success { "finished" } else { "failed" },
+                    "status": terminal_manager::process_status_label(&entry.status),
                     "duration_ms": duration_ms,
                     "execution_type": "isolated"
                 });
 
                 info!(
-                    "Isolated shell command executed: {} (session: {}, exit: {:?}, duration: {}ms)",
-                    command, session_id, exit_code, duration_ms
+                    "Isolated shell command executed: {} (session: {}, status: {:?}, exit: {:?}, duration: {}ms)",
+                    command, session_id, entry.status, entry.exit_code, duration_ms
                 );
 
-                // ✅ CRITICAL FIX: Handle non-zero exit codes as errors
                 if !success {
                     let error_output = if !stderr.is_empty() {
                         format!("Error output:\n{}", stderr)
@@ -211,7 +360,6 @@ impl WorkspaceServer {
                         "No error output captured".to_string()
                     };
 
-                    // Provide context-specific guidance based on exit code
                     let guidance = match actual_exit_code {
                         1 => vec![
                             "General command failure - review error output above".to_string(),
@@ -257,17 +405,13 @@ impl WorkspaceServer {
                     .to_mcp_result());
                 }
 
-                // Enhanced text response with explicit status and output visibility
                 let header = format!(
                     "Command executed in {} (exit code: 0)",
                     format_duration_ms(duration_ms)
                 );
-
-                // Include output in text message if available (CRITICAL FIX for sync visibility)
                 let text_message =
                     format_command_io_message(&header, "Output", &stdout, "Stderr", &stderr);
 
-                // ✅ ENHANCED: Detect signs of interactive prompts or cancelled operations
                 let output_lower = (stdout.clone() + &stderr).to_lowercase();
                 let cancellation_indicators = [
                     "operation cancelled",
@@ -287,7 +431,6 @@ impl WorkspaceServer {
                     .iter()
                     .any(|indicator| output_lower.contains(indicator));
 
-                // If interactive indicators detected, provide enhanced guidance
                 if detected_cancellation || detected_prompt {
                     let indicator_type = if detected_cancellation {
                         "operation was cancelled"
@@ -329,96 +472,66 @@ impl WorkspaceServer {
                 );
                 Ok(hint.to_mcp_result_with_data(Some(response)))
             }
-            Ok(Err(e)) => {
-                // Update registry entry to Failed
-                if let Some(entry) = reg.entries.get_mut(&process_id) {
-                    entry.status = terminal_manager::ProcessStatus::Failed;
-                    entry.finished_at = Some(chrono::Utc::now());
-                }
-                reg.cancellation_tokens.remove(&process_id);
-                drop(reg);
+            None => {
+                self.invalidate_context_cache().await;
 
-                // Cleanup temp directory
-                let _ = tokio::fs::remove_dir_all(&process_tmp_dir).await;
-
-                error!(
-                    "Failed to execute isolated shell command '{}': {}",
-                    command, e
-                );
-                Ok(guided_error(
-                    ErrorCategory::OperationFailed,
-                    e.to_string(),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Verify the command syntax is correct".to_string(),
-                    "Check if required programs are installed".to_string(),
-                    "Use listDirectory to verify file paths exist".to_string(),
-                ])
-                .to_mcp_result())
-            }
-            Err(_) => {
-                // Timeout - cancel the process
-                cancel_token.cancel();
-
-                // Update registry entry to Killed
-                if let Some(entry) = reg.entries.get_mut(&process_id) {
-                    entry.status = terminal_manager::ProcessStatus::Killed;
-                    entry.finished_at = Some(chrono::Utc::now());
-                }
-                reg.cancellation_tokens.remove(&process_id);
-                drop(reg);
-
-                // Cleanup temp directory
-                let _ = tokio::fs::remove_dir_all(&process_tmp_dir).await;
-
-                error!(
-                    "Isolated shell command '{}' timed out after {} seconds",
-                    command, timeout_secs
-                );
-
-                // ✅ ENHANCED: Check if timeout might be due to waiting for interactive input
-                let might_be_interactive = validation::is_likely_interactive_command(command);
-
-                let error_message = if might_be_interactive {
-                    format!(
-                        "Command timed out after {} seconds (possibly waiting for interactive input)",
-                        timeout_secs
-                    )
-                } else {
-                    format!("Command timed out after {} seconds", timeout_secs)
+                let status = {
+                    let registry = self.process_registry.read().await;
+                    registry
+                        .entries
+                        .get(&process_id)
+                        .map(|entry| terminal_manager::process_status_label(&entry.status))
+                        .unwrap_or_else(|| "running".to_string())
                 };
 
-                let mut guidance = Vec::new();
+                warn!(
+                    "Isolated shell command '{}' exceeded sync timeout after {} seconds; handing off to background process {}",
+                    command, timeout_secs, process_id
+                );
+
+                let might_be_interactive = validation::is_likely_interactive_command(command);
+                let mut message = format!(
+                    "Command exceeded the synchronous wait window after {} seconds and is still running in background.\n\nProcess ID: {}\nStatus: {}\nExit code: pending",
+                    timeout_secs, process_id, status
+                );
 
                 if might_be_interactive {
-                    guidance.push(
-                        "⚠️ This command may be waiting for interactive input (password, prompts, confirmations)".to_string()
+                    message.push_str(
+                        "\n\nThe command also looks interactive, so verify it is not waiting for prompts or passwords.",
                     );
-                    guidance.push(format!(
-                        "Use {} with requireUserInput: true for interactive commands",
-                        PERSISTENT_SHELL_TOOL
-                    ));
-                    guidance.push(
-                        "Or add non-interactive flags: --yes, --force, -y, --non-interactive"
-                            .to_string(),
-                    );
-                    guidance
-                        .push("Examples: npm init --yes, npx create-vite . --force".to_string());
-                } else {
-                    guidance.push(format!(
-                        "Increase timeout parameter (current: {}s)",
-                        timeout_secs
-                    ));
-                    guidance.push("Use spawnProcess for long-running background tasks".to_string());
-                    guidance.push("Use waitForProcess(processId, 0) to check status, or waitForProcess(processId) to block until done".to_string());
                 }
 
-                Ok(
-                    guided_error(ErrorCategory::Timeout, error_message, ToolGroup::Workspace)
-                        .guidance(guidance)
-                        .to_mcp_result(),
-                )
+                let mut next_actions = vec![
+                    format!(
+                        "Use waitForProcess(\"{}\", 0) to check current status",
+                        process_id
+                    ),
+                    format!(
+                        "Use readProcessOutput(\"{}\", \"both\") to inspect stdout and stderr",
+                        process_id
+                    ),
+                    format!("Use stopProcess(\"{}\") to terminate it", process_id),
+                ];
+
+                if might_be_interactive {
+                    next_actions.insert(
+                        0,
+                        format!(
+                            "If the command needed input, rerun it with {} and requireUserInput: true",
+                            PERSISTENT_SHELL_TOOL
+                        ),
+                    );
+                }
+
+                let response = serde_json::json!({
+                    "command": command,
+                    "process_id": process_id,
+                    "status": status,
+                    "timeout_seconds": timeout_secs,
+                    "execution_type": "isolated_background_handoff"
+                });
+
+                Ok(SuccessHint::new(message, next_actions).to_mcp_result_with_data(Some(response)))
             }
         }
     }

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
@@ -22,7 +22,7 @@ impl WorkspaceServer {
             .values()
             .filter(|e| e.session_id == session_id)
             .filter(|e| match status_filter {
-                "running" => matches!(e.status, terminal_manager::ProcessStatus::Running),
+                "running" => terminal_manager::is_active_process_status(&e.status),
                 "finished" => matches!(
                     e.status,
                     terminal_manager::ProcessStatus::Finished
@@ -35,7 +35,7 @@ impl WorkspaceServer {
                     "process_id": e.id,
                     "name": e.name,
                     "command": e.command,
-                    "status": format!("{:?}", e.status).to_lowercase(),
+                    "status": terminal_manager::process_status_label(&e.status),
                     "pid": e.pid,
                     "started_at": e.started_at.to_rfc3339(),
                     "exit_code": e.exit_code,
@@ -54,7 +54,7 @@ impl WorkspaceServer {
             .entries
             .values()
             .filter(|e| e.session_id == session_id)
-            .filter(|e| matches!(e.status, terminal_manager::ProcessStatus::Running))
+            .filter(|e| terminal_manager::is_active_process_status(&e.status))
             .count();
         let finished = registry
             .entries

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
@@ -43,7 +43,7 @@ impl OutputSelection {
 }
 
 fn status_label(status: &terminal_manager::ProcessStatus) -> String {
-    format!("{status:?}").to_lowercase()
+    terminal_manager::process_status_label(status)
 }
 
 fn stream_file_path(entry: &terminal_manager::ProcessEntry, stream: &str) -> PathBuf {

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/stop.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/stop.rs
@@ -42,7 +42,7 @@ impl WorkspaceServer {
                 .entries
                 .values()
                 .filter(|e| e.session_id == session_id)
-                .filter(|e| matches!(e.status, terminal_manager::ProcessStatus::Running))
+                .filter(|e| terminal_manager::is_active_process_status(&e.status))
                 .take(5)
                 .map(|e| format!("{} [{}]", e.id, e.command))
                 .collect();

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
@@ -47,8 +47,7 @@ impl WorkspaceServer {
                     entry.last_poll_at = Some(now);
                     entry.poll_count += 1;
 
-                    let is_running =
-                        matches!(entry.status, terminal_manager::ProcessStatus::Running);
+                    let is_running = terminal_manager::is_active_process_status(&entry.status);
                     if is_running {
                         if entry.first_running_poll_at.is_none() {
                             entry.first_running_poll_at = Some(now);
@@ -113,7 +112,7 @@ impl WorkspaceServer {
             ) {
                 let response = serde_json::json!({
                     "process_id": process_id,
-                    "status": format!("{:?}", status).to_lowercase(),
+                    "status": terminal_manager::process_status_label(&status),
                     "command": entry_data.command,
                     "exit_code": entry_data.exit_code,
                     "pid": entry_data.pid,
@@ -132,7 +131,7 @@ impl WorkspaceServer {
             if is_polling_mode {
                 let response = serde_json::json!({
                     "process_id": process_id,
-                    "status": format!("{:?}", status).to_lowercase(),
+                    "status": terminal_manager::process_status_label(&status),
                     "command": entry_data.command,
                     "exit_code": entry_data.exit_code,
                     "pid": entry_data.pid,
@@ -182,16 +181,18 @@ impl WorkspaceServer {
             // 4. Wait before next loop iteration.
             // Use push-notification (notifier) with a 30s heartbeat fallback so the loop
             // wakes up immediately when the process finishes instead of busy-polling every 100ms.
+            let remaining = timeout.saturating_sub(start_time.elapsed());
+            let wait_slice = remaining.min(tokio::time::Duration::from_secs(30));
             match notifier {
                 Some(n) => {
                     tokio::select! {
                         _ = n.notified() => {}
-                        _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {}
+                        _ = tokio::time::sleep(wait_slice) => {}
                     }
                 }
                 None => {
                     // Defensive fallback: notifier missing (shouldn't happen for valid processes).
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    tokio::time::sleep(wait_slice.min(std::time::Duration::from_millis(500))).await;
                 }
             }
         }

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -321,7 +321,7 @@ impl WorkspaceServer {
 
                 // Kill running processes
                 if let Some(pid) = entry.pid {
-                    if matches!(entry.status, terminal_manager::ProcessStatus::Running) {
+                    if terminal_manager::is_active_process_status(&entry.status) {
                         info!("Killing running process {} (PID {})", id, pid);
 
                         #[cfg(unix)]
@@ -673,7 +673,7 @@ Internal paths: .libragent/tmp/ (process outputs), .libragent/exports/ (exported
                         .entries
                         .values()
                         .filter(|e| e.session_id == session_id)
-                        .filter(|e| matches!(e.status, terminal_manager::ProcessStatus::Running))
+                        .filter(|e| terminal_manager::is_active_process_status(&e.status))
                         .map(|e| (e.id.clone(), e.command.clone()))
                         .collect();
 

--- a/src-tauri/src/mcp/builtin/workspace/terminal_manager.rs
+++ b/src-tauri/src/mcp/builtin/workspace/terminal_manager.rs
@@ -143,6 +143,21 @@ pub fn create_process_registry() -> ProcessRegistry {
     }))
 }
 
+pub fn is_active_process_status(status: &ProcessStatus) -> bool {
+    matches!(status, ProcessStatus::Starting | ProcessStatus::Running)
+}
+
+pub fn is_terminal_process_status(status: &ProcessStatus) -> bool {
+    matches!(
+        status,
+        ProcessStatus::Finished | ProcessStatus::Failed | ProcessStatus::Killed
+    )
+}
+
+pub fn process_status_label(status: &ProcessStatus) -> String {
+    format!("{status:?}").to_lowercase()
+}
+
 /// Read last N lines from file (max 100, text only)
 /// For large files (>1MB), uses optimized seek-from-end strategy
 pub async fn tail_lines(file_path: &PathBuf, n: usize) -> Result<Vec<String>, String> {

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -34,7 +34,8 @@ pub fn create_run_shell_tool() -> MCPTool {
         title: Some("Run Shell Command (Isolated)".to_string()),
         description: "Run a synchronous shell command (bash/sh). Stateless — each call starts fresh at workspace root.\n\
                         Use 'cd dir && command' for subdirectories.\n\
-                       For persistent cd/env vars: runInPersistentShell. For longer or non-blocking tasks: spawnProcess."
+                       If the command exceeds the sync timeout, it stays alive in background and returns a processId for waitForProcess/readProcessOutput/stopProcess.\n\
+                       For persistent cd/env vars: runInPersistentShell. For explicitly non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,

--- a/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
+++ b/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
@@ -13,11 +13,13 @@ use tauri_mcp_agent_lib::mcp::builtin::workspace::utils::{
     default_sync_execution_timeout, max_sync_execution_timeout, resolve_sync_timeout,
 };
 use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::builtin::BuiltinMCPServer;
 use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
 use tauri_mcp_agent_lib::session::SessionManager;
 use tauri_mcp_agent_lib::{init_concurrency_gate, init_session_bus};
 use tempfile::tempdir;
 use tokio::sync::OnceCell;
+use tokio::time::{Duration, Instant};
 
 fn extract_text_content(result: &MCPResult) -> String {
     result
@@ -65,6 +67,16 @@ fn simple_shell_command() -> &'static str {
 #[cfg(windows)]
 fn simple_shell_command() -> &'static str {
     "Write-Output 'hello'"
+}
+
+#[cfg(unix)]
+fn delayed_shell_command() -> &'static str {
+    "sleep 2; printf 'delayed done\\n'"
+}
+
+#[cfg(windows)]
+fn delayed_shell_command() -> &'static str {
+    "Start-Sleep -Seconds 2; Write-Output 'delayed done'"
 }
 
 #[test]
@@ -183,5 +195,187 @@ async fn persistent_shell_rejects_timeout_above_sync_limit() {
     assert!(
         text.contains("spawnProcess"),
         "persistent shell guidance should point to background execution: {text}"
+    );
+}
+
+#[tokio::test]
+async fn run_shell_timeout_hands_off_to_background_process() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "run-shell-timeout-handoff";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_run_shell(
+            json!({
+                "command": delayed_shell_command(),
+                "timeout": 1
+            }),
+            session_id,
+        )
+        .await
+        .expect("runShell should return MCPResult");
+
+    assert_eq!(result.is_error, Some(false));
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("still running in background"),
+        "timeout handoff should be explicit in text: {text}"
+    );
+    assert!(
+        text.contains("Process ID:"),
+        "timeout handoff text should include processId: {text}"
+    );
+    assert!(
+        text.contains("waitForProcess("),
+        "timeout handoff should suggest the next wait action: {text}"
+    );
+    assert!(
+        text.contains("readProcessOutput("),
+        "timeout handoff should suggest how to inspect output: {text}"
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("timeout handoff should include structured data");
+    let process_id = structured["process_id"]
+        .as_str()
+        .expect("timeout handoff should return process_id")
+        .to_string();
+    assert_eq!(
+        structured["execution_type"],
+        json!("isolated_background_handoff")
+    );
+    assert!(
+        matches!(
+            structured["status"].as_str(),
+            Some("starting") | Some("running")
+        ),
+        "timeout handoff should expose an active status: {}",
+        structured["status"]
+    );
+
+    let wait_result = server
+        .call_tool(
+            "waitForProcess",
+            json!({
+                "processId": process_id,
+                "timeout": 5
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("waitForProcess should succeed");
+
+    let wait_structured = wait_result
+        .structured_content
+        .as_ref()
+        .expect("waitForProcess structured content expected");
+    assert_eq!(wait_structured["status"], json!("finished"));
+
+    let output_result = server
+        .call_tool(
+            "readProcessOutput",
+            json!({
+                "processId": wait_structured["process_id"].clone(),
+                "stream": "stdout",
+                "mode": "tail",
+                "lines": 20
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readProcessOutput should succeed");
+    let output_text = extract_text_content(&output_result);
+    assert!(
+        output_text.contains("delayed done"),
+        "background handoff should preserve process output: {output_text}"
+    );
+}
+
+#[tokio::test]
+async fn run_shell_success_does_not_leave_process_registry_artifacts() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "run-shell-clean-success";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_run_shell(
+            json!({
+                "command": simple_shell_command(),
+                "timeout": 5
+            }),
+            session_id,
+        )
+        .await
+        .expect("runShell should return MCPResult");
+
+    assert_eq!(result.is_error, Some(false));
+
+    let listed = server
+        .call_tool("listProcesses", json!({}), Some(session_id.to_string()))
+        .await
+        .expect("listProcesses should succeed");
+    let structured = listed
+        .structured_content
+        .as_ref()
+        .expect("listProcesses structured content expected");
+    assert_eq!(structured["total"], json!(0));
+}
+
+#[tokio::test]
+async fn wait_for_process_respects_timeout_budget() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "wait-process-timeout-budget";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let spawn_result = server
+        .handle_spawn_process(
+            json!({
+                "command": delayed_shell_command()
+            }),
+            session_id,
+        )
+        .await
+        .expect("spawnProcess should succeed");
+
+    let process_id = spawn_result
+        .structured_content
+        .as_ref()
+        .and_then(|data| data.get("process_id"))
+        .and_then(|value| value.as_str())
+        .expect("spawnProcess should return process_id")
+        .to_string();
+
+    let started = Instant::now();
+    let wait_result = server
+        .call_tool(
+            "waitForProcess",
+            json!({
+                "processId": process_id,
+                "timeout": 1
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("waitForProcess should return MCPResult");
+    let elapsed = started.elapsed();
+
+    let text = extract_text_content(&wait_result);
+    assert!(
+        text.contains("Timeout waiting for process"),
+        "waitForProcess should report timeout when the process keeps running: {text}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "waitForProcess exceeded the caller timeout budget too much: {:?}",
+        elapsed
     );
 }


### PR DESCRIPTION
## Summary
- hand off timed-out isolated runShell commands to tracked background processes instead of killing them
- centralize workspace process status helpers and keep active/terminal state handling consistent
- cap waitForProcess sleeps by the caller timeout budget and add focused integration coverage

## Validation
- pnpm rust:test --test session_and_workspace_timeout_regression_tests