### PR TITLE
feat(scheduler): session callback UI and cascade cleanup

### DIFF
--- a/src-tauri/bundled_skills/delegate/SKILL.md
+++ b/src-tauri/bundled_skills/delegate/SKILL.md
@@ -54,7 +54,8 @@ Assume these rules:
 If the parent is running inside a task-force workspace, check `.libragent/teamwork.json` before delegating:
 
 - If `executionSubstrate.mode` is `"org"`, prefer `startSession(..., includeCurrentOrg=true)` so the child joins the org and inherits the parent effective workspace by default. Switch to `org` for org-specific operating rules.
-- If `executionSubstrate.mode` is `"scheduled"`, the delegation is likely a scheduled wake-up. Follow `schedule` for group management instead of ad-hoc delegation.
+- If `executionSubstrate.mode` is `"scheduled"`, the wake-up is likely a global scheduled task group. Follow `schedule` for group management instead of ad-hoc delegation.
+- If the user wants a future reminder inside the current session, use `session-schedule` instead of delegation.
 - Treat the app-local teamwork artifact directory as the orchestration/constitution storage. If the child also needs to edit code in a repo, keep the session workspace semantics separate from the teamwork artifact path.
 
 Important limitations:

--- a/src-tauri/bundled_skills/org/SKILL.md
+++ b/src-tauri/bundled_skills/org/SKILL.md
@@ -13,7 +13,8 @@ Use `teamwork` first when the workspace constitution is not ready.
 
 1. Confirm org is the right substrate.
    - Use org when the user wants org visibility, durable org identity, coordinator/specialist lineage, or root-session resume behavior.
-   - If the real need is recurring or cron-like automation, stop and use `schedule`.
+   - If the real need is app-wide recurring or cron-like automation, stop and use `schedule`.
+   - If the user only wants a delay or follow-up inside the current conversation, stop and use `session-schedule`.
    - If the governing root session has not prepared the teamwork artifact directory yet, stop and use `teamwork` to call `prepareTeamworkWorkspace()` first.
 2. Read `.libragent/teamwork.json` before acting.
    - Confirm `executionSubstrate.mode` is `"org"` and `orgLineage.intended` is `true`.

--- a/src-tauri/bundled_skills/schedule/SKILL.md
+++ b/src-tauri/bundled_skills/schedule/SKILL.md
@@ -1,52 +1,98 @@
 ---
 name: schedule
-description: Run scheduled-task-group teamwork in LibrAgent. Use when collaboration needs recurring, cron-like, heartbeat, or resumable background automation across a shared workspace using grouped scheduled tasks under backend-governed policy.
+description: Create and manage global scheduled tasks in LibrAgent (single or grouped, cron-based). Use when automation should outlive the current session, wake a specific assistant on a cron, or run recurring background work app-wide. For one-shot delays or session-bound recurrence inside the active conversation, use session-schedule instead.
 ---
 
 # Schedule
 
-Scheduled collaboration is grouped automation. It is not org identity.
+Global scheduled tasks wake an assistant later without requiring the current session to stay open. They are not org identity and they are not session-bound follow-ups.
 
-Use `teamwork` first when the workspace constitution is not ready.
+## When to use this skill
+
+Use `schedule` when:
+
+- the work should continue after the current session ends or is closed
+- the user wants app-wide recurring automation (daily digest, weekly report, heartbeat)
+- a specific assistant must run on a cron, with or without a task group
+- teamwork chose the `scheduled` execution substrate and needs grouped automation loops
+
+Stop and use `session-schedule` when:
+
+- the user wants a delay or reminder inside **this conversation** ("check back in 5 minutes", "continue tomorrow morning in this thread")
+- the injected message must resume the **current** session context
+
+Stop and use `org` when the real need is org-visible lineage, not cron automation.
+
+Stop and use `teamwork` first only when you are setting up a multi-agent workspace constitution and have not scaffolded it yet.
+
+## Routing decision
+
+```text
+Should the run stay bound to the current session?
+  Yes -> session-schedule (scheduleCallback)
+  No  -> schedule (createScheduledTask)
+```
+
+Recurring vs one-shot is **not** the primary split. Global tasks require cron. Session-bound one-shots use `session-schedule`.
 
 ## Workflow
 
