### PR TITLE
🛡️ Sentinel: Fix XSS vulnerability in resource link

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-13 - [Fix XSS vulnerability in resource link]
+**Vulnerability:** XSS vulnerability where user-provided URIs in `resource_link` items were rendered directly into the `href` attribute of an anchor tag without validation.
+**Learning:** `resource_link` components didn't use `isSafeExternalUrl` that markdown renderer used.
+**Prevention:** Always validate external inputs that render into `href` to prevent Javascript protocol attacks. Ensure safe fallback (like plain `<span>`) is present when URL is unsafe.

--- a/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
@@ -13,6 +13,7 @@ import {
   VideoContentRenderer,
 } from './MediaContentRenderer';
 import { MarkdownText } from './MarkdownText';
+import { isSafeExternalUrl } from '../utils/url';
 
 const logger = getLogger('AgentMessageRenderer');
 
@@ -205,15 +206,21 @@ export function ContentItemRenderer({
     }
     case 'resource_link': {
       const linkItem = contentItem as ResourceLinkContentItem;
+      const isSafe = isSafeExternalUrl(linkItem.uri);
+
       return (
         <div className="rounded-lg border bg-muted p-2">
-          <a
-            href={linkItem.uri}
-            onClick={(event) => onLinkClick(event, linkItem.uri)}
-            className="text-primary underline hover:text-primary/90"
-          >
-            {linkItem.name}
-          </a>
+          {isSafe ? (
+            <a
+              href={linkItem.uri}
+              onClick={(event) => onLinkClick(event, linkItem.uri)}
+              className="text-primary underline hover:text-primary/90"
+            >
+              {linkItem.name}
+            </a>
+          ) : (
+            <span className="text-muted-foreground">{linkItem.name}</span>
+          )}
           {linkItem.description ? (
             <div className="mt-1 text-sm text-muted-foreground">
               {linkItem.description}


### PR DESCRIPTION
## Summary

Fixes a [HIGH] XSS vulnerability in ContentItemRenderer where esource_link URIs were rendered directly into <a href> without validation.

## Changes

- **src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx**: Added isSafeExternalUrl check on esource_link URIs. Unsafe URLs (e.g., javascript: protocol) now render as <span> instead of <a>.
- **.jules/sentinel.md**: Added vulnerability record for prevention tracking.

## Security Detail

| Field | Value |
|-------|-------|
| Severity | HIGH |
| Type | XSS via javascript: protocol in esource_link URI |
| Fix | Validate with existing isSafeExternalUrl utility; render as <span> when unsafe |

## Risk Assessment

- **Low risk**: Uses existing isSafeExternalUrl function already trusted in MarkdownText |
- **Scope**: Only affects esource_link content items in agent messages |
- **No behavioral change** for safe URLs |
