### PR TITLE
⚡ Bolt: Optimize OpenRouter model list processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Avoid GC Pressure in Startup Metrics
 **Learning:** In non-React data processing code like startup metrics, using `.reduce()` when the callback allocates a new object on every iteration creates severe garbage collection pressure.
 **Action:** Refactor these reducers to use primitive variables during a standard `for` loop and allocate a single object at the end to improve startup performance.
+## 2024-06-15 - Optimize Collection Processing
+**Learning:** When mapping values from a large Map (e.g., OpenRouter's 400+ models), chaining `Array.from(map.values()).map(...)` allocates an unnecessary intermediate array, which increases garbage collection pressure.
+**Action:** Use a `for...of` loop directly on the map iterator (`map.values()`) to iterate and map the collection without the intermediate array allocation.

--- a/src/lib/ai-service/openrouter.ts
+++ b/src/lib/ai-service/openrouter.ts
@@ -102,24 +102,27 @@ export class OpenRouterService extends OpenAIService {
       logger.info('Fetching models from OpenRouter public metadata API');
       const models = await fetchOpenRouterModels();
 
-      const result: ModelInfo[] = Array.from(models.values()).map((m) => ({
-        id: m.id,
-        name: m.name,
-        contextWindow: m.context_length ?? 4096,
-        supportReasoning:
-          m.supported_parameters.includes('reasoning') ||
-          !!m.pricing.internal_reasoning,
-        supportTools: m.supported_parameters.includes('tools'),
-        supportStreaming:
-          m.supported_parameters.includes('stream') ||
-          m.supported_parameters.includes('streaming'),
-        cost: {
-          // OpenRouter pricing is per-token; convert to per-million for ModelInfo
-          input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
-          output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
-        },
-        description: m.description || m.name,
-      }));
+      const result: ModelInfo[] = [];
+      for (const m of models.values()) {
+        result.push({
+          id: m.id,
+          name: m.name,
+          contextWindow: m.context_length ?? 4096,
+          supportReasoning:
+            m.supported_parameters.includes('reasoning') ||
+            !!m.pricing.internal_reasoning,
+          supportTools: m.supported_parameters.includes('tools'),
+          supportStreaming:
+            m.supported_parameters.includes('stream') ||
+            m.supported_parameters.includes('streaming'),
+          cost: {
+            // OpenRouter pricing is per-token; convert to per-million for ModelInfo
+            input: parseFloat(m.pricing.prompt ?? '0') * 1_000_000,
+            output: parseFloat(m.pricing.completion ?? '0') * 1_000_000,
+          },
+          description: m.description || m.name,
+        });
+      }
 
       logger.info(`OpenRouter: ${result.length} models available`);
       return result;


### PR DESCRIPTION
💡 What: Replaced `Array.from(models.values()).map()` with a `for...of` loop in OpenRouter model fetching.
🎯 Why: To avoid an unnecessary intermediate array allocation when mapping the 400+ models from OpenRouter, reducing garbage collection pressure.
📊 Impact: Reduces memory allocation and GC overhead during the parsing of model metadata.
🔬 Measurement: Review memory usage/allocation during OpenRouter metadata refresh.

---
*PR created automatically by Jules for task [13071139324668887449](https://jules.google.com/task/13071139324668887449) started by @fritzprix*