### PR TITLE
fix(history): sync bookmarked sessions filter state with URL hash

### DIFF
--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -76,6 +76,8 @@ interface SessionHistoryPanelProps {
   emptyStateSubtitle?: string;
   initialSortKey?: SessionSortKey;
   initialSortDirection?: SessionSortDirection;
+  showBookmarkedOnly?: boolean;
+  onShowBookmarkedOnlyChange?: (value: boolean) => void;
 }
 
 export function SessionHistoryPanel({
@@ -100,6 +102,8 @@ export function SessionHistoryPanel({
   emptyStateSubtitle,
   initialSortKey = 'updatedAt',
   initialSortDirection = 'desc',
+  showBookmarkedOnly: controlledShowBookmarkedOnly,
+  onShowBookmarkedOnlyChange,
 }: SessionHistoryPanelProps) {
   const { t } = useTranslation('common');
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -108,7 +112,26 @@ export function SessionHistoryPanel({
   const [selectedLineageId, setSelectedLineageId] = useState<string | null>(
     null,
   );
-  const [showBookmarkedOnly, setShowBookmarkedOnly] = useState(false);
+  const [localShowBookmarkedOnly, setLocalShowBookmarkedOnly] = useState(false);
+  const showBookmarkedOnly =
+    controlledShowBookmarkedOnly !== undefined
+      ? controlledShowBookmarkedOnly
+      : localShowBookmarkedOnly;
+
+  const setShowBookmarkedOnly = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      if (controlledShowBookmarkedOnly !== undefined) {
+        const nextValue =
+          typeof value === 'function'
+            ? value(controlledShowBookmarkedOnly)
+            : value;
+        onShowBookmarkedOnlyChange?.(nextValue);
+      } else {
+        setLocalShowBookmarkedOnly(value);
+      }
+    },
+    [controlledShowBookmarkedOnly, onShowBookmarkedOnlyChange],
+  );
   const [activeSortKey, setActiveSortKey] =
     useState<SessionSortKey>(initialSortKey);
   const [activeSortDirection, setActiveSortDirection] =

--- a/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
+++ b/src/features/agent/components/__tests__/SessionHistoryPanel.test.tsx
@@ -649,4 +649,67 @@ describe('SessionHistoryPanel', () => {
     expect(screen.getByTestId('session-card-root')).toBeInTheDocument();
     expect(screen.getByTestId('session-card-child-beta')).toBeInTheDocument();
   });
+
+  it('supports controlled showBookmarkedOnly prop', () => {
+    const sessions: AgentSession[] = [
+      createSession('root', 'Root'),
+      createSession('bookmarked-child', 'Bookmarked Child', {
+        parentSessionId: 'root',
+        isBookmarked: true,
+      }),
+    ];
+
+    const { rerender } = render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+        showBookmarkedOnly={true}
+      />,
+    );
+
+    expect(screen.getByText('Showing bookmarked sessions')).toBeInTheDocument();
+
+    rerender(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+        showBookmarkedOnly={false}
+      />,
+    );
+
+    expect(screen.queryByText('Showing bookmarked sessions')).not.toBeInTheDocument();
+  });
+
+  it('triggers onShowBookmarkedOnlyChange callback when clicked', () => {
+    const sessions: AgentSession[] = [
+      createSession('root', 'Root'),
+      createSession('bookmarked-child', 'Bookmarked Child', {
+        parentSessionId: 'root',
+        isBookmarked: true,
+      }),
+    ];
+    const onShowBookmarkedOnlyChange = vi.fn();
+
+    render(
+      <SessionHistoryPanel
+        sessions={sessions}
+        isLoading={false}
+        {...defaultProps}
+        activeStatusFilter="all"
+        searchQuery=""
+        showBookmarkedOnly={false}
+        onShowBookmarkedOnlyChange={onShowBookmarkedOnlyChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bookmarked (1)' }));
+
+    expect(onShowBookmarkedOnlyChange).toHaveBeenCalledWith(true);
+  });
 });

--- a/src/features/history/History.tsx
+++ b/src/features/history/History.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   useAgentSessionListActions,
@@ -14,6 +14,7 @@ const logger = getLogger('History');
 
 export default function History() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation('common');
   const {
     sessions,
@@ -32,6 +33,19 @@ export default function History() {
     'all' | SessionStatus
   >('all');
   const [searchQuery, setSearchQuery] = useState('');
+
+  const showBookmarkedOnly = location.hash === '#bookmarked-sessions';
+
+  const handleShowBookmarkedOnlyChange = useCallback(
+    (value: boolean) => {
+      if (value) {
+        navigate('/history#bookmarked-sessions', { replace: true });
+      } else {
+        navigate('/history', { replace: true });
+      }
+    },
+    [navigate],
+  );
 
   const handleResumeSession = useCallback(
     (sessionId: string) => {
@@ -103,6 +117,8 @@ export default function History() {
         onDelete={handleDeleteSession}
         onDeleteOnly={handleDeleteSessionOnly}
         onToggleBookmark={toggleBookmark}
+        showBookmarkedOnly={showBookmarkedOnly}
+        onShowBookmarkedOnlyChange={handleShowBookmarkedOnlyChange}
         heading={t('sessionHistory.heading', 'Session History')}
         description={t(
           'sessionHistory.description',


### PR DESCRIPTION
## 목적
* 사이드바 "북마크" 메뉴 클릭 시 URL 해시 `#bookmarked-sessions` 가 설정되지만, 실제 세션 필터 상태에 반영되지 않아 북마크 세션만 보이지 않고 전체 히스토리가 노출되던 문제를 해결합니다.

## 변경 사항
1. **`History.tsx` (URL 해시 감지 및 라우팅 바인딩):**
   - `react-router-dom`의 `useLocation`을 사용하여 `#bookmarked-sessions` 해시의 상태를 구독 및 감지합니다.
   - `showBookmarkedOnly` 상태 및 이를 제어할 수 있는 `onShowBookmarkedOnlyChange` 콜백을 구성하여 `SessionHistoryPanel`로 주입합니다.
   - UI에서 토글 시 `navigate`를 활용하여 URL 해시를 유기적으로 반영하거나 지웁니다 (`replace: true`).
2. **`SessionHistoryPanel.tsx` (Controlled Props 하이브리드 지원):**
   - `showBookmarkedOnly`와 `onShowBookmarkedOnlyChange`를 Props로 제공받는 Controlled State 형태로 확장하였습니다.
   - Props가 전달되지 않을 때는 내부 Local State로 동작하는 하이브리드 구조를 보존하여 기존 유닛 테스트와 호환됩니다.
3. **단위 테스트 추가:**
   - `SessionHistoryPanel.test.tsx` 파일에 Controlled prop 테스트 및 콜백 감지 테스트 2종을 작성했습니다.