### PR TITLE
⚡ Bolt: Remove intermediate array allocation in OpenRouter listModels

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Avoid GC Pressure in Startup Metrics
 **Learning:** In non-React data processing code like startup metrics, using `.reduce()` when the callback allocates a new object on every iteration creates severe garbage collection pressure.
 **Action:** Refactor these reducers to use primitive variables during a standard `for` loop and allocate a single object at the end to improve startup performance.
+## 2025-06-13 - [Optimize OpenRouter listModels Iteration]
+**Learning:** [Replacing `Array.from(map.values()).map(...)` with a `for...of` loop directly on the map iterator avoids intermediate array allocations and reduces garbage collection pressure.]
+**Action:** [When converting iterables or map values into an array, iterate directly with `for...of` instead of allocating intermediate arrays via `Array.from()` followed by `.map()`.]

--- a/src-tauri/src/commands/dataset_commands.rs
+++ b/src-tauri/src/commands/dataset_commands.rs
@@ -115,7 +115,7 @@ pub async fn export_dataset(
     let mut exported_messages = 0;
 
     for s in &sessions_to_export {
-        let messages = load_session_messages(&message_repo, &s.id).await?;
+        let messages = load_session_messages(message_repo, &s.id).await?;
 
         if messages.is_empty() {
             continue;
@@ -147,7 +147,7 @@ pub async fn export_dataset(
             .map(|m| {
                 m.content
                     .iter()
-                    .map(|c| extract_message_text(c))
+                    .map(extract_message_text)
                     .collect::<Vec<String>>()
                     .join(" ")
                     .len()
@@ -176,7 +176,7 @@ pub async fn export_dataset(
                     let text = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     conv.push(ShareGPTMessage { from, value: text });
@@ -191,7 +191,7 @@ pub async fn export_dataset(
                     let text = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     if m.role == "user" {
@@ -217,7 +217,7 @@ pub async fn export_dataset(
                     let content = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     conv.push(OpenAIJSONLMessage { role, content });

--- a/src/lib/ai-service/openrouter.ts
+++ b/src/lib/ai-service/openrouter.ts
@@ -102,24 +102,29 @@ export class OpenRouterService extends OpenAIService {
       logger.info('Fetching models from OpenRouter public metadata API');
       const models = await fetchOpenRouterModels();
 
-      const result: ModelInfo[] = Array.from(models.values()).map((m) => ({
-        id: m.id,
-        name: m.name,
-        contextWindow: m.context_length ?? 4096,
-        supportReasoning:
-          m.supported_parameters.includes('reasoning') ||
-          !!m.pricing.internal_reasoning,
-        supportTools: m.supported_parameters.includes('tools'),
-        supportStreaming:
-          m.supported_parameters.includes('stream') ||
-          m.supported_parameters.includes('streaming'),
-        cost: {
-          // OpenRouter pricing is per-token; convert to per-million for ModelInfo
-          input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
-          output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
-        },
-        description: m.description || m.name,
-      }));
+      // ⚡ Bolt: Replaced Array.from(map.values()).map(...) with a for...of loop directly on the map iterator
+      // to avoid intermediate array allocations and reduce garbage collection pressure.
+      const result: ModelInfo[] = [];
+      for (const m of models.values()) {
+        result.push({
+          id: m.id,
+          name: m.name,
+          contextWindow: m.context_length ?? 4096,
+          supportReasoning:
+            m.supported_parameters.includes('reasoning') ||
+            !!m.pricing.internal_reasoning,
+          supportTools: m.supported_parameters.includes('tools'),
+          supportStreaming:
+            m.supported_parameters.includes('stream') ||
+            m.supported_parameters.includes('streaming'),
+          cost: {
+            // OpenRouter pricing is per-token; convert to per-million for ModelInfo
+            input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
+            output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
+          },
+          description: m.description || m.name,
+        });
+      }
 
       logger.info(`OpenRouter: ${result.length} models available`);
       return result;


### PR DESCRIPTION
💡 What: Replaced Array.from(models.values()).map(...) with a for...of loop directly on the models.values() iterator in the OpenRouter listModels implementation.
🎯 Why: Calling Array.from() on an iterator allocates a new array containing all values, which is immediately iterated over by .map() to create another new array. This causes unnecessary intermediate array allocation and garbage collection pressure when processing hundreds of models.
📊 Impact: Faster parsing and reduced memory overhead/GC pressure when fetching and processing the list of available OpenRouter models.
🔬 Measurement: Verify OpenRouter model loading still functions correctly in settings/UI, and observe memory allocation patterns during model refresh.

---
*PR created automatically by Jules for task [12539282027369143853](https://jules.google.com/task/12539282027369143853) started by @fritzprix*