### PR TITLE
fix(i18n): sync UI language from settings on startup

### DIFF
--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_SETTING,
 } from '@/lib/services/settings-service';
 import { markStartupMilestone } from '@/lib/performance/startup-metrics';
+import i18n from '@/lib/i18n';
 
 const logger = getLogger('SettingsContext');
 
@@ -83,6 +84,19 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
 
     markStartupMilestone('settings-settled', error ? 'error' : 'ready');
   }, [loading, error]);
+
+  useEffect(() => {
+    if (loading || !value) {
+      return;
+    }
+
+    const savedLanguage = value.uiLanguage || DEFAULT_SETTING.uiLanguage;
+    if (savedLanguage !== i18n.language) {
+      i18n.changeLanguage(savedLanguage).catch((err: unknown) => {
+        logger.error('Failed to sync i18n language from settings', err);
+      });
+    }
+  }, [loading, value, i18n]);
 
   // Update method
   const update = useCallback(

--- a/src/context/__tests__/SettingsContext.test.tsx
+++ b/src/context/__tests__/SettingsContext.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { safeInvoke } from '@/lib/backend/core';
 import {
+  DEFAULT_SETTING,
   SettingsProvider,
   useSettings,
 } from '../SettingsContext';
@@ -26,9 +27,19 @@ vi.mock('@/lib/performance/startup-metrics', () => ({
   markStartupMilestone: vi.fn(),
 }));
 
+const i18nMock = vi.hoisted(() => ({
+  language: 'ko',
+  changeLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/i18n', () => ({
+  default: i18nMock,
+}));
+
 describe('SettingsContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    i18nMock.language = 'ko';
     __resetRustSettingsServiceCacheForTests();
   });
 
@@ -134,5 +145,66 @@ describe('SettingsContext', () => {
     });
 
     expect(vi.mocked(safeInvoke)).toHaveBeenCalledTimes(3);
+  });
+
+  it('syncs i18n language from persisted settings after initial load', async () => {
+    expect(i18nMock.language).toBe('ko');
+
+    vi.mocked(safeInvoke).mockResolvedValue([
+      { key: 'uiLanguage', value: 'en', createdAt: 0, updatedAt: 0 },
+    ]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SettingsProvider>{children}</SettingsProvider>
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  it('does not call changeLanguage when persisted language matches i18n', async () => {
+    i18nMock.language = 'en';
+
+    vi.mocked(safeInvoke).mockResolvedValue([
+      { key: 'uiLanguage', value: 'en', createdAt: 0, updatedAt: 0 },
+    ]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SettingsProvider>{children}</SettingsProvider>
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(i18nMock.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to DEFAULT_SETTING.uiLanguage when uiLanguage is missing', async () => {
+    expect(i18nMock.language).toBe('ko');
+
+    vi.mocked(safeInvoke).mockResolvedValue([]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SettingsProvider>{children}</SettingsProvider>
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.value.uiLanguage).toBe(DEFAULT_SETTING.uiLanguage);
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith(
+      DEFAULT_SETTING.uiLanguage,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Sync i18n with persisted `uiLanguage` after settings load in `SettingsProvider`, fixing the fresh-install race where the browser language appeared before the default English setting was applied (#1455).
- Add SettingsContext tests for startup sync, no-op when languages match, and fallback to `DEFAULT_SETTING.uiLanguage`.

## Test plan

- [x] `pnpm vitest run src/context/__tests__/SettingsContext.test.tsx`
- [ ] Fresh install / cleared localStorage: UI shows English when default setting is English
- [ ] Change language in Settings and restart app: persisted language is applied on startup

Fixes #1455
