### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Workspace Export

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/mcp/builtin/workspace/export_operations.rs
+++ b/src-tauri/src/mcp/builtin/workspace/export_operations.rs
@@ -68,10 +68,11 @@ impl WorkspaceServer {
 
         if paths_array.len() == 1 {
             if let Some(path_str) = paths_array[0].as_str() {
-                let check_path = workspace_dir_canon.join(path_str);
-                // Canonicalize the candidate path and ensure it stays within the workspace
-                if let Ok(canon_check) = std::fs::canonicalize(&check_path) {
-                    if canon_check.starts_with(&workspace_dir_canon) && canon_check.is_file() {
+                if let Ok(canon_check) =
+                    crate::utils::security::resolve_secure_path(&workspace_dir_canon, path_str)
+                        .await
+                {
+                    if canon_check.is_file() {
                         is_single_file_mode = true;
                         single_file_path = Some(canon_check);
                         single_file_rel_path_str = path_str.to_string();
@@ -180,9 +181,13 @@ impl WorkspaceServer {
         let mut missing_files = Vec::new();
         for file_value in paths_array {
             if let Some(path_str) = file_value.as_str() {
-                let file_path = workspace_dir_canon.join(path_str);
-                if !file_path.exists() {
-                    missing_files.push(path_str.to_string());
+                match crate::utils::security::resolve_secure_path(&workspace_dir_canon, path_str)
+                    .await
+                {
+                    Ok(file_path) if file_path.exists() => {}
+                    _ => {
+                        missing_files.push(path_str.to_string());
+                    }
                 }
             }
         }
@@ -232,10 +237,15 @@ impl WorkspaceServer {
 
         for file_value in paths_array {
             if let Some(path_str) = file_value.as_str() {
-                let source_path = workspace_dir_canon.join(path_str);
-                if !source_path.exists() {
-                    continue;
-                }
+                let source_path = match crate::utils::security::resolve_secure_path(
+                    &workspace_dir_canon,
+                    path_str,
+                )
+                .await
+                {
+                    Ok(p) if p.exists() => p,
+                    _ => continue,
+                };
 
                 let roots: Vec<PathBuf> = if source_path.is_file() {
                     vec![source_path]

--- a/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
+++ b/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use super::super::WorkspaceServer;
-    use crate::mcp::builtin::BuiltinMCPServer;
     use crate::session::SessionManager;
     use serde_json::json;
     use std::sync::Arc;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal vulnerability in the workspace export tool. Using `PathBuf::join` with unvalidated user input could allow exporting arbitrary files outside the workspace root, as `join` replaces the base if the input is absolute.
🎯 **Impact:** An attacker could potentially extract sensitive files from the host system.
🔧 **Fix:** Replaced vulnerable `PathBuf::join` calls with the repository's `crate::utils::security::resolve_secure_path` utility to ensure paths are strictly bounded to the workspace directory.
✅ **Verification:** Validated that `cargo test --lib mcp::builtin::workspace::export_operations` and integration tests pass. Checked code visually to ensure no other vulnerable `join` calls exist in this file.

---
*PR created automatically by Jules for task [11614496057053276094](https://jules.google.com/task/11614496057053276094) started by @fritzprix*