### PR TITLE
refactor(agent): @skill references as metadata with mandatory read guidance

### DIFF
--- a/src-tauri/src/agent/references/mod.rs
+++ b/src-tauri/src/agent/references/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use regex::Regex;
+use std::collections::HashSet;
 
 mod file;
 mod playbook;
@@ -8,6 +9,18 @@ mod skill;
 pub use file::{list_relative_paths_in_root, list_workspace_relative_paths, FileReferenceResolver};
 pub use playbook::PlaybookReferenceResolver;
 pub use skill::SkillReferenceResolver;
+
+fn reference_dedupe_key(type_name: &str, arg: &str) -> String {
+    if type_name.eq_ignore_ascii_case("skill") {
+        format!("{type_name}:{}", arg.to_ascii_lowercase())
+    } else {
+        format!("{type_name}:{arg}")
+    }
+}
+
+const MULTIPLE_SKILLS_REFERENCE_PREAMBLE: &str = "**Multiple skills referenced:** Read all \
+instruction files listed below before calling any other tool or taking action on the user's \
+message. Apply each skill only where it fits the task.";
 
 /// Resolves a single `@type:arg` reference to its injectable text content.
 #[async_trait]
@@ -18,10 +31,16 @@ pub trait ReferenceResolver: Send + Sync {
     /// Attempt to resolve the given argument to injectable text.
     /// Returns `None` if the reference cannot be found (silently skipped).
     async fn resolve(&self, arg: &str) -> Option<String>;
+
+    /// When `true`, resolved content is appended after the original user text.
+    /// When `false` (default), resolved content is prepended before the user text.
+    fn append_after_user_text(&self) -> bool {
+        false
+    }
 }
 
 /// Registry of all active reference resolvers.
-/// Parses `@type:arg` tokens from user message text and prepends resolved content.
+/// Parses `@type:arg` tokens from user message text and injects resolved content.
 pub struct ReferenceRegistry {
     resolvers: Vec<Box<dyn ReferenceResolver>>,
 }
@@ -36,9 +55,12 @@ impl ReferenceRegistry {
         self.resolvers.push(resolver);
     }
 
