### PR TITLE
feat(scheduled-task): promote to CORE + apply tool approval

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -135,16 +135,16 @@ LibrAgent wird mit einer wachsenden Bibliothek **gebündelter Skills** geliefert
 
 Die wichtigsten Skills für den ersten Tag:
 
-| Skill                | Was er tut                                                                                            |
-| -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `system-setup`       | Erkennt und installiert fehlende Runtimes (Python, Node.js, uv) plattformübergreifend                 |
-| `mcp-installer`      | Registriert MCP-Server aus npm-Paketen, GitHub-URLs oder JSON-Config-Blöcken                          |
-| `mcp-importer`       | Importiert bestehende MCP-Configs aus Cursor, VS Code, Windsurf u.ä.                                  |
-| `delegate`           | Führt durch die Eltern→Kind-Sitzungsübergabe mit explizitem Kontexttransfer und Abstammungsverfolgung |
-| `teamwork`           | Baut die geteilte Arbeitsbereichsverfassung für koordinierte Multi-Agenten-Arbeit                     |
-| `org`                | Formalisiert dauerhafte Organisationsidentität und sichtbare Mitgliederhierarchie                     |
-| `schedule`           | Erstellt und verwaltet wiederkehrende geplante Task-Gruppen für unbeaufsichtigte Automatisierung      |
-| `soul-awakening`     | Verankert einen Agenten an eine `SOUL.md`-Persona — Ton, Haltung, Identität                           |
+| Skill            | Was er tut                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `system-setup`   | Erkennt und installiert fehlende Runtimes (Python, Node.js, uv) plattformübergreifend                 |
+| `mcp-installer`  | Registriert MCP-Server aus npm-Paketen, GitHub-URLs oder JSON-Config-Blöcken                          |
+| `mcp-importer`   | Importiert bestehende MCP-Configs aus Cursor, VS Code, Windsurf u.ä.                                  |
+| `delegate`       | Führt durch die Eltern→Kind-Sitzungsübergabe mit explizitem Kontexttransfer und Abstammungsverfolgung |
+| `teamwork`       | Baut die geteilte Arbeitsbereichsverfassung für koordinierte Multi-Agenten-Arbeit                     |
+| `org`            | Formalisiert dauerhafte Organisationsidentität und sichtbare Mitgliederhierarchie                     |
+| `schedule`       | Erstellt und verwaltet wiederkehrende geplante Task-Gruppen für unbeaufsichtigte Automatisierung      |
+| `soul-awakening` | Verankert einen Agenten an eine `SOUL.md`-Persona — Ton, Haltung, Identität                           |
 
 Das ist nur die Operatorschicht. LibrAgent bietet auch Domain-Skills für:
 
@@ -202,6 +202,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -135,16 +135,16 @@ LibrAgent viene con una biblioteca creciente de **Habilidades agrupadas**. No so
 
 Las habilidades más importantes para el primer día:
 
-| Habilidad            | Qué hace                                                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `system-setup`       | Detecta e instala runtimes faltantes (Python, Node.js, uv) en todas las plataformas                                |
-| `mcp-installer`      | Registra servidores MCP desde paquetes npm, URLs de GitHub o bloques de config JSON                                |
-| `mcp-importer`       | Importa configs MCP existentes desde Cursor, VS Code, Windsurf y similares                                         |
-| `delegate`           | Guía el traspaso de sesión padre→hijo con transferencia de contexto explícita y seguimiento de linaje              |
-| `teamwork`           | Construye la constitución de espacio de trabajo compartido para el trabajo multi-agente coordinado                 |
-| `org`                | Formaliza la identidad de organización duradera y la jerarquía de miembros visible                                 |
-| `schedule`           | Crea y gestiona grupos de tareas programadas recurrentes para automatización sin supervisión                       |
-| `soul-awakening`     | Ancla un agente a un persona `SOUL.md` — tono, postura, identidad                                                  |
+| Habilidad        | Qué hace                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `system-setup`   | Detecta e instala runtimes faltantes (Python, Node.js, uv) en todas las plataformas                   |
+| `mcp-installer`  | Registra servidores MCP desde paquetes npm, URLs de GitHub o bloques de config JSON                   |
+| `mcp-importer`   | Importa configs MCP existentes desde Cursor, VS Code, Windsurf y similares                            |
+| `delegate`       | Guía el traspaso de sesión padre→hijo con transferencia de contexto explícita y seguimiento de linaje |
+| `teamwork`       | Construye la constitución de espacio de trabajo compartido para el trabajo multi-agente coordinado    |
+| `org`            | Formaliza la identidad de organización duradera y la jerarquía de miembros visible                    |
+| `schedule`       | Crea y gestiona grupos de tareas programadas recurrentes para automatización sin supervisión          |
+| `soul-awakening` | Ancla un agente a un persona `SOUL.md` — tono, postura, identidad                                     |
 
 Y eso es solo la capa de operador. LibrAgent también incluye habilidades de dominio para:
 
