### PR TITLE
feat: implement Queued status and background task concurrency slot waiting

### DIFF
--- a/src-tauri/src/agent/lifecycle/management.rs
+++ b/src-tauri/src/agent/lifecycle/management.rs
@@ -249,7 +249,14 @@ pub async fn update_session_status_with_dispatcher(
         let gate = crate::state::get_concurrency_gate();
         match (is_prev_busy, is_next_busy) {
             (false, true) => {
-                acquired_permit = Some(gate.acquire_active_agent().await?);
+                let active = active_sessions.read().await;
+                let has_permit = active
+                    .get(session_id)
+                    .and_then(|s| s.active_permit.as_ref())
+                    .is_some();
+                if !has_permit {
+                    acquired_permit = Some(gate.acquire_active_agent().await?);
+                }
             }
             (true, false) => {
                 let mut active = active_sessions.write().await;

--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -164,15 +164,21 @@ pub async fn recover_sessions_with_dispatcher(
     let mut recovered_count = 0;
 
     for session in all_sessions {
-        // Only recover sessions that were BUSY (actively running)
-        if matches!(session.status, SessionStatus::Busy) {
+        // Only recover sessions that were BUSY (actively running) or QUEUED (waiting for concurrency slot)
+        if matches!(session.status, SessionStatus::Busy | SessionStatus::Queued) {
+            let target_status = match session.status {
+                SessionStatus::Busy => SessionStatus::Paused,
+                _ => SessionStatus::Idle,
+            };
+
             log::warn!(
-                "Recovering session '{}' from BUSY state (possible crash)",
-                session.id
+                "Recovering session '{}' from {:?} state (possible crash)",
+                session.id,
+                session.status
             );
 
             let mut recovered_metadata = session.clone();
-            recovered_metadata.status = SessionStatus::Paused;
+            recovered_metadata.status = target_status.clone();
 
             // Ensure the session exists in memory before persisting the pause transition.
             // Recovery used to call update_session_status first, which failed because the
@@ -202,17 +208,19 @@ pub async fn recover_sessions_with_dispatcher(
                 active_sessions,
                 dispatcher,
                 &session.id,
-                SessionStatus::Paused,
+                target_status.clone(),
             )
             .await?;
 
-            // Close any orphaned tool calls that never got a result (crash tombstones)
-            if let Err(e) = close_orphaned_tool_calls(&session.id).await {
-                log::warn!(
-                    "Failed to close orphaned tool calls for session '{}': {}",
-                    session.id,
-                    e
-                );
+            if matches!(session.status, SessionStatus::Busy) {
+                // Close any orphaned tool calls that never got a result (crash tombstones)
+                if let Err(e) = close_orphaned_tool_calls(&session.id).await {
+                    log::warn!(
+                        "Failed to close orphaned tool calls for session '{}': {}",
+                        session.id,
+                        e
+                    );
+                }
             }
 
             recovered_count += 1;

--- a/src-tauri/src/agent/session_manager/message_injection.rs
+++ b/src-tauri/src/agent/session_manager/message_injection.rs
@@ -1,6 +1,7 @@
 use super::AgentSessionManager;
 use crate::models::chat::Message;
 use crate::repositories::SessionStatus;
+use std::sync::Arc;
 
 pub async fn inject_messages(
     manager: &AgentSessionManager,
@@ -12,14 +13,19 @@ pub async fn inject_messages(
         let session = sessions
             .get(&session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
-        let is_transitioning_to_busy = matches!(
-            session.status_transition.read().await.as_ref(),
-            Some(crate::agent::state::SessionStatusTransition::ToStatus(
-                SessionStatus::Busy
-            ))
-        );
+        let is_transitioning_to_busy_or_queued = {
+            let trans = session.status_transition.read().await;
+            matches!(
+                trans.as_ref(),
+                Some(crate::agent::state::SessionStatusTransition::ToStatus(
+                    SessionStatus::Busy | SessionStatus::Queued
+                ))
+            )
+        };
 
-        session.metadata.status != SessionStatus::Busy && !is_transitioning_to_busy
+        session.metadata.status != SessionStatus::Busy
+            && session.metadata.status != SessionStatus::Queued
+            && !is_transitioning_to_busy_or_queued
     };
 
     // Delegate message persistence, caching, and event emission to MessageService
@@ -45,13 +51,13 @@ pub async fn inject_messages(
             }
         }
 
-        // Update status to Busy
+        // Update status to Queued immediately
         crate::agent::lifecycle::update_session_status(
             &manager.session_repo,
             &manager.active_sessions,
             &manager.app_handle,
             &session_id,
-            crate::repositories::SessionStatus::Busy,
+            crate::repositories::SessionStatus::Queued,
         )
         .await?;
 
@@ -66,22 +72,108 @@ pub async fn inject_messages(
             );
         }
 
-        crate::agent::workflow::start::ensure_proxy_ready(
-            &manager.proxy_manager,
-            &manager.app_handle,
-            &session_id,
-            60,
-        )
-        .await?;
+        let session_repo = Arc::clone(&manager.session_repo);
+        let active_sessions = Arc::clone(&manager.active_sessions);
+        let proxy_manager = Arc::clone(&manager.proxy_manager);
+        let app_handle = manager.app_handle.clone();
+        let session_id_clone = session_id.clone();
 
-        crate::agent::llm::request_llm_completion_with_recovery(
-            &manager.session_repo,
-            &manager.active_sessions,
-            &manager.proxy_manager,
-            &manager.app_handle,
-            session_id,
-        )
-        .await?;
+        tokio::spawn(async move {
+            // Transition status to Busy (blocks on ConcurrencyGate)
+            if let Err(e) = crate::agent::lifecycle::update_session_status(
+                &session_repo,
+                &active_sessions,
+                &app_handle,
+                &session_id_clone,
+                SessionStatus::Busy,
+            )
+            .await
+            {
+                log::error!(
+                    "Failed to transition injected session {} to Busy: {}",
+                    session_id_clone,
+                    e
+                );
+                let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                    session_id: session_id_clone.clone(),
+                    error: crate::agent::llm::types::AgentRuntimeError::new(
+                        crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                        e.to_string(),
+                    )
+                    .with_code("BACKGROUND_INJECTION_FAILED"),
+                };
+                let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+                return;
+            }
+
+            // Ensure proxy is ready
+            if let Err(e) = crate::agent::workflow::start::ensure_proxy_ready(
+                &proxy_manager,
+                &app_handle,
+                &session_id_clone,
+                60,
+            )
+            .await
+            {
+                log::error!(
+                    "Proxy check failed during background injection for session {}: {}",
+                    session_id_clone,
+                    e
+                );
+                let _ = crate::agent::lifecycle::update_session_status(
+                    &session_repo,
+                    &active_sessions,
+                    &app_handle,
+                    &session_id_clone,
+                    SessionStatus::Error,
+                )
+                .await;
+                let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                    session_id: session_id_clone.clone(),
+                    error: crate::agent::llm::types::AgentRuntimeError::new(
+                        crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                        e.to_string(),
+                    )
+                    .with_code("BACKGROUND_INJECTION_FAILED"),
+                };
+                let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+                return;
+            }
+
+            // Trigger LLM to pick up where it left off
+            if let Err(e) = crate::agent::llm::request_llm_completion_with_recovery(
+                &session_repo,
+                &active_sessions,
+                &proxy_manager,
+                &app_handle,
+                session_id_clone.clone(),
+            )
+            .await
+            {
+                log::error!(
+                    "LLM completion failed in background injection for session {}: {:?}",
+                    session_id_clone,
+                    e
+                );
+                let _ = crate::agent::lifecycle::update_session_status(
+                    &session_repo,
+                    &active_sessions,
+                    &app_handle,
+                    &session_id_clone,
+                    SessionStatus::Error,
+                )
+                .await;
+                let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                    session_id: session_id_clone.clone(),
+                    error: crate::agent::llm::types::AgentRuntimeError::new(
+                        crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                        e.to_string(),
+                    )
+                    .with_code("BACKGROUND_INJECTION_FAILED"),
+                };
+                let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+            }
+        });
     }
 
     Ok(should_trigger_workflow)

--- a/src-tauri/src/agent/session_manager/message_injection.rs
+++ b/src-tauri/src/agent/session_manager/message_injection.rs
@@ -79,7 +79,55 @@ pub async fn inject_messages(
         let session_id_clone = session_id.clone();
 
         tokio::spawn(async move {
-            // Transition status to Busy (blocks on ConcurrencyGate)
+            // 1. Acquire active agent permit first (blocks safely outside transition lock)
+            let gate = crate::state::get_concurrency_gate();
+            let permit = match gate.acquire_active_agent().await {
+                Ok(p) => p,
+                Err(e) => {
+                    log::error!(
+                        "Failed to acquire active agent permit for session {}: {}",
+                        session_id_clone,
+                        e
+                    );
+                    let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                        session_id: session_id_clone.clone(),
+                        error: crate::agent::llm::types::AgentRuntimeError::new(
+                            crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                            e.to_string(),
+                        )
+                        .with_code("BACKGROUND_INJECTION_FAILED"),
+                    };
+                    let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+                    return;
+                }
+            };
+
+            // 2. Put permit into memory and verify not cancelled/changed
+            {
+                let mut active = active_sessions.write().await;
+                if let Some(session) = active.get_mut(&session_id_clone) {
+                    if session.cancellation_token.is_cancelled()
+                        || session.metadata.status != SessionStatus::Queued
+                    {
+                        log::info!(
+                            "Session {} cancelled or status changed while queued. Aborting background injection.",
+                            session_id_clone
+                        );
+                        drop(permit);
+                        return;
+                    }
+                    session.active_permit = Some(permit);
+                } else {
+                    log::warn!(
+                        "Session {} not found in active sessions during background injection. Aborting.",
+                        session_id_clone
+                    );
+                    drop(permit);
+                    return;
+                }
+            }
+
+            // Transition status to Busy (bypasses concurrency gate block since permit is held)
             if let Err(e) = crate::agent::lifecycle::update_session_status(
                 &session_repo,
                 &active_sessions,
@@ -94,6 +142,12 @@ pub async fn inject_messages(
                     session_id_clone,
                     e
                 );
+                {
+                    let mut active = active_sessions.write().await;
+                    if let Some(session) = active.get_mut(&session_id_clone) {
+                        session.active_permit.take();
+                    }
+                }
                 let error_event = crate::agent::events::AgentEvent::WorkflowError {
                     session_id: session_id_clone.clone(),
                     error: crate::agent::llm::types::AgentRuntimeError::new(

--- a/src-tauri/src/agent/workflow/pause_resume.rs
+++ b/src-tauri/src/agent/workflow/pause_resume.rs
@@ -63,7 +63,55 @@ pub async fn resume_workflow(
     let session_id_clone = session_id.clone();
 
     tokio::spawn(async move {
-        // Transition status to Busy (blocks on ConcurrencyGate)
+        // 1. Acquire active agent permit first (blocks safely outside transition lock)
+        let gate = crate::state::get_concurrency_gate();
+        let permit = match gate.acquire_active_agent().await {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!(
+                    "Failed to acquire active agent permit for session {}: {}",
+                    session_id_clone,
+                    e
+                );
+                let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                    session_id: session_id_clone.clone(),
+                    error: crate::agent::llm::types::AgentRuntimeError::new(
+                        crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                        e.to_string(),
+                    )
+                    .with_code("BACKGROUND_RESUME_FAILED"),
+                };
+                let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+                return;
+            }
+        };
+
+        // 2. Put permit into memory and verify not cancelled/changed
+        {
+            let mut active = active_sessions.write().await;
+            if let Some(session) = active.get_mut(&session_id_clone) {
+                if session.cancellation_token.is_cancelled()
+                    || session.metadata.status != SessionStatus::Queued
+                {
+                    log::info!(
+                        "Session {} cancelled or status changed while queued. Aborting background resume.",
+                        session_id_clone
+                    );
+                    drop(permit);
+                    return;
+                }
+                session.active_permit = Some(permit);
+            } else {
+                log::warn!(
+                    "Session {} not found in active sessions during background resume. Aborting.",
+                    session_id_clone
+                );
+                drop(permit);
+                return;
+            }
+        }
+
+        // Transition status to Busy (bypasses concurrency gate block since permit is held)
         if let Err(e) = crate::agent::lifecycle::update_session_status(
             &session_repo,
             &active_sessions,
@@ -78,6 +126,12 @@ pub async fn resume_workflow(
                 session_id_clone,
                 e
             );
+            {
+                let mut active = active_sessions.write().await;
+                if let Some(session) = active.get_mut(&session_id_clone) {
+                    session.active_permit.take();
+                }
+            }
             let error_event = crate::agent::events::AgentEvent::WorkflowError {
                 session_id: session_id_clone.clone(),
                 error: crate::agent::llm::types::AgentRuntimeError::new(

--- a/src-tauri/src/agent/workflow/pause_resume.rs
+++ b/src-tauri/src/agent/workflow/pause_resume.rs
@@ -44,29 +44,120 @@ pub async fn resume_workflow(
     // Ensure cache is initialized before resuming (lazy load if needed, preserve if exists)
     crate::agent::lifecycle::ensure_cache_initialized(active_sessions, &session_id).await?;
 
+    // Transition status to Queued immediately
     crate::agent::lifecycle::update_session_status(
         session_repo,
         active_sessions,
         app_handle,
         &session_id,
-        SessionStatus::Busy,
+        SessionStatus::Queued,
     )
     .await?;
 
-    log::info!("Resumed workflow status for session: {}", session_id);
+    log::info!("Queued workflow resume for session: {}", session_id);
 
-    crate::agent::workflow::start::ensure_proxy_ready(proxy_manager, app_handle, &session_id, 60)
-        .await?;
+    let session_repo = Arc::clone(session_repo);
+    let active_sessions = Arc::clone(active_sessions);
+    let proxy_manager = Arc::clone(proxy_manager);
+    let app_handle = app_handle.clone();
+    let session_id_clone = session_id.clone();
 
-    // Trigger LLM to pick up where it left off
-    crate::agent::llm::request_llm_completion_with_recovery(
-        session_repo,
-        active_sessions,
-        proxy_manager,
-        app_handle,
-        session_id,
-    )
-    .await?;
+    tokio::spawn(async move {
+        // Transition status to Busy (blocks on ConcurrencyGate)
+        if let Err(e) = crate::agent::lifecycle::update_session_status(
+            &session_repo,
+            &active_sessions,
+            &app_handle,
+            &session_id_clone,
+            SessionStatus::Busy,
+        )
+        .await
+        {
+            log::error!(
+                "Failed to transition resumed session {} to Busy: {}",
+                session_id_clone,
+                e
+            );
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_RESUME_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+            return;
+        }
+
+        // Ensure proxy is ready
+        if let Err(e) = crate::agent::workflow::start::ensure_proxy_ready(
+            &proxy_manager,
+            &app_handle,
+            &session_id_clone,
+            60,
+        )
+        .await
+        {
+            log::error!(
+                "Proxy check failed during background resume for session {}: {}",
+                session_id_clone,
+                e
+            );
+            let _ = crate::agent::lifecycle::update_session_status(
+                &session_repo,
+                &active_sessions,
+                &app_handle,
+                &session_id_clone,
+                SessionStatus::Error,
+            )
+            .await;
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_RESUME_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+            return;
+        }
+
+        // Trigger LLM to pick up where it left off
+        if let Err(e) = crate::agent::llm::request_llm_completion_with_recovery(
+            &session_repo,
+            &active_sessions,
+            &proxy_manager,
+            &app_handle,
+            session_id_clone.clone(),
+        )
+        .await
+        {
+            log::error!(
+                "LLM completion failed in background resume for session {}: {:?}",
+                session_id_clone,
+                e
+            );
+            let _ = crate::agent::lifecycle::update_session_status(
+                &session_repo,
+                &active_sessions,
+                &app_handle,
+                &session_id_clone,
+                SessionStatus::Error,
+            )
+            .await;
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_RESUME_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+        }
+    });
 
     Ok(())
 }

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -56,22 +56,28 @@ pub async fn start_workflow(
             }
 
             // Check Status
-            let is_transitioning_to_busy = matches!(
-                session.status_transition.read().await.as_ref(),
-                Some(crate::agent::state::SessionStatusTransition::ToStatus(
-                    SessionStatus::Busy
-                ))
-            );
+            let is_transitioning_to_busy = {
+                let trans = session.status_transition.read().await;
+                matches!(
+                    trans.as_ref(),
+                    Some(crate::agent::state::SessionStatusTransition::ToStatus(
+                        SessionStatus::Busy | SessionStatus::Queued
+                    ))
+                )
+            };
 
-            if session.metadata.status == SessionStatus::Busy || is_transitioning_to_busy {
+            if session.metadata.status == SessionStatus::Busy
+                || session.metadata.status == SessionStatus::Queued
+                || is_transitioning_to_busy
+            {
                 log::info!(
-                    "Session {} is busy. Queueing message: {} in pending_events only.",
+                    "Session {} is busy or queued. Queueing message: {} in pending_events only.",
                     session_id,
                     user_message.id
                 );
                 true // Signal that we queued it
             } else {
-                false // Not busy, proceed to start workflow
+                false // Not busy/queued, proceed to start workflow
             }
         } else {
             false // Session not found, will be handled by standard flow (or fail there)
@@ -105,13 +111,13 @@ pub async fn start_workflow(
 
     // --- STANDARD START WORKFLOW (Idle/Paused) ---
 
-    // Update status to Busy
+    // Update status to Queued immediately
     crate::agent::lifecycle::update_session_status(
         session_repo,
         active_sessions,
         app_handle,
         &session_id,
-        SessionStatus::Busy,
+        SessionStatus::Queued,
     )
     .await?;
 
@@ -120,12 +126,9 @@ pub async fn start_workflow(
         session_id: session_id.clone(),
     };
     log::info!("Emitting WorkflowStarted event for session: {}", session_id);
-    match crate::agent::tauri_events::emit_agent_event(app_handle, event) {
-        Ok(()) => log::info!("✅ WorkflowStarted event emitted successfully"),
-        Err(e) => {
-            log::error!("❌ Failed to emit WorkflowStarted event: {}", e);
-            return Err(format!("Failed to emit event: {}", e));
-        }
+    if let Err(e) = crate::agent::tauri_events::emit_agent_event(app_handle, event) {
+        log::error!("Failed to emit WorkflowStarted event: {}", e);
+        return Err(format!("Failed to emit event: {}", e));
     }
 
     // Delegate message deduplication, cache update, DB insertion, and UI event emission
@@ -139,22 +142,106 @@ pub async fn start_workflow(
     .await?;
 
     log::info!(
-        "Started workflow for session: {} with message: {}",
+        "Queued workflow for session: {} with message: {}",
         session_id,
         user_message.id
     );
 
-    ensure_proxy_ready(proxy_manager, app_handle, &session_id, 60).await?;
+    let session_repo = Arc::clone(session_repo);
+    let active_sessions = Arc::clone(active_sessions);
+    let proxy_manager = Arc::clone(proxy_manager);
+    let app_handle = app_handle.clone();
+    let session_id_clone = session_id.clone();
 
-    // Request LLM completion with cached messages (no DB query)
-    crate::agent::llm::request_llm_completion_with_recovery(
-        session_repo,
-        active_sessions,
-        proxy_manager,
-        app_handle,
-        session_id,
-    )
-    .await?;
+    tokio::spawn(async move {
+        // Transition status to Busy (blocks on ConcurrencyGate)
+        if let Err(e) = crate::agent::lifecycle::update_session_status(
+            &session_repo,
+            &active_sessions,
+            &app_handle,
+            &session_id_clone,
+            SessionStatus::Busy,
+        )
+        .await
+        {
+            log::error!(
+                "Failed to transition session {} to Busy: {}",
+                session_id_clone,
+                e
+            );
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_WORKFLOW_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+            return;
+        }
+
+        if let Err(e) = ensure_proxy_ready(&proxy_manager, &app_handle, &session_id_clone, 60).await
+        {
+            log::error!(
+                "Proxy check failed during background start for session {}: {}",
+                session_id_clone,
+                e
+            );
+            let _ = crate::agent::lifecycle::update_session_status(
+                &session_repo,
+                &active_sessions,
+                &app_handle,
+                &session_id_clone,
+                SessionStatus::Error,
+            )
+            .await;
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_WORKFLOW_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+            return;
+        }
+
+        // Request LLM completion with cached messages
+        if let Err(e) = crate::agent::llm::request_llm_completion_with_recovery(
+            &session_repo,
+            &active_sessions,
+            &proxy_manager,
+            &app_handle,
+            session_id_clone.clone(),
+        )
+        .await
+        {
+            log::error!(
+                "LLM completion failed in background start for session {}: {:?}",
+                session_id_clone,
+                e
+            );
+            let _ = crate::agent::lifecycle::update_session_status(
+                &session_repo,
+                &active_sessions,
+                &app_handle,
+                &session_id_clone,
+                SessionStatus::Error,
+            )
+            .await;
+            let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                session_id: session_id_clone.clone(),
+                error: crate::agent::llm::types::AgentRuntimeError::new(
+                    crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                    e.to_string(),
+                )
+                .with_code("BACKGROUND_WORKFLOW_FAILED"),
+            };
+            let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+        }
+    });
 
     Ok(())
 }

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -154,7 +154,55 @@ pub async fn start_workflow(
     let session_id_clone = session_id.clone();
 
     tokio::spawn(async move {
-        // Transition status to Busy (blocks on ConcurrencyGate)
+        // 1. Acquire active agent permit first (blocks safely outside transition lock)
+        let gate = crate::state::get_concurrency_gate();
+        let permit = match gate.acquire_active_agent().await {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!(
+                    "Failed to acquire active agent permit for session {}: {}",
+                    session_id_clone,
+                    e
+                );
+                let error_event = crate::agent::events::AgentEvent::WorkflowError {
+                    session_id: session_id_clone.clone(),
+                    error: crate::agent::llm::types::AgentRuntimeError::new(
+                        crate::agent::llm::types::AgentRuntimeErrorType::AiServiceError,
+                        e.to_string(),
+                    )
+                    .with_code("BACKGROUND_WORKFLOW_FAILED"),
+                };
+                let _ = crate::agent::tauri_events::emit_agent_event(&app_handle, error_event);
+                return;
+            }
+        };
+
+        // 2. Put permit into memory and verify not cancelled/changed
+        {
+            let mut active = active_sessions.write().await;
+            if let Some(session) = active.get_mut(&session_id_clone) {
+                if session.cancellation_token.is_cancelled()
+                    || session.metadata.status != SessionStatus::Queued
+                {
+                    log::info!(
+                        "Session {} cancelled or status changed while queued. Aborting background start.",
+                        session_id_clone
+                    );
+                    drop(permit);
+                    return;
+                }
+                session.active_permit = Some(permit);
+            } else {
+                log::warn!(
+                    "Session {} not found in active sessions during background start. Aborting.",
+                    session_id_clone
+                );
+                drop(permit);
+                return;
+            }
+        }
+
+        // Transition status to Busy (bypasses concurrency gate block since permit is held)
         if let Err(e) = crate::agent::lifecycle::update_session_status(
             &session_repo,
             &active_sessions,
@@ -169,6 +217,12 @@ pub async fn start_workflow(
                 session_id_clone,
                 e
             );
+            {
+                let mut active = active_sessions.write().await;
+                if let Some(session) = active.get_mut(&session_id_clone) {
+                    session.active_permit.take();
+                }
+            }
             let error_event = crate::agent::events::AgentEvent::WorkflowError {
                 session_id: session_id_clone.clone(),
                 error: crate::agent::llm::types::AgentRuntimeError::new(

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -353,7 +353,9 @@ pub async fn stop_session(
         Err(result) => return Ok(result),
     };
 
-    if target_session.status != SessionStatus::Busy {
+    if target_session.status != SessionStatus::Busy
+        && target_session.status != SessionStatus::Queued
+    {
         let current_status = target_session.status.as_str().to_string();
         let message = format!(
             "Session {} was already {}. No action taken.",
@@ -444,7 +446,9 @@ pub async fn compact_session_context(
         Err(result) => return Ok(result),
     };
 
-    if target_session.status == SessionStatus::Busy {
+    if target_session.status == SessionStatus::Busy
+        || target_session.status == SessionStatus::Queued
+    {
         return Ok(guided_error(
             ErrorCategory::InvalidState,
             format!(

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -452,7 +452,7 @@ pub async fn compact_session_context(
         return Ok(guided_error(
             ErrorCategory::InvalidState,
             format!(
-                "Session {} is busy. compactSessionContext only supports idle, paused, or error sessions.",
+                "Session {} is busy or queued. compactSessionContext only supports idle, paused, or error sessions.",
                 session_id
             ),
             ToolGroup::Agent,

--- a/src-tauri/src/repositories/session_child_context.rs
+++ b/src-tauri/src/repositories/session_child_context.rs
@@ -54,7 +54,7 @@ pub fn format_active_sessions_notice(children: &[SessionMetadata]) -> Option<Str
             SessionStatus::Idle => idle_sessions.push(child),
             SessionStatus::Paused => paused_sessions.push(child),
             SessionStatus::Error => error_sessions.push(child),
-            SessionStatus::Busy => busy_sessions.push(child),
+            SessionStatus::Busy | SessionStatus::Queued => busy_sessions.push(child),
         }
     }
 

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -52,6 +52,7 @@ pub enum SessionStatus {
     Busy,
     Paused,
     Error,
+    Queued,
 }
 
 impl SessionStatus {
@@ -61,6 +62,7 @@ impl SessionStatus {
             SessionStatus::Busy => "busy",
             SessionStatus::Paused => "paused",
             SessionStatus::Error => "error",
+            SessionStatus::Queued => "queued",
         }
     }
 }
@@ -74,6 +76,7 @@ impl FromStr for SessionStatus {
             "busy" => Ok(SessionStatus::Busy),
             "paused" => Ok(SessionStatus::Paused),
             "error" => Ok(SessionStatus::Error),
+            "queued" => Ok(SessionStatus::Queued),
             _ => Err(DbError::InvalidInput(format!(
                 "Invalid session status: {}",
                 s

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -45,6 +45,14 @@ function StatusDot({ status }: { status: string }) {
       />
     );
   }
+  if (status === 'queued') {
+    return (
+      <Circle
+        size={8}
+        className="fill-warning text-warning flex-shrink-0 animate-pulse"
+      />
+    );
+  }
   if (status === 'error') {
     return (
       <Circle

--- a/src/context/AgentChatContext.tsx
+++ b/src/context/AgentChatContext.tsx
@@ -57,7 +57,7 @@ interface AgentChatStateContextValue {
   pendingMessages: Message[]; // NEW: Export pending queue for set-based detection
   error: MessageError | null;
   llmError: MessageError | null;
-  workflowStatus: 'idle' | 'busy' | 'paused' | 'error';
+  workflowStatus: 'idle' | 'busy' | 'paused' | 'error' | 'queued';
   serviceContexts: Record<string, ServiceContext>;
 }
 

--- a/src/context/AgentSessionListContext.tsx
+++ b/src/context/AgentSessionListContext.tsx
@@ -13,6 +13,7 @@ import { listen } from '@tauri-apps/api/event';
 import { matchPath, useLocation } from 'react-router-dom';
 import { getLogger } from '../lib/logger';
 import { useModelOptions } from './ModelProvider';
+import { toast } from 'sonner';
 import { useBackendResource } from './GlobalEventContext';
 import type { AgentSession, CreateSessionParams } from '@/models/agent';
 import { getAssistant, listAssistants } from '@/lib/backend/assistants';
@@ -410,6 +411,10 @@ export function AgentSessionListProvider({
 
         // Add to list
         mutateSessions((prev) => [session, ...prev]);
+
+        toast.success(
+          `Session "${session.name || session.id.slice(0, 8)}" created successfully`,
+        );
 
         logger.info('Agent session created successfully', {
           sessionId: session.id,

--- a/src/context/agent-session/types.ts
+++ b/src/context/agent-session/types.ts
@@ -20,7 +20,7 @@ export type AgentEventPayload =
   | {
       type: 'statusChanged';
       sessionId: string;
-      status: 'idle' | 'busy' | 'paused' | 'error';
+      status: 'idle' | 'busy' | 'paused' | 'error' | 'queued';
     }
   | { type: 'messageAdded'; sessionId: string; message: RustMessage }
   | { type: 'toolExecutionStarted'; sessionId: string; toolName: string }
@@ -115,7 +115,7 @@ export interface AgentSessionStateContextValue {
   hasOlderMessages: boolean;
   error: MessageError | null;
   llmError: MessageError | null;
-  workflowStatus: 'idle' | 'busy' | 'paused' | 'error';
+  workflowStatus: 'idle' | 'busy' | 'paused' | 'error' | 'queued';
   workflowPhase: WorkflowPhase;
   runtimeState: SessionRuntimeState;
   preflightTokenMetrics: PreflightTokenMetrics | null;

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -101,11 +101,9 @@ export function useAgentSessionEvents(
             }
 
             case 'workflowStarted': {
-              setters.setWorkflowStatus('busy');
-              setters.setWorkflowPhase('thinking');
               setters.setError(null);
               setters.setLlmError(null);
-              logger.info('Workflow phase: thinking');
+              logger.info('Workflow started');
               break;
             }
 
@@ -116,10 +114,12 @@ export function useAgentSessionEvents(
                 prev ? { ...prev, status: newStatus } : null,
               );
 
-              if (newStatus === 'busy') {
+              if (newStatus === 'busy' || newStatus === 'queued') {
                 setters.setError(null);
                 setters.setLlmError(null);
-                setters.setWorkflowPhase('thinking');
+                setters.setWorkflowPhase(
+                  newStatus === 'busy' ? 'thinking' : 'idle',
+                );
               } else if (newStatus === 'idle') {
                 setters.setWorkflowPhase('idle');
               } else if (newStatus === 'error') {

--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -40,7 +40,7 @@ export function useAgentSessionState() {
   const [error, setErrorState] = useState<MessageError | null>(null);
   const [llmError, setLlmError] = useState<MessageError | null>(null);
   const [workflowStatus, setWorkflowStatus] = useState<
-    'idle' | 'busy' | 'paused' | 'error'
+    'idle' | 'busy' | 'paused' | 'error' | 'queued'
   >('idle');
   const [workflowPhase, setWorkflowPhase] = useState<WorkflowPhase>('idle');
   const [runtimeState, setRuntimeState] = useState<SessionRuntimeState>(

--- a/src/features/agent/components/AgentChatStatusBar.tsx
+++ b/src/features/agent/components/AgentChatStatusBar.tsx
@@ -14,6 +14,7 @@ import {
   AlertTriangle,
   Zap,
   DatabaseZap,
+  Clock,
 } from 'lucide-react';
 import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker';
 import { useAgentTools } from '@/hooks/use-agent-tools';
@@ -439,6 +440,17 @@ export function AgentChatStatusBar() {
         return {
           icon: <Loader2 className="w-4 h-4 animate-spin" />,
           text: t('agent.statusBar.statusBusy'),
+          className: 'bg-warning/10 border-warning/20 text-warning-foreground',
+          showRetry: false,
+          showResume: false,
+        };
+      case 'queued':
+        return {
+          icon: <Clock className="w-4 h-4 text-warning animate-pulse" />,
+          text: t(
+            'agent.statusBar.statusQueued',
+            'Queued (Waiting for available agent slot...)',
+          ),
           className: 'bg-warning/10 border-warning/20 text-warning-foreground',
           showRetry: false,
           showResume: false,

--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -89,6 +89,17 @@ export function SessionCard({
               'border-warning/30 bg-warning/5 shadow-sm shadow-warning/10 hover:bg-warning/10',
             accentClassName: 'bg-warning/70',
           };
+        case 'queued':
+          return {
+            icon: 'queued',
+            badge: t('sessionHistory.status.queued', 'Queued'),
+            variant: 'outline' as const,
+            className:
+              'bg-warning/10 text-warning-foreground border-warning/20 animate-pulse',
+            cardClassName:
+              'border-warning/30 bg-warning/5 shadow-sm shadow-warning/10 hover:bg-warning/10',
+            accentClassName: 'bg-warning/70',
+          };
         case 'idle':
           return {
             icon: 'idle',
@@ -174,7 +185,10 @@ export function SessionCard({
   }, []);
 
   const statusConfig = getStatusConfig(session.status);
-  const isActive = session.status === 'busy' || session.status === 'idle';
+  const isActive =
+    session.status === 'busy' ||
+    session.status === 'idle' ||
+    session.status === 'queued';
   const isViewOnly = session.status === 'error';
   const isPaused = session.status === 'paused';
   const shortLineageId = session.lineageId?.slice(0, 8);

--- a/src/features/agent/components/SessionCard.tsx
+++ b/src/features/agent/components/SessionCard.tsx
@@ -315,7 +315,8 @@ export function SessionCard({
                 { status: statusConfig.badge },
               )}
             >
-              {statusConfig.icon === 'active' && (
+              {(statusConfig.icon === 'active' ||
+                statusConfig.icon === 'queued') && (
                 <Circle className="h-3 w-3 fill-current" />
               )}
               {statusConfig.icon === 'idle' && (

--- a/src/features/agent/components/SessionHistoryPanel.tsx
+++ b/src/features/agent/components/SessionHistoryPanel.tsx
@@ -308,6 +308,7 @@ export function SessionHistoryPanel({
     idle: `${t('sessionHistory.tabs.idle', 'Idle')} (${statusCounts.idle})`,
     paused: `${t('sessionHistory.tabs.paused', 'Paused')} (${statusCounts.paused})`,
     error: `${t('sessionHistory.tabs.error', 'Error')} (${statusCounts.error})`,
+    queued: `${t('sessionHistory.tabs.queued', 'Queued')} (${statusCounts.queued})`,
   };
   const sortLabelByValue: Record<SessionSortKey, string> = {
     updatedAt: t('sessionHistory.sort.updatedAt', 'Recent activity'),

--- a/src/features/agent/components/session-tree.ts
+++ b/src/features/agent/components/session-tree.ts
@@ -40,12 +40,13 @@ interface ComputeSessionTreeParams {
 /**
  * Calculates the counts of sessions in each status.
  */
-function calculateStatusCounts(sessions: AgentSession[]): {
+function getStatusCounts(sessions: AgentSession[]): {
   all: number;
   busy: number;
   idle: number;
   paused: number;
   error: number;
+  queued: number;
 } {
   const counts = {
     all: sessions.length,
@@ -53,6 +54,7 @@ function calculateStatusCounts(sessions: AgentSession[]): {
     idle: 0,
     paused: 0,
     error: 0,
+    queued: 0,
   };
   sessions.forEach((session) => {
     if (Object.prototype.hasOwnProperty.call(counts, session.status)) {
@@ -291,7 +293,7 @@ export function computeSessionTree({
     : lineageSessions;
 
   // 3. Count statuses in scope
-  const statusCounts = calculateStatusCounts(bookmarkedScopeSessions);
+  const statusCounts = getStatusCounts(bookmarkedScopeSessions);
 
   // 4. Determine derived filtersActive flag
   const filtersActive =

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -7,6 +7,7 @@ export interface SessionStatusCounts {
   idle: number;
   paused: number;
   error: number;
+  queued: number;
 }
 
 function createEmptyStatusCounts(): SessionStatusCounts {
@@ -15,6 +16,7 @@ function createEmptyStatusCounts(): SessionStatusCounts {
     idle: 0,
     paused: 0,
     error: 0,
+    queued: 0,
   };
 }
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -193,7 +193,8 @@
       "busy": "Beschäftigt",
       "idle": "Leerlauf",
       "paused": "Pausiert",
-      "error": "Fehler"
+      "error": "Fehler",
+      "queued": "In Warteschlange"
     },
     "statusFilter": {
       "label": "Status",
@@ -221,7 +222,8 @@
       "idle": "Leerlauf",
       "paused": "Pausiert",
       "error": "Fehler",
-      "unknown": "Unbekannt"
+      "unknown": "Unbekannt",
+      "queued": "In Warteschlange"
     },
     "card": {
       "fallbackName": "Sitzung {{id}}",
@@ -938,7 +940,8 @@
       "agentMode": "Agent-Modus",
       "chatMode": "Chat-Modus",
       "toolsLabel": "Werkzeuge:",
-      "viewToolsTitle": "Klicken, um verfügbare Werkzeuge anzuzeigen"
+      "viewToolsTitle": "Klicken, um verfügbare Werkzeuge anzuzeigen",
+      "statusQueued": "In der Warteschlange (warten auf verfügbaren Agenten-Slot...)"
     },
     "attachment": {
       "sessionError": "Datei kann nicht angehängt werden: Sitzung nicht verfügbar.",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -194,7 +194,8 @@
       "busy": "Busy",
       "idle": "Idle",
       "paused": "Paused",
-      "error": "Error"
+      "error": "Error",
+      "queued": "Queued"
     },
     "statusFilter": {
       "label": "Status",
@@ -222,7 +223,8 @@
       "idle": "Idle",
       "paused": "Paused",
       "error": "Error",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "queued": "Queued"
     },
     "card": {
       "fallbackName": "Session {{id}}",
@@ -949,7 +951,8 @@
       "agentMode": "Agent Mode",
       "chatMode": "Chat Mode",
       "toolsLabel": "Tools:",
-      "viewToolsTitle": "Click to view available tools"
+      "viewToolsTitle": "Click to view available tools",
+      "statusQueued": "Queued (Waiting for available agent slot...)"
     },
     "attachment": {
       "sessionError": "Cannot attach file: session not available.",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -193,7 +193,8 @@
       "busy": "Ocupado",
       "idle": "Inactivo",
       "paused": "En pausa",
-      "error": "Error"
+      "error": "Error",
+      "queued": "En cola"
     },
     "statusFilter": {
       "label": "Estado",
@@ -221,7 +222,8 @@
       "idle": "Inactivo",
       "paused": "En pausa",
       "error": "Error",
-      "unknown": "Desconocido"
+      "unknown": "Desconocido",
+      "queued": "En cola"
     },
     "card": {
       "fallbackName": "Sesión {{id}}",
@@ -938,7 +940,8 @@
       "agentMode": "Modo Agente",
       "chatMode": "Modo Chat",
       "toolsLabel": "Herramientas:",
-      "viewToolsTitle": "Haga clic para ver las herramientas disponibles"
+      "viewToolsTitle": "Haga clic para ver las herramientas disponibles",
+      "statusQueued": "En cola (esperando ranura de agente disponible...)"
     },
     "attachment": {
       "sessionError": "No se puede adjuntar el archivo: sesión no disponible.",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -193,7 +193,8 @@
       "busy": "Occupé",
       "idle": "Inactif",
       "paused": "En pause",
-      "error": "Erreur"
+      "error": "Erreur",
+      "queued": "En file d'attente"
     },
     "statusFilter": {
       "label": "Statut",
@@ -221,7 +222,8 @@
       "idle": "Inactif",
       "paused": "En pause",
       "error": "Erreur",
-      "unknown": "Inconnu"
+      "unknown": "Inconnu",
+      "queued": "En file d'attente"
     },
     "card": {
       "fallbackName": "Session {{id}}",
@@ -938,7 +940,8 @@
       "agentMode": "Mode Agent",
       "chatMode": "Mode Chat",
       "toolsLabel": "Outils :",
-      "viewToolsTitle": "Cliquez pour voir les outils disponibles"
+      "viewToolsTitle": "Cliquez pour voir les outils disponibles",
+      "statusQueued": "En file d'attente (en attente d'un emplacement d'agent disponible...)"
     },
     "attachment": {
       "sessionError": "Impossible de joindre le fichier : session non disponible.",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -192,7 +192,8 @@
       "idle": "待機中",
       "paused": "一時停止中",
       "error": "エラー",
-      "bookmarked": "ブックマーク"
+      "bookmarked": "ブックマーク",
+      "queued": "待機中"
     },
     "lineageHint": {
       "child": "↳ {{parentName}} の子",
@@ -203,7 +204,8 @@
       "idle": "待機中",
       "paused": "一時停止中",
       "error": "エラー",
-      "unknown": "不明"
+      "unknown": "不明",
+      "queued": "待機中"
     },
     "card": {
       "fallbackName": "セッション {{id}}",
@@ -912,7 +914,8 @@
       "agentMode": "エージェントモード",
       "chatMode": "チャットモード",
       "toolsLabel": "ツール:",
-      "viewToolsTitle": "クリックして利用可能なツールを表示"
+      "viewToolsTitle": "クリックして利用可能なツールを表示",
+      "statusQueued": "待機中 (利用可能なエージェントスロットを待っています...)"
     },
     "attachment": {
       "sessionError": "ファイルを添付できません：セッションが利用不可です。",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -193,7 +193,8 @@
       "busy": "진행 중",
       "idle": "대기 중",
       "paused": "일시 중지",
-      "error": "오류"
+      "error": "오류",
+      "queued": "대기 중"
     },
     "statusFilter": {
       "label": "상태",
@@ -221,7 +222,8 @@
       "idle": "대기",
       "paused": "일시 중지됨",
       "error": "오류",
-      "unknown": "알 수 없음"
+      "unknown": "알 수 없음",
+      "queued": "대기 중"
     },
     "card": {
       "fallbackName": "세션 {{id}}",
@@ -949,7 +951,8 @@
       "agentMode": "에이전트 모드",
       "chatMode": "채팅 모드",
       "toolsLabel": "도구:",
-      "viewToolsTitle": "클릭하여 사용 가능한 도구 보기"
+      "viewToolsTitle": "클릭하여 사용 가능한 도구 보기",
+      "statusQueued": "대기 중 (사용 가능한 에이전트 슬롯 대기 중...)"
     },
     "attachment": {
       "sessionError": "파일을 첨부할 수 없습니다: 세션을 사용할 수 없습니다.",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -193,7 +193,8 @@
       "busy": "Ocupado",
       "idle": "Inativo",
       "paused": "Pausado",
-      "error": "Erro"
+      "error": "Erro",
+      "queued": "Na fila"
     },
     "statusFilter": {
       "label": "Status",
@@ -221,7 +222,8 @@
       "idle": "Inativo",
       "paused": "Pausado",
       "error": "Erro",
-      "unknown": "Desconhecido"
+      "unknown": "Desconhecido",
+      "queued": "Na fila"
     },
     "card": {
       "fallbackName": "Sessão {{id}}",
@@ -938,7 +940,8 @@
       "agentMode": "Modo Agente",
       "chatMode": "Modo Chat",
       "toolsLabel": "Ferramentas:",
-      "viewToolsTitle": "Clique para ver as ferramentas disponíveis"
+      "viewToolsTitle": "Clique para ver as ferramentas disponíveis",
+      "statusQueued": "Na fila (aguardando slot de agente disponível...)"
     },
     "attachment": {
       "sessionError": "Não é possível anexar o arquivo: sessão não disponível.",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -193,7 +193,8 @@
       "busy": "忙碌",
       "idle": "空闲",
       "paused": "已暂停",
-      "error": "错误"
+      "error": "错误",
+      "queued": "排队中"
     },
     "statusFilter": {
       "label": "状态",
@@ -221,7 +222,8 @@
       "idle": "空闲",
       "paused": "已暂停",
       "error": "错误",
-      "unknown": "未知"
+      "unknown": "未知",
+      "queued": "排队中"
     },
     "card": {
       "fallbackName": "会话 {{id}}",
@@ -938,7 +940,8 @@
       "agentMode": "代理模式",
       "chatMode": "聊天模式",
       "toolsLabel": "工具:",
-      "viewToolsTitle": "点击查看可用工具"
+      "viewToolsTitle": "点击查看可用工具",
+      "statusQueued": "排队中 (等待可用的智能体槽位...)"
     },
     "attachment": {
       "sessionError": "无法附加文件：会话不可用。",

--- a/src/models/agent-ipc.ts
+++ b/src/models/agent-ipc.ts
@@ -234,7 +234,7 @@ export interface ToolExecutionResult {
 export interface AgentSessionMetadata {
   id: string;
   name?: string;
-  status: 'idle' | 'busy' | 'paused' | 'error';
+  status: 'idle' | 'busy' | 'paused' | 'error' | 'queued';
   model: string;
   provider: string;
   /** FK to assistants table; authoritative assistant binding for the session */

--- a/src/models/agent.ts
+++ b/src/models/agent.ts
@@ -8,7 +8,7 @@ import type { SessionAttentionReason } from './agent-ipc';
 export interface AgentSession {
   id: string;
   name?: string;
-  status: 'idle' | 'busy' | 'paused' | 'error';
+  status: 'idle' | 'busy' | 'paused' | 'error' | 'queued';
   model: string;
   provider: string;
   createdAt: Date;


### PR DESCRIPTION
This PR introduces a new 'Queued' status to agent sessions to prevent UI freezing/blocking when active concurrency slots (max 4) are full. The Tauri handler now spawns a background task for slot acquisition and returns immediately, and the frontend updates status indicators (AppSidebar, SessionCard, AgentChatStatusBar) and displays a success toast upon session creation.