### PR TITLE
feat(agent): Markdown copy export and streaming supersession fix

### DIFF
--- a/src/context/AgentChatContext.tsx
+++ b/src/context/AgentChatContext.tsx
@@ -17,11 +17,8 @@ import type { AgentResponse, InjectMessagesRequest } from '@/models/agent-ipc';
 import type { Message, MessageError, RustMessage } from '@/models/chat';
 import type { ServiceContext } from '@/models/service-context';
 import { isValidMessage } from '@/models/validation';
-import {
-  isAssistantStreamingMessageSuperseded,
-  summarizeMessageForLog,
-  toRustMessage,
-} from '@/lib/message-utils';
+import { isAssistantStreamingMessageSuperseded } from '@/lib/message-streaming-supersession';
+import { summarizeMessageForLog, toRustMessage } from '@/lib/message-utils';
 import { useDebounce } from 'react-use';
 import { getLogger } from '../lib/logger';
 import { useLLMService, useStreamingMessage } from './LLMServiceContext';
@@ -42,7 +39,7 @@ const findLastPersistedAssistantMessage = (
   return undefined;
 };
 
-export { isAssistantStreamingMessageSuperseded } from '@/lib/message-utils';
+export { isAssistantStreamingMessageSuperseded } from '@/lib/message-streaming-supersession';
 
 /**
  * Agent event from Rust backend (currently using Record<string, unknown> in listeners)

--- a/src/features/agent/components/AgentChatHeader.tsx
+++ b/src/features/agent/components/AgentChatHeader.tsx
@@ -22,6 +22,7 @@ import { PanelRight, FolderOpen, Copy, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { useClipboard } from '@/hooks/useClipboard';
+import { messagesToMarkdown } from '@/lib/message-utils';
 
 interface AgentChatHeaderProps {
   children?: React.ReactNode;
@@ -68,11 +69,19 @@ export function AgentChatHeader({
     if (isCopying) return;
     setIsCopying(true);
     try {
-      const json = JSON.stringify(messages, null, 2);
-      await copyToClipboard(json);
-      toast.success(t('agent.header.copySuccess'));
-    } catch {
-      toast.error(t('agent.header.copyError'));
+      const { content, truncated } = messagesToMarkdown(messages);
+      await copyToClipboard(content);
+      toast.success(
+        truncated
+          ? t('agent.header.copySuccessPartial')
+          : t('agent.header.copySuccess'),
+      );
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        toast.error(t('agent.header.copyDenied'));
+      } else {
+        toast.error(t('agent.header.copyError'));
+      }
     } finally {
       setIsCopying(false);
     }

--- a/src/lib/__tests__/message-streaming-supersession.test.ts
+++ b/src/lib/__tests__/message-streaming-supersession.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { isAssistantStreamingMessageSuperseded } from '../message-streaming-supersession';
+import type { Message } from '@/models/chat';
+
+function assistantMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'assistant-1',
+    sessionId: 'session-1',
+    threadId: 'session-1',
+    role: 'assistant',
+    content: [],
+    createdAt: new Date('2026-04-04T05:00:00.000Z'),
+    updatedAt: new Date('2026-04-04T05:00:01.000Z'),
+    ...overrides,
+  };
+}
+
+describe('isAssistantStreamingMessageSuperseded', () => {
+  it('requires persisted tool calls to catch up before superseding', () => {
+    const streaming = assistantMessage({
+      content: [{ type: 'text', text: 'Building artifact...' }],
+      thinking: 'Need a tool...',
+      tool_calls: [
+        {
+          id: 'call-streaming',
+          type: 'function',
+          function: {
+            name: 'workspace__writeFile',
+            arguments: '{"path":"index.html"',
+          },
+        },
+      ],
+    });
+
+    const persistedWithoutTools = assistantMessage({
+      id: 'persisted-1',
+      content: streaming.content,
+      thinking: streaming.thinking,
+      tool_calls: [],
+      updatedAt: new Date('2026-04-04T05:00:02.000Z'),
+    });
+
+    const persistedWithTools = assistantMessage({
+      id: 'persisted-2',
+      content: streaming.content,
+      thinking: streaming.thinking,
+      tool_calls: [
+        {
+          id: 'call-streaming',
+          type: 'function',
+          function: {
+            name: 'workspace__writeFile',
+            arguments: '{"path":"index.html","content":"ok"}',
+          },
+        },
+      ],
+      updatedAt: new Date('2026-04-04T05:00:03.000Z'),
+    });
+
+    expect(
+      isAssistantStreamingMessageSuperseded(streaming, persistedWithoutTools),
+    ).toBe(false);
+    expect(
+      isAssistantStreamingMessageSuperseded(streaming, persistedWithTools),
+    ).toBe(true);
+  });
+
+  it('supersedes when persisted reuses the same tool call id with different arguments', () => {
+    const streaming = assistantMessage({
+      tool_calls: [
+        {
+          id: 'call-retry',
+          type: 'function',
+          function: {
+            name: 'workspace__readFile',
+            arguments: '{"path":"draft.txt"',
+          },
+        },
+      ],
+      updatedAt: new Date('2026-04-04T05:00:01.000Z'),
+    });
+
+    const persisted = assistantMessage({
+      id: 'persisted-retry',
+      tool_calls: [
+        {
+          id: 'call-retry',
+          type: 'function',
+          function: {
+            name: 'workspace__readFile',
+            arguments: '{"path":"final.txt"}',
+          },
+        },
+      ],
+      updatedAt: new Date('2026-04-04T05:00:02.000Z'),
+    });
+
+    expect(isAssistantStreamingMessageSuperseded(streaming, persisted)).toBe(
+      true,
+    );
+  });
+
+  it('resolves persisted tool calls by id when index order differs', () => {
+    const streaming = assistantMessage({
+      tool_calls: [
+        {
+          id: 'call-b',
+          type: 'function',
+          function: {
+            name: 'tool_b',
+            arguments: '{"b":1',
+          },
+        },
+      ],
+    });
+
+    const persisted = assistantMessage({
+      id: 'persisted-order',
+      tool_calls: [
+        {
+          id: 'call-a',
+          type: 'function',
+          function: { name: 'tool_a', arguments: '{}' },
+        },
+        {
+          id: 'call-b',
+          type: 'function',
+          function: { name: 'tool_b', arguments: '{"b":123}' },
+        },
+      ],
+      updatedAt: new Date('2026-04-04T05:00:02.000Z'),
+    });
+
+    expect(isAssistantStreamingMessageSuperseded(streaming, persisted)).toBe(
+      true,
+    );
+  });
+
+  it('rejects supersession when persisted timestamp is older than streaming', () => {
+    const streaming = assistantMessage({
+      content: [{ type: 'text', text: 'Hello' }],
+      updatedAt: new Date('2026-04-04T05:00:02.000Z'),
+    });
+
+    const persisted = assistantMessage({
+      id: 'persisted-old',
+      content: [{ type: 'text', text: 'Hello world' }],
+      updatedAt: new Date('2026-04-04T05:00:01.000Z'),
+    });
+
+    expect(isAssistantStreamingMessageSuperseded(streaming, persisted)).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/__tests__/message-utils.test.ts
+++ b/src/lib/__tests__/message-utils.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import {
+  messagesToMarkdown,
+  summarizeMessageForLog,
+  toRustMessage,
+} from '../message-utils';
+import type { Message } from '@/models/chat';
+
+function createMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-1',
+    sessionId: 'session-1',
+    threadId: 'session-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'Hello' }],
+    ...overrides,
+  };
+}
+
+describe('messagesToMarkdown', () => {
+  it('formats user and assistant messages as readable markdown', () => {
+    const messages: Message[] = [
+      createMessage({ role: 'user', content: [{ type: 'text', text: 'Hi' }] }),
+      createMessage({
+        id: 'msg-2',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello there' }],
+      }),
+    ];
+
+    const { content, truncated } = messagesToMarkdown(messages);
+
+    expect(truncated).toBe(false);
+    expect(content).toContain('## User');
+    expect(content).toContain('Hi');
+    expect(content).toContain('## Assistant');
+    expect(content).toContain('Hello there');
+    expect(content).not.toContain('"sessionId"');
+    expect(content).not.toContain('base64');
+  });
+
+  it('excludes system messages and synthetic compaction sources by default', () => {
+    const messages: Message[] = [
+      createMessage({ role: 'system', content: [{ type: 'text', text: 'System' }] }),
+      createMessage({
+        id: 'msg-2',
+        source: 'compact-summary',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Summary' }],
+      }),
+      createMessage({
+        id: 'msg-3',
+        role: 'user',
+        content: [{ type: 'text', text: 'Visible' }],
+      }),
+    ];
+
+    const { content } = messagesToMarkdown(messages);
+
+    expect(content).not.toContain('System');
+    expect(content).not.toContain('Summary');
+    expect(content).toContain('Visible');
+  });
+
+  it('skips streaming messages', () => {
+    const messages: Message[] = [
+      createMessage({
+        isStreaming: true,
+        content: [{ type: 'text', text: 'In progress' }],
+      }),
+      createMessage({
+        id: 'msg-2',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      }),
+    ];
+
+    const { content } = messagesToMarkdown(messages);
+
+    expect(content).not.toContain('In progress');
+    expect(content).toContain('Done');
+  });
+
+  it('includes tool calls and tool role metadata when enabled', () => {
+    const messages: Message[] = [
+      createMessage({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'read_file', arguments: '{"path":"a.txt"}' },
+          },
+        ],
+        content: [],
+      }),
+      createMessage({
+        id: 'msg-2',
+        role: 'tool',
+        tool_call_id: 'call-1',
+        content: [{ type: 'text', text: 'file contents' }],
+      }),
+    ];
+
+    const { content } = messagesToMarkdown(messages);
+
+    expect(content).toContain('**Tool:** read_file');
+    expect(content).toContain('"path": "a.txt"');
+    expect(content).toContain('## Tool');
+    expect(content).toContain('Tool Call ID: call-1');
+    expect(content).toContain('file contents');
+  });
+
+  it('summarizes binary and resource content without embedding payloads', () => {
+    const messages: Message[] = [
+      createMessage({
+        role: 'assistant',
+        content: [
+          { type: 'image', mimeType: 'image/png', data: 'aGVsbG8=' },
+          {
+            type: 'resource_link',
+            uri: 'file:///tmp/report.pdf',
+            name: 'report.pdf',
+          },
+          {
+            type: 'resource',
+            resource: {
+              mimeType: 'text/html',
+              uri: 'ui://widget',
+              text: '<p>hidden</p>',
+            },
+          },
+        ],
+      }),
+    ];
+
+    const { content } = messagesToMarkdown(messages);
+
+    expect(content).toContain('[Image: image/png]');
+    expect(content).toContain('[Resource Link: report.pdf](file:///tmp/report.pdf)');
+    expect(content).toContain('[UI Resource: text/html - ui://widget]');
+    expect(content).not.toContain('aGVsbG8=');
+    expect(content).not.toContain('<p>hidden</p>');
+  });
+
+  it('includes attachment filename and preview without inline binary data', () => {
+    const messages: Message[] = [
+      createMessage({
+        attachments: [
+          {
+            sessionId: 'session-1',
+            filename: 'notes.txt',
+            mimeType: 'text/plain',
+            size: 12,
+            lineCount: 2,
+            preview: 'line one\nline two',
+            uploadedAt: '2026-01-01T00:00:00.000Z',
+            status: 'inline',
+            inlineContent: {
+              type: 'image',
+              data: 'secret-base64',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      }),
+    ];
+
+    const { content } = messagesToMarkdown(messages);
+
+    expect(content).toContain('**Attachment:** notes.txt');
+    expect(content).toContain('> line one');
+    expect(content).toContain('> line two');
+    expect(content).not.toContain('secret-base64');
+  });
+
+  it('marks truncation when byte budget is exceeded', () => {
+    const messages: Message[] = Array.from({ length: 5 }, (_, index) =>
+      createMessage({
+        id: `msg-${index}`,
+        content: [{ type: 'text', text: 'x'.repeat(200) }],
+      }),
+    );
+
+    const { content, truncated, omittedCount } = messagesToMarkdown(messages, {
+      maxBytes: 300,
+    });
+
+    expect(truncated).toBe(true);
+    expect(omittedCount).toBeGreaterThan(0);
+    expect(content).toContain('message(s) omitted due to size limits');
+  });
+
+  it('omits older messages when maxMessages is set', () => {
+    const messages: Message[] = Array.from({ length: 4 }, (_, index) =>
+      createMessage({
+        id: `msg-${index}`,
+        content: [{ type: 'text', text: `message-${index}` }],
+      }),
+    );
+
+    const { content, truncated, omittedCount } = messagesToMarkdown(messages, {
+      maxMessages: 2,
+    });
+
+    expect(truncated).toBe(true);
+    expect(omittedCount).toBe(2);
+    expect(content).toContain('message-2');
+    expect(content).toContain('message-3');
+    expect(content).not.toContain('message-0');
+  });
+});
+
+describe('toRustMessage', () => {
+  it('maps tool_calls to toolCalls and converts Date timestamps to milliseconds', () => {
+    const createdAt = new Date('2026-06-15T10:00:00.000Z');
+    const updatedAt = new Date('2026-06-15T10:05:00.000Z');
+    const message = createMessage({
+      createdAt,
+      updatedAt,
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'search', arguments: '{"q":"test"}' },
+        },
+      ],
+      tool_call_id: 'call-1',
+    });
+
+    const rustMessage = toRustMessage(message);
+
+    expect(rustMessage.toolCalls).toEqual(message.tool_calls);
+    expect(rustMessage.toolCallId).toBe('call-1');
+    expect(rustMessage.createdAt).toBe(createdAt.getTime());
+    expect(rustMessage.updatedAt).toBe(updatedAt.getTime());
+  });
+
+  it('falls back to numeric timestamps and now when dates are missing', () => {
+    const createdAt = 1_700_000_000_000;
+    const message = createMessage({
+      createdAt,
+      updatedAt: undefined,
+    });
+
+    const rustMessage = toRustMessage(message);
+
+    expect(rustMessage.createdAt).toBe(createdAt);
+    expect(rustMessage.updatedAt).toBe(createdAt);
+  });
+});
+
+describe('summarizeMessageForLog', () => {
+  it('returns null for undefined input', () => {
+    expect(summarizeMessageForLog(undefined)).toBeNull();
+  });
+
+  it('summarizes content types, lengths, and tool call metadata', () => {
+    const message = createMessage({
+      role: 'assistant',
+      isStreaming: true,
+      content: [
+        { type: 'text', text: 'Hello' },
+        { type: 'image', mimeType: 'image/png', data: 'abc' },
+      ],
+      thinking: 'reasoning',
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'search', arguments: '{"q":"test"}' },
+        },
+      ],
+    });
+
+    expect(summarizeMessageForLog(message)).toEqual({
+      id: message.id,
+      role: 'assistant',
+      isStreaming: true,
+      contentTypes: ['text', 'image'],
+      textLength: 5,
+      thinkingLength: 9,
+      toolCallCount: 1,
+      toolCalls: [
+        {
+          id: 'call-1',
+          name: 'search',
+          argumentsLength: '{"q":"test"}'.length,
+        },
+      ],
+    });
+  });
+});

--- a/src/lib/__tests__/message-utils.test.ts
+++ b/src/lib/__tests__/message-utils.test.ts
@@ -238,10 +238,11 @@ describe('toRustMessage', () => {
 
   it('falls back to numeric timestamps and now when dates are missing', () => {
     const createdAt = 1_700_000_000_000;
-    const message = createMessage({
-      createdAt,
+    const message = {
+      ...createMessage(),
+      createdAt: createdAt as unknown,
       updatedAt: undefined,
-    });
+    } as Message;
 
     const rustMessage = toRustMessage(message);
 

--- a/src/lib/message-markdown.ts
+++ b/src/lib/message-markdown.ts
@@ -1,0 +1,266 @@
+import type { AttachmentReference, Message, ToolCall } from '@/models/chat';
+import type { MCPContent } from '@/lib/mcp/protocol/content';
+
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+const EXCLUDED_SOURCES = new Set([
+  'compact-summary',
+  'compaction-instruction',
+  'recovery',
+]);
+
+export interface MessagesToMarkdownOptions {
+  maxMessages?: number;
+  maxBytes?: number;
+  includeThinking?: boolean;
+  includeToolCalls?: boolean;
+  includeTimestamps?: boolean;
+  includeSystem?: boolean;
+}
+
+export interface MessagesToMarkdownResult {
+  content: string;
+  truncated: boolean;
+  omittedCount?: number;
+}
+
+type ResolvedMarkdownOptions = Required<
+  Pick<
+    MessagesToMarkdownOptions,
+    | 'includeThinking'
+    | 'includeToolCalls'
+    | 'includeTimestamps'
+    | 'includeSystem'
+  >
+> & {
+  maxBytes: number;
+  maxMessages?: number;
+};
+
+function shouldIncludeMessage(
+  message: Message,
+  options: Pick<ResolvedMarkdownOptions, 'includeSystem'>,
+): boolean {
+  if (message.isStreaming) {
+    return false;
+  }
+  if (!options.includeSystem && message.role === 'system') {
+    return false;
+  }
+  if (message.source && EXCLUDED_SOURCES.has(message.source)) {
+    return false;
+  }
+  return true;
+}
+
+function formatRoleHeader(role: Message['role']): string {
+  switch (role) {
+    case 'user':
+      return 'User';
+    case 'assistant':
+      return 'Assistant';
+    case 'tool':
+      return 'Tool';
+    case 'system':
+      return 'System';
+    default:
+      return role;
+  }
+}
+
+function formatToolArguments(argumentsJson: string): string {
+  try {
+    return JSON.stringify(JSON.parse(argumentsJson), null, 2);
+  } catch {
+    return argumentsJson;
+  }
+}
+
+function formatToolCalls(toolCalls: ToolCall[]): string {
+  return toolCalls
+    .map((toolCall) => {
+      const args = formatToolArguments(toolCall.function.arguments);
+      return `**Tool:** ${toolCall.function.name}\n\`\`\`json\n${args}\n\`\`\``;
+    })
+    .join('\n\n');
+}
+
+function formatContentItem(
+  item: MCPContent,
+  options: Pick<
+    ResolvedMarkdownOptions,
+    'includeThinking' | 'includeToolCalls'
+  >,
+): string | null {
+  switch (item.type) {
+    case 'text':
+      return item.text;
+    case 'thinking':
+      if (!options.includeThinking) {
+        return null;
+      }
+      return `<details>\n<summary>Thinking</summary>\n\n${item.thinking}\n</details>`;
+    case 'tool_call':
+      if (!options.includeToolCalls) {
+        return null;
+      }
+      return formatToolCalls([
+        {
+          id: item.id,
+          type: 'function',
+          function: {
+            name: item.name,
+            arguments: item.arguments,
+          },
+        },
+      ]);
+    case 'image':
+      return `[Image: ${item.mimeType}]`;
+    case 'audio':
+      return `[Audio: ${item.mimeType}]`;
+    case 'video':
+      return `[Video: ${item.mimeType}]`;
+    case 'resource_link':
+      return `[Resource Link: ${item.name}](${item.uri})`;
+    case 'resource': {
+      const resource = item.resource;
+      const mimeType = resource?.mimeType ?? 'unknown';
+      const uri = resource?.uri;
+      return uri
+        ? `[UI Resource: ${mimeType} - ${uri}]`
+        : `[UI Resource: ${mimeType}]`;
+    }
+  }
+}
+
+function formatAttachments(attachments: AttachmentReference[]): string {
+  return attachments
+    .map((attachment) => {
+      const lines = [
+        `**Attachment:** ${attachment.filename} (${attachment.mimeType}, ${attachment.size} bytes)`,
+      ];
+      if (attachment.preview.trim()) {
+        const preview = attachment.preview
+          .split('\n')
+          .map((line) => `> ${line}`)
+          .join('\n');
+        lines.push(preview);
+      }
+      return lines.join('\n');
+    })
+    .join('\n\n');
+}
+
+function formatTimestamp(createdAt: Date): string {
+  return `*${createdAt.toISOString()}*`;
+}
+
+function formatSingleMessage(
+  message: Message,
+  options: ResolvedMarkdownOptions,
+): string {
+  const parts: string[] = [`## ${formatRoleHeader(message.role)}`];
+
+  if (options.includeTimestamps && message.createdAt) {
+    parts.push(formatTimestamp(message.createdAt));
+  }
+
+  if (options.includeThinking && message.thinking) {
+    parts.push(
+      `<details>\n<summary>Thinking</summary>\n\n${message.thinking}\n</details>`,
+    );
+  }
+
+  const bodyParts: string[] = [];
+  for (const item of message.content ?? []) {
+    const formatted = formatContentItem(item, options);
+    if (formatted) {
+      bodyParts.push(formatted);
+    }
+  }
+
+  if (options.includeToolCalls && message.tool_calls?.length) {
+    bodyParts.push(formatToolCalls(message.tool_calls));
+  }
+
+  if (message.tool_call_id) {
+    bodyParts.push(`*Tool Call ID: ${message.tool_call_id}*`);
+  }
+
+  if (message.error?.displayMessage) {
+    bodyParts.push(`**Error:** ${message.error.displayMessage}`);
+  }
+
+  if (message.attachments?.length) {
+    bodyParts.push(formatAttachments(message.attachments));
+  }
+
+  const body = bodyParts.join('\n\n').trim();
+  if (body) {
+    parts.push(body);
+  }
+
+  return parts.join('\n\n');
+}
+
+export function messagesToMarkdown(
+  messages: Message[],
+  options: MessagesToMarkdownOptions = {},
+): MessagesToMarkdownResult {
+  const resolvedOptions: ResolvedMarkdownOptions = {
+    maxMessages: options.maxMessages,
+    maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
+    includeThinking: options.includeThinking ?? false,
+    includeToolCalls: options.includeToolCalls ?? true,
+    includeTimestamps: options.includeTimestamps ?? false,
+    includeSystem: options.includeSystem ?? false,
+  };
+
+  let eligible = messages.filter((message) =>
+    shouldIncludeMessage(message, resolvedOptions),
+  );
+
+  let omittedCount = 0;
+  if (
+    resolvedOptions.maxMessages !== undefined &&
+    eligible.length > resolvedOptions.maxMessages
+  ) {
+    omittedCount = eligible.length - resolvedOptions.maxMessages;
+    eligible = eligible.slice(-resolvedOptions.maxMessages);
+  }
+
+  const encoder = new TextEncoder();
+  const sections: string[] = [];
+  let totalBytes = 0;
+
+  for (let index = 0; index < eligible.length; index += 1) {
+    const section = formatSingleMessage(eligible[index], resolvedOptions);
+    const sectionBytes = encoder.encode(section).length;
+    const separatorBytes =
+      sections.length > 0 ? encoder.encode('\n\n---\n\n').length : 0;
+
+    if (totalBytes + separatorBytes + sectionBytes > resolvedOptions.maxBytes) {
+      omittedCount += eligible.length - index;
+      break;
+    }
+
+    if (sections.length > 0) {
+      sections.push('---');
+    }
+    sections.push(section);
+    totalBytes += separatorBytes + sectionBytes;
+  }
+
+  const truncated = omittedCount > 0;
+  let content = sections.join('\n\n');
+
+  if (truncated) {
+    const notice = `> *Note: ${omittedCount} message(s) omitted due to size limits.*`;
+    content = content ? `${notice}\n\n${content}` : notice;
+  }
+
+  return {
+    content,
+    truncated,
+    omittedCount: truncated ? omittedCount : undefined,
+  };
+}

--- a/src/lib/message-streaming-supersession.ts
+++ b/src/lib/message-streaming-supersession.ts
@@ -1,0 +1,158 @@
+import type { Message, ToolCall } from '@/models/chat';
+import { extractTextContent } from '@/lib/message-utils';
+
+function toTimestamp(
+  value: Message['createdAt'] | Message['updatedAt'] | undefined,
+): number | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.getTime();
+  return typeof value === 'number' ? value : null;
+}
+
+function resolvePersistedToolCall(
+  streamingToolCall: ToolCall,
+  persistedToolCalls: ToolCall[],
+  index: number,
+): ToolCall | undefined {
+  const atIndex = persistedToolCalls[index];
+  if (!streamingToolCall.id) {
+    return atIndex;
+  }
+
+  const byId = persistedToolCalls.find(
+    (toolCall) => toolCall.id === streamingToolCall.id,
+  );
+  return byId ?? atIndex;
+}
+
+/**
+ * Returns whether a persisted assistant message's tool calls cover the
+ * in-flight streaming tool-call snapshot.
+ *
+ * Matching rules per streaming tool call:
+ * - Resolve the persisted counterpart by shared `id` when present, otherwise by index.
+ * - Reject when names differ.
+ * - When both sides share the same non-empty `id`, treat as covered (handles retries
+ *   that replace arguments while reusing the call id).
+ * - Otherwise require persisted arguments to extend the streaming prefix (incremental JSON).
+ */
+function persistedToolCallsCoverStreamingState(
+  streamingMessage: Message,
+  persistedMessage: Message,
+): boolean {
+  const streamingToolCalls = streamingMessage.tool_calls ?? [];
+  if (streamingToolCalls.length === 0) {
+    return true;
+  }
+
+  const persistedToolCalls = persistedMessage.tool_calls ?? [];
+  if (persistedToolCalls.length < streamingToolCalls.length) {
+    return false;
+  }
+
+  return streamingToolCalls.every((streamingToolCall, index) => {
+    const persistedToolCall = resolvePersistedToolCall(
+      streamingToolCall,
+      persistedToolCalls,
+      index,
+    );
+    if (!persistedToolCall) {
+      return false;
+    }
+
+    if (
+      streamingToolCall.id &&
+      persistedToolCall.id &&
+      streamingToolCall.id !== persistedToolCall.id
+    ) {
+      return false;
+    }
+
+    if (
+      streamingToolCall.function.name &&
+      persistedToolCall.function.name !== streamingToolCall.function.name
+    ) {
+      return false;
+    }
+
+    if (
+      streamingToolCall.id &&
+      persistedToolCall.id &&
+      streamingToolCall.id === persistedToolCall.id
+    ) {
+      return true;
+    }
+
+    const streamingArguments = streamingToolCall.function.arguments || '';
+    const persistedArguments = persistedToolCall.function.arguments || '';
+
+    return (
+      persistedArguments.length >= streamingArguments.length &&
+      persistedArguments.startsWith(streamingArguments)
+    );
+  });
+}
+
+/**
+ * Determines whether a persisted assistant message supersedes a streaming
+ * assistant placeholder so the UI can drop the streaming copy.
+ *
+ * All of the following must pass (logical AND):
+ * - Both messages are assistant role.
+ * - Persisted `updatedAt`/`createdAt` is at least as new as streaming.
+ * - Thinking text in persisted extends the streaming prefix (when streaming had thinking).
+ * - Visible text content in persisted extends the streaming prefix (when streaming had text).
+ * - Tool calls in persisted cover the streaming snapshot (see
+ *   `persistedToolCallsCoverStreamingState`).
+ */
+export function isAssistantStreamingMessageSuperseded(
+  streamingMessage: Message,
+  persistedMessage: Message,
+): boolean {
+  if (
+    streamingMessage.role !== 'assistant' ||
+    persistedMessage.role !== 'assistant'
+  ) {
+    return false;
+  }
+
+  const streamingTimestamp =
+    toTimestamp(streamingMessage.updatedAt) ??
+    toTimestamp(streamingMessage.createdAt);
+  const persistedTimestamp =
+    toTimestamp(persistedMessage.updatedAt) ??
+    toTimestamp(persistedMessage.createdAt);
+
+  if (
+    streamingTimestamp === null ||
+    persistedTimestamp === null ||
+    persistedTimestamp < streamingTimestamp
+  ) {
+    return false;
+  }
+
+  const streamingThinking = streamingMessage.thinking || '';
+  const persistedThinking = persistedMessage.thinking || '';
+  if (
+    streamingThinking &&
+    (persistedThinking.length < streamingThinking.length ||
+      !persistedThinking.startsWith(streamingThinking))
+  ) {
+    return false;
+  }
+
+  const streamingText = extractTextContent(streamingMessage);
+  const persistedText = extractTextContent(persistedMessage);
+  if (
+    streamingText &&
+    (persistedText.length < streamingText.length ||
+      !persistedText.startsWith(streamingText))
+  ) {
+    return false;
+  }
+
+  return persistedToolCallsCoverStreamingState(
+    streamingMessage,
+    persistedMessage,
+  );
+}

