### PR TITLE
feat(skills): add consensus-delegation bundled skill

### DIFF
--- a/src-tauri/bundled_skills/consensus-delegation/SKILL.md
+++ b/src-tauri/bundled_skills/consensus-delegation/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: consensus-delegation
+description: Orchestrate multiple specialized child sessions to evaluate the same question from different perspectives, collect their independent conclusions, and reconcile disagreements through parent-mediated follow-ups. Use for code review triangulation, architecture or risk assessment, security vs performance tradeoff analysis, or any bounded decision that benefits from 2-4 distinct expert viewpoints—not for persistent teams (teamwork/org) or single one-off delegation (delegate).
+---
+
+# Consensus via Delegation
+
+Use this skill when one parent session should **compare independent expert opinions** on the same scoped question, then synthesize a final answer.
+
+This is parent-mediated orchestration: child sessions do not talk to each other. The parent spawns specialists, collects results, detects disagreement, and sends targeted follow-ups.
+
+For general spawn/monitor mechanics and workspace isolation rules, follow `delegate` first. Read this skill when you need the **multi-reviewer workflow**, not a single child task.
+
+## When to Use
+
+Good fits:
+
+- 2-4 specialists reviewing the **same** change, design, or proposal
+- architecture evaluation with distinct lenses (structure, security, performance)
+- risk analysis where tradeoffs must be explicit
+- bounded questions with a clear deliverable the parent can compare
+
+Avoid this skill when:
+
+- one capable agent can finish cleanly alone → stay in the parent session
+- you need a persistent multi-agent workspace → use `teamwork` or `org`
+- children must debate each other directly → not supported; parent must mediate
+- the work is open-ended implementation with no comparison step → use `delegate` once
+
+## Core Rules
+
+1. **Same question, same scope.** Every child must receive the same objective, boundaries, and output shape. Change only the perspective or assistant specialization.
+2. **Shared evidence when code matters.** If reviewers must inspect the same repo, use `workspaceOverride` with the parent's effective workspace path—or paste critical excerpts into every handoff. Children do not inherit parent workspace or `agents.md` automatically.
+3. **Parent is the hub.** Only the parent can `checkSession` or `messageToSession` its descendants. Sibling sessions cannot see or message each other.
+4. **Structured handoffs, human synthesis.** Ask each child for a fixed section layout (verdict, findings, risks, confidence). The parent compares text results; there is no built-in vote or merge algorithm.
+5. **Do not blindly trust children.** Verify file paths, claims, and scope before presenting a final answer.
+
+## Workflow
+
+### 1. Frame the decision
+
+Define before spawning anything:
+
+- the exact question or artifact under review
+- in-scope paths/modules and hard boundaries
+- the output sections every child must return
+- what counts as agreement vs material disagreement
+
+### 2. Pick specialists
+
+- `list(type="configs")` to discover assistants; use returned IDs in `startSession`
+- Prefer assistants whose system prompts or assistant-scoped skills match each perspective
+- If no suitable assistant exists, `create` a config first, then spawn with the new ID
+- Keep the panel small (usually 2-4). More reviewers add noise and hit fanout/concurrency limits
+
+### 3. Prepare identical handoffs
+
+Each task should differ only in **review lens**, not in scope or deliverable format.
+
+Include:
+
+- shared objective and scope
+- shared output template (see `references/workflow-templates.md`)
+- critical workspace rules copied from the parent when needed
+- absolute paths or identifiers the child must use
+
+When all reviewers need the same codebase, start each child with the same `workspaceOverride`.
+
+### 4. Spawn and run
+
+Default pattern:
+
+1. `startSession(agentId="...", task="...", waitForResult=false, workspaceOverride="...")` for each specialist
+2. `list(type="sessions")` if you need to confirm child IDs and status—this does not return review results
+3. Collect with `checkSession(sessionId)` or `checkSession(sessionId, wait=true)` for actual conclusions
+
+Notes:
+
+- Prefer `waitForResult=false` on spawn so multiple children can run while the parent plans the synthesis
+- Tool calls in one turn execute sequentially; children still run in parallel once started, subject to the global active-session slot limit (default 4, configurable via `maxConcurrentActiveSessions`)
+- While `checkSession(wait=true)` blocks, the parent releases its active slot so children can finish—use waits deliberately
+
+### 5. Compare results
+
+For each child result, extract:
+
+- verdict or recommendation
+- top findings with evidence (paths, symbols, commands)
+- risks and confidence level
+
+Flag **material disagreement** when verdicts conflict or findings contradict on the same fact. Minor wording differences are not disagreement.
+
+### 6. Reconcile (only when needed)
+
+When perspectives conflict:
+
+1. State the specific conflict (fact, tradeoff, or recommendation)
+2. `compactSessionContext(sessionId)` on children with long histories before large follow-ups
+3. `messageToSession` each relevant child with the opposing finding and ask for a focused re-check
+4. `checkSession(..., wait=true)` again after follow-ups
+5. Stop after 1-2 reconciliation rounds unless new blocking facts appear
+
+Read `references/reconciliation.md` for round templates and stop conditions.
+
+### 7. Synthesize in the parent
+
+Produce the final answer yourself:
+
+- summarize agreed facts
+- explain unresolved tradeoffs
+- state your recommendation and what each perspective contributed
+- cite which child sessions supported each conclusion
+
+Do not present a single child's output as the final answer without comparison.
+
+## Builtin Tools
+
+| Step | Tool |
+| --- | --- |
+| Discover assistants | `list(type="configs")` |
+| Create missing specialist | `create(...)` |
+| Spawn reviewer | `startSession(..., waitForResult=false)` |
+| Inspect children | `list(type="sessions")` — IDs and status only |
+| Poll or wait | `checkSession(sessionId)` / `checkSession(sessionId, wait=true)` — results |
+| Reconcile | `messageToSession(sessionId, message)` |
+| Stop stuck work | `stopSession(sessionId)` |
+| Long histories | `compactSessionContext(sessionId)` |
+
+## Common Mistakes
+
+- **Different scopes per child** — comparisons become meaningless; keep scope identical
+- **Assuming shared workspace without `workspaceOverride`** — reviewers inspect different files
+- **Expecting children to respond to each other** — repackage opposing views in the parent message
+- **Skipping output format** — parent cannot compare unstructured prose reliably
+- **Trusting verdicts without evidence** — re-open files or traces before deciding
+- **Blocking the parent on every spawn** — use async spawn + targeted waits
+- **Ignoring paused/error sessions** — recover with `messageToSession`, not another blind `checkSession`
+
+## References
+
+- `references/workflow-templates.md` — handoff and output templates by scenario
+- `references/reconciliation.md` — disagreement handling, follow-up rounds, stop rules

