### PR TITLE
feat(mcp): add deleteSession builtin MCP tool

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -542,6 +542,6 @@ pub use orgs::{
     inspect_teamwork_scaffold, TeamworkScaffoldStatus,
 };
 pub use sessions::{
-    compact_session_context, message_to_session, parse_message_to_session_wait_config,
-    start_session, stop_session,
+    compact_session_context, delete_session, message_to_session,
+    parse_message_to_session_wait_config, start_session, stop_session,
 };

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -599,3 +599,93 @@ pub async fn compact_session_context(
     Ok(SuccessHint::new(message, vec![])
         .to_mcp_result_with_data(Some(Value::Object(response_data))))
 }
+
+pub async fn delete_session(
+    server: &AgentServer,
+    args: Value,
+    caller_session_id: &str,
+) -> Result<MCPResult, String> {
+    let manager = server
+        .get_manager()
+        .ok_or("AgentSessionManager not available")?;
+    let session_id = read_required_string(&args, "sessionId")?;
+
+    // 1. Prevent self-deletion (matching stopSession pattern)
+    if caller_session_id == session_id {
+        return Ok(self_target_session_action_result(
+            "deleteSession",
+            "Self-deletion is not allowed via deleteSession.",
+            vec![
+                "If the current session should be removed, use the normal session deletion controls in the UI instead."
+                    .to_string(),
+            ],
+        ));
+    }
+
+    // 2. Perform lineage permissions check (reuse load_accessible_delegated_session)
+    let _target_session = match load_accessible_delegated_session(
+        manager,
+        caller_session_id,
+        &session_id,
+        "deleteSession",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(result) => return Ok(result),
+    };
+
+    // 3. Execute cascade deletion
+    let deleted_ids = manager.delete_session(session_id.clone()).await?;
+
+    // 4. Clean up lineage metadata (sync with Tauri command behavior to prevent memory leaks)
+    for deleted_id in &deleted_ids {
+        crate::services::agent_service::remove_lineage(deleted_id).await;
+    }
+
+    // 5. Compose the response message
+    // Provide a list of deleted descendant IDs so that the AI agent can parse and comprehend it
+    let cascade_count = deleted_ids.len() - 1; // Exclude self
+    let message = if cascade_count > 0 {
+        let descendant_list = deleted_ids
+            .get(1..)
+            .unwrap_or(&[])
+            .iter()
+            .map(|id| format!("  - {}", id))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "Session {} deleted.\nCascade removed {} descendant session(s):\n{}",
+            session_id, cascade_count, descendant_list
+        )
+    } else {
+        format!("Session {} deleted.", session_id)
+    };
+
+    let hint = SuccessHint::new(message.clone(), vec![]);
+    let mut response_data = build_agent_tool_data(
+        "deleteSession",
+        "session",
+        Some(&session_id),
+        &message,
+        "success",
+        vec![],
+    );
+    response_data.insert("sessionId".to_string(), Value::String(session_id));
+    response_data.insert("deleted".to_string(), Value::Bool(true));
+    response_data.insert(
+        "descendantCount".to_string(),
+        Value::Number(cascade_count.into()),
+    );
+    response_data.insert(
+        "deletedIds".to_string(),
+        Value::Array(
+            deleted_ids
+                .iter()
+                .map(|id| Value::String(id.clone()))
+                .collect(),
+        ),
+    );
+
+    Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
+}

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -675,7 +675,7 @@ pub async fn delete_session(
     response_data.insert("deleted".to_string(), Value::Bool(true));
     response_data.insert(
         "descendantCount".to_string(),
-        Value::Number(cascade_count.into()),
+        Value::Number((cascade_count as u64).into()),
     );
     response_data.insert(
         "deletedIds".to_string(),

--- a/src-tauri/src/mcp/builtin/agent/mod.rs
+++ b/src-tauri/src/mcp/builtin/agent/mod.rs
@@ -113,6 +113,7 @@ impl BuiltinMCPServer for AgentServer {
                 handlers::compact_session_context(self, args, &session_id).await
             }
             "stopSession" => handlers::stop_session(self, args, &session_id).await,
+            "deleteSession" => handlers::delete_session(self, args, &session_id).await,
             "createAssistant" => {
                 let assistant_server = self.legacy_assistant_server().await?;
                 crate::mcp::builtin::assistant::operations::create_assistant(

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -328,7 +328,7 @@ fn delete_session_tool() -> MCPTool {
     MCPTool {
         name: "deleteSession".to_string(),
         title: Some("Delete Agent Session".to_string()),
-        description: "Permanently delete a delegated child session and all its data. Self-deletion is not allowed. Only descendant sessions of the current session can be deleted via this tool.".to_string(),
+        description: "Permanently delete a delegated descendant session and all its data. Self-deletion is not allowed. Only descendant sessions of the current session can be deleted via this tool.".to_string(),
         input_schema: object_prop(
             vec![
                 ("sessionId".to_string(), string_prop_required("ID of the session to delete.")),

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -16,6 +16,7 @@ pub fn all_tools() -> Vec<MCPTool> {
         check_session_tool(),
         compact_session_context_tool(),
         stop_session_tool(),
+        delete_session_tool(),
     ]
 }
 
@@ -314,6 +315,23 @@ fn compact_session_context_tool() -> MCPTool {
                         Some("Maximum seconds to wait for the compaction to finish and return the new compact summary."),
                     ),
                 ),
+            ],
+            vec!["sessionId".to_string()],
+            None,
+        ),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+fn delete_session_tool() -> MCPTool {
+    MCPTool {
+        name: "deleteSession".to_string(),
+        title: Some("Delete Agent Session".to_string()),
+        description: "Permanently delete a delegated child session and all its data. Self-deletion is not allowed. Only descendant sessions of the current session can be deleted via this tool.".to_string(),
+        input_schema: object_prop(
+            vec![
+                ("sessionId".to_string(), string_prop_required("ID of the session to delete.")),
             ],
             vec!["sessionId".to_string()],
             None,

--- a/src-tauri/tests/integration/builtin_service_registry_tests.rs
+++ b/src-tauri/tests/integration/builtin_service_registry_tests.rs
@@ -659,6 +659,20 @@ fn message_to_session_tool_schema_supports_inline_waiting() {
 }
 
 #[test]
+fn delete_session_tool_schema_is_exposed() {
+    let delete_tool = agent_tools::all_tools()
+        .into_iter()
+        .find(|tool| tool.name == "deleteSession")
+        .expect("deleteSession tool must exist");
+    let props = extract_object_properties(&delete_tool.input_schema, "deleteSession");
+
+    assert!(
+        props.contains_key("sessionId"),
+        "deleteSession input_schema must include 'sessionId'"
+    );
+}
+
+#[test]
 fn tool_transport_schema_allows_env_and_header_maps() {
     let register_tool = tool_tools::register_server_tool();
     let props = extract_object_properties(&register_tool.input_schema, "register");


### PR DESCRIPTION
Add deleteSession builtin MCP tool with cascade deletion, lineage metadata cleanup, and defensive slicing for descendant session lists.