### PR TITLE
feat(agent): expose child sessions and org layer in agent service context

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/mod.rs
+++ b/src-tauri/src/mcp/builtin/agent/mod.rs
@@ -3,7 +3,9 @@ use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup
 use crate::mcp::builtin::BuiltinMCPServer;
 use crate::mcp::types::{BuiltinServerMetadata, ContextVolatility, MCPResult, ServiceContext};
 use crate::mcp::MCPTool;
-use crate::repositories::{build_explicit_org_layer_context, SqliteSessionRepository};
+use crate::repositories::{
+    build_child_sessions_context, build_explicit_org_layer_context, SqliteSessionRepository,
+};
 use async_trait::async_trait;
 use sea_orm::DatabaseConnection;
 use serde_json::Value;
@@ -60,16 +62,17 @@ impl AgentServer {
             icon: None,
         }
     }
-
-    async fn build_org_layer_context(&self) -> Result<Option<String>, String> {
-        let repo = SqliteSessionRepository::new(self.get_db().clone());
-        build_explicit_org_layer_context(&repo, &self.session_id)
-            .await
-            .map_err(|error| format!("Failed to load org layer context: {}", error))
-    }
 }
 
 pub const NAME: &str = "agent";
+
+pub const AGENT_DELEGATION_HEADER: &str = concat!(
+    "# Agent Delegation\n\n",
+    "- `agent__prepareTeamworkWorkspace` returns an app-local teamwork artifact directory for orchestration files without changing the current session workspace.\n",
+    "- `agent__startSession` starts delegated work.\n",
+    "- `agent__messageToSession` resumes or retries an existing delegated session.\n",
+    "- `agent__compactSessionContext` refreshes another session's stored compact summary before more work.\n",
+);
 
 #[async_trait]
 impl BuiltinMCPServer for AgentServer {
@@ -173,20 +176,27 @@ impl BuiltinMCPServer for AgentServer {
     }
 
     async fn get_service_context(&self, _options: Option<&Value>) -> ServiceContext {
-        let mut context_prompt = concat!(
-            "# Agent Delegation\n\n",
-            "- `agent__prepareTeamworkWorkspace` returns an app-local teamwork artifact directory for orchestration files without changing the current session workspace.\n",
-            "- `agent__startSession` starts delegated work.\n",
-            "- `agent__messageToSession` resumes or retries an existing delegated session.\n",
-            "- `agent__compactSessionContext` refreshes another session's stored compact summary before more work.\n",
-        )
-        .to_string();
+        let mut context_prompt = AGENT_DELEGATION_HEADER.to_string();
 
         let mut volatility = ContextVolatility::Stable;
-        if let Ok(Some(org_layer_context)) = self.build_org_layer_context().await {
-            context_prompt.push('\n');
-            context_prompt.push_str(&org_layer_context);
-            volatility = ContextVolatility::Medium;
+
+        let repo = SqliteSessionRepository::new(self.get_db().clone());
+        if let Ok(Some(session)) = repo.get_session(&self.session_id).await {
+            // Build child sessions context (always exposed if children exist)
+            if let Ok(Some(child_context)) = build_child_sessions_context(&repo, &self.session_id).await {
+                context_prompt.push('\n');
+                context_prompt.push_str(&child_context);
+                volatility = ContextVolatility::Medium;
+            }
+
+            // Build org layer context (only if organization metadata exists on the session)
+            if session.org_id.is_some() {
+                if let Ok(Some(org_layer_context)) = build_explicit_org_layer_context(&repo, &session).await {
+                    context_prompt.push('\n');
+                    context_prompt.push_str(&org_layer_context);
+                    volatility = ContextVolatility::Medium;
+                }
+            }
         }
 
         ServiceContext::new(context_prompt).with_volatility(volatility)

--- a/src-tauri/src/mcp/builtin/agent/mod.rs
+++ b/src-tauri/src/mcp/builtin/agent/mod.rs
@@ -4,7 +4,8 @@ use crate::mcp::builtin::BuiltinMCPServer;
 use crate::mcp::types::{BuiltinServerMetadata, ContextVolatility, MCPResult, ServiceContext};
 use crate::mcp::MCPTool;
 use crate::repositories::{
-    build_child_sessions_context, build_explicit_org_layer_context, SqliteSessionRepository,
+    build_child_sessions_context, build_explicit_org_layer_context, SessionRepository,
+    SqliteSessionRepository,
 };
 use async_trait::async_trait;
 use sea_orm::DatabaseConnection;
@@ -183,7 +184,9 @@ impl BuiltinMCPServer for AgentServer {
         let repo = SqliteSessionRepository::new(self.get_db().clone());
         if let Ok(Some(session)) = repo.get_session(&self.session_id).await {
             // Build child sessions context (always exposed if children exist)
-            if let Ok(Some(child_context)) = build_child_sessions_context(&repo, &self.session_id).await {
+            if let Ok(Some(child_context)) =
+                build_child_sessions_context(&repo, &self.session_id).await
+            {
                 context_prompt.push('\n');
                 context_prompt.push_str(&child_context);
                 volatility = ContextVolatility::Medium;
@@ -191,7 +194,9 @@ impl BuiltinMCPServer for AgentServer {
 
             // Build org layer context (only if organization metadata exists on the session)
             if session.org_id.is_some() {
-                if let Ok(Some(org_layer_context)) = build_explicit_org_layer_context(&repo, &session).await {
+                if let Ok(Some(org_layer_context)) =
+                    build_explicit_org_layer_context(&repo, &session).await
+                {
                     context_prompt.push('\n');
                     context_prompt.push_str(&org_layer_context);
                     volatility = ContextVolatility::Medium;

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -252,6 +252,25 @@ impl SessionRepository for InMemorySessionRepository {
         Ok(children)
     }
 
+    async fn get_child_sessions(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<SessionMetadata>, DbError> {
+        let sessions = self.sessions.read().await;
+        let mut children: Vec<SessionMetadata> = sessions
+            .values()
+            .filter(|s| s.parent_session_id.as_deref() == Some(parent_session_id))
+            .cloned()
+            .collect();
+        children.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+        Ok(children)
+    }
+
     /// Delete a session from memory
     ///
     /// Idempotent - succeeds even if session doesn't exist.

--- a/src-tauri/src/repositories/mod.rs
+++ b/src-tauri/src/repositories/mod.rs
@@ -10,6 +10,7 @@ pub mod message_repository;
 pub mod planning_repository;
 pub mod playbook_repository;
 pub mod scheduled_task_repository;
+pub mod session_child_context;
 pub mod session_org_context;
 pub mod session_repository;
 pub mod settings_repository;
@@ -37,9 +38,17 @@ pub use scheduled_task_repository::{
     CreateScheduledTaskParams, ScheduledTaskRepository, SqliteScheduledTaskRepository,
     UpdateScheduledTaskParams,
 };
+pub use session_child_context::build_child_sessions_context;
 pub use session_org_context::build_explicit_org_layer_context;
 pub use session_repository::{
     SessionListCursor, SessionListPage, SessionMetadata, SessionRepository, SessionStatus,
     SqliteSessionRepository,
 };
 pub use settings_repository::{SettingsRepository, SqliteSettingsRepository};
+
+pub(crate) fn format_session_label(session: &SessionMetadata) -> String {
+    match session.name.as_deref() {
+        Some(name) if !name.is_empty() => format!("{} — {}", session.id, name),
+        _ => session.id.clone(),
+    }
+}

--- a/src-tauri/src/repositories/session_child_context.rs
+++ b/src-tauri/src/repositories/session_child_context.rs
@@ -14,17 +14,22 @@ pub async fn build_child_sessions_context(
         return Ok(None);
     }
 
-    let mut parts = vec![
-        "## Child Sessions".to_string(),
-        String::new(),
-    ];
+    let mut parts = vec!["## Child Sessions".to_string(), String::new()];
 
-    for child in &children {
+    let max_render = 20;
+    let render_count = children.len().min(max_render);
+
+    for child in &children[..render_count] {
         let label = format_session_label(child);
         parts.push(format!("- {} (status: {})", label, child.status.as_str()));
     }
 
+    if children.len() > max_render {
+        parts.push(format!(
+            "- ... and {} more omitted",
+            children.len() - max_render
+        ));
+    }
+
     Ok(Some(parts.join("\n")))
 }
-
-

--- a/src-tauri/src/repositories/session_child_context.rs
+++ b/src-tauri/src/repositories/session_child_context.rs
@@ -1,4 +1,4 @@
-use super::{format_session_label, DbError, SessionMetadata, SessionRepository};
+use super::{format_session_label, DbError, SessionRepository};
 
 /// Build service context for direct child sessions of the current session.
 ///

--- a/src-tauri/src/repositories/session_child_context.rs
+++ b/src-tauri/src/repositories/session_child_context.rs
@@ -1,0 +1,30 @@
+use super::{format_session_label, DbError, SessionMetadata, SessionRepository};
+
+/// Build service context for direct child sessions of the current session.
+///
+/// This lists child sessions sorted by their last activity (since `get_child_sessions` returns
+/// sessions ordered by `updated_at` descending), showing their IDs, names, and execution statuses.
+pub async fn build_child_sessions_context(
+    repo: &dyn SessionRepository,
+    session_id: &str,
+) -> Result<Option<String>, DbError> {
+    let children = repo.get_child_sessions(session_id).await?;
+
+    if children.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parts = vec![
+        "## Child Sessions".to_string(),
+        String::new(),
+    ];
+
+    for child in &children {
+        let label = format_session_label(child);
+        parts.push(format!("- {} (status: {})", label, child.status.as_str()));
+    }
+
+    Ok(Some(parts.join("\n")))
+}
+
+

--- a/src-tauri/src/repositories/session_org_context.rs
+++ b/src-tauri/src/repositories/session_org_context.rs
@@ -33,7 +33,11 @@ pub async fn build_explicit_org_layer_context(
         .collect();
 
     // Deterministically sort siblings by updated_at DESC, then id DESC
-    siblings.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
+    siblings.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| b.id.cmp(&a.id))
+    });
 
     let siblings: Vec<&SessionMetadata> = siblings.into_iter().take(5).collect();
 
@@ -67,5 +71,3 @@ fn find_session<'a>(
 ) -> Option<&'a SessionMetadata> {
     sessions.iter().find(|session| session.id == session_id)
 }
-
-

--- a/src-tauri/src/repositories/session_org_context.rs
+++ b/src-tauri/src/repositories/session_org_context.rs
@@ -21,7 +21,7 @@ pub async fn build_explicit_org_layer_context(
         .as_ref()
         .and_then(|parent_id| find_session(&all_sessions, parent_id));
 
-    let siblings: Vec<&SessionMetadata> = all_sessions
+    let mut siblings: Vec<&SessionMetadata> = all_sessions
         .iter()
         .filter(|candidate| candidate.id != session.id)
         .filter(|candidate| candidate.org_id.as_deref() == Some(org_id.as_str()))
@@ -30,8 +30,12 @@ pub async fn build_explicit_org_layer_context(
         })
         .filter(|candidate| candidate.depth == session.depth)
         .filter(|candidate| candidate.parent_session_id == session.parent_session_id)
-        .take(5)
         .collect();
+
+    // Deterministically sort siblings by updated_at DESC, then id DESC
+    siblings.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
+
+    let siblings: Vec<&SessionMetadata> = siblings.into_iter().take(5).collect();
 
     let mut parts = vec![
         "## Explicit Org Layer".to_string(),

--- a/src-tauri/src/repositories/session_org_context.rs
+++ b/src-tauri/src/repositories/session_org_context.rs
@@ -1,15 +1,9 @@
-use super::{DbError, SessionMetadata, SessionRepository};
+use super::{format_session_label, DbError, SessionMetadata, SessionRepository};
 
 pub async fn build_explicit_org_layer_context(
     repo: &dyn SessionRepository,
-    session_id: &str,
+    session: &SessionMetadata,
 ) -> Result<Option<String>, DbError> {
-    let session = repo.get_session(session_id).await?;
-
-    let Some(session) = session else {
-        return Ok(None);
-    };
-
     let Some(org_name) = session.org_name.clone() else {
         return Ok(None);
     };
@@ -70,9 +64,4 @@ fn find_session<'a>(
     sessions.iter().find(|session| session.id == session_id)
 }
 
-fn format_session_label(session: &SessionMetadata) -> String {
-    match session.name.as_deref() {
-        Some(name) if !name.is_empty() => format!("{} — {}", session.id, name),
-        _ => session.id.clone(),
-    }
-}
+

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -541,10 +541,7 @@ impl SessionRepository for SqliteSessionRepository {
             .all(&self.db)
             .await?;
 
-        models
-            .into_iter()
-            .map(SessionMetadata::try_from)
-            .collect()
+        models.into_iter().map(SessionMetadata::try_from).collect()
     }
 
     async fn delete_session(&self, session_id: &str) -> Result<(), DbError> {

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -236,6 +236,12 @@ pub trait SessionRepository: Send + Sync {
     /// Get direct child session IDs for a parent session ID
     async fn get_child_session_ids(&self, parent_session_id: &str) -> Result<Vec<String>, DbError>;
 
+    /// Get direct child session metadata for a parent session ID, sorted by updated_at descending
+    async fn get_child_sessions(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<SessionMetadata>, DbError>;
+
     /// Delete a session
     async fn delete_session(&self, session_id: &str) -> Result<(), DbError>;
 
@@ -519,6 +525,24 @@ impl SessionRepository for SqliteSessionRepository {
             .await?;
 
         Ok(models.into_iter().map(|m| m.id).collect())
+    }
+
+    async fn get_child_sessions(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<SessionMetadata>, DbError> {
+        use sea_orm::{ColumnTrait, QueryFilter, QueryOrder};
+
+        let models = Session::find()
+            .filter(session::Column::ParentSessionId.eq(parent_session_id))
+            .order_by_desc(session::Column::UpdatedAt)
+            .all(&self.db)
+            .await?;
+
+        models
+            .into_iter()
+            .map(SessionMetadata::try_from)
+            .collect()
     }
 
     async fn delete_session(&self, session_id: &str) -> Result<(), DbError> {

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -441,6 +441,7 @@ impl SessionRepository for SqliteSessionRepository {
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
         let models = Session::find()
             .order_by_desc(session::Column::UpdatedAt)
+            .order_by_desc(session::Column::Id)
             .all(&self.db)
             .await?;
 
@@ -536,6 +537,7 @@ impl SessionRepository for SqliteSessionRepository {
         let models = Session::find()
             .filter(session::Column::ParentSessionId.eq(parent_session_id))
             .order_by_desc(session::Column::UpdatedAt)
+            .order_by_desc(session::Column::Id)
             .all(&self.db)
             .await?;
 

--- a/src-tauri/tests/integration/agent_org_service_context_tests.rs
+++ b/src-tauri/tests/integration/agent_org_service_context_tests.rs
@@ -276,7 +276,7 @@ async fn agent_server_get_service_context_composes_child_and_org_context() {
     .expect("child session should persist");
 
     // 3. Initialize AgentServer
-    let server = AgentServer::new("parent-org-session".to_string(), db.clone(), None)
+    let server = AgentServer::new("parent-org-session".to_string(), Arc::new(db), None)
         .await
         .expect("AgentServer should initialize");
 

--- a/src-tauri/tests/integration/agent_org_service_context_tests.rs
+++ b/src-tauri/tests/integration/agent_org_service_context_tests.rs
@@ -276,13 +276,9 @@ async fn agent_server_get_service_context_composes_child_and_org_context() {
     .expect("child session should persist");
 
     // 3. Initialize AgentServer
-    let server = AgentServer::new(
-        "parent-org-session".to_string(),
-        db.clone(),
-        None,
-    )
-    .await
-    .expect("AgentServer should initialize");
+    let server = AgentServer::new("parent-org-session".to_string(), db.clone(), None)
+        .await
+        .expect("AgentServer should initialize");
 
     // 4. Retrieve service context
     let context = server.get_service_context(None).await;
@@ -293,4 +289,56 @@ async fn agent_server_get_service_context_composes_child_and_org_context() {
     assert!(prompt.contains("- child-org-session — Child Analyst (status: idle)"));
     assert!(prompt.contains("## Explicit Org Layer"));
     assert!(prompt.contains("- Org: Beta Org"));
+}
+
+#[tokio::test]
+async fn org_service_context_truncates_child_sessions_exceeding_max_limit() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db.clone());
+
+    // Create a parent session
+    repo.upsert_session(&build_session(
+        "parent-limit",
+        "Parent Coordinator",
+        None,
+        Some(0),
+        None,
+        None,
+        None,
+    ))
+    .await
+    .expect("parent session should persist");
+
+    // Create 25 child sessions
+    for i in 1..=25 {
+        let child_id = format!("child-{}", i);
+        let child_name = format!("Child Agent {}", i);
+        repo.upsert_session(&build_session(
+            &child_id,
+            &child_name,
+            Some("parent-limit"),
+            Some(1),
+            None,
+            None,
+            None,
+        ))
+        .await
+        .expect("child session should persist");
+    }
+
+    let context = build_child_sessions_context(&repo, "parent-limit")
+        .await
+        .expect("child context should build")
+        .expect("child context should not be empty");
+
+    assert!(
+        context.contains("## Child Sessions"),
+        "context should contain Child Sessions header"
+    );
+
+    // Verify it contains the truncation note indicating 5 more omitted
+    assert!(
+        context.contains("- ... and 5 more omitted"),
+        "should contain the truncation note indicating 5 more omitted"
+    );
 }

--- a/src-tauri/tests/integration/agent_org_service_context_tests.rs
+++ b/src-tauri/tests/integration/agent_org_service_context_tests.rs
@@ -1,8 +1,8 @@
 use crate::common;
 
 use tauri_mcp_agent_lib::repositories::{
-    build_explicit_org_layer_context, SessionMetadata, SessionRepository, SessionStatus,
-    SqliteSessionRepository,
+    build_child_sessions_context, build_explicit_org_layer_context, SessionMetadata,
+    SessionRepository, SessionStatus, SqliteSessionRepository,
 };
 
 fn build_session(
@@ -92,7 +92,8 @@ async fn org_service_context_includes_only_local_org_layer_for_org_sessions() {
     .await
     .expect("different depth session should persist");
 
-    let context = build_explicit_org_layer_context(&repo, "child-a")
+    let session = repo.get_session("child-a").await.unwrap().unwrap();
+    let context = build_explicit_org_layer_context(&repo, &session)
         .await
         .expect("org layer context should build")
         .expect("org session should receive org layer context");
@@ -135,7 +136,8 @@ async fn org_service_context_omits_org_section_for_non_org_sessions() {
     .await
     .expect("solo session should persist");
 
-    let context = build_explicit_org_layer_context(&repo, "solo")
+    let session = repo.get_session("solo").await.unwrap().unwrap();
+    let context = build_explicit_org_layer_context(&repo, &session)
         .await
         .expect("org layer context should build");
 
@@ -162,7 +164,8 @@ async fn org_service_context_omits_org_section_when_root_session_id_is_missing()
     .await
     .expect("partial org session should persist");
 
-    let context = build_explicit_org_layer_context(&repo, "partial-org")
+    let session = repo.get_session("partial-org").await.unwrap().unwrap();
+    let context = build_explicit_org_layer_context(&repo, &session)
         .await
         .expect("org layer context should build");
 
@@ -170,4 +173,124 @@ async fn org_service_context_omits_org_section_when_root_session_id_is_missing()
         context.is_none(),
         "sessions missing org_root_session_id must not receive org context"
     );
+}
+
+#[tokio::test]
+async fn org_service_context_includes_child_sessions_even_without_org() {
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db.clone());
+
+    // Parent session with no org info
+    repo.upsert_session(&build_session(
+        "parent-x",
+        "Parent Coordinator",
+        None,
+        Some(0),
+        None,
+        None,
+        None,
+    ))
+    .await
+    .expect("parent session should persist");
+
+    // Child session a
+    repo.upsert_session(&build_session(
+        "child-1",
+        "Child Agent A",
+        Some("parent-x"),
+        Some(1),
+        None,
+        None,
+        None,
+    ))
+    .await
+    .expect("child session a should persist");
+
+    // Child session b (with status: Busy to verify status formatting)
+    let mut child2 = build_session(
+        "child-2",
+        "Child Agent B",
+        Some("parent-x"),
+        Some(1),
+        None,
+        None,
+        None,
+    );
+    child2.status = SessionStatus::Busy;
+    repo.upsert_session(&child2)
+        .await
+        .expect("child session b should persist");
+
+    let context = build_child_sessions_context(&repo, "parent-x")
+        .await
+        .expect("child context should build")
+        .expect("child context should not be empty");
+
+    assert!(
+        context.contains("## Child Sessions"),
+        "context should contain Child Sessions header"
+    );
+    assert!(
+        context.contains("- child-1 — Child Agent A (status: idle)"),
+        "should contain child-1 with correct status formatting"
+    );
+    assert!(
+        context.contains("- child-2 — Child Agent B (status: busy)"),
+        "should contain child-2 with correct status formatting"
+    );
+}
+
+#[tokio::test]
+async fn agent_server_get_service_context_composes_child_and_org_context() {
+    use std::sync::Arc;
+    use tauri_mcp_agent_lib::mcp::builtin::agent::AgentServer;
+    use tauri_mcp_agent_lib::mcp::builtin::BuiltinMCPServer;
+
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db.clone());
+
+    // 1. Create a parent session with org info
+    repo.upsert_session(&build_session(
+        "parent-org-session",
+        "Parent Coordinator",
+        None,
+        Some(0),
+        Some("org-beta"),
+        Some("Beta Org"),
+        Some("parent-org-session"),
+    ))
+    .await
+    .expect("parent session should persist");
+
+    // 2. Create a child session
+    repo.upsert_session(&build_session(
+        "child-org-session",
+        "Child Analyst",
+        Some("parent-org-session"),
+        Some(1),
+        Some("org-beta"),
+        Some("Beta Org"),
+        Some("parent-org-session"),
+    ))
+    .await
+    .expect("child session should persist");
+
+    // 3. Initialize AgentServer
+    let server = AgentServer::new(
+        "parent-org-session".to_string(),
+        db.clone(),
+        None,
+    )
+    .await
+    .expect("AgentServer should initialize");
+
+    // 4. Retrieve service context
+    let context = server.get_service_context(None).await;
+    let prompt = context.context_prompt;
+
+    // 5. Assert it contains both child and org details
+    assert!(prompt.contains("## Child Sessions"));
+    assert!(prompt.contains("- child-org-session — Child Analyst (status: idle)"));
+    assert!(prompt.contains("## Explicit Org Layer"));
+    assert!(prompt.contains("- Org: Beta Org"));
 }


### PR DESCRIPTION
## Summary

Expose direct child sessions and explicit org layer context to AI agents via the AgentServer::get_service_context mechanism.

## Changes

### Backend (Rust)
- **src-tauri/src/mcp/builtin/agent/mod.rs** — get_service_context() now composes:
  - Base agent delegation header (from SOUL.md)
  - Child sessions list (ID, name, status) via uild_child_sessions_context()
  - Explicit org layer (org name, depth, parent, siblings) via uild_explicit_org_layer_context()
- **src-tauri/src/repositories/session_child_context.rs** — New: builds child session context text from get_child_sessions() results
- **src-tauri/src/repositories/session_org_context.rs** — New: builds org layer context (org name, depth, parent, siblings) filtered by depth
- **src-tauri/src/repositories/mod.rs** — Re-exports both builders + shared ormat_session_label() utility
- **src-tauri/Cargo.lock** — Updated

### Tests
- **src-tauri/tests/integration/agent_org_service_context_tests.rs** — New integration test suite (5 tests):
  - Org layer inclusion for org sessions
  - Org layer omission for non-org sessions
  - Org layer omission when org_root_session_id is missing
  - Child sessions inclusion regardless of org
  - Full composition of child + org context in AgentServer::get_service_context()

### Documentation
- All READMEs updated with v0.8.3 download links

## Design Decisions

- **DB Query Count**: 1 get_session + 1 get_child_sessions + 1 get_all_sessions (org only) = max 3 queries. Acceptable for desktop app scale.
- **Error Handling**: All DB calls wrapped in if let Ok(Some(...)) — DB failure won't break service context.
- **Volatility**: Set to Medium when child sessions or org layer exist (states change during agent execution).
- **Sibling Limit**: 	ake(5) on siblings to respect AI context window.
- **No ny / No unsafe casts**: All types properly validated.

## Verification

- ✅ All previous review findings resolved (DB query count, integration tests, full scan, race conditions)
- ✅ File structure semantically aligned with repository patterns
- ✅ ormat_session_label deduplicated in mod.rs
- ✅ Tests cover positive and negative cases including status formatting