-    /// Parse all `@type:arg` tokens from `text`, resolve each, and return
-    /// the message text with resolved content prepended.
-    /// References that cannot be resolved are silently skipped.
+    /// Parse all `@type:arg` tokens from `text`, resolve each, and return the message
+    /// text with resolved reference blocks injected.
+    ///
+    /// Most resolvers prepend content before the user text. Skill references append
+    /// metadata and read guidance after the user text so `@skill:name ...` sentences
+    /// stay intact at the top of the payload.
     /// Returns the original `text` unchanged if no references exist.
     pub async fn preprocess_message_text(&self, text: &str) -> String {
         // Matches @word:non-whitespace tokens anywhere in the text
@@ -48,6 +70,11 @@ impl ReferenceRegistry {
         };
 
         let mut prefix_parts: Vec<String> = Vec::new();
+        // Blocks from resolvers with `append_after_user_text()` (skill today; others stay prefix).
+        let mut skill_suffix_parts: Vec<String> = Vec::new();
+        let mut other_suffix_parts: Vec<String> = Vec::new();
+        let mut seen_resolved_keys: HashSet<String> = HashSet::new();
+        let mut seen_unresolved_tokens: HashSet<String> = HashSet::new();
         let mut unresolved_tokens: Vec<String> = Vec::new();
 
         for cap in re.captures_iter(text) {
@@ -59,40 +86,71 @@ impl ReferenceRegistry {
             for resolver in &self.resolvers {
                 if resolver.type_name() == type_name {
                     if let Some(content) = resolver.resolve(arg).await {
-                        prefix_parts.push(format!(
-                            "## Reference: @{}:{}\n\n{}",
-                            type_name, arg, content
-                        ));
+                        let dedupe_key = reference_dedupe_key(type_name, arg);
+                        if !seen_resolved_keys.insert(dedupe_key) {
+                            resolved = true;
+                            break;
+                        }
+
+                        let block = format!("## Reference: @{}:{}\n\n{}", type_name, arg, content);
+                        if resolver.append_after_user_text() {
+                            skill_suffix_parts.push(block);
+                        } else {
+                            prefix_parts.push(block);
+                        }
                         resolved = true;
                     }
                     break;
                 }
             }
 
-            // Replace unresolved tokens inline so the AI knows the reference failed
-            if !resolved {
+            if !resolved && seen_unresolved_tokens.insert(token.clone()) {
                 unresolved_tokens.push(token);
             }
         }
 
-        // Build inline notice for unresolved references
         if !unresolved_tokens.is_empty() {
             let notice = unresolved_tokens
                 .iter()
                 .map(|t| format!("`{}` (not found)", t))
                 .collect::<Vec<_>>()
                 .join(", ");
-            prefix_parts.push(format!(
+            other_suffix_parts.push(format!(
                 "⚠️ The following references could not be resolved and their content was NOT injected: {}",
                 notice
             ));
         }
 
-        if prefix_parts.is_empty() {
+        let mut suffix_parts: Vec<String> = Vec::new();
+        if skill_suffix_parts.len() > 1 {
+            suffix_parts.push(MULTIPLE_SKILLS_REFERENCE_PREAMBLE.to_string());
+        }
+        suffix_parts.extend(skill_suffix_parts);
+        suffix_parts.extend(other_suffix_parts);
+
+        if prefix_parts.is_empty() && suffix_parts.is_empty() {
             return text.to_string();
         }
 
-        format!("{}\n\n---\n\n{}", prefix_parts.join("\n\n---\n\n"), text)
+        let mut result = text.to_string();
+
+        if !prefix_parts.is_empty() {
+            result = format!(
+                "{}\n\n---\n\n{}",
+                prefix_parts.join("\n\n---\n\n"),
+                result
+            );
+        }
+
+        if !suffix_parts.is_empty() {
+            result = format!(
+                "{}\n\n---\n\n{}",
+                result,
+                suffix_parts.join("\n\n---\n\n")
+            );
+        }
+
+        result
     }
 }
 

--- a/src-tauri/src/agent/references/mod.rs
+++ b/src-tauri/src/agent/references/mod.rs
@@ -135,19 +135,11 @@ impl ReferenceRegistry {
         let mut result = text.to_string();
 
         if !prefix_parts.is_empty() {
-            result = format!(
-                "{}\n\n---\n\n{}",
-                prefix_parts.join("\n\n---\n\n"),
-                result
-            );
+            result = format!("{}\n\n---\n\n{}", prefix_parts.join("\n\n---\n\n"), result);
         }
 
         if !suffix_parts.is_empty() {
-            result = format!(
-                "{}\n\n---\n\n{}",
-                result,
-                suffix_parts.join("\n\n---\n\n")
-            );
+            result = format!("{}\n\n---\n\n{}", result, suffix_parts.join("\n\n---\n\n"));
         }
 
         result

--- a/src-tauri/src/agent/references/skill.rs
+++ b/src-tauri/src/agent/references/skill.rs
@@ -1,12 +1,10 @@
 use super::ReferenceResolver;
-use crate::services::skill_service;
+use crate::services::skill_service::{self, SkillMetadata};
 use async_trait::async_trait;
 use std::path::PathBuf;
 
-/// Max size for inlining skill content into context (100 KB)
-const MAX_SKILL_INLINE_BYTES: u64 = 100 * 1024;
-
-/// Resolves `@skill:name` references by reading the corresponding SKILL.md file.
+/// Resolves `@skill:name` references with skill metadata and read guidance.
+/// Full SKILL.md content is not inlined; the agent is directed to read the file.
 pub struct SkillReferenceResolver {
     session_id: String,
     assistant_id: Option<String>,
@@ -21,13 +19,44 @@ impl SkillReferenceResolver {
     }
 }
 
+pub(crate) fn format_skill_reference_block(skill: &SkillMetadata) -> String {
+    let path = PathBuf::from(&skill.path);
+    let base_dir = path.parent().unwrap_or(&path);
+    let instructions_path = path.display().to_string();
+
+    format!(
+        "**Name:** {}\n\
+         **Description:** {}\n\
+         **Instructions file:** `{}`\n\
+         **Base directory:** `{}`\n\n\
+         **Required — read before any other action:** The user message above is the primary \
+         task. This block only identifies which skill applies. You MUST NOT call other tools, \
+         delegate, or answer from the description alone.\n\n\
+         1. First, call `workspace__readFile(path: \"{}\")`.\n\
+         2. Follow the workflow in that file exactly.\n\
+         3. Apply it to the task stated in the user message above.\n\n\
+         Do not infer the skill workflow from its name or description. Skipping the read step \
+         is not allowed. Interpret any relative paths mentioned in the skill relative to the \
+         base directory.",
+        skill.name,
+        skill.description,
+        instructions_path,
+        base_dir.display(),
+        instructions_path
+    )
+}
+
 #[async_trait]
 impl ReferenceResolver for SkillReferenceResolver {
     fn type_name(&self) -> &'static str {
         "skill"
     }
 
-    /// Looks up the skill named `arg` in the configured skills directory and returns its content.
+    fn append_after_user_text(&self) -> bool {
+        true
+    }
+
+    /// Looks up the skill named `arg` and returns metadata plus read guidance.
     async fn resolve(&self, arg: &str) -> Option<String> {
         let system_dir = skill_service::get_system_skills_directory().ok()?;
         let user_dir = skill_service::get_user_skills_directory().ok()?;
@@ -38,56 +67,49 @@ impl ReferenceResolver for SkillReferenceResolver {
             skill_service::get_workspace_skills_directory_for_session(&self.session_id).ok();
 
         let skills = skill_service::resolve_skills(
-            system_dir.clone(),
-            user_dir.clone(),
-            assistant_dir.clone(),
-            workspace_dir.clone(),
-        )
-        .await
-        .ok()?;
-
-        // Find skill by case-insensitive name match
-        let skill = skills
-            .into_iter()
-            .find(|s| s.name.eq_ignore_ascii_case(arg))?;
-
-        let path = PathBuf::from(&skill.path);
-
-        // Guard: check file size before reading
-        let file_size = tokio::fs::metadata(&path).await.ok()?.len();
-        if file_size > MAX_SKILL_INLINE_BYTES {
-            return Some(format!(
-                "# Follow Instruction `{}`\n\n⚠️ Skill file is too large to inline ({} KB).",
-                skill.path,
-                file_size / 1024
-            ));
-        }
-
-        let allowed_roots = skill_service::collect_allowed_skill_roots(
             system_dir,
             user_dir,
             assistant_dir,
             workspace_dir,
-        );
-        let content =
-            skill_service::get_skill_content_from_roots(skill.path.clone(), &allowed_roots)
-                .await
-                .ok()?;
-        let base_dir = path.parent().unwrap_or(&path);
+        )
+        .await
+        .ok()?;
 
-        // Pre-inject content with explicit Base Directory metadata.
-        // This gives the AI immediate access to instructions while clarifying the
-        // absolute path context for any relative resources or templates mentioned in the skill.
-        Some(format!(
-            "# Follow Instruction `{}`\n\
-            **Base Directory for this skill is**: `{}`\n\n\
-            --- Content Start ---\n\n\
-            {}\n\n\
-            --- Content End ---\n\n\
-            **Note**: All relative paths mentioned in the instructions above must be interpreted relative to the **Base Directory** provided.",
-            path.display(),
-            base_dir.display(),
-            content
-        ))
+        let skill = skills
+            .into_iter()
+            .find(|s| s.name.eq_ignore_ascii_case(arg))?;
+
+        if !PathBuf::from(&skill.path).is_file() {
+            return None;
+        }
+
+        Some(format_skill_reference_block(&skill))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_skill_reference_block_includes_metadata_and_read_guidance() {
+        let skill = SkillMetadata {
+            name: "delegate".to_string(),
+            description: "Delegate work between sessions.".to_string(),
+            path: "/tmp/skills/delegate/SKILL.md".to_string(),
+            source: None,
+            origin: None,
+        };
+
+        let output = format_skill_reference_block(&skill);
+
+        assert!(output.contains("**Name:** delegate"));
+        assert!(output.contains("**Description:** Delegate work between sessions."));
+        assert!(output.contains("**Instructions file:** `/tmp/skills/delegate/SKILL.md`"));
+        assert!(output.contains("**Base directory:** `/tmp/skills/delegate`"));
+        assert!(output.contains("workspace__readFile(path: \"/tmp/skills/delegate/SKILL.md\")"));
+        assert!(output.contains("Required — read before any other action"));
+        assert!(output.contains("Skipping the read step is not allowed"));
+        assert!(!output.contains("--- Content Start ---"));
     }
 }

--- a/src-tauri/src/agent/references/skill.rs
+++ b/src-tauri/src/agent/references/skill.rs
@@ -66,14 +66,10 @@ impl ReferenceResolver for SkillReferenceResolver {
         let workspace_dir =
             skill_service::get_workspace_skills_directory_for_session(&self.session_id).ok();
 
-        let skills = skill_service::resolve_skills(
-            system_dir,
-            user_dir,
-            assistant_dir,
-            workspace_dir,
-        )
-        .await
-        .ok()?;
+        let skills =
+            skill_service::resolve_skills(system_dir, user_dir, assistant_dir, workspace_dir)
+                .await
+                .ok()?;
 
         let skill = skills
             .into_iter()

--- a/src-tauri/src/mcp/builtin/skills/mod.rs
+++ b/src-tauri/src/mcp/builtin/skills/mod.rs
@@ -153,7 +153,8 @@ impl BuiltinMCPServer for SkillsServer {
         let prompt = format!(
             "## Available Skills\n\n\
             You have access to the following skills. The <location> tag specifies the main documentation file for each skill.\n\
-            To use a skill, you MUST first read its <location> file using the `readFile` tool. This file contains all necessary instructions and commands.\n\n\
+            To use a skill, you MUST first read its <location> file using `workspace__readFile`. \
+            Do not act from the description alone; read the file before any other tool call.\n\n\
             <available_skills>\n{}\n</available_skills>",
             skills_xml
         );

--- a/src-tauri/tests/integration/reference_resolver_tests.rs
+++ b/src-tauri/tests/integration/reference_resolver_tests.rs
@@ -34,7 +34,10 @@ async fn test_preprocess_unresolved_mention_appends_notice() {
         result.contains("not found"),
         "Expected unresolved notice, got: {result}"
     );
-    assert!(result.starts_with(text), "Original user text must come first");
+    assert!(
+        result.starts_with(text),
+        "Original user text must come first"
+    );
     assert!(result.contains(text), "Original text must be preserved");
 }
 

--- a/src-tauri/tests/integration/reference_resolver_tests.rs
+++ b/src-tauri/tests/integration/reference_resolver_tests.rs
@@ -2,25 +2,16 @@
 ///
 /// Covers:
 ///   - `ReferenceRegistry::preprocess_message_text` output format
-///   - `SkillReferenceResolver`: path in header, content wrapped in markdown fence, size guard
+///   - `SkillReferenceResolver`: metadata + read guidance appended after user text
 ///   - `FileReferenceResolver`: compact workspace-file references with targeted read guidance
 ///     and path traversal protection
 use std::fs;
-use std::path::Path;
 use tauri_mcp_agent_lib::agent::references::{ReferenceRegistry, ReferenceResolver};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Write a minimal valid SKILL.md into `dir/<subdir>/SKILL.md`.
-fn write_skill(dir: &Path, subdir: &str, name: &str, body: &str) {
-    let skill_dir = dir.join(subdir);
-    fs::create_dir_all(&skill_dir).unwrap();
-    let content = format!("---\nname: {}\ndescription: test\n---\n{}", name, body);
-    fs::write(skill_dir.join("SKILL.md"), content).unwrap();
-}
 
 // ---------------------------------------------------------------------------
 // ReferenceRegistry::preprocess_message_text
@@ -43,8 +34,106 @@ async fn test_preprocess_unresolved_mention_appends_notice() {
         result.contains("not found"),
         "Expected unresolved notice, got: {result}"
     );
-    // Original text still present after the separator
+    assert!(result.starts_with(text), "Original user text must come first");
     assert!(result.contains(text), "Original text must be preserved");
+}
+
+#[tokio::test]
+async fn test_preprocess_skill_like_resolver_appends_after_original_text() {
+    use async_trait::async_trait;
+
+    struct SkillLikeResolver;
+    #[async_trait]
+    impl ReferenceResolver for SkillLikeResolver {
+        fn type_name(&self) -> &'static str {
+            "skill"
+        }
+
+        fn append_after_user_text(&self) -> bool {
+            true
+        }
+
+        async fn resolve(&self, _arg: &str) -> Option<String> {
+            Some("SKILL META".to_string())
+        }
+    }
+
+    let mut registry = ReferenceRegistry::new();
+    registry.register(Box::new(SkillLikeResolver));
+
+    let text = "@skill:delegate 로컬 변경 사항을 리뷰";
+    let result = registry.preprocess_message_text(text).await;
+
+    assert!(result.starts_with(text), "User text must stay at the top");
+    let meta_pos = result.find("SKILL META").unwrap();
+    let original_pos = result.find(text).unwrap();
+    assert!(
+        original_pos < meta_pos,
+        "Skill reference must be appended after original text"
+    );
+    assert!(result.contains("## Reference: @skill:delegate"));
+}
+
+#[tokio::test]
+async fn test_preprocess_duplicate_skill_reference_injects_once() {
+    use async_trait::async_trait;
+
+    struct SkillLikeResolver;
+    #[async_trait]
+    impl ReferenceResolver for SkillLikeResolver {
+        fn type_name(&self) -> &'static str {
+            "skill"
+        }
+
+        fn append_after_user_text(&self) -> bool {
+            true
+        }
+
+        async fn resolve(&self, arg: &str) -> Option<String> {
+            Some(format!("SKILL META for {arg}").to_string())
+        }
+    }
+
+    let mut registry = ReferenceRegistry::new();
+    registry.register(Box::new(SkillLikeResolver));
+
+    let text = "@skill:delegate review @skill:delegate again @skill:Delegate";
+    let result = registry.preprocess_message_text(text).await;
+
+    assert_eq!(result.matches("## Reference: @skill:").count(), 1);
+    assert!(!result.contains("Multiple skills referenced"));
+}
+
+#[tokio::test]
+async fn test_preprocess_multiple_distinct_skill_references_each_injected_once() {
+    use async_trait::async_trait;
+
+    struct SkillLikeResolver;
+    #[async_trait]
+    impl ReferenceResolver for SkillLikeResolver {
+        fn type_name(&self) -> &'static str {
+            "skill"
+        }
+
+        fn append_after_user_text(&self) -> bool {
+            true
+        }
+
+        async fn resolve(&self, arg: &str) -> Option<String> {
+            Some(format!("SKILL META for {arg}").to_string())
+        }
+    }
+
+    let mut registry = ReferenceRegistry::new();
+    registry.register(Box::new(SkillLikeResolver));
+
+    let text = "@skill:delegate review @skill:code-audit-expert audit @skill:delegate";
+    let result = registry.preprocess_message_text(text).await;
+
+    assert!(result.contains("Multiple skills referenced"));
+    assert!(result.contains("## Reference: @skill:delegate"));
+    assert!(result.contains("## Reference: @skill:code-audit-expert"));
+    assert_eq!(result.matches("## Reference: @skill:").count(), 2);
 }
 
 #[tokio::test]
@@ -77,88 +166,6 @@ async fn test_preprocess_resolved_content_prepended_before_original_text() {
     );
     // Section header format
     assert!(result.contains("## Reference: @stub:anything"));
-}
-
-// ---------------------------------------------------------------------------
-// SkillReferenceResolver
-// ---------------------------------------------------------------------------
-
-/// Directly invoke SkillReferenceResolver using a temp skills directory.
-/// We bypass the global config by using `scan_skills_directory` + `get_skill_content`
-/// indirectly through a custom registry wired to a temp path.
-///
-/// Since SkillReferenceResolver reads from the configured global skills directory
-/// (not injectable), we test its output *format* via the service layer directly.
-/// Note: get_skill_content requires the settings repository singleton; we bypass it
-/// by reading the file directly to validate the formatter output shape.
-#[tokio::test]
-async fn test_skill_resolve_output_format_includes_path_and_fence() {
-    use tauri_mcp_agent_lib::services::skill_service;
-
-    let tmp = TempDir::new().unwrap();
-    write_skill(
-        tmp.path(),
-        "my-skill",
-        "My Skill",
-        "## Instructions\nDo things.",
-    );
-
-    let skills = skill_service::scan_skills_directory(tmp.path())
-        .await
-        .unwrap();
-    assert_eq!(skills.len(), 1);
-
-    let skill = &skills[0];
-    // Read directly to avoid settings-repo dependency in get_skill_content
-    let content = fs::read_to_string(&skill.path).unwrap();
-
-    // Replicate what SkillReferenceResolver produces
-    let output = format!(
-        "# Follow Instruction `{}`\n\n```markdown\n{}\n```",
-        skill.path, content
-    );
-
-    assert!(
-        output.starts_with("# Follow Instruction `"),
-        "Must start with path header"
-    );
-    assert!(
-        output.contains(&skill.path),
-        "Absolute path must appear in header"
-    );
-    assert!(
-        output.contains("```markdown"),
-        "Must wrap content in markdown fence"
-    );
-    assert!(
-        output.contains("## Instructions"),
-        "Skill body must be present"
-    );
-}
-
-#[tokio::test]
-async fn test_skill_size_guard_triggers_at_limit() {
-    use tauri_mcp_agent_lib::services::skill_service;
-
-    let tmp = TempDir::new().unwrap();
-    // Write a skill whose SKILL.md content is just over 100 KB
-    let large_body = "x".repeat(101 * 1024);
-    write_skill(tmp.path(), "big-skill", "Big Skill", &large_body);
-
-    let skills = skill_service::scan_skills_directory(tmp.path())
-        .await
-        .unwrap();
-    assert_eq!(skills.len(), 1);
-
-    let path = std::path::PathBuf::from(&skills[0].path);
-    let file_size = tokio::fs::metadata(&path).await.unwrap().len();
-
-    // Guard threshold
-    const MAX: u64 = 100 * 1024;
-    assert!(
-        file_size > MAX,
-        "Test setup: skill file must exceed 100 KB, got {file_size} bytes"
-    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop inlining full SKILL.md into user turns; keep the user's `@skill:name ...` line at the top and append compact metadata plus strict read-first guidance via `workspace__readFile`.
- Dedupe repeated `@skill:` mentions (case-insensitive) and add a multi-skill preamble when several distinct skills are referenced.
- Align the skills system prompt with `workspace__readFile` instead of `readFile`.

## Test plan
- [x] `cargo test reference_resolver` (13/13)
- [x] `cargo test format_skill_reference_block`
- [ ] Manual: send `@skill:delegate <task>` and confirm agent reads SKILL.md before other tools
- [ ] Manual: message with two distinct `@skill:` mentions shows one preamble + two reference blocks


Made with [Cursor](https://cursor.com)