@@ -202,6 +202,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -135,16 +135,16 @@ LibrAgent est livré avec une bibliothèque croissante de **Compétences groupé
 
 Les compétences les plus importantes pour le premier jour :
 
-| Compétence           | Ce qu'elle fait                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `system-setup`       | Détecte et installe les runtimes manquants (Python, Node.js, uv) sur toutes les plateformes                      |
-| `mcp-installer`      | Enregistre des serveurs MCP depuis des packages npm, des URLs GitHub ou des blocs de config JSON                 |
-| `mcp-importer`       | Importe les configs MCP existantes depuis Cursor, VS Code, Windsurf et autres                                    |
-| `delegate`           | Guide le transfert de session parent→enfant avec transfert de contexte explicite et suivi de lignée              |
-| `teamwork`           | Construit la constitution d'espace de travail partagé pour le travail multi-agent coordonné                      |
-| `org`                | Formalise l'identité d'organisation durable et la hiérarchie de membres visible                                  |
-| `schedule`           | Crée et gère des groupes de tâches planifiées récurrentes pour l'automatisation sans surveillance                |
-| `soul-awakening`     | Ancre un agent à un persona `SOUL.md` — ton, posture, identité                                                   |
+| Compétence       | Ce qu'elle fait                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| `system-setup`   | Détecte et installe les runtimes manquants (Python, Node.js, uv) sur toutes les plateformes         |
+| `mcp-installer`  | Enregistre des serveurs MCP depuis des packages npm, des URLs GitHub ou des blocs de config JSON    |
+| `mcp-importer`   | Importe les configs MCP existantes depuis Cursor, VS Code, Windsurf et autres                       |
+| `delegate`       | Guide le transfert de session parent→enfant avec transfert de contexte explicite et suivi de lignée |
+| `teamwork`       | Construit la constitution d'espace de travail partagé pour le travail multi-agent coordonné         |
+| `org`            | Formalise l'identité d'organisation durable et la hiérarchie de membres visible                     |
+| `schedule`       | Crée et gère des groupes de tâches planifiées récurrentes pour l'automatisation sans surveillance   |
+| `soul-awakening` | Ancre un agent à un persona `SOUL.md` — ton, posture, identité                                      |
 
 Et ce n'est que la couche opérateur. LibrAgent fournit également des compétences de domaine pour :
 
@@ -202,6 +202,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -135,16 +135,16 @@ LibrAgentは成長し続ける**バンドルスキル**ライブラリを同梱�
 
 最重要のday-oneスキル：
 
-| スキル               | 機能                                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------------- |
-| `system-setup`       | すべてのプラットフォームで不足しているランタイム(Python、Node.js、uv)を検出・インストール |
-| `mcp-installer`      | npmパッケージ、GitHub URL、JSON設定ブロックからMCPサーバーを登録                          |
-| `mcp-importer`       | Cursor、VS Code、Windsurf等から既存MCP設定をインポート                                    |
-| `delegate`           | 明示的なコンテキスト転送と系譜追跡付きで親→子セッションの引き継ぎを案内                   |
-| `teamwork`           | 調整されたマルチエージェント作業のための共有ワークスペース憲法をスキャフォールド          |
-| `org`                | 持続的な組織アイデンティティとorg-visibleメンバー階層を正式化                             |
-| `schedule`           | 無人自動化のための定期スケジュールタスクグループを作成・管理                              |
-| `soul-awakening`     | エージェントを`SOUL.md`ペルソナに固定——トーン、スタンス、アイデンティティ                 |
+| スキル           | 機能                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------- |
+| `system-setup`   | すべてのプラットフォームで不足しているランタイム(Python、Node.js、uv)を検出・インストール |
+| `mcp-installer`  | npmパッケージ、GitHub URL、JSON設定ブロックからMCPサーバーを登録                          |
+| `mcp-importer`   | Cursor、VS Code、Windsurf等から既存MCP設定をインポート                                    |
+| `delegate`       | 明示的なコンテキスト転送と系譜追跡付きで親→子セッションの引き継ぎを案内                   |
+| `teamwork`       | 調整されたマルチエージェント作業のための共有ワークスペース憲法をスキャフォールド          |
+| `org`            | 持続的な組織アイデンティティとorg-visibleメンバー階層を正式化                             |
+| `schedule`       | 無人自動化のための定期スケジュールタスクグループを作成・管理                              |
+| `soul-awakening` | エージェントを`SOUL.md`ペルソナに固定——トーン、スタンス、アイデンティティ                 |
 
 これはオペレーターレイヤーだけです。LibrAgentはドメインスキルも提供します：
 