-1. Confirm scheduled collaboration is the right substrate.
-   - Use it for periodic wake-ups, background recurrence, heartbeat loops, or resumable async automation.
-   - If the user wants org-visible lineage or org-root resume behavior, stop and use `org`.
-   - If the governing root session has not prepared the teamwork artifact directory yet, stop and use `teamwork` to call `prepareTeamworkWorkspace()` first.
-2. Read `.libragent/teamwork.json` before acting.
-   - Confirm `executionSubstrate.mode` is `"scheduled"` and `scheduledTaskGroups.intended` is `true`.
-   - If no manifest exists yet, run `teamwork` first to scaffold the workspace constitution.
-3. Check whether the workspace scaffold exists.
-   - If `agents.md`, `MISSION.md`, or `coordination/KANBAN.md` are missing, repair the scaffold before creating scheduled tasks.
-   - A master agent woken by a scheduled task must verify the scaffold is present and current before issuing directives.
-4. Reuse the existing workspace constitution.
-   - Treat the app-local teamwork artifact scaffold as the SSOT.
-   - Scheduled runs should keep the session's intended effective workspace unless a task explicitly targets a different implementation workspace.
-5. Create the task group explicitly.
-   - Use `createScheduledTask(message, cronExpression, groupName, agentId)` for the first loop in a new group.
-   - The `groupName` must be stable, readable, and unique within the team. Record it in `coordination/DECISIONS.md`.
-   - Use `createScheduledTask(message, cronExpression, groupName, agentId, groupId)` to add subsequent tasks to the same group.
-   - Record the returned `groupId` in `.libragent/teamwork.json` under `scheduledTaskGroups.groupId` so it is available across sessions.
-6. Operate the group deliberately.
-   - Use `listScheduledTasks()` or `getScheduledTask(taskId)` to inspect the current group.
-   - Use `updateScheduledTask(taskId, ...)` to retune cadence, message, or grouping.
-   - Use `toggleScheduledTask(taskId)` to pause or resume.
-   - Use `deleteScheduledTask(taskId)` to remove stale automation.
-7. Respect governance limits.
-   - Backend policy enforces a maximum number of scheduled task groups and a minimum interval between runs.
-   - Do not assume unlimited groups or unlimited frequency. Check the current policy before creating new groups.
-   - If policy limits are reached, consolidate existing groups or request a limit increase through Settings.
-8. Keep identity clean.
-   - A scheduled task may wake the coordinator, but the group is still not an org.
-   - Group membership is scheduled-task metadata, not lineage identity.
+### 1. Confirm global scheduling is appropriate
+
+- Use global tasks for cron-based wake-ups, background recurrence, heartbeat loops, or assistant-level automation.
+- Single tasks are normal. Groups are optional.
+- Do not require teamwork scaffolding for a standalone global task.
+
+### 2. Create the task
+
+**Single global task (default path):**
+
+- Use `createScheduledTask(name, cronExpression, assistantId, message)`.
+- Optional: `scheduleTimezone`, `yoloMode`, `workspaceOverride`.
+- The tool returns a task ID. Keep it for follow-up calls.
+
+**Grouped automation (teamwork / scheduled substrate only):**
+
+- Use when multiple related loops should be managed together under backend group policy.
+- First task in a group: `createScheduledTask(..., groupName="...")`.
+- Additional tasks in the same group: pass the returned `groupId`.
+- If `.libragent/teamwork.json` exists with `executionSubstrate.mode = "scheduled"`, record `groupId` there for cross-session visibility.
+- If no teamwork manifest exists, groups still work; manifest recording is optional convenience, not a prerequisite.
+
+### 3. Operate tasks deliberately
+
+- `listScheduledTasks()` — discover task IDs and enabled state
+- `getScheduledTask(taskId)` — read message, cron, group, and pinned session state
+- `updateScheduledTask(taskId, ...)` — retune cadence, message, grouping, or workspace
+- `toggleScheduledTask(taskId, enabled=...)` — pause or resume
+- `deleteScheduledTask(taskId)` — remove stale automation
+
+### 4. Respect governance limits
+
+- Backend policy enforces a maximum number of scheduled task groups and a minimum interval between runs.
+- Do not assume unlimited groups or unlimited frequency.
+- If policy limits are reached, consolidate existing groups or request a limit increase through Settings.
+
+### 5. Keep identity clean
+
+- A scheduled task may wake a coordinator, but a task group is still not an org.
+- Group membership is scheduled-task metadata, not lineage identity.
+
+## Teamwork integration (optional)
+
+When the workspace already uses the scheduled teamwork substrate:
+
+1. Read `.libragent/teamwork.json` if present.
+2. Confirm `executionSubstrate.mode` is `"scheduled"` when the user expects grouped collaboration automation.
+3. Ensure teamwork scaffold files (`agents.md`, `MISSION.md`, coordination files) are current before a scheduled coordinator wakes up.
+4. Treat the app-local teamwork artifact directory as orchestration SSOT; use `workspaceOverride` only when a run must target a different implementation workspace.
+
+If the user only wants one global cron job with no multi-agent constitution, skip teamwork entirely.
 
 ## Guardrails
 
-- Default to the app-local teamwork artifact scaffold; do not fall back to a repo root just because work is asynchronous.
-- Use `workspaceOverride` only when the scheduled run must target a specific existing shared workspace.
-- Keep group names stable and readable. Changing a `groupName` mid-run makes group tracking unreliable.
-- Always record `groupId` in `.libragent/teamwork.json` after the first task in a group is created.
-- Backend policy limits still apply. Do not assume unlimited groups or unlimited frequency.
+- Do not use global scheduled tasks for simple in-session delays; use `session-schedule`.
 - Do not use scheduled task groups as a substitute for org identity.
+- Keep `groupName` stable when using groups. Renaming mid-run makes tracking unreliable.
+- Use `workspaceOverride` only when the scheduled run must target a specific existing workspace.
+- Backend policy limits still apply. Do not assume unlimited groups or unlimited frequency.

