### PR TITLE
refactor: unify SeaORM sorting to order_by_asc/desc for prompt cache stability

### DIFF
--- a/src-tauri/src/repositories/planning_repository.rs
+++ b/src-tauri/src/repositories/planning_repository.rs
@@ -374,7 +374,8 @@ impl PlanningRepository for SqlitePlanningRepository {
     ) -> Result<Vec<planning_todo::Model>, DbError> {
         let mut query = planning_todo::Entity::find()
             .filter(planning_todo::Column::SessionId.eq(session_id))
-            .order_by_asc(planning_todo::Column::CreatedAt);
+            .order_by_asc(planning_todo::Column::CreatedAt)
+            .order_by_asc(planning_todo::Column::Id);
 
         if !include_checked {
             query = query.filter(planning_todo::Column::IsChecked.eq(false));
@@ -545,6 +546,7 @@ impl PlanningRepository for SqlitePlanningRepository {
         planning_scratchpad::Entity::find()
             .filter(planning_scratchpad::Column::SessionId.eq(session_id))
             .order_by_desc(planning_scratchpad::Column::CreatedAt)
+            .order_by_desc(planning_scratchpad::Column::Id)
             .all(&self.db)
             .await
             .map_err(DbError::SeaOrmQueryFailed)

--- a/src-tauri/src/repositories/playbook_repository.rs
+++ b/src-tauri/src/repositories/playbook_repository.rs
@@ -8,7 +8,7 @@ use crate::entity::playbook::{self, Entity as PlaybookEntity};
 use crate::utils::pagination::{Page, PaginationParams};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, Order,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
     PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set,
 };
 
@@ -150,7 +150,8 @@ impl PlaybookRepository for SqlitePlaybookRepository {
 
         // Get paginated items
         let items = query
-            .order_by(playbook::Column::UpdatedAt, Order::Desc)
+            .order_by_desc(playbook::Column::UpdatedAt)
+            .order_by_desc(playbook::Column::Id)
             .limit(page_size)
             .offset(offset)
             .all(&self.db)
@@ -236,7 +237,8 @@ impl PlaybookRepository for SqlitePlaybookRepository {
                 "LOWER(goal) LIKE ?",
                 vec![sea_orm::Value::from(query_pattern)],
             ))
-            .order_by(playbook::Column::UpdatedAt, Order::Desc)
+            .order_by_desc(playbook::Column::UpdatedAt)
+            .order_by_desc(playbook::Column::Id)
             .all(&self.db)
             .await
             .map_err(DbError::SeaOrmQueryFailed)
@@ -249,7 +251,8 @@ impl PlaybookRepository for SqlitePlaybookRepository {
         PlaybookEntity::find()
             .filter(playbook::Column::AssistantId.eq(assistant_id))
             .filter(playbook::Column::IsBookmarked.eq(true))
-            .order_by(playbook::Column::UpdatedAt, Order::Desc)
+            .order_by_desc(playbook::Column::UpdatedAt)
+            .order_by_desc(playbook::Column::Id)
             .all(&self.db)
             .await
             .map_err(DbError::SeaOrmQueryFailed)

--- a/src-tauri/src/repositories/scheduled_task_repository.rs
+++ b/src-tauri/src/repositories/scheduled_task_repository.rs
@@ -5,7 +5,7 @@
 
 use crate::entity::scheduled_task::{self, Entity as ScheduledTaskEntity};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel, Order,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel,
     QueryFilter, QueryOrder, Set,
 };
 
@@ -139,8 +139,9 @@ impl ScheduledTaskRepository for SqliteScheduledTaskRepository {
         &self,
         assistant_id: Option<&str>,
     ) -> Result<Vec<scheduled_task::Model>, DbErr> {
-        let query =
-            ScheduledTaskEntity::find().order_by(scheduled_task::Column::CreatedAt, Order::Asc);
+        let query = ScheduledTaskEntity::find()
+            .order_by_asc(scheduled_task::Column::CreatedAt)
+            .order_by_asc(scheduled_task::Column::Id);
 
         if let Some(aid) = assistant_id {
             query
@@ -156,9 +157,9 @@ impl ScheduledTaskRepository for SqliteScheduledTaskRepository {
         ScheduledTaskEntity::find()
             .filter(scheduled_task::Column::Enabled.eq(true))
             .filter(scheduled_task::Column::NextRunAt.lte(now_ms))
-            .order_by(scheduled_task::Column::NextRunAt, Order::Asc)
-            .order_by(scheduled_task::Column::CreatedAt, Order::Asc)
-            .order_by(scheduled_task::Column::Id, Order::Asc)
+            .order_by_asc(scheduled_task::Column::NextRunAt)
+            .order_by_asc(scheduled_task::Column::CreatedAt)
+            .order_by_asc(scheduled_task::Column::Id)
             .all(&self.db)
             .await
     }

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -516,6 +516,7 @@ impl SessionRepository for SqliteSessionRepository {
 
         let models = Session::find()
             .filter(session::Column::ParentSessionId.eq(parent_session_id))
+            .order_by_desc(session::Column::CreatedAt)
             .order_by_desc(session::Column::Id)
             .all(&self.db)
             .await?;

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -435,6 +435,7 @@ impl SessionRepository for SqliteSessionRepository {
     async fn get_all_sessions(&self) -> Result<Vec<SessionMetadata>, DbError> {
         let models = Session::find()
             .order_by_desc(session::Column::UpdatedAt)
+            .order_by_desc(session::Column::Id)
             .all(&self.db)
             .await?;
 
@@ -511,10 +512,11 @@ impl SessionRepository for SqliteSessionRepository {
     }
 
     async fn get_child_session_ids(&self, parent_session_id: &str) -> Result<Vec<String>, DbError> {
-        use sea_orm::{ColumnTrait, QueryFilter};
+        use sea_orm::{ColumnTrait, QueryFilter, QueryOrder};
 
         let models = Session::find()
             .filter(session::Column::ParentSessionId.eq(parent_session_id))
+            .order_by_desc(session::Column::Id)
             .all(&self.db)
             .await?;
 

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -46,7 +45,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
This PR refactors database repositories to unify SeaORM sorting syntax using order_by_asc and order_by_desc. It also adds secondary sorting on primary keys (Id) to ensure deterministic ordering, preventing prompt cache fragmentation and cache busts on the LLM side.