--- a/src-tauri/bundled_skills/consensus-delegation/references/reconciliation.md
+++ b/src-tauri/bundled_skills/consensus-delegation/references/reconciliation.md
@@ -1,0 +1,93 @@
+# Reconciliation Guide
+
+Use after the first collection pass when specialist verdicts or material findings conflict.
+
+## What Counts as Disagreement
+
+Treat as **material**:
+
+- approve vs reject on the same scoped question
+- contradictory factual claims about the same file, API, or behavior
+- one reviewer flags a blocking risk another marks as negligible without evidence
+
+Treat as **non-material**:
+
+- different emphasis or ordering
+- extra non-blocking suggestions
+- confidence differences with the same verdict
+
+## Parent-Mediated Follow-Up
+
+Children cannot message each other. The parent must:
+
+1. Quote the specific conflict
+2. Include both sides with session attribution
+3. Ask for a focused re-check—not a full re-review
+
+Template:
+
+```text
+Reconciliation round — focused re-check only.
+
+Conflict:
+- Session [A-id / perspective]: [claim + evidence]
+- Session [B-id / perspective]: [claim + evidence]
+
+Your task:
+- Re-examine only the disputed point within the original scope
+- Return the same output format as before
+- Update verdict only if this conflict changes your conclusion
+- If unchanged, explain why the opposing view is wrong or out of scope
+```
+
+Send tailored messages to each involved child. If a child already has a long history from round 1, call `compactSessionContext(sessionId)` before sending a large follow-up. Then `checkSession(sessionId, wait=true)` for each.
+
+## Round Limits
+
+Default:
+
+- **Round 1:** independent reviews
+- **Round 2:** one targeted reconciliation pass for material conflicts only
+- **Stop** unless a new blocking fact appears
+
+Escalate to the user when:
+
+- verdicts still conflict after reconciliation
+- evidence is missing from both sides
+- scope was insufficient to decide
+
+Do not loop indefinitely. `messageToSession` has no round cap, but cost, timeouts, and context grow quickly.
+
+## Operational Constraints
+
+Keep in mind during multi-child workflows:
+
+- **Fanout:** `maxFanout` on the parent lineage can cap how many direct children you may spawn
+- **Depth:** nested delegation consumes `maxDepth`; prefer flat panels under one parent
+- **Concurrency:** global active-session slots are capped (default 4, configurable via `maxConcurrentActiveSessions`); async spawn + selective waits is safer than blocking on every child up front
+- **Timeouts:** `checkSession(wait=true)` and `messageToSession` waits honor a timeout (default up to 3600 seconds)
+- **Truncation:** terminal `checkSession` summarizes recent assistant output; ask for full detail via `messageToSession` when results are long
+- **Context growth:** deep reconciliation rounds accumulate history; use `compactSessionContext(sessionId)` before large follow-ups to keep token costs reasonable
+
+## Paused, Error, or Terminated Children
+
+If `checkSession` reports paused, error, or terminated state:
+
+- do not treat the panel as complete
+- use `messageToSession` with a recovery instruction referencing the last stable step
+- re-check after the child reaches a terminal state
+
+If a child is stuck or no longer needed:
+
+- `stopSession(sessionId)` to free resources
+- either replace that perspective or proceed with fewer reviewers and note the gap in the final synthesis
+
+## Final Synthesis Checklist
+
+Before answering the user:
+
+- [ ] All reviewers used the same scope and output format
+- [ ] Material conflicts were reconciled or explicitly marked unresolved
+- [ ] Evidence was verified for blocking findings
+- [ ] Final recommendation states tradeoffs, not just a majority verdict
+- [ ] Child session IDs or perspectives are traceable in the explanation