--- a/src-tauri/bundled_skills/session-schedule/SKILL.md
+++ b/src-tauri/bundled_skills/session-schedule/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: session-schedule
+description: Schedule one-shot delays or recurring runs bound to the current agent session in LibrAgent. Use delaySeconds for a single future injection, cronExpression for session-scoped recurrence, or when the user asks to continue, remind, or follow up later in this conversation. Does not require teamwork or task groups. For app-wide automation that outlives the session, use schedule instead.
+---
+
+# Session Schedule
+
+Session schedules inject a message into **the current session** at a future time. They survive tab switches and app restarts, but they are tied to this session's lifecycle.
+
+The MCP tool is `scheduleCallback`. The skill name is `session-schedule`.
+
+## When to use this skill
+
+Use `session-schedule` when:
+
+- the user wants to continue **this conversation** later ("check in 5 minutes", "resume tomorrow morning here")
+- a reminder or follow-up must reuse the current session context and history
+- the user schedules multiple callbacks in the same thread (N:1 on one session)
+- recurrence should stay inside the current session (hourly summary of **this** thread)
+
+Stop and use `schedule` when:
+
+- automation should outlive the session or target a different assistant explicitly
+- the user wants app-wide cron jobs visible in Scheduled Tasks settings
+- teamwork needs grouped global automation loops with `groupName` / `groupId`
+
+Teamwork scaffolding is **not** required.
+
+## Routing decision
+
+```text
+Should the run stay bound to the current session?
+  Yes -> session-schedule (scheduleCallback)
+  No  -> schedule (createScheduledTask)
+```
+
+Both one-shot and recurring schedules are supported here. Pick the timing mode, not a different skill.
+
+## Workflow
+
+### 1. Choose timing mode
+
+Provide **exactly one** of:
+
+- **`delaySeconds`** — one-shot delay (1–86400 seconds). Example: 300 for "check back in 5 minutes".
+- **`cronExpression`** — recurring session schedule. Example: `0 9 * * *` for every day at 09:00 local time.
+
+Do not pass both. Do not pass neither.
+
+### 2. Create the schedule
+
+```text
+scheduleCallback(
+  message="...",
+  name="...",              // optional label for Planning panel / lists
+  delaySeconds=300         // OR cronExpression="0 9 * * *"
+)
+```
+
+Requirements:
+
+- Must run from an **active session**. The tool binds to the current session automatically.
+- `message` is injected when the schedule fires. Make it self-contained enough for the agent to act without guessing.
+- `assistantId` is not required; the backend resolves it from the current session.
+
+### 3. Manage existing session schedules
+
+After creation, use the returned task ID:
+
+- `getScheduledTask(taskId)` — inspect timing, message, and enabled state
+- `toggleScheduledTask(taskId, enabled=false)` — cancel or pause before it fires
+- `deleteScheduledTask(taskId)` — remove it entirely
+
+The user can also cancel from the session Planning panel Schedules section.
+
+### 4. Set expectations honestly
+
+- One-shot schedules disable themselves after firing.
+- If the session is deleted, session schedules are invalidated; they do not create a replacement session.
+- Recurring session schedules keep firing until paused, deleted, or the session is removed.
+- Injected messages appear in the chat stream when the schedule fires.
+
+## Guardrails
+
+- Do not use `createScheduledTask` for in-session delays; it creates global tasks and requires `assistantId` plus cron.
+- Do not use `groupName` or `groupId`; session schedules do not support groups.
+- Do not require `.libragent/teamwork.json` or teamwork scaffold files.
+- Prefer `delaySeconds` for relative delays; use cron when the user names a wall-clock recurrence.
+- When scheduling multiple callbacks, give each a distinct `name` when possible so the Planning panel stays readable.
+
+## Related skills
+
+- **`schedule`** — global cron tasks, optional groups, survives beyond the current session
+- **`delegate`** — spawn a child session now, not a future injection into this one
+- **`teamwork`** — only when building multi-agent workspace constitution; not needed for simple session schedules

--- a/src-tauri/bundled_skills/teamwork/SKILL.md
+++ b/src-tauri/bundled_skills/teamwork/SKILL.md
@@ -68,12 +68,14 @@ Pick the execution substrate that matches the job:
 - **Plain child sessions** - use `startSession(...)` for one-off delegation that does not need org visibility.
 - **Explicit org lineage** - call `prepareTeamworkWorkspace()` first, then use `createOrg(...)` once from the root session, then use `startSession(...)` for org-visible children. Under the explicit org root, org inheritance is automatic unless you set `includeCurrentOrg=false`. Org-visible children inherit the governing session's effective workspace by default.
 - **Scheduled task groups** - use `createScheduledTask(...)` and the other `scheduled_task` tools for recurring, heartbeat, cron-like, or resumable automation loops.
+- **Session-bound follow-ups** - use `session-schedule` with `scheduleCallback(...)` when a delay or reminder must stay inside the current conversation. This does not require teamwork scaffolding.
 
 Keep these separate:
 
 - **Org** is for explicit lineage-based teamwork and org UX.
 - **Org** keeps the normal parent workspace semantics; only the teamwork artifacts move out of the repo/workspace.
-- **Scheduled task groups** are for recurring automation and policy-governed background collaboration.
+- **Scheduled task groups** are for global recurring automation and policy-governed background collaboration.
+- **Session schedules** are for in-conversation delays and session-scoped recurrence, not teamwork groups.
 - A recurring task group may wake a coordinator session, but that does not make the scheduled group an org.
 
 ### 2.6 Route to the specialist skill
@@ -82,7 +84,8 @@ After choosing the execution substrate, route to the matching specialist skill:
 
 - **Plain child sessions** - stay here and use `delegate` when child-session mechanics matter.
 - **Explicit org lineage** - switch to `org`.
-- **Scheduled task groups** - switch to `schedule`.
+- **Global scheduled tasks or groups** - switch to `schedule`.
+- **In-session delays or session-bound recurrence** - switch to `session-schedule`.
 
 `teamwork` decides and scaffolds. The specialist skill handles the execution-specific operating rules.
 
@@ -146,7 +149,9 @@ Shared files are the coordination contract. Keep the loop explicit.
 
 ### 6. Handle persistence honestly
 
-If recurring execution is needed, switch to `schedule` and define the loops explicitly with the `scheduled_task` builtin tools. Use `createScheduledTask(...)` to create the first grouped loop with a clear `groupName`, then use `groupId` plus the other scheduled-task tools to extend, inspect, pause, or retune the group.
+If global recurring execution is needed, switch to `schedule` and define the loops with the `scheduled_task` builtin tools. Use `createScheduledTask(...)` for a single global task, or add `groupName` / `groupId` when grouped automation is intentional.
+
+If the user only wants a delay or reminder inside the current conversation, switch to `session-schedule` instead. That path uses `scheduleCallback(...)` and does not require teamwork scaffolding.
 
 Refresh behavior:
 

--- a/src-tauri/bundled_skills/teamwork/references/framework-selection.md
+++ b/src-tauri/bundled_skills/teamwork/references/framework-selection.md
@@ -60,6 +60,7 @@ After choosing the coordination model, choose the execution substrate explicitly
 | One-off specialist delegation | `startSession(...)` | `delegate` | Lightweight child session without org coupling |
 | Org-visible lineage under a governing teamwork session | `prepareTeamworkWorkspace()`, then `createOrg(...)`, then `startSession(..., includeCurrentOrg=true)` | `org` | Preserves explicit org membership, Org view semantics, and parent-workspace inheritance while keeping teamwork artifacts in app-local storage |
 | Recurring, cron, heartbeat, or resumable automation | Scheduled task groups via `createScheduledTask(...)` and related `scheduled_task` tools | `schedule` | Keeps recurring collaboration separate from org lineage and under policy control |
