### PR TITLE
⚡ Bolt: Replace reduce with loop in summarizeLongTasks

### DIFF
--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -45,7 +46,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/performance/startup-metrics.ts
+++ b/src/lib/performance/startup-metrics.ts
@@ -99,18 +99,24 @@ function nowMs(): number {
 function summarizeLongTasks(
   longTasks: readonly StartupLongTaskEntry[],
 ): StartupLongTaskSummary {
-  return longTasks.reduce<StartupLongTaskSummary>(
-    (summary, task) => ({
-      count: summary.count + 1,
-      totalDurationMs: summary.totalDurationMs + task.durationMs,
-      maxDurationMs: Math.max(summary.maxDurationMs, task.durationMs),
-    }),
-    {
-      count: 0,
-      totalDurationMs: 0,
-      maxDurationMs: 0,
-    },
-  );
+  // ⚡ Bolt: Replace .reduce() with for-loop to avoid allocating a new object on every iteration
+  let count = 0;
+  let totalDurationMs = 0;
+  let maxDurationMs = 0;
+
+  for (const task of longTasks) {
+    count++;
+    totalDurationMs += task.durationMs;
+    if (task.durationMs > maxDurationMs) {
+      maxDurationMs = task.durationMs;
+    }
+  }
+
+  return {
+    count,
+    totalDurationMs,
+    maxDurationMs,
+  };
 }
 
 function summarizeIpcCalls(


### PR DESCRIPTION
## 💡 What
Replaced `.reduce()` with a single-pass `for...of` loop in `summarizeLongTasks`.

## 🎯 Why
The original `.reduce()` implementation allocated a new accumulator object on every single iteration. For arrays with many long tasks, this creates unnecessary garbage collection pressure during application startup, which is a critical phase.

## 📊 Impact
Eliminates O(N) object allocations during startup metric aggregation, replacing them with a single object allocation at the end of the loop, reducing GC overhead.

## 🔬 Measurement
Run the application startup sequence and profile memory allocations. The number of objects allocated during `summarizeLongTasks` execution will be reduced to 1.

---
*PR created automatically by Jules for task [5184622693508798203](https://jules.google.com/task/5184622693508798203) started by @fritzprix*