--- a/src-tauri/bundled_skills/consensus-delegation/references/workflow-templates.md
+++ b/src-tauri/bundled_skills/consensus-delegation/references/workflow-templates.md
@@ -1,0 +1,111 @@
+# Consensus Delegation Templates
+
+Use these when every child must return comparable sections. Adjust labels to the task; keep the section list identical across all children.
+
+## Shared Output Shape
+
+Ask every reviewer to use this structure:
+
+```text
+Verdict: [approve | approve-with-caveats | reject | inconclusive]
+Confidence: [high | medium | low]
+
+Findings:
+- [finding]: [evidence: path, symbol, line, or command output]
+
+Risks:
+- [risk]: [why it matters]
+
+Scope notes:
+- [anything outside scope that might affect the verdict]
+```
+
+Rule: if a section is empty, the reviewer must write `None` explicitly so the parent can detect gaps.
+
+## Panel Handoff Wrapper
+
+Use the same wrapper for each child; change only `[PERSPECTIVE]` and optional lens-specific instructions.
+
+```text
+You are reviewing as: [PERSPECTIVE — e.g. security reviewer, performance reviewer]
+
+Shared objective:
+- [one sentence decision or review target]
+
+Scope:
+- In scope: [paths/modules/constraints]
+- Out of scope: [explicit exclusions]
+- Do not modify code unless explicitly allowed
+
+Required output format:
+[Paste the Shared Output Shape section above]
+
+Lens-specific focus:
+- [2-4 bullets unique to this perspective]
+
+Context the parent requires you to respect:
+- [critical rules copied from workspace instructions if needed]
+```
+
+## Scenario: Code Change Review
+
+Spawn 2-3 children with lenses such as correctness, security, and performance.
+
+```text
+Shared objective:
+- Review the proposed change for [feature/fix summary] before merge.
+
+Scope:
+- In scope: [files or diff range]
+- Out of scope: unrelated refactors, style-only nits unless they hide bugs
+
+Lens-specific focus (example — security):
+- Injection, authz, secret handling, unsafe deserialization
+```
+
+Parent synthesis sections:
+
+```text
+Agreed findings:
+Conflicting findings:
+Unresolved risks:
+Recommendation:
+```
+
+## Scenario: Architecture Option Evaluation
+
+Use when comparing one proposal (or option A vs B stated in the shared objective).
+
+```text
+Shared objective:
+- Evaluate [option/proposal] for production use in [system/context].
+
+Scope:
+- In scope: [components, interfaces, deployment model]
+- Out of scope: full rewrites not requested in the proposal
+
+Lens-specific focus (example — operability):
+- Observability, rollback, failure modes, runbook burden
+```
+
+## Scenario: Risk / Tradeoff Assessment
+
+```text
+Shared objective:
+- Assess whether [decision] is acceptable given [constraints].
+
+Scope:
+- In scope: [systems, time horizon, compliance boundaries]
+
+Lens-specific focus (example — compliance):
+- Data residency, audit trail, access control, retention
+```
+
+## Workspace Reminder
+
+If reviewers must read the same repository:
+
+- pass the same `workspaceOverride` to every `startSession`, or
+- paste the minimum excerpts each reviewer needs when sharing a workspace is impossible
+
+Never assume children inherit the parent workspace or workspace `agents.md` without explicit action. See `delegate` for the full isolation matrix.


### PR DESCRIPTION
## Summary
- Add bundled skill for parent-mediated multi-reviewer workflows (code review, architecture, risk assessment).
- Document spawn, collect, compare, and reconcile flows using startSession, checkSession, and messageToSession.
- Include handoff templates and reconciliation guidance aligned with delegate workspace isolation rules.

## Test plan
- [ ] Run quick_validate on consensus-delegation skill
- [ ] Restart app and confirm skill syncs to managed system_skills
- [ ] Trigger skill in an agent session for a 2-3 reviewer scenario

Made with [Cursor](https://cursor.com)