### PR TITLE
fix(session): ensure checkSession returns the final assistant answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.8.6] - 2026-06-06
 
+### 🚀 Features
+
+- **Terminal Wait Flows**: Fixed race conditions and stale terminal session results in `checkSession` and wait flows by awaiting the final database insert and providing an in-memory fallback for incomplete slices.
+
 ### 🐛 Fixes
 
 - **Telegram Skill Compatibility**: Fixed an `ImportError` on Telethon startup by removing unused error class imports and resolved a `TypeError` by calling `client.disconnect()` synchronously.

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -89,6 +89,23 @@ fn assistant_message_has_only_internal_ui_callback_tool_calls(message: &Message)
         .unwrap_or(false)
 }
 
+async fn persist_assistant_message_to_db(message: &Message) {
+    let repo = crate::state::get_message_repository();
+    if let Err(error) = repo.insert(message).await {
+        log::error!(
+            "Failed to save assistant message to DB: msg_id={}, error={}",
+            message.id,
+            error
+        );
+    }
+}
+
+fn spawn_persist_assistant_message_to_db(message: Message) {
+    tokio::spawn(async move {
+        persist_assistant_message_to_db(&message).await;
+    });
+}
+
 async fn cache_assistant_message(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     session_id: &str,
@@ -368,19 +385,7 @@ pub async fn handle_llm_response(
     crate::agent::tauri_events::emit_agent_event(app_handle, message_added_event)
         .map_err(|e| format!("Failed to emit MessageAdded event: {}", e))?;
 
-    // 3. Persist to DB asynchronously
     let msg_for_db = assistant_message.clone();
-
-    tokio::spawn(async move {
-        let repo = crate::state::get_message_repository();
-        if let Err(e) = repo.insert(&msg_for_db).await {
-            log::error!(
-                "Failed to save assistant message to DB: msg_id={}, error={}",
-                msg_for_db.id,
-                e
-            );
-        }
-    });
 
     // Parse tool calls
     // ⚡ Bolt: Use take() to move the vector out of the struct instead of cloning it, saving a deep copy.
@@ -393,6 +398,7 @@ pub async fn handle_llm_response(
         let has_pending = session_has_pending_events(active_sessions, &session_id).await;
 
         if has_pending {
+            spawn_persist_assistant_message_to_db(msg_for_db);
             log::info!(
                 "🔄 Pending messages detected for session {}. Continuing workflow.",
                 session_id
@@ -409,6 +415,9 @@ pub async fn handle_llm_response(
             .map(|_| ())
             .map_err(String::from);
         }
+
+        // Ensure the final assistant row is visible before waking terminal waiters.
+        persist_assistant_message_to_db(&msg_for_db).await;
 
         // No pending messages remain, so finish the workflow now.
         crate::agent::lifecycle::update_session_status(
@@ -429,6 +438,8 @@ pub async fn handle_llm_response(
 
         log::info!("Completed workflow for session: {}", session_id);
     } else {
+        spawn_persist_assistant_message_to_db(msg_for_db);
+
         // Tools found! Initiate execution
         log::info!(
             "Processing {} tool calls for session: {}",

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -2,14 +2,13 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
-use crate::mcp::builtin::session_api::formatting::{
-    latest_assistant_message_text, latest_tool_message_text,
-};
+use crate::mcp::builtin::session_api::formatting::latest_session_output;
 use crate::mcp::builtin::session_api::utils::{
-    build_agent_session_tool_data, build_agent_tool_data,
+    build_agent_session_tool_data, build_agent_tool_data, fetch_session_messages_for_result,
+    CHECK_SESSION_RESULT_MESSAGE_LIMIT,
 };
 use crate::mcp::types::{MCPContent, MCPResult};
-use crate::repositories::{message_repository::MessageRepository, SessionMetadata};
+use crate::repositories::SessionMetadata;
 
 fn read_optional_string(args: &Value, key: &str) -> Result<Option<String>, String> {
     match args.get(key) {
@@ -331,19 +330,6 @@ fn recovery_action_for_session(session_id: &str, status: &str, reason: &str) -> 
     })
 }
 
-fn latest_session_output(messages_value: &[Value]) -> String {
-    let (_, mut assistant_text) = latest_assistant_message_text(messages_value, None)
-        .unwrap_or(("none".to_string(), "No final answer yet.".to_string()));
-
-    if assistant_text == "[assistant message has no text content]" {
-        if let Some(tool_text) = latest_tool_message_text(messages_value) {
-            assistant_text = format!("[Tool Response Fallback]\n{}", tool_text);
-        }
-    }
-
-    assistant_text
-}
-
 pub fn build_paused_check_session_result_from_messages(
     session_id: &str,
     turn_count: usize,
@@ -487,16 +473,11 @@ async fn build_terminal_check_session_result(
     status: &str,
     turn_count: usize,
 ) -> Result<MCPResult, String> {
-    let repo = crate::state::get_message_repository();
-    let messages = repo
-        .get_messages_by_session(session_id, 5)
-        .await
-        .map_err(|e| format!("Failed to fetch session messages: {}", e))?;
-
-    let messages_value: Vec<Value> = messages
-        .into_iter()
-        .map(|m| serde_json::to_value(m).unwrap_or_default())
-        .collect();
+    let messages_value = fetch_session_messages_for_result(
+        session_id,
+        CHECK_SESSION_RESULT_MESSAGE_LIMIT,
+    )
+    .await?;
 
     Ok(build_terminal_check_session_result_from_messages(
         session_id,
@@ -510,16 +491,11 @@ async fn build_paused_check_session_result(
     session_id: &str,
     turn_count: usize,
 ) -> Result<MCPResult, String> {
-    let repo = crate::state::get_message_repository();
-    let messages = repo
-        .get_messages_by_session(session_id, 5)
-        .await
-        .map_err(|e| format!("Failed to fetch session messages: {}", e))?;
-
-    let messages_value: Vec<Value> = messages
-        .into_iter()
-        .map(|m| serde_json::to_value(m).unwrap_or_default())
-        .collect();
+    let messages_value = fetch_session_messages_for_result(
+        session_id,
+        CHECK_SESSION_RESULT_MESSAGE_LIMIT,
+    )
+    .await?;
 
     Ok(build_paused_check_session_result_from_messages(
         session_id,

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -473,11 +473,8 @@ async fn build_terminal_check_session_result(
     status: &str,
     turn_count: usize,
 ) -> Result<MCPResult, String> {
-    let messages_value = fetch_session_messages_for_result(
-        session_id,
-        CHECK_SESSION_RESULT_MESSAGE_LIMIT,
-    )
-    .await?;
+    let messages_value =
+        fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
 
     Ok(build_terminal_check_session_result_from_messages(
         session_id,
@@ -491,11 +488,8 @@ async fn build_paused_check_session_result(
     session_id: &str,
     turn_count: usize,
 ) -> Result<MCPResult, String> {
-    let messages_value = fetch_session_messages_for_result(
-        session_id,
-        CHECK_SESSION_RESULT_MESSAGE_LIMIT,
-    )
-    .await?;
+    let messages_value =
+        fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
 
     Ok(build_paused_check_session_result_from_messages(
         session_id,

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -224,7 +224,7 @@ fn message_to_session_tool() -> MCPTool {
                 (
                     "waitForResponse".to_string(),
                     {
-                        let mut schema = boolean_prop(Some("If true (default), block until the child reaches a terminal response after receiving this message."));
+                        let mut schema = boolean_prop(Some("If true, block until the child reaches a terminal response after receiving this message."));
                         schema.default = Some(json!(true));
                         schema
                     },

--- a/src-tauri/src/mcp/builtin/session_api/formatting.rs
+++ b/src-tauri/src/mcp/builtin/session_api/formatting.rs
@@ -253,7 +253,7 @@ pub fn latest_assistant_message_text(
             None => continue,
         };
 
-        for item in content {
+        for item in content.iter().rev() {
             let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
             if item_type != "text" {
                 continue;
@@ -284,11 +284,6 @@ pub fn latest_tool_message_text(messages: &[Value]) -> Option<String> {
     for message in messages {
         let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
 
-        // If we reach an assistant message, we've gone past the latest tool responses.
-        if role == "assistant" {
-            break;
-        }
-
         if role != "tool" {
             continue;
         }
@@ -308,6 +303,26 @@ pub fn latest_tool_message_text(messages: &[Value]) -> Option<String> {
         }
     }
     None
+}
+
+pub fn latest_session_output(messages: &[Value]) -> String {
+    let (_, mut assistant_text) = latest_assistant_message_text(messages, None)
+        .unwrap_or(("none".to_string(), "No final answer yet.".to_string()));
+
+    if assistant_text == "[assistant message has no text content]" {
+        if let Some(tool_text) = latest_tool_message_text(messages) {
+            assistant_text = format!("[Tool Response Fallback]\n{}", tool_text);
+        }
+    }
+
+    assistant_text
+}
+
+pub fn session_output_is_missing(output: &str) -> bool {
+    matches!(
+        output,
+        "No final answer yet." | "[assistant message has no text content]"
+    )
 }
 
 #[cfg(test)]
@@ -416,5 +431,43 @@ mod tests {
     fn terminal_status_error_is_terminal() {
         assert!(is_terminal_status("error"));
         assert!(is_terminal_status("failed"));
+    }
+
+    #[test]
+    fn latest_assistant_message_text_prefers_last_text_block_in_content() {
+        let messages = vec![json!({
+            "role": "assistant",
+            "id": "assistant-final",
+            "content": [
+                {"type": "text", "text": "Working on it..."},
+                {"type": "thinking", "thinking": "internal reasoning"},
+                {"type": "text", "text": "Final answer for the delegated task."}
+            ]
+        })];
+
+        let (message_id, text) = latest_assistant_message_text(&messages, None)
+            .expect("assistant text should be found");
+
+        assert_eq!(message_id, "assistant-final");
+        assert_eq!(text, "Final answer for the delegated task.");
+    }
+
+    #[test]
+    fn latest_tool_message_text_skips_leading_assistant_without_text() {
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": [{"type": "tool_call", "name": "workspace__readFile"}]
+            }),
+            json!({
+                "role": "tool",
+                "content": [{"type": "text", "text": "Structured tool output summary"}]
+            }),
+        ];
+
+        assert_eq!(
+            latest_tool_message_text(&messages).as_deref(),
+            Some("Structured tool output summary")
+        );
     }
 }

--- a/src-tauri/src/mcp/builtin/session_api/formatting.rs
+++ b/src-tauri/src/mcp/builtin/session_api/formatting.rs
@@ -445,8 +445,8 @@ mod tests {
             ]
         })];
 
-        let (message_id, text) = latest_assistant_message_text(&messages, None)
-            .expect("assistant text should be found");
+        let (message_id, text) =
+            latest_assistant_message_text(&messages, None).expect("assistant text should be found");
 
         assert_eq!(message_id, "assistant-final");
         assert_eq!(text, "Final answer for the delegated task.");

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -366,8 +366,9 @@ pub async fn fetch_session_messages_for_result(
 
     let mut messages_value: Vec<Value> = messages
         .into_iter()
-        .map(|message| serde_json::to_value(message).unwrap_or_default())
-        .collect();
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<Value>, serde_json::Error>>()
+        .map_err(|e| format!("Failed to serialize session messages: {}", e))?;
 
     let output = latest_session_output(&messages_value);
     if session_output_is_missing(&output) {

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
-use super::formatting::{extract_session_status, is_terminal_status, truncate_text};
+use super::formatting::{
+    extract_session_status, is_terminal_status, latest_session_output, session_output_is_missing,
+    truncate_text,
+};
 use super::types::MessageSummaryOptions;
 use crate::agent::AgentSessionManager;
 use crate::mcp::types::{MCPContent, MCPResult};
@@ -13,6 +16,7 @@ use crate::repositories::{MessageRepository, SessionRepository};
 
 pub const SWARM_CONTEXT_PREVIEW_LIMIT: usize = 20;
 pub const SWARM_MESSAGE_PREVIEW_MAX_CHARS: usize = 140;
+pub const CHECK_SESSION_RESULT_MESSAGE_LIMIT: u64 = 20;
 
 pub fn success_result<T: serde::Serialize>(text: String, data: T) -> MCPResult {
     MCPResult {
@@ -323,16 +327,61 @@ pub async fn fetch_session_value(
 }
 
 pub async fn fetch_messages_value(session_id: &str, limit: u64) -> Result<Value, String> {
+    let messages_value = fetch_session_messages_for_result(session_id, limit).await?;
+    Ok(json!({ "messages": messages_value }))
+}
+
+async fn fetch_cached_session_messages_newest_first(
+    session_id: &str,
+    limit: usize,
+) -> Option<Vec<Value>> {
+    let sessions = crate::state::try_get_active_sessions()?;
+    let active = sessions.read().await;
+    let session = active.get(session_id)?;
+    let cached_messages = session.messages.read().await;
+    if cached_messages.is_empty() {
+        return None;
+    }
+
+    let take = limit.min(cached_messages.len());
+    let newest_first = cached_messages
+        .iter()
+        .rev()
+        .take(take)
+        .filter_map(|message| serde_json::to_value(message).ok())
+        .collect::<Vec<_>>();
+
+    Some(newest_first)
+}
+
+pub async fn fetch_session_messages_for_result(
+    session_id: &str,
+    limit: u64,
+) -> Result<Vec<Value>, String> {
     let repo = crate::state::get_message_repository();
     let messages = repo
         .get_messages_by_session(session_id, limit)
         .await
         .map_err(|e| format!("Failed to fetch session messages: {}", e))?;
 
-    let messages_json = serde_json::to_value(messages)
-        .map_err(|e| format!("Failed to serialize session messages: {}", e))?;
+    let mut messages_value: Vec<Value> = messages
+        .into_iter()
+        .map(|message| serde_json::to_value(message).unwrap_or_default())
+        .collect();
 
-    Ok(json!({ "messages": messages_json }))
+    let output = latest_session_output(&messages_value);
+    if session_output_is_missing(&output) {
+        if let Some(cached) =
+            fetch_cached_session_messages_newest_first(session_id, limit as usize).await
+        {
+            let cached_output = latest_session_output(&cached);
+            if !session_output_is_missing(&cached_output) {
+                messages_value = cached;
+            }
+        }
+    }
+
+    Ok(messages_value)
 }
 
 /// Consolidates timeout handling for spawnAgent, awaitAgent, and checkSession.

--- a/src-tauri/src/mcp/builtin/workspace/dispatch.rs
+++ b/src-tauri/src/mcp/builtin/workspace/dispatch.rs
@@ -77,7 +77,6 @@ impl WorkspaceServer {
             "export" => self.handle_export(args, session_id).await,
 
             // ── Terminal / Process management tools ───────────────────────────
-            // ── Terminal / Process management tools ───────────────────────────
             "readProcessOutput" => {
                 self.handle_read_process_output(args, &target_session_id)
                     .await

--- a/src-tauri/tests/integration/check_session_terminal_result_tests.rs
+++ b/src-tauri/tests/integration/check_session_terminal_result_tests.rs
@@ -99,6 +99,33 @@ fn terminal_check_session_result_includes_final_answer_without_waiting() {
 }
 
 #[test]
+fn terminal_check_session_result_uses_last_text_block_in_assistant_content() {
+    let result = build_terminal_check_session_result_from_messages(
+        "session-terminal-multi-text",
+        "idle",
+        2,
+        &[json!({
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Working on it..."},
+                {"type": "thinking", "thinking": "internal reasoning"},
+                {"type": "text", "text": "All subtasks completed successfully."}
+            ]
+        })],
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+
+    assert_eq!(
+        structured.get("result").and_then(|value| value.as_str()),
+        Some("All subtasks completed successfully.")
+    );
+}
+
+#[test]
 fn terminal_check_session_result_falls_back_to_tool_text_when_assistant_has_no_text() {
     let result = build_terminal_check_session_result_from_messages(
         "session-terminal-456",

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.6_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64-setup.exe) · [`LibrAgent_0.8.6_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.6_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.6_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.AppImage) · [`LibrAgent_0.8.6_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent_0.8.6_amd64.deb) · [`LibrAgent-0.8.6-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.6/LibrAgent-0.8.6-1.x86_64.rpm)


### PR DESCRIPTION
## Description

`checkSession`, `startSession(waitForResult=true)`, and `messageToSession(waitForResponse=true)` could return stale or empty results even after a child session reached `idle`.

This PR fixes three related issues:

1. **Race condition** — final assistant messages were persisted via `tokio::spawn` while `Idle` was set immediately afterward, so terminal waiters could read the DB before the final row existed.
2. **Text extraction** — `latest_assistant_message_text` returned the first text block in assistant `content` instead of the last one (e.g. `[text, thinking, text]`).
3. **Tool fallback** — `latest_tool_message_text` stopped at the first assistant message and skipped newer tool output above it in newest-first slices.

Changes:

- Await final assistant DB insert before marking sessions `Idle` on natural completion.
- Add in-memory cache fallback when DB slices are missing the final answer.
- Increase `checkSession` result message limit from 5 to 20.
- Centralize terminal result fetching in `fetch_session_messages_for_result`.

Fixes # (issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (changes to README, docs/, or docstrings)

## Testing Performed

- [ ] Tested locally with `pnpm tauri dev`
- [ ] All automated tests pass (`pnpm test:run`)
- [x] Rust tests pass (`cd src-tauri && cargo test`)
  - `cargo test formatting::tests::latest_`
  - `cargo test terminal_check_session_result`

## Checklist:

- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have run `pnpm refactor:validate` and all checks pass without errors.


Made with [Cursor](https://cursor.com)