### PR TITLE
⚡ Bolt: [Performance] Eliminate intermediate array allocation in OpenRouter listModels

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Avoid GC Pressure in Startup Metrics
 **Learning:** In non-React data processing code like startup metrics, using `.reduce()` when the callback allocates a new object on every iteration creates severe garbage collection pressure.
 **Action:** Refactor these reducers to use primitive variables during a standard `for` loop and allocate a single object at the end to improve startup performance.
+
+## 2024-06-14 - Optimize Map iteration in openrouter.ts
+**Learning:** Using `Array.from(map.values()).map(...)` creates unnecessary intermediate array allocations, increasing garbage collection pressure.
+**Action:** Iterate directly over `map.values()` using a `for...of` loop and push to a result array to avoid intermediate allocations on hot paths or large collections.

--- a/src-tauri/src/commands/dataset_commands.rs
+++ b/src-tauri/src/commands/dataset_commands.rs
@@ -115,7 +115,7 @@ pub async fn export_dataset(
     let mut exported_messages = 0;
 
     for s in &sessions_to_export {
-        let messages = load_session_messages(&message_repo, &s.id).await?;
+        let messages = load_session_messages(message_repo, &s.id).await?;
 
         if messages.is_empty() {
             continue;
@@ -147,7 +147,7 @@ pub async fn export_dataset(
             .map(|m| {
                 m.content
                     .iter()
-                    .map(|c| extract_message_text(c))
+                    .map(extract_message_text)
                     .collect::<Vec<String>>()
                     .join(" ")
                     .len()
@@ -176,7 +176,7 @@ pub async fn export_dataset(
                     let text = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     conv.push(ShareGPTMessage { from, value: text });
@@ -191,7 +191,7 @@ pub async fn export_dataset(
                     let text = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     if m.role == "user" {
@@ -217,7 +217,7 @@ pub async fn export_dataset(
                     let content = m
                         .content
                         .iter()
-                        .map(|c| extract_message_text(c))
+                        .map(extract_message_text)
                         .collect::<Vec<String>>()
                         .join("\n");
                     conv.push(OpenAIJSONLMessage { role, content });

--- a/src/lib/ai-service/openrouter.ts
+++ b/src/lib/ai-service/openrouter.ts
@@ -102,24 +102,28 @@ export class OpenRouterService extends OpenAIService {
       logger.info('Fetching models from OpenRouter public metadata API');
       const models = await fetchOpenRouterModels();
 
-      const result: ModelInfo[] = Array.from(models.values()).map((m) => ({
-        id: m.id,
-        name: m.name,
-        contextWindow: m.context_length ?? 4096,
-        supportReasoning:
-          m.supported_parameters.includes('reasoning') ||
-          !!m.pricing.internal_reasoning,
-        supportTools: m.supported_parameters.includes('tools'),
-        supportStreaming:
-          m.supported_parameters.includes('stream') ||
-          m.supported_parameters.includes('streaming'),
-        cost: {
-          // OpenRouter pricing is per-token; convert to per-million for ModelInfo
-          input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
-          output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
-        },
-        description: m.description || m.name,
-      }));
+      // ⚡ Bolt: Eliminate intermediate array allocation by iterating directly over the map values.
+      const result: ModelInfo[] = [];
+      for (const m of models.values()) {
+        result.push({
+          id: m.id,
+          name: m.name,
+          contextWindow: m.context_length ?? 4096,
+          supportReasoning:
+            m.supported_parameters.includes('reasoning') ||
+            !!m.pricing.internal_reasoning,
+          supportTools: m.supported_parameters.includes('tools'),
+          supportStreaming:
+            m.supported_parameters.includes('stream') ||
+            m.supported_parameters.includes('streaming'),
+          cost: {
+            // OpenRouter pricing is per-token; convert to per-million for ModelInfo
+            input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
+            output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
+          },
+          description: m.description || m.name,
+        });
+      }
 
       logger.info(`OpenRouter: ${result.length} models available`);
       return result;


### PR DESCRIPTION
## 💡 What
Replaced `Array.from(models.values()).map(...)` with a `for...of` loop in `src/lib/ai-service/openrouter.ts`.

## 🎯 Why
To reduce garbage collection pressure by avoiding the creation of an unnecessary intermediate array during the fetching of OpenRouter models.

## 📊 Impact
Eliminates one O(N) array allocation step for each fetch of the OpenRouter model list, reducing memory allocation and subsequent garbage collection overhead.

## 🔬 Measurement
Performance can be measured via memory profiling during the application's AI model fetching lifecycle to observe reduced allocation sizes.

---
*PR created automatically by Jules for task [5711147363108355633](https://jules.google.com/task/5711147363108355633) started by @fritzprix*