+| Delay or recurrence inside the current conversation | `scheduleCallback(...)` | `session-schedule` | Session-bound follow-ups without teamwork scaffolding or global task groups |
 
 ## Hard separation rules
 
@@ -70,3 +71,4 @@ After choosing the coordination model, choose the execution substrate explicitly
 - Do not keep execution-specific org and scheduled-task operating rules mixed together once the substrate is chosen. Route to the specialist skill.
 - If the user wants an org chart, root-session resume, or explicit lineage visibility, choose explicit org lineage.
 - If the user wants periodic wake-ups, background recurrence, or governed automation cohorts, choose scheduled task groups.
+- If the user wants a reminder or delay inside the current conversation, choose `session-schedule` instead of global scheduled tasks.

--- a/src-tauri/src/commands/scheduled_task_commands.rs
+++ b/src-tauri/src/commands/scheduled_task_commands.rs
@@ -3,7 +3,7 @@
 use crate::entity::scheduled_task::Model as ScheduledTaskModel;
 use crate::repositories::UpdateScheduledTaskParams;
 use crate::scheduled::runner::compute_next_run_for_schedule_timezone;
-use crate::scheduled::TASK_CATEGORY_GLOBAL;
+use crate::scheduled::{is_one_shot_task, TASK_CATEGORY_GLOBAL};
 use crate::services::{default_schedule_timezone, CreateScheduledTaskInput, ScheduledTaskService};
 use crate::state::get_scheduled_task_repository;
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,29 @@ pub struct ScheduledTaskDto {
     pub next_run_at: Option<i64>,
     pub created_at: i64,
     pub updated_at: i64,
+}
+
+/// Session callback shown in the active session planning panel
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduledTaskDto {
+    pub id: String,
+    pub name: String,
+    pub message: String,
+    pub is_one_shot: bool,
+    pub next_run_at: Option<i64>,
+}
+
+impl From<ScheduledTaskModel> for SessionScheduledTaskDto {
+    fn from(m: ScheduledTaskModel) -> Self {
+        Self {
+            id: m.id,
+            name: m.name,
+            message: m.message,
+            is_one_shot: is_one_shot_task(&m.cron_expression),
+            next_run_at: m.next_run_at,
+        }
+    }
 }
 
 impl From<ScheduledTaskModel> for ScheduledTaskDto {
@@ -211,4 +234,33 @@ pub async fn toggle_scheduled_task(id: String, enabled: bool) -> Result<Schedule
 #[command]
 pub async fn delete_scheduled_task(id: String) -> Result<(), String> {
     ScheduledTaskService::delete_scheduled_task(get_scheduled_task_repository(), &id).await
+}
+
+/// List SESSION callbacks pinned to an active session
+#[command]
+pub async fn list_session_scheduled_tasks(
+    session_id: String,
+) -> Result<Vec<SessionScheduledTaskDto>, String> {
+    ScheduledTaskService::list_session_scheduled_tasks(get_scheduled_task_repository(), &session_id)
+        .await
+        .map(|tasks| {
+            tasks
+                .into_iter()
+                .map(SessionScheduledTaskDto::from)
+                .collect()
+        })
+}
+
+/// Cancel a SESSION callback from the active session panel
+#[command]
+pub async fn cancel_session_scheduled_task(
+    session_id: String,
+    task_id: String,
+) -> Result<(), String> {
+    ScheduledTaskService::cancel_session_scheduled_task(
+        get_scheduled_task_repository(),
+        &session_id,
+        &task_id,
+    )
+    .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,8 +83,9 @@ use commands::playbook_commands::{
     update_playbook,
 };
 use commands::scheduled_task_commands::{
-    create_scheduled_task, delete_scheduled_task, get_scheduled_task, list_scheduled_tasks,
-    toggle_scheduled_task, update_scheduled_task,
+    cancel_session_scheduled_task, create_scheduled_task, delete_scheduled_task,
+    get_scheduled_task, list_scheduled_tasks, list_session_scheduled_tasks, toggle_scheduled_task,
+    update_scheduled_task,
 };
 use commands::session_commands::remove_session;
 use commands::settings_commands::{
@@ -308,6 +309,8 @@ pub fn run() {
                 update_scheduled_task,
                 toggle_scheduled_task,
                 delete_scheduled_task,
+                list_session_scheduled_tasks,
+                cancel_session_scheduled_task,
                 set_setting,
                 update_settings,
                 get_setting,

--- a/src-tauri/src/repositories/scheduled_task_repository.rs
+++ b/src-tauri/src/repositories/scheduled_task_repository.rs
@@ -4,6 +4,7 @@
 //! `@skill:name`) which is expanded at execution time by `resolve_message_references`.
 
 use crate::entity::scheduled_task::{self, Entity as ScheduledTaskEntity};
+use crate::scheduled::TASK_CATEGORY_SESSION;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel,
     QueryFilter, QueryOrder, Set,
@@ -82,6 +83,18 @@ pub trait ScheduledTaskRepository: Send + Sync {
 
     /// Delete a scheduled task
     async fn delete_scheduled_task(&self, id: &str) -> Result<(), DbErr>;
+
+    /// List enabled SESSION callbacks pinned to a session.
+    ///
+    /// Disabled rows (completed one-shots, runner orphan handling, user cancel) are omitted
+    /// because the session panel only surfaces active pending callbacks.
+    async fn list_session_scheduled_tasks(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<scheduled_task::Model>, DbErr>;
+
+    /// Delete SESSION callbacks pinned to any of the given session IDs
+    async fn delete_session_scheduled_tasks(&self, session_ids: &[&str]) -> Result<u64, DbErr>;
 }
 
 // ─── SQLite implementation ───────────────────────────────────────────────────
@@ -238,5 +251,34 @@ impl ScheduledTaskRepository for SqliteScheduledTaskRepository {
     async fn delete_scheduled_task(&self, id: &str) -> Result<(), DbErr> {
         ScheduledTaskEntity::delete_by_id(id).exec(&self.db).await?;
         Ok(())
+    }
+
+    async fn list_session_scheduled_tasks(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<scheduled_task::Model>, DbErr> {
+        ScheduledTaskEntity::find()
+            .filter(scheduled_task::Column::TaskCategory.eq(TASK_CATEGORY_SESSION))
+            .filter(scheduled_task::Column::SessionId.eq(session_id))
+            .filter(scheduled_task::Column::Enabled.eq(true))
+            .order_by_asc(scheduled_task::Column::NextRunAt)
+            .order_by_asc(scheduled_task::Column::CreatedAt)
+            .order_by_asc(scheduled_task::Column::Id)
+            .all(&self.db)
+            .await
+    }
+
+    async fn delete_session_scheduled_tasks(&self, session_ids: &[&str]) -> Result<u64, DbErr> {
+        if session_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let result = ScheduledTaskEntity::delete_many()
+            .filter(scheduled_task::Column::TaskCategory.eq(TASK_CATEGORY_SESSION))
+            .filter(scheduled_task::Column::SessionId.is_in(session_ids.iter().copied()))
+            .exec(&self.db)
+            .await?;
+
+        Ok(result.rows_affected)
     }
 }

--- a/src-tauri/src/services/scheduled_task_service.rs
+++ b/src-tauri/src/services/scheduled_task_service.rs
@@ -304,6 +304,55 @@ impl ScheduledTaskService {
             .await
             .map_err(|e| e.to_string())
     }
+
+    pub async fn list_session_scheduled_tasks(
+        repo: &dyn ScheduledTaskRepository,
+        session_id: &str,
+    ) -> Result<Vec<ScheduledTaskModel>, String> {
+        repo.list_session_scheduled_tasks(session_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn cancel_session_scheduled_task(
+        repo: &dyn ScheduledTaskRepository,
+        session_id: &str,
+        task_id: &str,
+    ) -> Result<(), String> {
+        let task = repo
+            .get_scheduled_task(task_id)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("ScheduledTask {task_id} not found"))?;
+
+        if !is_session_task(&task.task_category) {
+            return Err(
+                "Only session callbacks can be cancelled from the session panel".to_string(),
+            );
+        }
+
+        if task.session_id.as_deref() != Some(session_id) {
+            return Err("Session callback does not belong to this session".to_string());
+        }
+
+        repo.delete_scheduled_task(task_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn delete_session_scheduled_tasks_for_sessions(
+        repo: &dyn ScheduledTaskRepository,
+        session_ids: &[String],
+    ) -> Result<u64, String> {
+        if session_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let ids: Vec<&str> = session_ids.iter().map(String::as_str).collect();
+        repo.delete_session_scheduled_tasks(&ids)
+            .await
+            .map_err(|e| e.to_string())
+    }
 }
 
 fn normalize_schedule_timezone(schedule_timezone: &str) -> Result<&'static str, String> {

--- a/src-tauri/src/services/session_cleanup_service.rs
+++ b/src-tauri/src/services/session_cleanup_service.rs
@@ -1,6 +1,8 @@
 use crate::repositories::session_repository::SessionRepository as SessionRepositoryTrait;
 use crate::repositories::MessageRepository;
 use crate::search::index_storage::delete_index;
+use crate::services::ScheduledTaskService;
+use crate::state::get_scheduled_task_repository;
 use log::{error, info};
 
 pub struct SessionCleanupService;
@@ -131,6 +133,24 @@ impl SessionCleanupService {
             );
         }
 
+        let mut session_ids = vec![session_id.to_string()];
+        // Descendants are removed by a single `delete_session(parent)` DB cascade, not via
+        // per-child cleanup. Include their IDs here so pinned SESSION callbacks are removed
+        // before those session rows disappear.
+        session_ids.extend(descendant_ids.iter().cloned());
+        if let Err(e) = ScheduledTaskService::delete_session_scheduled_tasks_for_sessions(
+            get_scheduled_task_repository(),
+            &session_ids,
+        )
+        .await
+        {
+            log::warn!(
+                "Failed to delete session scheduled callbacks for {}: {}",
+                session_id,
+                e
+            );
+        }
+
         let session_repo = crate::state::get_session_repository();
         session_repo
             .delete_session(session_id)
@@ -147,6 +167,19 @@ impl SessionCleanupService {
         if let Err(e) = delete_index(session_id) {
             log::warn!(
                 "Failed to delete search index for session {}: {}",
+                session_id,
+                e
+            );
+        }
+
+        if let Err(e) = ScheduledTaskService::delete_session_scheduled_tasks_for_sessions(
+            get_scheduled_task_repository(),
+            &[session_id.to_string()],
+        )
+        .await
+        {
+            log::warn!(
+                "Failed to delete session scheduled callbacks for {}: {}",
                 session_id,
                 e
             );

--- a/src-tauri/tests/integration/scheduled_task_session_callback_tests.rs
+++ b/src-tauri/tests/integration/scheduled_task_session_callback_tests.rs
@@ -1,8 +1,8 @@
 use crate::common;
 
 use tauri_mcp_agent_lib::repositories::{
-    SessionMetadata, SessionRepository, SessionStatus, SqliteScheduledTaskRepository,
-    SqliteSessionRepository,
+    ScheduledTaskRepository, SessionMetadata, SessionRepository, SessionStatus,
+    SqliteScheduledTaskRepository, SqliteSessionRepository,
 };
 use tauri_mcp_agent_lib::scheduled::{TASK_CATEGORY_GLOBAL, TASK_CATEGORY_SESSION};
 use tauri_mcp_agent_lib::services::scheduled_task_service::{
@@ -150,4 +150,204 @@ async fn global_tasks_still_require_cron_expression() {
     .expect_err("GLOBAL tasks without cron should fail");
 
     assert!(error.contains("cron_expression"));
+}
+
+#[tokio::test]
+async fn delete_session_scheduled_tasks_removes_only_session_callbacks() {
+    let db = common::setup_test_db_with_migrations().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let scheduled_repo = SqliteScheduledTaskRepository::new(db);
+
+    let session_id = "session-delete-callbacks";
+    session_repo
+        .upsert_session(&make_session(session_id, "assistant-1"))
+        .await
+        .expect("session should be persisted");
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let governance = ScheduledTaskGovernanceSettings::default();
+
+    let session_task = ScheduledTaskService::create_scheduled_task_with_governance(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Session callback".to_string(),
+            task_category: TASK_CATEGORY_SESSION.to_string(),
+            cron_expression: None,
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Follow up".to_string(),
+            yolo_mode: false,
+            created_by_session_id: Some(session_id.to_string()),
+            session_id: Some(session_id.to_string()),
+            workspace_override: None,
+            next_run_at: Some(now_ms + 60_000),
+        },
+        &governance,
+    )
+    .await
+    .expect("session callback should be created");
+
+    let global_task = ScheduledTaskService::create_scheduled_task_with_governance(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Global recurring".to_string(),
+            task_category: TASK_CATEGORY_GLOBAL.to_string(),
+            cron_expression: Some("0 9 * * *".to_string()),
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Daily check".to_string(),
+            yolo_mode: false,
+            created_by_session_id: None,
+            session_id: Some(session_id.to_string()),
+            workspace_override: None,
+            next_run_at: None,
+        },
+        &governance,
+    )
+    .await
+    .expect("global task should be created");
+
+    let deleted = ScheduledTaskService::delete_session_scheduled_tasks_for_sessions(
+        &scheduled_repo,
+        &[session_id.to_string()],
+    )
+    .await
+    .expect("session callback cleanup should succeed");
+
+    assert_eq!(deleted, 1);
+    assert!(scheduled_repo
+        .get_scheduled_task(&session_task.id)
+        .await
+        .expect("lookup should succeed")
+        .is_none());
+    assert!(scheduled_repo
+        .get_scheduled_task(&global_task.id)
+        .await
+        .expect("lookup should succeed")
+        .is_some());
+}
+
+#[tokio::test]
+async fn list_session_scheduled_tasks_returns_enabled_session_callbacks_only() {
+    let db = common::setup_test_db_with_migrations().await;
+    let scheduled_repo = SqliteScheduledTaskRepository::new(db);
+
+    let session_id = "session-list-callbacks";
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let governance = ScheduledTaskGovernanceSettings::default();
+
+    ScheduledTaskService::create_scheduled_task_with_governance(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Active callback".to_string(),
+            task_category: TASK_CATEGORY_SESSION.to_string(),
+            cron_expression: None,
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Ping".to_string(),
+            yolo_mode: false,
+            created_by_session_id: Some(session_id.to_string()),
+            session_id: Some(session_id.to_string()),
+            workspace_override: None,
+            next_run_at: Some(now_ms + 30_000),
+        },
+        &governance,
+    )
+    .await
+    .expect("active callback should be created");
+
+    ScheduledTaskService::create_scheduled_task_with_governance(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Other session callback".to_string(),
+            task_category: TASK_CATEGORY_SESSION.to_string(),
+            cron_expression: None,
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Other".to_string(),
+            yolo_mode: false,
+            created_by_session_id: Some("other-session".to_string()),
+            session_id: Some("other-session".to_string()),
+            workspace_override: None,
+            next_run_at: Some(now_ms + 30_000),
+        },
+        &governance,
+    )
+    .await
+    .expect("other callback should be created");
+
+    let listed = ScheduledTaskService::list_session_scheduled_tasks(&scheduled_repo, session_id)
+        .await
+        .expect("list should succeed");
+
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "Active callback");
+}
+
+#[tokio::test]
+async fn cascade_cleanup_deletes_callbacks_pinned_to_descendant_sessions() {
+    let db = common::setup_test_db_with_migrations().await;
+    let session_repo = SqliteSessionRepository::new(db.clone());
+    let scheduled_repo = SqliteScheduledTaskRepository::new(db);
+
+    let parent_id = "parent-session";
+    let child_id = "child-session";
+    session_repo
+        .upsert_session(&make_session(parent_id, "assistant-1"))
+        .await
+        .expect("parent session should be persisted");
+
+    let mut child = make_session(child_id, "assistant-1");
+    child.parent_session_id = Some(parent_id.to_string());
+    session_repo
+        .upsert_session(&child)
+        .await
+        .expect("child session should be persisted");
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let governance = ScheduledTaskGovernanceSettings::default();
+
+    let child_callback = ScheduledTaskService::create_scheduled_task_with_governance(
+        &scheduled_repo,
+        CreateScheduledTaskInput {
+            name: "Child callback".to_string(),
+            task_category: TASK_CATEGORY_SESSION.to_string(),
+            cron_expression: None,
+            schedule_timezone: "local".to_string(),
+            assistant_id: "assistant-1".to_string(),
+            group_id: None,
+            group_name: None,
+            message: "Child follow up".to_string(),
+            yolo_mode: false,
+            created_by_session_id: Some(child_id.to_string()),
+            session_id: Some(child_id.to_string()),
+            workspace_override: None,
+            next_run_at: Some(now_ms + 60_000),
+        },
+        &governance,
+    )
+    .await
+    .expect("child callback should be created");
+
+    let deleted = ScheduledTaskService::delete_session_scheduled_tasks_for_sessions(
+        &scheduled_repo,
+        &[parent_id.to_string(), child_id.to_string()],
+    )
+    .await
+    .expect("cascade cleanup should succeed");
+
+    assert_eq!(deleted, 1);
+    assert!(scheduled_repo
+        .get_scheduled_task(&child_callback.id)
+        .await
+        .expect("lookup should succeed")
+        .is_none());
 }

--- a/src/features/agent/components/AgentPlanningPanel.tsx
+++ b/src/features/agent/components/AgentPlanningPanel.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from '@/components/ui';
 import { getLogger } from '@/lib/logger';
 import { parsePlanningState, parseScratchpadState } from '@/models/planning';
 import { cn } from '@/lib/utils';
+import { SessionSchedulesSection } from './SessionSchedulesSection';
 
 const logger = getLogger('AgentPlanningPanel');
 
@@ -241,6 +242,8 @@ export function AgentPlanningPanel({
             </ScrollArea>
           </div>
         </section>
+
+        <SessionSchedulesSection sessionId={session.id} isVisible={isVisible} />
       </CardContent>
     </Card>
   );

--- a/src/features/agent/components/SessionSchedulesSection.tsx
+++ b/src/features/agent/components/SessionSchedulesSection.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Clock, Loader2, Timer, X } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui';
+import { getDateTimeFormatter } from '@/lib/date-utils';
+import { useSessionSchedules } from '../hooks/useSessionSchedules';
+import { toast } from 'sonner';
+
+interface SessionSchedulesSectionProps {
+  sessionId: string;
+  isVisible?: boolean;
+}
+
+function formatCountdown(nextRunAt: number | null): string {
+  if (nextRunAt === null) {
+    return '--:--';
+  }
+
+  const diffMs = nextRunAt - Date.now();
+  if (diffMs <= 0) {
+    return '0:00';
+  }
+
+  const totalSeconds = Math.ceil(diffMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function SessionSchedulesSection({
+  sessionId,
+  isVisible = true,
+}: SessionSchedulesSectionProps) {
+  const { t } = useTranslation();
+  const { tasks, loading, cancellingIds, cancelTask } = useSessionSchedules(
+    sessionId,
+    isVisible,
+  );
+  const [, setTick] = useState(0);
+
+  const hasOneShot = useMemo(
+    () => tasks.some((task) => task.isOneShot),
+    [tasks],
+  );
+
+  useEffect(() => {
+    if (!isVisible || !hasOneShot) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setTick((value) => value + 1);
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [hasOneShot, isVisible]);
+
+  const formatNextRun = (nextRunAt: number | null): string => {
+    if (!nextRunAt) {
+      return t('agent.planning.schedules.nextRunNone', 'Not scheduled');
+    }
+
+    return getDateTimeFormatter().format(new Date(nextRunAt));
+  };
+
+  const handleCancel = async (taskId: string) => {
+    try {
+      await cancelTask(taskId);
+    } catch {
+      toast.error(
+        t(
+          'agent.planning.schedules.cancelFailed',
+          'Failed to cancel scheduled callback',
+        ),
+      );
+    }
+  };
+
+  return (
+    <section className="flex shrink-0 flex-col space-y-2 border-t border-border/40 pt-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Timer className="h-3.5 w-3.5 text-muted-foreground" />
+          <h4 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('agent.planning.schedules.title', 'Schedules')}
+          </h4>
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          {tasks.length}
+        </span>
+      </div>
+
+      <div className="max-h-40 overflow-hidden rounded-lg border border-border/40 bg-muted/[0.18]">
+        <ScrollArea className="h-full max-h-40">
+          {loading ? (
+            <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('common.loading', 'Loading...')}
+            </div>
+          ) : tasks.length === 0 ? (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              {t(
+                'agent.planning.schedules.empty',
+                'No session callbacks scheduled',
+              )}
+            </div>
+          ) : (
+            <div>
+              {tasks.map((task) => (
+                <div
+                  key={task.id}
+                  className="border-b border-border/25 px-3 py-3 last:border-b-0"
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {task.name}
+                        </span>
+                        {task.isOneShot ? (
+                          <Badge variant="secondary" className="text-[10px]">
+                            {t('agent.planning.schedules.oneShot', 'One-shot')}
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline" className="text-[10px]">
+                            {t(
+                              'agent.planning.schedules.recurring',
+                              'Recurring',
+                            )}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                        {task.message}
+                      </p>
+                      <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                        {task.isOneShot ? (
+                          <>
+                            <Timer className="h-3.5 w-3.5 shrink-0" />
+                            <span>
+                              {t(
+                                'agent.planning.schedules.remaining',
+                                '{{time}} remaining',
+                                { time: formatCountdown(task.nextRunAt) },
+                              )}
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            <Clock className="h-3.5 w-3.5 shrink-0" />
+                            <span>
+                              {t(
+                                'agent.planning.schedules.nextRun',
+                                'Next run: {{time}}',
+                                { time: formatNextRun(task.nextRunAt) },
+                              )}
+                            </span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => void handleCancel(task.id)}
+                      disabled={cancellingIds.has(task.id)}
+                      aria-label={t(
+                        'agent.planning.schedules.cancelAria',
+                        'Cancel {{name}}',
+                        { name: task.name },
+                      )}
+                    >
+                      {cancellingIds.has(task.id) ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <X className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+      </div>
+    </section>
+  );
+}

--- a/src/features/agent/hooks/useSessionSchedules.ts
+++ b/src/features/agent/hooks/useSessionSchedules.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import {
+  cancelSessionScheduledTask,
+  listSessionScheduledTasks,
+  type SessionScheduledTask,
+} from '@/lib/backend/scheduled-tasks';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('useSessionSchedules');
+
+export function useSessionSchedules(
+  sessionId: string | undefined,
+  enabled: boolean,
+) {
+  const {
+    data: tasks = [],
+    isLoading,
+    mutate,
+  } = useSWR<SessionScheduledTask[]>(
+    enabled && sessionId ? ['session-scheduled-tasks', sessionId] : null,
+    () => listSessionScheduledTasks(sessionId!),
+    {
+      refreshInterval: 15_000,
+      revalidateOnFocus: true,
+      onError: (error: unknown) => {
+        logger.error('Failed to load session schedules', error);
+      },
+    },
+  );
+
+  const [cancellingIds, setCancellingIds] = useState<Set<string>>(new Set());
+
+  const cancelTask = useCallback(
+    async (taskId: string) => {
+      if (!sessionId || cancellingIds.has(taskId)) {
+        return;
+      }
+
+      setCancellingIds((prev) => new Set(prev).add(taskId));
+      try {
+        await cancelSessionScheduledTask(sessionId, taskId);
+        await mutate((prev = []) => prev.filter((task) => task.id !== taskId), {
+          revalidate: false,
+        });
+      } catch (error: unknown) {
+        logger.error('Failed to cancel session schedule', error);
+        throw error;
+      } finally {
+        setCancellingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(taskId);
+          return next;
+        });
+      }
+    },
+    [cancellingIds, mutate, sessionId],
+  );
+
+  return {
+    tasks,
+    loading: isLoading,
+    cancellingIds,
+    cancelTask,
+    refresh: mutate,
+  };
+}

--- a/src/lib/backend/scheduled-tasks.test.ts
+++ b/src/lib/backend/scheduled-tasks.test.ts
@@ -6,6 +6,8 @@ import {
   updateScheduledTask,
   toggleScheduledTask,
   deleteScheduledTask,
+  listSessionScheduledTasks,
+  cancelSessionScheduledTask,
 } from './scheduled-tasks';
 import { safeInvoke } from './core';
 
@@ -133,6 +135,33 @@ describe('scheduled-tasks backend wrapper', () => {
 
     expect(safeInvoke).toHaveBeenCalledWith('delete_scheduled_task', {
       id: 'task-1',
+    });
+  });
+});
+
+describe('session scheduled tasks backend wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('listSessionScheduledTasks calls safeInvoke with sessionId', async () => {
+    vi.mocked(safeInvoke).mockResolvedValueOnce([]);
+
+    await listSessionScheduledTasks('session-1');
+
+    expect(safeInvoke).toHaveBeenCalledWith('list_session_scheduled_tasks', {
+      sessionId: 'session-1',
+    });
+  });
+
+  it('cancelSessionScheduledTask calls safeInvoke with session and task ids', async () => {
+    vi.mocked(safeInvoke).mockResolvedValueOnce(undefined);
+
+    await cancelSessionScheduledTask('session-1', 'task-1');
+
+    expect(safeInvoke).toHaveBeenCalledWith('cancel_session_scheduled_task', {
+      sessionId: 'session-1',
+      taskId: 'task-1',
     });
   });
 });

--- a/src/lib/backend/scheduled-tasks.ts
+++ b/src/lib/backend/scheduled-tasks.ts
@@ -27,6 +27,15 @@ export interface ScheduledTask {
   updatedAt: number;
 }
 
+/** SESSION callback shown in the active session planning panel */
+export interface SessionScheduledTask {
+  id: string;
+  name: string;
+  message: string;
+  isOneShot: boolean;
+  nextRunAt: number | null;
+}
+
 export interface CreateScheduledTaskRequest {
   name: string;
   cronExpression: string;
@@ -90,4 +99,23 @@ export async function toggleScheduledTask(
 export async function deleteScheduledTask(id: string): Promise<void> {
   logger.info('Deleting scheduled task', { id });
   await safeInvoke<void>('delete_scheduled_task', { id });
+}
+
+export async function listSessionScheduledTasks(
+  sessionId: string,
+): Promise<SessionScheduledTask[]> {
+  return safeInvoke<SessionScheduledTask[]>('list_session_scheduled_tasks', {
+    sessionId,
+  });
+}
+
+export async function cancelSessionScheduledTask(
+  sessionId: string,
+  taskId: string,
+): Promise<void> {
+  logger.info('Cancelling session scheduled task', { sessionId, taskId });
+  await safeInvoke<void>('cancel_session_scheduled_task', {
+    sessionId,
+    taskId,
+  });
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1022,7 +1022,18 @@
       "noScratchpad": "No scratchpad notes",
       "untitledNote": "Untitled note",
       "moreTasks": "more tasks",
-      "updated": "updated"
+      "updated": "updated",
+      "schedules": {
+        "title": "Schedules",
+        "empty": "No session callbacks scheduled",
+        "oneShot": "One-shot",
+        "recurring": "Recurring",
+        "remaining": "{{time}} remaining",
+        "nextRun": "Next run: {{time}}",
+        "nextRunNone": "Not scheduled",
+        "cancelFailed": "Failed to cancel scheduled callback",
+        "cancelAria": "Cancel {{name}}"
+      }
     },
     "bubble": {
       "notification": "Notification",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -1022,7 +1022,18 @@
       "noScratchpad": "스크래치패드 메모 없음",
       "untitledNote": "제목 없는 메모",
       "moreTasks": "개 작업 더 있음",
-      "updated": "업데이트됨"
+      "updated": "업데이트됨",
+      "schedules": {
+        "title": "예약",
+        "empty": "세션 콜백 예약 없음",
+        "oneShot": "일회성",
+        "recurring": "반복",
+        "remaining": "{{time}} 남음",
+        "nextRun": "다음 실행: {{time}}",
+        "nextRunNone": "예약 없음",
+        "cancelFailed": "예약 콜백 취소에 실패했습니다",
+        "cancelAria": "{{name}} 취소"
+      }
     },
     "bubble": {
       "notification": "알림",


### PR DESCRIPTION
## Summary

- Add a **Schedules** section to the agent planning panel for `scheduleCallback` (SESSION) tasks, with one-shot countdown and cancel actions.
- Add Tauri commands `list_session_scheduled_tasks` and `cancel_session_scheduled_task` with session ownership validation.
- Delete pinned SESSION callbacks when a session is removed (`delete_session_data_cascade` includes descendant IDs before DB cascade; `delete_session_data_only` cleans the single session only).
- Keep `/scheduled-tasks` scoped to GLOBAL recurring jobs (existing filter unchanged).

## Test plan

- [x] `pnpm refactor:validate`
- [x] Integration tests in `scheduled_task_session_callback_tests.rs` (list, delete, cascade descendant cleanup)
- [x] Frontend wrapper tests in `scheduled-tasks.test.ts`
- [ ] Manual: run `scheduleCallback` in a session → verify Schedules section in planning panel
- [ ] Manual: cancel a pending callback from the panel
- [ ] Manual: delete session → verify SESSION callbacks are removed from DB
- [ ] Manual: `/scheduled-tasks` still shows GLOBAL tasks only


Made with [Cursor](https://cursor.com)