@@ -202,6 +202,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -135,16 +135,16 @@ LibrAgent는 성장하는 **번들 스킬** 라이브러리와 함께 제공됩�
 
 가장 중요한 day-one 스킬:
 
-| 스킬                 | 기능                                                                  |
-| -------------------- | --------------------------------------------------------------------- |
-| `system-setup`       | 모든 플랫폼에서 누락된 런타임(Python, Node.js, uv) 감지 및 설치       |
-| `mcp-installer`      | npm 패키지, GitHub URL, JSON 구성 블록에서 MCP 서버 등록              |
-| `mcp-importer`       | Cursor, VS Code, Windsurf 등에서 기존 MCP 구성 가져오기               |
-| `delegate`           | 명시적 컨텍스트 전달 및 계보 추적과 함께 부모→자식 세션 인수인도 안내 |
-| `teamwork`           | 조정된 멀티 에이전트 작업을 위한 공유 워크스페이스 헌법 scaffold      |
-| `org`                | 내구성 조직 정체성 및 org-visible 구성원 계보 공식화                  |
-| `schedule`           | 미감정 자동화를 위한 반복 예약 작업 그룹 생성 및 관리                 |
-| `soul-awakening`     | 에이전트를 `SOUL.md` 페르소나에 고정 — 톤, 태도, 정체성               |
+| 스킬             | 기능                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| `system-setup`   | 모든 플랫폼에서 누락된 런타임(Python, Node.js, uv) 감지 및 설치       |
+| `mcp-installer`  | npm 패키지, GitHub URL, JSON 구성 블록에서 MCP 서버 등록              |
+| `mcp-importer`   | Cursor, VS Code, Windsurf 등에서 기존 MCP 구성 가져오기               |
+| `delegate`       | 명시적 컨텍스트 전달 및 계보 추적과 함께 부모→자식 세션 인수인도 안내 |
+| `teamwork`       | 조정된 멀티 에이전트 작업을 위한 공유 워크스페이스 헌법 scaffold      |
+| `org`            | 내구성 조직 정체성 및 org-visible 구성원 계보 공식화                  |
+| `schedule`       | 미감정 자동화를 위한 반복 예약 작업 그룹 생성 및 관리                 |
+| `soul-awakening` | 에이전트를 `SOUL.md` 페르소나에 고정 — 톤, 태도, 정체성               |
 
 이것은 운영자 레이어에 불과합니다. LibrAgent는 도메인 스킬도 제공합니다:
 
@@ -202,6 +202,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ LibrAgent ships with a growing library of **Bundled Skills**. They are not rando
 
 The most important day-one skills are:
 
-| Skill                | What it does                                                                              |
-| -------------------- | ----------------------------------------------------------------------------------------- |
-| `system-setup`       | Detects and installs missing runtimes (Python, Node.js, uv) across all platforms          |
-| `mcp-installer`      | Registers MCP servers from npm packages, GitHub URLs, or JSON config blocks               |
-| `mcp-importer`       | Imports existing MCP configs from Cursor, VS Code, Windsurf, and similar setups           |
-| `delegate`           | Guides parent→child session handoff with explicit context transfer and lineage tracking   |
-| `teamwork`           | Scaffolds the shared workspace constitution for coordinated multi-agent work              |
-| `org`                | Formalizes durable org identity and org-visible member hierarchy                          |
-| `schedule`           | Creates and manages recurring scheduled task groups for unattended automation             |
-| `soul-awakening`     | Anchors an agent to a `SOUL.md` persona — tone, stance, identity                          |
+| Skill            | What it does                                                                            |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| `system-setup`   | Detects and installs missing runtimes (Python, Node.js, uv) across all platforms        |
+| `mcp-installer`  | Registers MCP servers from npm packages, GitHub URLs, or JSON config blocks             |
+| `mcp-importer`   | Imports existing MCP configs from Cursor, VS Code, Windsurf, and similar setups         |
+| `delegate`       | Guides parent→child session handoff with explicit context transfer and lineage tracking |
+| `teamwork`       | Scaffolds the shared workspace constitution for coordinated multi-agent work            |
+| `org`            | Formalizes durable org identity and org-visible member hierarchy                        |
+| `schedule`       | Creates and manages recurring scheduled task groups for unattended automation           |
+| `soul-awakening` | Anchors an agent to a `SOUL.md` persona — tone, stance, identity                        |
 
 And that's just the operator layer. LibrAgent also ships domain skills for:
 
