### PR TITLE
⚡ Bolt: Replace map/filter chains in AppSidebar with loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-06-07 - Refactoring .map/.filter in AppSidebar to standard loops
+**Learning:** React component useMemos with multiple array method chains (`.map`, `.filter`, `.forEach`) create intermediate array allocations on every recalculation.
+**Action:** Replace `Array.prototype.map` and `Array.prototype.filter` chains with standard `for` loops in components with frequent re-renders or large object collections to minimize GC pressure and improve render performance.

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,19 +1,11 @@
-### 💡 What
+💡 What
+Replaced `.map()` and `.filter().forEach()` array method chains with standard `for` loops inside the `recentSessions` useMemo hook in `src/components/layout/AppSidebar.tsx`.
 
-- Added `limit` and `offset` schema parameters to the builtin `tool__list` discovery tool in the `tool` server.
-- Mapped the raw JSON list response to a dense, paginated Markdown table.
-- Sanitized descriptions by escaping pipe characters and replacing newlines.
+🎯 Why
+React component useMemos containing multiple array method chains create intermediate array allocations on every recalculation. By utilizing standard `for` loops, we eliminate the unnecessary allocations of temporary arrays, reducing garbage collection pressure during UI updates in the Sidebar.
 
-### 🎯 Why
+📊 Impact
+Slight reduction in memory allocation and GC overhead during AppSidebar re-renders.
 
-- Resolves context window bloat when returning hundreds of cached tools from builtin or external servers.
-- Improves LLM readability by presenting tool properties (Source, Server, Tool, Status, Description) in an aligned table layout instead of a sprawling hierarchical list.
-
-### 📉 Token Impact
-
-- Output token usage scales linearly with `limit` (default: 50 rows) instead of growing uncontrollably with the user's inventory size.
-- Dense table formatting eliminates redundant structural prefixes and whitespace from previous list representations, compressing the payload per tool row.
-
-### 🛠️ Error Recovery
-
-- Includes actionable pagination hints at the bottom of the table, explicitly directing the LLM to call `tool__list` again with `offset` to fetch the next block of results if more tools exist.
+🔬 Measurement
+Verified via `pnpm test run` and linting to ensure functionality is preserved.

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -92,9 +92,14 @@ export default function AppSidebar() {
     };
 
     const sortedSessions = [...sessions].sort(sortByPriority);
-    const sessionById = new Map(
-      sortedSessions.map((session) => [session.id, session]),
-    );
+
+    // ⚡ Bolt: Replaced .map() with a single-pass loop to avoid intermediate array allocation
+    const sessionById = new Map<string, (typeof sessions)[number]>();
+    for (let i = 0; i < sortedSessions.length; i++) {
+      const session = sortedSessions[i];
+      sessionById.set(session.id, session);
+    }
+
     const childrenByParent = buildChildrenMap(sortedSessions);
     const rows: Array<{
       session: (typeof sessions)[number];
@@ -114,23 +119,25 @@ export default function AppSidebar() {
       rows.push({ session, nestingLevel });
 
       const children = childrenByParent.get(session.id) || [];
-      children.forEach((child) => {
-        pushSession(child, Math.min(nestingLevel + 1, 2));
-      });
+      // ⚡ Bolt: Replaced .forEach() with a loop for slight performance gain
+      for (let i = 0; i < children.length; i++) {
+        pushSession(children[i], Math.min(nestingLevel + 1, 2));
+      }
     };
 
-    sortedSessions
-      .filter(
-        (session) =>
-          !session.parentSessionId || !sessionById.has(session.parentSessionId),
-      )
-      .forEach((root) => {
-        pushSession(root, 0);
-      });
+    // ⚡ Bolt: Replaced .filter().forEach() chain with a single-pass loop to eliminate array allocation
+    for (let i = 0; i < sortedSessions.length; i++) {
+      const session = sortedSessions[i];
+      if (!session.parentSessionId || !sessionById.has(session.parentSessionId)) {
+        pushSession(session, 0);
+      }
+    }
 
-    sortedSessions.forEach((session) => {
+    // ⚡ Bolt: Replaced .forEach() with a loop
+    for (let i = 0; i < sortedSessions.length; i++) {
+      const session = sortedSessions[i];
       pushSession(session, session.parentSessionId ? 1 : 0);
-    });
+    }
 
     return rows;
   }, [sessions]);

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -128,7 +128,10 @@ export default function AppSidebar() {
     // ⚡ Bolt: Replaced .filter().forEach() chain with a single-pass loop to eliminate array allocation
     for (let i = 0; i < sortedSessions.length; i++) {
       const session = sortedSessions[i];
-      if (!session.parentSessionId || !sessionById.has(session.parentSessionId)) {
+      if (
+        !session.parentSessionId ||
+        !sessionById.has(session.parentSessionId)
+      ) {
         pushSession(session, 0);
       }
     }


### PR DESCRIPTION
💡 What
Replaced `.map()` and `.filter().forEach()` array method chains with standard `for` loops inside the `recentSessions` useMemo hook in `src/components/layout/AppSidebar.tsx`.

🎯 Why
React component useMemos containing multiple array method chains create intermediate array allocations on every recalculation. By utilizing standard `for` loops, we eliminate the unnecessary allocations of temporary arrays, reducing garbage collection pressure during UI updates in the Sidebar.

📊 Impact
Slight reduction in memory allocation and GC overhead during AppSidebar re-renders.

🔬 Measurement
Verified via `pnpm test run` and linting to ensure functionality is preserved.

---
*PR created automatically by Jules for task [11642883480775518277](https://jules.google.com/task/11642883480775518277) started by @fritzprix*