### PR TITLE
🪨 Rosetta: Localize SessionFilesPopover & Expand KO

### DIFF
--- a/src/components/shared/SessionFilesPopover.tsx
+++ b/src/components/shared/SessionFilesPopover.tsx
@@ -87,12 +87,18 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
             // However, let's keep the logic aligned with what the legacy tool did if possible.
             // Legacy tool seemed to handle a custom 'structuredContent' field in result.
             // Let's assume the Rust tool returns standard MCP content now.
-            content = 'File content format not supported for display.';
+            content = t(
+              'sessionFiles.formatNotSupported',
+              'File content format not supported for display.',
+            );
           } else {
-            content = 'File content not availble.';
+            content = t(
+              'sessionFiles.notAvailable',
+              'File content not available.',
+            );
           }
         } else {
-          content = 'File content not available';
+          content = t('sessionFiles.notAvailable', 'File content not available.');
         }
 
         // Refined logic based on expected Rust output for read

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -98,7 +98,9 @@
     "created": "Created:",
     "workspace": "Workspace:",
     "sessionId": "Session ID:",
-    "workspaceValue": "Workspace"
+    "workspaceValue": "Workspace",
+    "formatNotSupported": "File content format not supported for display.",
+    "notAvailable": "File content not available."
   },
   "fileAttachment": {
     "attachFiles": "Attach files",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -98,7 +98,9 @@
     "created": "생성:",
     "workspace": "워크스페이스:",
     "sessionId": "Session ID:",
-    "workspaceValue": "워크스페이스"
+    "workspaceValue": "워크스페이스",
+    "formatNotSupported": "표시할 수 없는 파일 내용 형식입니다.",
+    "notAvailable": "파일 내용을 사용할 수 없습니다."
   },
   "fileAttachment": {
     "attachFiles": "파일 첨부",


### PR DESCRIPTION
### 🌐 Scope
- `src/components/shared/SessionFilesPopover.tsx`

### 🔑 Keys Added
- `sessionFiles.formatNotSupported`
- `sessionFiles.notAvailable`

### 🌍 Languages
- `en.json`
- `ko.json`

### ⚠️ Visual QA
- Verified that longer text strings do not break Flex/Grid layouts.

---
*PR created automatically by Jules for task [1908401238276017054](https://jules.google.com/task/1908401238276017054) started by @fritzprix*