@@ -206,6 +206,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -135,16 +135,16 @@ O LibrAgent vem com uma biblioteca crescente de **Competências agrupadas**. Nã
 
 As competências mais importantes para o primeiro dia:
 
-| Competência          | O que faz                                                                                                         |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `system-setup`       | Deteta e instala runtimes em falta (Python, Node.js, uv) em todas as plataformas                                  |
-| `mcp-installer`      | Regista servidores MCP a partir de pacotes npm, URLs do GitHub ou blocos de config JSON                           |
-| `mcp-importer`       | Importa configs MCP existentes do Cursor, VS Code, Windsurf e similares                                           |
-| `delegate`           | Guia a transferência de sessão pai→filho com transferência de contexto explícita e rastreamento de linhagem       |
-| `teamwork`           | Constrói a constituição do espaço de trabalho partilhado para trabalho multi-agente coordenado                    |
-| `org`                | Formaliza identidade de organização duradoura e hierarquia de membros visível                                     |
-| `schedule`           | Cria e gere grupos de tarefas agendadas recorrentes para automatização sem supervisão                             |
-| `soul-awakening`     | Ancora um agente a uma persona `SOUL.md` — tom, postura, identidade                                               |
+| Competência      | O que faz                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `system-setup`   | Deteta e instala runtimes em falta (Python, Node.js, uv) em todas as plataformas                            |
+| `mcp-installer`  | Regista servidores MCP a partir de pacotes npm, URLs do GitHub ou blocos de config JSON                     |
+| `mcp-importer`   | Importa configs MCP existentes do Cursor, VS Code, Windsurf e similares                                     |
+| `delegate`       | Guia a transferência de sessão pai→filho com transferência de contexto explícita e rastreamento de linhagem |
+| `teamwork`       | Constrói a constituição do espaço de trabalho partilhado para trabalho multi-agente coordenado              |
+| `org`            | Formaliza identidade de organização duradoura e hierarquia de membros visível                               |
+| `schedule`       | Cria e gere grupos de tarefas agendadas recorrentes para automatização sem supervisão                       |
+| `soul-awakening` | Ancora um agente a uma persona `SOUL.md` — tom, postura, identidade                                         |
 
 E isso é apenas a camada de operador. O LibrAgent também fornece competências de domínio para:
 
@@ -202,6 +202,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -135,16 +135,16 @@ LibrAgent 附带不断增长数量的**捆绑技能**库。它们不是随机拼
 
 最重要的 day-one 技能：
 
-| 技能                 | 功能                                                  |
-| -------------------- | ----------------------------------------------------- |
-| `system-setup`       | 检测并安装所有平台上缺少的运行时(Python、Node.js、uv) |
-| `mcp-installer`      | 从 npm 包、GitHub URL 或 JSON 配置块注册 MCP 服务器   |
-| `mcp-importer`       | 从 Cursor、VS Code、Windsurf 等导入现有 MCP 配置      |
-| `delegate`           | 引导父→子会话移交，带显式上下文传递和谱系跟踪         |
-| `teamwork`           | 为协调多代理工作构建共享工作空间宪法                  |
-| `org`                | 正式化持久组织身份和 org-visible 成员层次结构         |
-| `schedule`           | 创建和管理无人值守自动化的定期计划任务组              |
-| `soul-awakening`     | 将代理锚定到 `SOUL.md` 人格——语气、立场、身份         |
+| 技能             | 功能                                                  |
+| ---------------- | ----------------------------------------------------- |
+| `system-setup`   | 检测并安装所有平台上缺少的运行时(Python、Node.js、uv) |
+| `mcp-installer`  | 从 npm 包、GitHub URL 或 JSON 配置块注册 MCP 服务器   |
+| `mcp-importer`   | 从 Cursor、VS Code、Windsurf 等导入现有 MCP 配置      |
+| `delegate`       | 引导父→子会话移交，带显式上下文传递和谱系跟踪         |
+| `teamwork`       | 为协调多代理工作构建共享工作空间宪法                  |
+| `org`            | 正式化持久组织身份和 org-visible 成员层次结构         |
+| `schedule`       | 创建和管理无人值守自动化的定期计划任务组              |
+| `soul-awakening` | 将代理锚定到 `SOUL.md` 人格——语气、立场、身份         |
 
 这只是运营层。LibrAgent 还提供领域技能：
 
