### PR TITLE
⚡ Bolt: [performance improvement] Optimize startup metric summarization to reduce GC pressure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid GC Pressure in Startup Metrics
+**Learning:** In non-React data processing code like startup metrics, using `.reduce()` when the callback allocates a new object on every iteration creates severe garbage collection pressure.
+**Action:** Refactor these reducers to use primitive variables during a standard `for` loop and allocate a single object at the end to improve startup performance.

--- a/src/lib/performance/startup-metrics.ts
+++ b/src/lib/performance/startup-metrics.ts
@@ -99,18 +99,22 @@ function nowMs(): number {
 function summarizeLongTasks(
   longTasks: readonly StartupLongTaskEntry[],
 ): StartupLongTaskSummary {
-  return longTasks.reduce<StartupLongTaskSummary>(
-    (summary, task) => ({
-      count: summary.count + 1,
-      totalDurationMs: summary.totalDurationMs + task.durationMs,
-      maxDurationMs: Math.max(summary.maxDurationMs, task.durationMs),
-    }),
-    {
-      count: 0,
-      totalDurationMs: 0,
-      maxDurationMs: 0,
-    },
-  );
+  // ⚡ Bolt: Replaced .reduce() with a single-pass loop to avoid allocating
+  // a new accumulator object on every iteration, reducing GC pressure during startup.
+  let count = 0;
+  let totalDurationMs = 0;
+  let maxDurationMs = 0;
+
+  for (let i = 0; i < longTasks.length; i++) {
+    const task = longTasks[i];
+    count++;
+    totalDurationMs += task.durationMs;
+    if (task.durationMs > maxDurationMs) {
+      maxDurationMs = task.durationMs;
+    }
+  }
+
+  return { count, totalDurationMs, maxDurationMs };
 }
 
 function summarizeIpcCalls(


### PR DESCRIPTION
### 💡 What
Replaced the `.reduce()` method in `summarizeLongTasks` with a standard `for` loop in `src/lib/performance/startup-metrics.ts`. Added explanatory Bolt comments.

### 🎯 Why
The original `.reduce()` implementation allocated a new accumulator object on every single iteration of the loop. During application startup, this generates unnecessary garbage collection (GC) pressure. By using primitive variables inside a loop and returning a single object at the end, we eliminate this overhead.

### 📉 Impact
Reduces memory allocations and GC pressure during the critical application startup phase, leading to slightly faster and more predictable startup times.

### 🔬 Measurement
Startup metrics can be measured via performance profiling in the browser developer tools, verifying that memory allocations during the `summarizeLongTasks` execution are significantly reduced.

---
*PR created automatically by Jules for task [1245820990502615425](https://jules.google.com/task/1245820990502615425) started by @fritzprix*