### PR TITLE
Improve workspace indexer script robustness

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,8 @@ public/
 .worktrees/
 .cargo/
 .agent/
+.antigravitycli/
+.refactor-logs/
 .editorconfig
 .gitattributes
 

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/build_index.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/build_index.py
@@ -30,14 +30,24 @@ Examples:
 """
 
 import argparse
+import io
 import re
 import sys
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
+# Windows에서 cp949 인코딩으로 인한 UnicodeEncodeError 방지
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+
+# Cwd 독립적인 임포트를 위해 sys.path에 scripts 디렉토리 추가
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import get_source_from_md
+
 # 무시할 기본 디렉터리
-DEFAULT_SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv", ".mypy_cache"}
+DEFAULT_SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv", ".mypy_cache", ".libragent", "attachments"}
 
 # 텍스트로 처리할 확장자
 TEXT_EXTS = {".md", ".txt", ".py", ".sh", ".json", ".yaml", ".yml", ".toml", ".csv", ".html", ".js", ".ts"}
@@ -92,15 +102,21 @@ def extract_keywords_from_files(text_files: list[Path], root: Path) -> dict[str,
     텍스트 파일에서 키워드(헤딩) 추출.
     반환: {keyword: [rel_path1, rel_path2, ...]}
     """
-    keyword_map: dict[str, list[str]] = defaultdict(list)
+    keyword_map: dict[str, set[str]] = defaultdict(set)
     for p in text_files:
         if p.suffix.lower() != ".md":
             continue
         headings = extract_headings(p)
         rel = str(p.relative_to(root).as_posix())
         for h in headings:
-            keyword_map[h].append(rel)
-    return dict(keyword_map)
+            keyword_map[h].add(rel)
+            # 단어 단위 토큰도 키워드로 추가하여 한글/영어 매핑/검색 개선
+            words = re.findall(r'[a-zA-Z0-9가-힣]+', h)
+            for w in words:
+                if len(w) >= 2 and w != h:
+                    keyword_map[w].add(rel)
+    # 리스트로 변환 및 정렬하여 일관된 출력 보장 (O(n) 성능 유지)
+    return {kw: sorted(list(files)) for kw, files in keyword_map.items()}
 
 
 def load_custom_keywords(keyword_file: Path, text_files: list[Path], root: Path) -> dict[str, list[str]]:
@@ -175,14 +191,33 @@ def render_index(
     # --- Binary 문서 ---
     lines += [f"---", f"", f"## Binary 문서 목록", f""]
     if binary_files:
+        # 마크다운 파일들의 Source 헤더를 읽어 binary 파일과 매핑 구축
+        src_to_md = {}
+        for p_md in text_files:
+            if p_md.suffix.lower() == ".md":
+                source_path = get_source_from_md(p_md)
+                if source_path:
+                    try:
+                        resolved_src = str(Path(source_path).resolve().as_posix())
+                        src_to_md[resolved_src] = str(p_md.relative_to(root).as_posix())
+                    except Exception:
+                        pass
+
         lines.append("| 파일명 | 경로 | 크기 | 변환 파일 |")
         lines.append("| --- | --- | --- | --- |")
         for p in sorted(binary_files):
             rel = str(p.relative_to(root).as_posix())
             size_kb = p.stat().st_size / 1024
-            md_path = p.with_suffix(".md")
-            md_rel = str(md_path.relative_to(root).as_posix()) if md_path.exists() else "-"
-            converted = f"[MD]({md_rel})" if md_path.exists() else "❌ 미변환"
+            resolved_p = str(p.resolve().as_posix())
+            
+            # 소스 매핑에서 먼저 찾고, 없으면 기존 규칙(같은 경로의 .md) 사용
+            md_rel = src_to_md.get(resolved_p)
+            if not md_rel:
+                md_path = p.with_suffix(".md")
+                if md_path.exists():
+                    md_rel = str(md_path.relative_to(root).as_posix())
+                    
+            converted = f"[MD]({md_rel})" if md_rel else "❌ 미변환"
             lines.append(f"| `{p.name}` | `{rel}` | {size_kb:.1f} KB | {converted} |")
     else:
         lines.append("_(Binary 문서 없음)_")

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/check_status.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/check_status.py
@@ -24,10 +24,20 @@ Examples:
 """
 
 import argparse
+import io
+import sys
 from datetime import datetime
 from pathlib import Path
 
-SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv"}
+# Windows에서 cp949 인코딩으로 인한 UnicodeEncodeError 방지
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import get_source_from_md
+
+SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv", ".libragent", "attachments"}
 
 
 def collect_binary_files(root: Path, formats: list[str], skip_dirs: set[str]) -> list[Path]:
@@ -43,13 +53,46 @@ def collect_binary_files(root: Path, formats: list[str], skip_dirs: set[str]) ->
     return result
 
 
-def check_conversion(files: list[Path]) -> tuple[list[Path], list[Path]]:
-    """변환 완료 / 미완료 파일 분리."""
-    converted, not_converted = [], []
+def build_source_to_md_map(root: Path, skip_dirs: set[str]) -> dict[str, Path]:
+    source_to_md: dict[str, Path] = {}
+    for md_path in sorted(root.rglob("*.md")):
+        if md_path.is_dir():
+            continue
+        if any(part in skip_dirs for part in md_path.relative_to(root).parts):
+            continue
+        source_path = get_source_from_md(md_path)
+        if not source_path:
+            continue
+        try:
+            source_to_md[str(Path(source_path).resolve().as_posix())] = md_path
+        except Exception:
+            continue
+    return source_to_md
+
+
+def resolve_converted_markdown(source_path: Path, source_to_md: dict[str, Path]) -> Path | None:
+    mapped_md = source_to_md.get(str(source_path.resolve().as_posix()))
+    if mapped_md and mapped_md.exists():
+        return mapped_md
+
+    default_md = source_path.with_suffix(".md")
+    if default_md.exists():
+        return default_md
+
+    return None
+
+
+def check_conversion(
+    files: list[Path],
+    source_to_md: dict[str, Path],
+) -> tuple[list[tuple[Path, Path]], list[Path]]:
+    """Split files into converted and not converted entries."""
+    converted: list[tuple[Path, Path]] = []
+    not_converted: list[Path] = []
     for f in files:
-        md = f.with_suffix(".md")
-        if md.exists():
-            converted.append(f)
+        md_path = resolve_converted_markdown(f, source_to_md)
+        if md_path is not None:
+            converted.append((f, md_path))
         else:
             not_converted.append(f)
     return converted, not_converted
@@ -64,7 +107,7 @@ def format_size(path: Path) -> str:
 
 def render_report(
     root: Path,
-    converted: list[Path],
+    converted: list[tuple[Path, Path]],
     not_converted: list[Path],
     show_converted: bool,
 ) -> str:
@@ -131,10 +174,11 @@ def render_report(
             f"| 파일명 | 원본 크기 | 변환 파일 |",
             f"| --- | --- | --- |",
         ]
-        for p in converted:
-            rel = str(p.relative_to(root).as_posix())
-            md_rel = str(p.with_suffix(".md").relative_to(root).as_posix())
-            lines.append(f"| `{p.name}` | {format_size(p)} | [`{p.stem}.md`]({md_rel}) |")
+        for source_path, md_path in converted:
+            md_rel = str(md_path.relative_to(root).as_posix())
+            lines.append(
+                f"| `{source_path.name}` | {format_size(source_path)} | [`{md_path.name}`]({md_rel}) |"
+            )
         lines.append("")
 
     return "\n".join(lines)
@@ -153,7 +197,8 @@ def main():
     skip_dirs = SKIP_DIRS | set(args.ignore_dirs)
 
     files = collect_binary_files(root, args.formats, skip_dirs)
-    converted, not_converted = check_conversion(files)
+    source_to_md = build_source_to_md_map(root, skip_dirs)
+    converted, not_converted = check_conversion(files, source_to_md)
 
     total = len(files)
     rate = (len(converted) / total * 100) if total else 0
@@ -172,9 +217,8 @@ def main():
 
     if args.show_converted and converted:
         print(f"\n✅ 변환 완료 ({len(converted)}개):")
-        for p in converted:
-            md = p.with_suffix(".md")
-            print(f"   {p.relative_to(root)}  →  {md.relative_to(root)}")
+        for source_path, md_path in converted:
+            print(f"   {source_path.relative_to(root)}  →  {md_path.relative_to(root)}")
 
     # 마크다운 리포트 저장
     if args.export:

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/convert_binary_docs.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/convert_binary_docs.py
@@ -29,10 +29,20 @@ Examples:
 """
 
 import argparse
+import io
 import sys
 from pathlib import Path
 
-SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv"}
+# Windows에서 cp949 인코딩으로 인한 UnicodeEncodeError 방지
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+
+# Cwd 독립적인 임포트를 위해 sys.path에 scripts 디렉토리 추가
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import get_source_from_md, get_path_hash
+
+SKIP_DIRS = {".git", "__pycache__", "node_modules", ".github", "venv", ".venv", ".libragent", "attachments"}
 
 
 def find_binary_files(root: Path, formats: list[str]) -> list[Path]:
@@ -160,7 +170,7 @@ CONVERTERS = {
 }
 
 
-def convert_file(src: Path, out_dir: Path | None, overwrite: bool) -> tuple[Path, str]:
+def convert_file(src: Path, out_dir: Path | None, overwrite: bool, used_dests: set[str]) -> tuple[Path, str]:
     """Convert a single file and return (output_path, status_message)."""
     ext = src.suffix.lower()
     converter = CONVERTERS.get(ext)
@@ -168,16 +178,55 @@ def convert_file(src: Path, out_dir: Path | None, overwrite: bool) -> tuple[Path
         return src, "SKIP (no converter)"
 
     dest_dir = out_dir if out_dir else src.parent
-    dest = dest_dir / (src.stem + ".md")
-
-    if dest.exists() and not overwrite:
-        return dest, "SKIP (exists)"
+    
+    base_dest = dest_dir / (src.stem + ".md")
+    dest = base_dest
+    dest_key = str(dest.resolve().as_posix())
+    
+    # Resolve unique filename by appending path hash if conflict occurs
+    if dest_key in used_dests or (dest.exists() and not overwrite):
+        source_in_md = get_source_from_md(dest)
+        if source_in_md and Path(source_in_md).resolve() == src.resolve():
+            # Same source, safe to skip
+            used_dests.add(dest_key)
+            return dest, "SKIP (exists)"
+        else:
+            # Different source (collision) -> append short hash of source path
+            path_hash = get_path_hash(src)
+            dest = dest_dir / f"{src.stem}_{path_hash}.md"
+            dest_key = str(dest.resolve().as_posix())
+            
+            # Resolve potential hash collisions
+            counter = 1
+            while True:
+                if dest_key in used_dests:
+                    dest = dest_dir / f"{src.stem}_{path_hash}_{counter}.md"
+                    dest_key = str(dest.resolve().as_posix())
+                    counter += 1
+                    continue
+                if dest.exists() and not overwrite:
+                    source_in_md = get_source_from_md(dest)
+                    if source_in_md and Path(source_in_md).resolve() == src.resolve():
+                        used_dests.add(dest_key)
+                        return dest, "SKIP (exists)"
+                    else:
+                        dest = dest_dir / f"{src.stem}_{path_hash}_{counter}.md"
+                        dest_key = str(dest.resolve().as_posix())
+                        counter += 1
+                        continue
+                break
 
     dest_dir.mkdir(parents=True, exist_ok=True)
+
+    # Performance logging for large files (e.g. pptx > 5MB)
+    size_mb = src.stat().st_size / (1024 * 1024)
+    if size_mb > 5:
+        print(f"       ⌛ Converting large file ({size_mb:.1f} MB)... this may take a moment.")
 
     content = converter(src)
     header = f"# {src.name}\n\n> Source: `{src}`  \n> Converted at: {_now()}\n\n---\n\n"
     dest.write_text(header + content, encoding="utf-8")
+    used_dests.add(dest_key)
     return dest, "OK"
 
 
@@ -207,9 +256,10 @@ def main():
         return
 
     results = {"OK": 0, "SKIP (exists)": 0, "SKIP (no converter)": 0, "ERROR": 0}
+    used_dests = set()
     for src in files:
         try:
-            dest, status = convert_file(src, out_dir, args.overwrite)
+            dest, status = convert_file(src, out_dir, args.overwrite, used_dests)
             results[status] = results.get(status, 0) + 1
             icon = "✅" if status == "OK" else "⏭️"
             print(f"  {icon} [{status}] {src.relative_to(root)}")

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/convert_binary_docs.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/convert_binary_docs.py
@@ -50,7 +50,7 @@ def find_binary_files(root: Path, formats: list[str]) -> list[Path]:
     exts = {f".{fmt.lstrip('.')}" for fmt in formats}
     result = []
     for p in root.rglob("*"):
-        if any(part in SKIP_DIRS for part in p.parts):
+        if any(part in SKIP_DIRS for part in p.relative_to(root).parts):
             continue
         if p.suffix.lower() in exts and p.is_file():
             result.append(p)
@@ -170,6 +170,21 @@ CONVERTERS = {
 }
 
 
+def is_same_source_markdown(dest: Path, src: Path) -> bool:
+    """Return True when the existing markdown file was generated from the same source."""
+    if not dest.exists():
+        return False
+
+    source_in_md = get_source_from_md(dest)
+    if not source_in_md:
+        return False
+
+    try:
+        return Path(source_in_md).resolve() == src.resolve()
+    except OSError:
+        return False
+
+
 def convert_file(src: Path, out_dir: Path | None, overwrite: bool, used_dests: set[str]) -> tuple[Path, str]:
     """Convert a single file and return (output_path, status_message)."""
     ext = src.suffix.lower()
@@ -178,43 +193,34 @@ def convert_file(src: Path, out_dir: Path | None, overwrite: bool, used_dests: s
         return src, "SKIP (no converter)"
 
     dest_dir = out_dir if out_dir else src.parent
-    
     base_dest = dest_dir / (src.stem + ".md")
-    dest = base_dest
-    dest_key = str(dest.resolve().as_posix())
-    
-    # Resolve unique filename by appending path hash if conflict occurs
-    if dest_key in used_dests or (dest.exists() and not overwrite):
-        source_in_md = get_source_from_md(dest)
-        if source_in_md and Path(source_in_md).resolve() == src.resolve():
-            # Same source, safe to skip
-            used_dests.add(dest_key)
-            return dest, "SKIP (exists)"
-        else:
-            # Different source (collision) -> append short hash of source path
-            path_hash = get_path_hash(src)
+    path_hash = get_path_hash(src)
+    collision_index = 0
+
+    while True:
+        if collision_index == 0:
+            dest = base_dest
+        elif collision_index == 1:
             dest = dest_dir / f"{src.stem}_{path_hash}.md"
-            dest_key = str(dest.resolve().as_posix())
-            
-            # Resolve potential hash collisions
-            counter = 1
-            while True:
-                if dest_key in used_dests:
-                    dest = dest_dir / f"{src.stem}_{path_hash}_{counter}.md"
-                    dest_key = str(dest.resolve().as_posix())
-                    counter += 1
-                    continue
-                if dest.exists() and not overwrite:
-                    source_in_md = get_source_from_md(dest)
-                    if source_in_md and Path(source_in_md).resolve() == src.resolve():
-                        used_dests.add(dest_key)
-                        return dest, "SKIP (exists)"
-                    else:
-                        dest = dest_dir / f"{src.stem}_{path_hash}_{counter}.md"
-                        dest_key = str(dest.resolve().as_posix())
-                        counter += 1
-                        continue
-                break
+        else:
+            dest = dest_dir / f"{src.stem}_{path_hash}_{collision_index - 1}.md"
+
+        dest_key = str(dest.resolve().as_posix())
+
+        if dest_key in used_dests:
+            collision_index += 1
+            continue
+
+        if not dest.exists():
+            break
+
+        if is_same_source_markdown(dest, src):
+            if not overwrite:
+                used_dests.add(dest_key)
+                return dest, "SKIP (exists)"
+            break
+
+        collision_index += 1
 
     dest_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/install_deps.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/install_deps.py
@@ -12,8 +12,14 @@ Usage:
 
 import argparse
 import importlib
+import io
 import subprocess
 import sys
+
+# Windows에서 cp949 인코딩으로 인한 UnicodeEncodeError 방지
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
 # 형식별 필요 패키지
 FORMAT_DEPS: dict[str, list[tuple[str, str]]] = {

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/run.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/run.py
@@ -37,9 +37,16 @@ Examples:
 """
 
 import argparse
+import io
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+# Windows에서 cp949 인코딩으로 인한 UnicodeEncodeError 방지
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
 SCRIPT_DIR = Path(__file__).parent
 CONVERT_SCRIPT = SCRIPT_DIR / "convert_binary_docs.py"
@@ -51,7 +58,12 @@ def run_step(label: str, cmd: list[str]) -> bool:
     print(f"\n{'='*60}")
     print(f"  {label}")
     print(f"{'='*60}")
-    result = subprocess.run(cmd)
+    
+    # Windows에서 하위 프로세스의 UTF-8 출력을 강제하기 위해 환경 변수 상속 및 설정
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    
+    result = subprocess.run(cmd, env=env)
     if result.returncode != 0:
         print(f"\n❌ {label} 실패 (exit code {result.returncode})")
         return False

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/run.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/run.py
@@ -58,11 +58,12 @@ def run_step(label: str, cmd: list[str]) -> bool:
     print(f"\n{'='*60}")
     print(f"  {label}")
     print(f"{'='*60}")
-    
-    # Windows에서 하위 프로세스의 UTF-8 출력을 강제하기 위해 환경 변수 상속 및 설정
+
     env = os.environ.copy()
-    env["PYTHONIOENCODING"] = "utf-8"
-    
+    if sys.platform.startswith("win"):
+        # Windows에서 하위 프로세스의 UTF-8 출력을 강제
+        env["PYTHONIOENCODING"] = "utf-8"
+
     result = subprocess.run(cmd, env=env)
     if result.returncode != 0:
         print(f"\n❌ {label} 실패 (exit code {result.returncode})")

--- a/src-tauri/bundled_skills/workspace-indexer/scripts/utils.py
+++ b/src-tauri/bundled_skills/workspace-indexer/scripts/utils.py
@@ -1,0 +1,25 @@
+import hashlib
+import re
+from pathlib import Path
+
+def get_source_from_md(md_path: Path) -> str | None:
+    """Read first 5 lines of markdown to extract the source path."""
+    if not md_path.exists():
+        return None
+    try:
+        with open(md_path, "r", encoding="utf-8", errors="ignore") as f:
+            for _ in range(5):
+                line = f.readline()
+                if not line:
+                    break
+                # matches: > Source: `path`
+                m = re.search(r">\s*Source:\s*`([^`]+)`", line)
+                if m:
+                    return m.group(1).strip()
+    except Exception:
+        pass
+    return None
+
+def get_path_hash(src: Path) -> str:
+    """Generate a short hash based on the absolute source path."""
+    return hashlib.sha256(str(src.resolve()).encode("utf-8")).hexdigest()[:4]


### PR DESCRIPTION
## Summary
- harden bundled workspace-indexer scripts for Windows UTF-8 console/subprocess behavior
- avoid markdown output collisions by hashing conflicting converted filenames and reusing Source header metadata
- make status/index reporting resolve converted markdown files through Source-header mappings instead of assuming source.ext -> source.md
- ignore local tool log directories in the repo root

## Review notes
- scoped review found one real bug: check_status.py misreported hashed collision outputs as unconverted
- that bug is fixed in this branch before opening this PR
- README blank-line edits, Cargo.lock, and mbed.rs formatting noise were intentionally left out of this PR

## Validation
- python -m py_compile src-tauri\\bundled_skills\\workspace-indexer\\scripts\\build_index.py src-tauri\\bundled_skills\\workspace-indexer\\scripts\\check_status.py src-tauri\\bundled_skills\\workspace-indexer\\scripts\\convert_binary_docs.py src-tauri\\bundled_skills\\workspace-indexer\\scripts\\install_deps.py src-tauri\\bundled_skills\\workspace-indexer\\scripts\\run.py src-tauri\\bundled_skills\\workspace-indexer\\scripts\\utils.py
- exercised check_status.py against a temporary same-stem binary collision case and verified both doc.md and hashed doc_ab12.md are recognized as converted