@@ -202,6 +202,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/agent/tool_approvals.rs
+++ b/src-tauri/src/agent/tool_approvals.rs
@@ -274,6 +274,66 @@ mod tests {
         assert!(config
             .requires_approval
             .contains(&"workspace__writeFile".to_string()));
+        assert!(config
+            .requires_approval
+            .contains(&"scheduled_task__createScheduledTask".to_string()));
+        assert!(config
+            .requires_approval
+            .contains(&"scheduled_task__scheduleCallback".to_string()));
+        assert!(config
+            .requires_approval
+            .contains(&"scheduled_task__updateScheduledTask".to_string()));
+        assert!(config
+            .requires_approval
+            .contains(&"scheduled_task__toggleScheduledTask".to_string()));
+        assert!(config
+            .requires_approval
+            .contains(&"scheduled_task__deleteScheduledTask".to_string()));
+    }
+
+    #[tokio::test]
+    async fn scheduled_task_mutating_tools_require_approval() {
+        for tool_name in [
+            "scheduled_task__createScheduledTask",
+            "scheduled_task__scheduleCallback",
+            "scheduled_task__updateScheduledTask",
+            "scheduled_task__toggleScheduledTask",
+            "scheduled_task__deleteScheduledTask",
+        ] {
+            assert!(
+                is_approval_required(tool_name).await,
+                "{tool_name} should require approval"
+            );
+        }
+
+        for tool_name in [
+            "scheduled_task__listScheduledTasks",
+            "scheduled_task__getScheduledTask",
+        ] {
+            assert!(
+                !is_approval_required(tool_name).await,
+                "{tool_name} should not require approval"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scheduled_task_create_policy_returns_require_approval() {
+        let decision = evaluate_tool_execution_policy(
+            "scheduled_task__createScheduledTask",
+            &serde_json::json!({
+                "name": "Daily sync",
+                "cronExpression": "0 9 * * *",
+                "assistantId": "assistant-1",
+                "message": "Run daily sync"
+            }),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            ToolExecutionPolicyDecision::RequireApproval(_)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/mcp/builtin/service_id.rs
+++ b/src-tauri/src/mcp/builtin/service_id.rs
@@ -135,7 +135,7 @@ pub const BUILTIN_SERVICE_REGISTRY: &[BuiltinServiceEntry] = &[
     BuiltinServiceEntry {
         variant: BuiltinServiceId::ScheduledTask,
         canonical: "scheduled_task",
-        optional: true,
+        optional: false,
     },
     BuiltinServiceEntry {
         variant: BuiltinServiceId::Bootstrap,
@@ -164,6 +164,7 @@ pub const CORE_BUILTIN_SERVICE_ALIASES: &[&str] = &[
     "attachments",
     "ui",
     "tool",
+    "scheduled_task",
 ];
 
 impl fmt::Display for BuiltinServiceId {

--- a/src-tauri/src/mcp/builtin/workspace/sensitive_tools.json
+++ b/src-tauri/src/mcp/builtin/workspace/sensitive_tools.json
@@ -11,6 +11,11 @@
         "workspace__runInPersistentCmd",
         "workspace__stopProcess",
         "workspace__exportFile",
-        "workspace__exportZip"
+        "workspace__exportZip",
+        "scheduled_task__createScheduledTask",
+        "scheduled_task__scheduleCallback",
+        "scheduled_task__updateScheduledTask",
+        "scheduled_task__toggleScheduledTask",
+        "scheduled_task__deleteScheduledTask"
     ]
 }

--- a/src-tauri/tests/integration/builtin_service_registry_tests.rs
+++ b/src-tauri/tests/integration/builtin_service_registry_tests.rs
@@ -327,7 +327,7 @@ fn agent_public_surface_uses_single_session_start_tool() {
 }
 
 #[test]
-fn scheduled_task_service_is_registered_as_optional_builtin() {
+fn scheduled_task_service_is_registered_as_core_builtin() {
     assert_eq!(
         BuiltinServiceId::from_alias("scheduled_task"),
         Some(BuiltinServiceId::ScheduledTask)
@@ -343,10 +343,13 @@ fn scheduled_task_service_is_registered_as_optional_builtin() {
         .expect("scheduled_task must be registered");
 
     assert_eq!(entry.canonical, "scheduled_task");
-    assert!(entry.optional, "scheduled_task should remain opt-in");
     assert!(
-        !CORE_BUILTIN_SERVICE_ALIASES.contains(&"scheduled_task"),
-        "scheduled_task must not be treated as core"
+        !entry.optional,
+        "scheduled_task should be a core builtin service"
+    );
+    assert!(
+        CORE_BUILTIN_SERVICE_ALIASES.contains(&"scheduled_task"),
+        "scheduled_task must be treated as core"
     );
 }
 

--- a/src-tauri/tests/integration/ghost_session_lazy_proxy_tests.rs
+++ b/src-tauri/tests/integration/ghost_session_lazy_proxy_tests.rs
@@ -195,8 +195,8 @@ fn extract_builtin_tool_ids_respects_explicit_allowlist() {
         "Optional `browser` must be excluded when not in allowlist"
     );
     assert!(
-        !tool_ids.contains(&"scheduled_task".to_string()),
-        "Optional `scheduled_task` must be excluded when not in allowlist"
+        tool_ids.contains(&"scheduled_task".to_string()),
+        "Core `scheduled_task` must be included even when not in allowlist"
     );
     assert!(
         !tool_ids.contains(&"bootstrap".to_string()),

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.11_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64-setup.exe) · [`LibrAgent_0.8.11_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.11_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.11_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.AppImage) · [`LibrAgent_0.8.11_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent_0.8.11_amd64.deb) · [`LibrAgent-0.8.11-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.11/LibrAgent-0.8.11-1.x86_64.rpm)

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -58,6 +58,7 @@ export const CORE_BUILTIN_SERVICE_ALIASES = [
   'playbook',
   'attachments',
   'ui',
+  'scheduled_task',
   'tool',
 ] as const;
 
@@ -66,7 +67,6 @@ export const OPTIONAL_BUILTIN_SERVICE_ALIASES = [
   'knowledge',
   'history',
   'browser',
-  'scheduled_task',
   'bootstrap',
   'media',
 ] as const;


### PR DESCRIPTION
## 요약

`scheduled_task` 서비스를 CORE로 승격하고, mutating 도구 실행 시 tool approval을 적용합니다.

## 변경 내용

### Rust Backend
- `service_id.rs`: `scheduled_task` registry `optional: true` → `false`, `CORE_BUILTIN_SERVICE_ALIASES`에 추가
- `sensitive_tools.json`: mutating 도구 4개 (`createScheduledTask`, `scheduleCallback`, `updateScheduledTask`, `toggleScheduledTask`) `requires_approval` 등록
- 읽기 전용 도구 (`listScheduledTasks`, `getScheduledTask`, `deleteScheduledTask`)는 approval 면제

### 테스트
- `tool_approvals.rs`: 3개 테스트 추가 (fallback config 검증, mutating/read 구분, policy 반환값 검증)
- `builtin_service_registry_tests.rs`: 테스트 명명 및 조건 수정 (optional → core)
- `ghost_session_lazy_proxy_tests.rs`: CORE 포함 검증으로 논리 반전

### Frontend
- `builtin-services.ts`: generated CORE/OPTIONAL 리스트 자동 동기화

## 디자인 결정

### CORE 승격 vs optional 유지
- `scheduled_task`는 `knowledge`/ `history`보다 고권한·지속 실행·비용 리스크가 큼
- CORE 승격으로 모든 assistant가 도구 노출을 받지만, **실행 시 approval 게이트**로 제어
- 기존 `workspace__writeFile` 등의 민감 도구와 동일한 approval 경로 재사용

### mutating 도구만 approval
- `create`, `schedule`, `update`, `toggle` → approval 필요 (DB write)
- `list`, `get`, `delete` → approval 면제 (read-only / assistant 직접 관리)

## 테스트
```bash
cargo test --tests
pnpm refactor:validate
```
