### PR TITLE
fix(agent): sync slash command UI with backend session state

### DIFF
--- a/src-tauri/src/commands/agent_commands/session_commands.rs
+++ b/src-tauri/src/commands/agent_commands/session_commands.rs
@@ -438,10 +438,10 @@ pub async fn agent_execute_command(
                 }
             }
 
-            // 3. 리소스 변경 이벤트 emit
+            // 3. Notify frontend that session messages were cleared (distinct from rename/mode updates)
             crate::agent::tauri_events::emit_resource_updated(
                 "session",
-                "update",
+                "clear",
                 Some(session_id.clone()),
             );
 

--- a/src/context/AgentSessionContext.tsx
+++ b/src/context/AgentSessionContext.tsx
@@ -107,10 +107,18 @@ export function AgentSessionProvider({
   const actionsValue: AgentSessionActionsContextValue = useMemo(
     () => ({
       ...customActions,
+      clearSessionHistory: stateProps.setters.clearSessionHistory,
+      applyExecutionMode: stateProps.setters.applyExecutionMode,
       addMessage: stateProps.setters.addMessage,
       setError: stateProps.setters.setError,
     }),
-    [customActions, stateProps.setters.addMessage, stateProps.setters.setError],
+    [
+      customActions,
+      stateProps.setters.clearSessionHistory,
+      stateProps.setters.applyExecutionMode,
+      stateProps.setters.addMessage,
+      stateProps.setters.setError,
+    ],
   );
 
   return (

--- a/src/context/GlobalEventContext.tsx
+++ b/src/context/GlobalEventContext.tsx
@@ -16,7 +16,7 @@ export type ResourceType = 'assistant' | 'mcpServer' | 'playbook' | 'session';
 export interface ResourceUpdatedPayload {
   type: 'resourceUpdated';
   resourceType: ResourceType;
-  action: 'create' | 'update' | 'delete' | 'verify';
+  action: 'create' | 'update' | 'delete' | 'verify' | 'clear';
   resourceId?: string;
 }
 

--- a/src/context/agent-session/types.ts
+++ b/src/context/agent-session/types.ts
@@ -133,6 +133,8 @@ export interface AgentSessionStateContextValue {
 export interface AgentSessionActionsContextValue {
   sendMessage: (content: string) => Promise<void>;
   stopSession: () => Promise<void>;
+  clearSessionHistory: () => void;
+  applyExecutionMode: (mode: ExecutionMode) => void;
   setError: (error: string | AgentRuntimeError | null) => void;
   addMessage: (message: Message) => void;
   loadOlderMessages: () => Promise<void>;

--- a/src/context/agent-session/useAgentSessionActions.ts
+++ b/src/context/agent-session/useAgentSessionActions.ts
@@ -27,17 +27,7 @@ export function useAgentSessionActionsLogic(
 
   const applyExecutionModeLocally = useCallback(
     (mode: ExecutionMode) => {
-      setters.setYoloModeEnabled(mode === 'yolo');
-      setters.setUnsafeModeEnabled(mode === 'unsafe');
-      setters.setSession((previous) =>
-        previous
-          ? {
-              ...previous,
-              yoloMode: mode === 'yolo',
-              unsafeMode: mode === 'unsafe',
-            }
-          : previous,
-      );
+      setters.applyExecutionMode(mode);
     },
     [setters],
   );

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -6,7 +6,7 @@ import { getLogger } from '@/lib/logger';
 import { mapSessionMetadataToAgentSession } from '@/lib/session-metadata';
 import { rustMessageToMessage } from '@/models/chat';
 import type { AgentEventPayload } from './types';
-import { buildMessageError } from './utils';
+import { buildMessageError, syncSessionMetadataFromBackend } from './utils';
 import type { useAgentSessionState } from './useAgentSessionState';
 import type { SessionRuntimeState } from '@/models/agent-ipc';
 
@@ -258,6 +258,28 @@ export function useAgentSessionEvents(
                   },
                 ];
               });
+              break;
+            }
+
+            case 'resourceUpdated': {
+              if (
+                payload.resourceType !== 'session' ||
+                payload.resourceId !== sessionId
+              ) {
+                break;
+              }
+
+              if (payload.action === 'clear') {
+                setters.clearSessionHistory();
+                logger.info(
+                  'Session history cleared via resourceUpdated event',
+                );
+                break;
+              }
+
+              if (payload.action === 'update') {
+                void syncSessionMetadataFromBackend(sessionId, setters);
+              }
               break;
             }
 

--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -84,6 +84,34 @@ export function useAgentSessionState() {
     });
   }, []);
 
