### PR TITLE
feat(ai-service): add prefill context overflow to context limit error detection

### DIFF
--- a/src/lib/ai-service/__tests__/base-service-strategies.test.ts
+++ b/src/lib/ai-service/__tests__/base-service-strategies.test.ts
@@ -78,4 +78,38 @@ describe('throwStreamingError', () => {
 
     throw new Error('Expected throwStreamingError to throw');
   });
+
+  it('classifies prefill memory overflow as a context-limit error', () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    try {
+      throwStreamingError({
+        error: {
+          error: {
+            type: 'server_error',
+            message:
+              'Prefill context too large for available memory (pre-chunk guard at 2048 tokens, kv_len=81920): predicted peak would exceed prefill safety cap 46.7GB (90% of effective ceiling 51.8GB)',
+          },
+        },
+        context,
+        logger,
+        provider: AIServiceProvider.OpenAI,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AIServiceError);
+      if (!(error instanceof AIServiceError)) {
+        throw error;
+      }
+
+      expect(error.metadata.kind).toBe('context_limit');
+      expect(error.metadata.retryable).toBe(false);
+      expect(error.metadata.providerStatus).toBe('server_error');
+      return;
+    }
+
+    throw new Error('Expected throwStreamingError to throw');
+  });
 });

--- a/src/lib/ai-service/__tests__/utils.unit.test.ts
+++ b/src/lib/ai-service/__tests__/utils.unit.test.ts
@@ -234,6 +234,32 @@ describe('AI Service Utils', () => {
         errorCode: 'RATE_LIMIT_EXCEEDED',
       });
     });
+
+    it('maps prefill memory overflow payloads to context-limit errors', () => {
+      const error = new AIServiceError(
+        'openai streaming failed: Prefill context too large for available memory (pre-chunk guard at 2048 tokens, kv_len=81920): predicted peak would exceed prefill safety cap 46.7GB (90% of effective ceiling 51.8GB)',
+        AIServiceProvider.OpenAI,
+        undefined,
+        undefined,
+        {
+          kind: 'unknown',
+          retryable: false,
+          rawPayload: {
+            message:
+              'Prefill context too large for available memory (pre-chunk guard at 2048 tokens, kv_len=81920): predicted peak would exceed prefill safety cap 46.7GB (90% of effective ceiling 51.8GB)',
+            type: 'server_error',
+          },
+        },
+      );
+
+      expect(normalizeAIServiceError(error)).toEqual({
+        type: 'CONTEXT_LIMIT_ERROR',
+        displayMessage:
+          'Prefill context too large for available memory (pre-chunk guard at 2048 tokens, kv_len=81920): predicted peak would exceed prefill safety cap 46.7GB (90% of effective ceiling 51.8GB)',
+        recoverable: true,
+        errorCode: 'CONTEXT_LIMIT_EXCEEDED',
+      });
+    });
   });
 
   describe('processMessageContent', () => {

--- a/src/lib/ai-service/base-service-strategies.ts
+++ b/src/lib/ai-service/base-service-strategies.ts
@@ -164,7 +164,11 @@ function classifyProviderErrorKind(args: {
     normalizedMessage?.includes('context window exceeded') ||
     normalizedMessage?.includes('prompt is too long') ||
     normalizedMessage?.includes('prompt too long') ||
-    normalizedMessage?.includes('exceeds max context window')
+    normalizedMessage?.includes('exceeds max context window') ||
+    normalizedMessage?.includes('prefill context too large') ||
+    normalizedMessage?.includes(
+      'predicted peak would exceed prefill safety cap',
+    )
   ) {
     return 'context_limit';
   }

--- a/src/lib/ai-service/utils/general.ts
+++ b/src/lib/ai-service/utils/general.ts
@@ -262,6 +262,15 @@ export function normalizeAIServiceError(error: unknown): {
     normalizedStatus === 'rate_limit_exceeded' ||
     lowerRawMessage.includes('rate limit') ||
     lowerRawMessage.includes('too many requests');
+  const isContextLimit =
+    lowerRawMessage.includes('context size has been exceeded') ||
+    lowerRawMessage.includes('maximum context length') ||
+    lowerRawMessage.includes('context window exceeded') ||
+    lowerRawMessage.includes('prompt is too long') ||
+    lowerRawMessage.includes('prompt too long') ||
+    lowerRawMessage.includes('exceeds max context window') ||
+    lowerRawMessage.includes('prefill context too large') ||
+    lowerRawMessage.includes('predicted peak would exceed prefill safety cap');
 
   if (isSpendingCapError(error)) {
     const billingMessage = billingUrl
@@ -284,6 +293,16 @@ export function normalizeAIServiceError(error: unknown): {
         'Rate limit exceeded. Please wait a moment and try again.',
       recoverable: true,
       errorCode: 'RATE_LIMIT_EXCEEDED',
+    };
+  }
+
+  if (isContextLimit) {
+    return {
+      type: 'CONTEXT_LIMIT_ERROR',
+      displayMessage:
+        normalizedProviderMessage ?? 'Context size has been exceeded.',
+      recoverable: true,
+      errorCode: 'CONTEXT_LIMIT_EXCEEDED',
     };
   }
 


### PR DESCRIPTION
## Summary

Detect two new LLM provider error patterns that were previously classified as \unknown\:

- \prefill context too large\
- \predicted peak would exceed prefill safety cap\

These errors indicate context window exceeded but were silently retried, causing poor UX and unnecessary API calls.

## Changes

- **base-service-strategies.ts**: Added new patterns to \classifyProviderErrorKind()\
- **utils/general.ts**: Added \isContextLimit\ check in \
ormalizeAIServiceError()\
- **tests**: Added test cases for prefill memory overflow in both test files

## Context

The AI service already had a \context_limit\ error type with retry bypass logic, but the new error messages from modern LLM providers (OpenAI/o3, etc.) were not matched. This meant context limit errors would retry 3 times before failing, wasting tokens and time.

Now they are correctly detected and surfaced immediately to the user.