--- a/src/lib/message-utils.ts
+++ b/src/lib/message-utils.ts
@@ -1,12 +1,10 @@
 import type { Message, RustMessage } from '@/models/chat';
 
-function toTimestamp(
-  value: Message['createdAt'] | Message['updatedAt'] | undefined,
-): number | null {
-  if (!value) return null;
-  if (value instanceof Date) return value.getTime();
-  return typeof value === 'number' ? value : null;
-}
+export {
+  messagesToMarkdown,
+  type MessagesToMarkdownOptions,
+  type MessagesToMarkdownResult,
+} from '@/lib/message-markdown';
 
 export function extractTextContent(
   message: Pick<Message, 'content'> | Partial<Message>,
@@ -64,101 +62,4 @@ export function summarizeMessageForLog(
       argumentsLength: toolCall.function.arguments.length,
     })),
   };
-}
-
-function persistedToolCallsCoverStreamingState(
-  streamingMessage: Message,
-  persistedMessage: Message,
-): boolean {
-  const streamingToolCalls = streamingMessage.tool_calls ?? [];
-  if (streamingToolCalls.length === 0) {
-    return true;
-  }
-
-  const persistedToolCalls = persistedMessage.tool_calls ?? [];
-  if (persistedToolCalls.length < streamingToolCalls.length) {
-    return false;
-  }
-
-  return streamingToolCalls.every((streamingToolCall, index) => {
-    const persistedToolCall = persistedToolCalls[index];
-    if (!persistedToolCall) {
-      return false;
-    }
-
-    if (
-      streamingToolCall.id &&
-      persistedToolCall.id &&
-      streamingToolCall.id !== persistedToolCall.id
-    ) {
-      return false;
-    }
-
-    if (
-      streamingToolCall.function.name &&
-      persistedToolCall.function.name !== streamingToolCall.function.name
-    ) {
-      return false;
-    }
-
-    const streamingArguments = streamingToolCall.function.arguments || '';
-    const persistedArguments = persistedToolCall.function.arguments || '';
-
-    return (
-      persistedArguments.length >= streamingArguments.length &&
-      persistedArguments.startsWith(streamingArguments)
-    );
-  });
-}
-
-export function isAssistantStreamingMessageSuperseded(
-  streamingMessage: Message,
-  persistedMessage: Message,
-): boolean {
-  if (
-    streamingMessage.role !== 'assistant' ||
-    persistedMessage.role !== 'assistant'
-  ) {
-    return false;
-  }
-
-  const streamingTimestamp =
-    toTimestamp(streamingMessage.updatedAt) ??
-    toTimestamp(streamingMessage.createdAt);
-  const persistedTimestamp =
-    toTimestamp(persistedMessage.updatedAt) ??
-    toTimestamp(persistedMessage.createdAt);
-
-  if (
-    streamingTimestamp === null ||
-    persistedTimestamp === null ||
-    persistedTimestamp < streamingTimestamp
-  ) {
-    return false;
-  }
-
-  const streamingThinking = streamingMessage.thinking || '';
-  const persistedThinking = persistedMessage.thinking || '';
-  if (
-    streamingThinking &&
-    (persistedThinking.length < streamingThinking.length ||
-      !persistedThinking.startsWith(streamingThinking))
-  ) {
-    return false;
-  }
-
-  const streamingText = extractTextContent(streamingMessage);
-  const persistedText = extractTextContent(persistedMessage);
-  if (
-    streamingText &&
-    (persistedText.length < streamingText.length ||
-      !persistedText.startsWith(streamingText))
-  ) {
-    return false;
-  }
-
-  return persistedToolCallsCoverStreamingState(
-    streamingMessage,
-    persistedMessage,
-  );
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -855,9 +855,11 @@
     },
     "header": {
       "copySuccess": "Konversation in die Zwischenablage kopiert",
+      "copySuccessPartial": "Konversation kopiert (einige Nachrichten aufgrund von Größenbeschränkungen ausgelassen)",
+      "copyDenied": "Zugriff auf die Zwischenablage verweigert. Überprüfen Sie die Browserberechtigungen.",
       "copyError": "Konversation konnte nicht kopiert werden",
-      "copyAria": "Konversation als JSON kopieren",
-      "copyTooltip": "Konversation als JSON kopieren",
+      "copyAria": "Konversation als Markdown kopieren",
+      "copyTooltip": "Konversation als Markdown kopieren",
       "toggleWorkspaceAria": "Arbeitsbereich-Dateipanel umschalten",
       "toggleWorkspaceTooltip": "Arbeitsbereich-Dateipanel umschalten",
       "togglePlanningAria": "KI-Planungspanel umschalten",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -866,9 +866,11 @@
     },
     "header": {
       "copySuccess": "Conversation copied to clipboard",
+      "copySuccessPartial": "Conversation copied (some messages omitted due to size limits)",
+      "copyDenied": "Clipboard access denied. Check your browser permissions.",
       "copyError": "Failed to copy conversation",
-      "copyAria": "Copy conversation as JSON",
-      "copyTooltip": "Copy conversation as JSON",
+      "copyAria": "Copy conversation as Markdown",
+      "copyTooltip": "Copy conversation as Markdown",
       "toggleWorkspaceAria": "Toggle Workspace Files Panel",
       "toggleWorkspaceTooltip": "Toggle Workspace Files Panel",
       "togglePlanningAria": "Toggle AI Planning Panel",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -855,9 +855,11 @@
     },
     "header": {
       "copySuccess": "Conversación copiada al portapapeles",
+      "copySuccessPartial": "Conversación copiada (se omitieron algunos mensajes por límites de tamaño)",
+      "copyDenied": "Acceso al portapapeles denegado. Comprueba los permisos del navegador.",
       "copyError": "Error al copiar la conversación",
-      "copyAria": "Copiar conversación como JSON",
-      "copyTooltip": "Copiar conversación como JSON",
+      "copyAria": "Copiar conversación como Markdown",
+      "copyTooltip": "Copiar conversación como Markdown",
       "toggleWorkspaceAria": "Alternar panel de archivos del espacio de trabajo",
       "toggleWorkspaceTooltip": "Alternar panel de archivos del espacio de trabajo",
       "togglePlanningAria": "Alternar panel de planificación de IA",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -855,9 +855,11 @@
     },
     "header": {
       "copySuccess": "Conversation copiée dans le presse-papiers",
+      "copySuccessPartial": "Conversation copiée (certains messages ont été omis en raison des limites de taille)",
+      "copyDenied": "Accès au presse-papiers refusé. Vérifiez les autorisations de votre navigateur.",
       "copyError": "Échec de la copie de la conversation",
-      "copyAria": "Copier la conversation au format JSON",
-      "copyTooltip": "Copier la conversation au format JSON",
+      "copyAria": "Copier la conversation en Markdown",
+      "copyTooltip": "Copier la conversation en Markdown",
       "toggleWorkspaceAria": "Basculer le panneau des fichiers de l'espace de travail",
       "toggleWorkspaceTooltip": "Basculer le panneau des fichiers de l'espace de travail",
       "togglePlanningAria": "Basculer le panneau de planification IA",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -829,9 +829,11 @@
     },
     "header": {
       "copySuccess": "会話をクリップボードにコピーしました",
+      "copySuccessPartial": "会話をコピーしました（サイズ制限により一部のメッセージは省略されました）",
+      "copyDenied": "クリップボードへのアクセスが拒否されました。ブラウザの権限を確認してください。",
       "copyError": "会話のコピーに失敗しました",
-      "copyAria": "会話をJSONとしてコピー",
-      "copyTooltip": "会話をJSONとしてコピー",
+      "copyAria": "会話をMarkdownとしてコピー",
+      "copyTooltip": "会話をMarkdownとしてコピー",
       "toggleWorkspaceAria": "ワークスペースファイルパネルを切り替え",
       "toggleWorkspaceTooltip": "ワークスペースファイルパネルを切り替え",
       "togglePlanningAria": "AIプランニングパネルを切り替え",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -866,9 +866,11 @@
     },
     "header": {
       "copySuccess": "대화 내용이 클립보드에 복사되었습니다",
+      "copySuccessPartial": "대화 내용이 복사되었습니다 (크기 제한으로 일부 메시지가 제외됨)",
+      "copyDenied": "클립보드 접근이 거부되었습니다. 브라우저 권한을 확인하세요.",
       "copyError": "클립보드 복사에 실패했습니다",
-      "copyAria": "대화 내용을 JSON으로 복사",
-      "copyTooltip": "대화 내용을 JSON으로 복사",
+      "copyAria": "대화 내용을 마크다운으로 복사",
+      "copyTooltip": "대화 내용을 마크다운으로 복사",
       "toggleWorkspaceAria": "워크스페이스 파일 패널 전환",
       "toggleWorkspaceTooltip": "워크스페이스 파일 패널 전환",
       "togglePlanningAria": "AI 계획 패널 전환",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -855,9 +855,11 @@
     },
     "header": {
       "copySuccess": "Conversa copiada para a área de transferência",
+      "copySuccessPartial": "Conversa copiada (algumas mensagens foram omitidas devido a limites de tamanho)",
+      "copyDenied": "Acesso à área de transferência negado. Verifique as permissões do navegador.",
       "copyError": "Falha ao copiar conversa",
-      "copyAria": "Copiar conversa como JSON",
-      "copyTooltip": "Copiar conversa como JSON",
+      "copyAria": "Copiar conversa como Markdown",
+      "copyTooltip": "Copiar conversa como Markdown",
       "toggleWorkspaceAria": "Alternar Painel de Arquivos do Espaço de Trabalho",
       "toggleWorkspaceTooltip": "Alternar Painel de Arquivos do Espaço de Trabalho",
       "togglePlanningAria": "Alternar Painel de Planejamento de IA",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -855,9 +855,11 @@
     },
     "header": {
       "copySuccess": "对话已复制到剪贴板",
+      "copySuccessPartial": "对话已复制（因大小限制省略了部分消息）",
+      "copyDenied": "剪贴板访问被拒绝。请检查浏览器权限。",
       "copyError": "复制对话失败",
-      "copyAria": "将对话复制为 JSON",
-      "copyTooltip": "将对话复制为 JSON",
+      "copyAria": "将对话复制为 Markdown",
+      "copyTooltip": "将对话复制为 Markdown",
       "toggleWorkspaceAria": "切换工作区文件面板",
       "toggleWorkspaceTooltip": "切换工作区文件面板",
       "togglePlanningAria": "切换 AI 计划面板",


### PR DESCRIPTION
## Summary
- Add Markdown conversation export from Agent chat header with truncation, clipboard feedback, and i18n across 8 locales.
- Split message utilities into message-markdown and message-streaming-supersession modules.
- Fix streaming supersession when the same tool call id receives different arguments (Claim 1 dual-display).
- Add 16 unit tests for markdown export and supersession behavior.

## Test plan
- [ ] Copy full conversation from agent chat header; verify Markdown output and success toast
- [ ] Copy long conversation; verify partial truncation toast and omitted count
- [ ] During streaming with incremental tool-call JSON, verify only latest assistant message is shown
- [ ] Run: pnpm exec vitest run src/lib/__tests__/message-utils.test.ts src/lib/__tests__/message-streaming-supersession.test.ts

Made with [Cursor](https://cursor.com)