+  const clearSessionHistory = useCallback(() => {
+    setMessages([]);
+    setHasOlderMessages(false);
+    setOldestMessageCursor(null);
+    setPendingApprovals([]);
+    setPendingInteractiveShellPrompt(null);
+    setErrorState(null);
+    setLlmError(null);
+    setWorkflowStatus('idle');
+    setWorkflowPhase('idle');
+    setPreflightTokenMetrics(null);
+    setSession((prev) => (prev ? { ...prev, status: 'idle' } : prev));
+  }, []);
+
+  const applyExecutionMode = useCallback((mode: ExecutionMode) => {
+    setYoloModeEnabled(mode === 'yolo');
+    setUnsafeModeEnabled(mode === 'unsafe');
+    setSession((previous) =>
+      previous
+        ? {
+            ...previous,
+            yoloMode: mode === 'yolo',
+            unsafeMode: mode === 'unsafe',
+          }
+        : previous,
+    );
+  }, []);
+
   const prependMessages = useCallback((olderMessages: Message[]) => {
     if (olderMessages.length === 0) {
       return;
@@ -123,6 +151,8 @@ export function useAgentSessionState() {
       applyLocalViewedAt,
       addMessage,
       prependMessages,
+      clearSessionHistory,
+      applyExecutionMode,
     }),
     [
       setSession,
@@ -143,6 +173,8 @@ export function useAgentSessionState() {
       applyLocalViewedAt,
       addMessage,
       prependMessages,
+      clearSessionHistory,
+      applyExecutionMode,
     ],
   );
 

--- a/src/context/agent-session/utils.ts
+++ b/src/context/agent-session/utils.ts
@@ -1,5 +1,11 @@
 import type { MessageError } from '@/models/chat';
 import type { AgentRuntimeError } from '@/models/agent-ipc';
+import { getAgentSessionMetadata } from '@/lib/backend/agent-commands';
+import { coalesceExecutionModeFlags } from '@/lib/session-metadata';
+import { getLogger } from '@/lib/logger';
+import type { useAgentSessionState } from './useAgentSessionState';
+
+const logger = getLogger('AgentSessionSync');
 
 export function buildMessageError(
   error: string | AgentRuntimeError,
@@ -18,4 +24,36 @@ export function buildMessageError(
       timestamp: new Date().toISOString(),
     },
   };
+}
+
+export async function syncSessionMetadataFromBackend(
+  sessionId: string,
+  setters: ReturnType<typeof useAgentSessionState>['setters'],
+): Promise<void> {
+  try {
+    const metadata = await getAgentSessionMetadata(sessionId);
+    if (!metadata) {
+      return;
+    }
+
+    const executionMode = coalesceExecutionModeFlags(
+      metadata.yoloMode,
+      metadata.unsafeMode,
+    );
+
+    setters.applyExecutionMode(executionMode.executionMode);
+    setters.setSession((previous) =>
+      previous
+        ? {
+            ...previous,
+            name: metadata.name,
+            status: metadata.status,
+            yoloMode: executionMode.yoloMode,
+            unsafeMode: executionMode.unsafeMode,
+          }
+        : previous,
+    );
+  } catch (error) {
+    logger.error('Failed to sync session metadata from backend', error);
+  }
 }

--- a/src/features/agent/components/AgentChatInput.tsx
+++ b/src/features/agent/components/AgentChatInput.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import { useAgentChat } from '@/context/AgentChatContext';
-import { useAgentSessionState } from '@/context/AgentSessionContext';
+import {
+  useAgentSessionActions,
+  useAgentSessionState,
+} from '@/context/AgentSessionContext';
 import { useLLMService } from '@/context/LLMServiceContext';
 import {
   Button,
@@ -45,6 +48,7 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
   const { t } = useTranslation();
   const { session, messages, yoloModeEnabled, unsafeModeEnabled } =
     useAgentSessionState();
+  const { clearSessionHistory, applyExecutionMode } = useAgentSessionActions();
   const { submit, isSessionLoading, workflowStatus, cancel, resume } =
     useAgentChat();
   const { isCompacting } = useLLMService();
@@ -116,6 +120,8 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
     refetchSessionFiles,
     hasPersistedMessages: messages.length > 0,
     onSubmitted: refreshScopedSkills,
+    onClearSession: clearSessionHistory,
+    onExecutionModeChange: applyExecutionMode,
   });
 
   const attachedFiles = pendingFiles;

--- a/src/features/agent/components/__tests__/AgentChatInput.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatInput.test.tsx
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   resume: vi.fn(),
   submit: vi.fn(),
   refreshSkills: vi.fn(),
+  clearSessionHistory: vi.fn(),
+  applyExecutionMode: vi.fn(),
   setInput: vi.fn(),
   onTokenInputChange: vi.fn(),
   handleSubmit: vi.fn((e?: Event) => e?.preventDefault?.()),
