### PR TITLE
refactor: simplify onSelect prop of AssistantSelectionCard to pass assistant ID string

### DIFF
--- a/src/features/agent/AgentChatStartView.tsx
+++ b/src/features/agent/AgentChatStartView.tsx
@@ -125,17 +125,17 @@ export default function AgentChatStartView() {
   }, [assistants, createSession, navigate, playbookId]);
 
   const handleAssistantSelect = useCallback(
-    (assistant: AssistantSummary) => {
-      setStartingAssistantId(assistant.id);
-      navigate(`/agent/draft?assistantId=${assistant.id}`);
+    (assistantId: string) => {
+      setStartingAssistantId(assistantId);
+      navigate(`/agent/draft?assistantId=${assistantId}`);
     },
     [navigate],
   );
 
   const handleStartSelection = useCallback(
-    (assistant: AssistantSummary) => {
+    (assistantId: string) => {
       setIsCreating(true);
-      handleAssistantSelect(assistant);
+      handleAssistantSelect(assistantId);
     },
     [handleAssistantSelect],
   );

--- a/src/features/agent/components/AssistantSelectionCard.tsx
+++ b/src/features/agent/components/AssistantSelectionCard.tsx
@@ -6,7 +6,7 @@ interface AssistantSelectionCardProps {
   assistant: AssistantSummary;
   isStarting: boolean;
   disabled: boolean;
-  onSelect: (assistant: AssistantSummary) => void;
+  onSelect: (assistantId: string) => void;
 }
 
 export function AssistantSelectionCard({
@@ -17,7 +17,7 @@ export function AssistantSelectionCard({
 }: AssistantSelectionCardProps) {
   return (
     <button
-      onClick={() => onSelect(assistant)}
+      onClick={() => onSelect(assistant.id)}
       disabled={disabled}
       aria-label={`Start session with ${assistant.name}`}
       aria-busy={isStarting}


### PR DESCRIPTION
Simplifies onSelect callback from AssistantSummary object to assistant ID string. Passed all validation checks.