### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in export operations

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -68,10 +68,11 @@ impl WorkspaceServer {
 
         if paths_array.len() == 1 {
             if let Some(path_str) = paths_array[0].as_str() {
-                let check_path = workspace_dir_canon.join(path_str);
-                // Canonicalize the candidate path and ensure it stays within the workspace
-                if let Ok(canon_check) = std::fs::canonicalize(&check_path) {
-                    if canon_check.starts_with(&workspace_dir_canon) && canon_check.is_file() {
+                if let Ok(canon_check) =
+                    crate::utils::security::resolve_secure_path(&workspace_dir_canon, path_str)
+                        .await
+                {
+                    if canon_check.is_file() {
                         is_single_file_mode = true;
                         single_file_path = Some(canon_check);
                         single_file_rel_path_str = path_str.to_string();
@@ -180,9 +181,13 @@ impl WorkspaceServer {
         let mut missing_files = Vec::new();
         for file_value in paths_array {
             if let Some(path_str) = file_value.as_str() {
-                let file_path = workspace_dir_canon.join(path_str);
-                if !file_path.exists() {
-                    missing_files.push(path_str.to_string());
+                match crate::utils::security::resolve_secure_path(&workspace_dir_canon, path_str)
+                    .await
+                {
+                    Ok(file_path) if file_path.exists() => {}
+                    _ => {
+                        missing_files.push(path_str.to_string());
+                    }
                 }
             }
         }
@@ -232,10 +237,15 @@ impl WorkspaceServer {
 
         for file_value in paths_array {
             if let Some(path_str) = file_value.as_str() {
-                let source_path = workspace_dir_canon.join(path_str);
-                if !source_path.exists() {
-                    continue;
-                }
+                let source_path = match crate::utils::security::resolve_secure_path(
+                    &workspace_dir_canon,
+                    path_str,
+                )
+                .await
+                {
+                    Ok(path) if path.exists() => path,
+                    _ => continue,
+                };
 
                 let roots: Vec<PathBuf> = if source_path.is_file() {
                     vec![source_path]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The workspace export functionality (`handle_export`) improperly used `Path::join` to construct paths from user-provided input before validation. This allowed path traversal (e.g., `../`) or absolute path bypasses, potentially letting an attacker export and exfiltrate sensitive files from outside the isolated workspace directory.
🎯 Impact: High risk of sensitive file read/exfiltration outside of the intended workspace isolation boundary.
🔧 Fix: Replaced raw `Path::join` calls with the repository's secure, built-in `crate::utils::security::resolve_secure_path` utility which robustly prevents traversal and absolute path injections.
✅ Verification: Tested locally via `cargo test` and verified that traversal attempts are correctly intercepted and yield a clean error instead of bypassing the workspace check.

---
*PR created automatically by Jules for task [3417337778294463884](https://jules.google.com/task/3417337778294463884) started by @fritzprix*