@@ -45,6 +47,10 @@ vi.mock('@/context/AgentSessionContext', () => ({
       },
     },
     messages: [],
+  }),
+  useAgentSessionActions: () => ({
+    clearSessionHistory: mocks.clearSessionHistory,
+    applyExecutionMode: mocks.applyExecutionMode,
   }),
 }));
 

--- a/src/features/agent/hooks/useChatSubmit.ts
+++ b/src/features/agent/hooks/useChatSubmit.ts
@@ -8,9 +8,21 @@ import type { MCPContent } from '@/lib/mcp';
 import type { useAgentChat } from '@/context/AgentChatContext';
 import type { useAgentResourceAttachment } from '@/features/agent/hooks/useAgentResourceAttachment';
 import { safeInvoke } from '@/lib/backend/core';
+import type { ExecutionMode } from '@/context/agent-session/types';
 
 const logger = getLogger('useChatSubmit');
 const OBVIOUS_OVERSIZE_CHAR_MULTIPLIER = 2;
+
+function parsePermissionCommand(commandText: string): ExecutionMode | null {
+  const match = /^\/permission\s+(yolo|unsafe|normal)$/i.exec(
+    commandText.trim(),
+  );
+  if (!match) {
+    return null;
+  }
+
+  return match[1].toLowerCase() as ExecutionMode;
+}
 
 interface UseChatSubmitProps {
   session: { id: string; threadId?: string } | null;
@@ -27,6 +39,8 @@ interface UseChatSubmitProps {
   >['refetchSessionFiles'];
   hasPersistedMessages: boolean;
   onSubmitted?: () => void | Promise<void>;
+  onClearSession?: () => void;
+  onExecutionModeChange?: (mode: ExecutionMode) => void;
 }
 
 export function useChatSubmit({
@@ -38,6 +52,8 @@ export function useChatSubmit({
   refetchSessionFiles,
   hasPersistedMessages,
   onSubmitted,
+  onClearSession,
+  onExecutionModeChange,
 }: UseChatSubmitProps) {
   const { value: settings } = useSettings();
   const [input, setInput] = useState('');
@@ -64,7 +80,6 @@ export function useChatSubmit({
         setIsSubmitting(true);
         const currentInput = input;
         setInput(''); // Clear input immediately for better UX
-        clearPendingFiles();
 
         try {
           const result = await safeInvoke<{
@@ -75,6 +90,15 @@ export function useChatSubmit({
             commandText: messageText,
           });
           if (result.success) {
+            clearPendingFiles();
+            if (messageText === '/clear') {
+              onClearSession?.();
+            } else {
+              const permissionMode = parsePermissionCommand(messageText);
+              if (permissionMode) {
+                onExecutionModeChange?.(permissionMode);
+              }
+            }
             toast.success(result.message);
           } else {
             toast.error(result.message || 'Command failed');
@@ -212,6 +236,8 @@ export function useChatSubmit({
       refetchSessionFiles,
       hasPersistedMessages,
       onSubmitted,
+      onClearSession,
+      onExecutionModeChange,
       settings.maxInputContext,
     ],
   );

--- a/src/lib/backend/agent-commands.ts
+++ b/src/lib/backend/agent-commands.ts
@@ -3,6 +3,7 @@ import { isWorkflowCancelledError } from '@/context/llm/types';
 import type {
   AgentResponse,
   AgentRuntimeError,
+  AgentSessionMetadata,
   CompletionCancelRequest,
   ExecuteUiTauriActionRequest,
   AgentOpenSessionResponse,
@@ -148,6 +149,14 @@ export async function openAgentSession(
   return safeInvoke<AgentOpenSessionResponse>('agent_open_session', {
     sessionId,
     initialMessageLimit,
+  });
+}
+
+export async function getAgentSessionMetadata(
+  sessionId: string,
+): Promise<AgentSessionMetadata | null> {
+  return safeInvoke<AgentSessionMetadata | null>('agent_get_session', {
+    sessionId,
   });
 }
 


### PR DESCRIPTION
## Summary

- Handle `resourceUpdated` events with `action: "clear"` and `action: "update"` so `/clear` clears chat messages and `/permission` refreshes YOLO/Unsafe badges without a full reload.
- Add optimistic execution-mode updates for `/permission yolo|unsafe|normal` and centralize `clearSessionHistory()` / `applyExecutionMode()` in agent session state.
- Defer `clearPendingFiles()` until slash commands succeed so attachments are preserved when a command fails.

## Test plan

- [ ] Run `/clear` in an active session — messages disappear immediately; execution mode badges remain unchanged.
- [ ] Run `/permission yolo`, `/permission unsafe`, and `/permission normal` — badges update immediately and stay in sync after backend refresh.
- [ ] Attach a file, run a failing slash command — input restores and attachments remain.
- [ ] Rename session or change mode from settings — metadata sync still works via `update` events without clearing messages.
