### PR TITLE
fix(agent): unblock parent wait on paused and finish pending race

### DIFF
--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::sync::RwLock;
 
-use super::completion::request_llm_completion;
 use super::response_admission;
 use super::response_circuit_breaker;
 use super::tool_execution;
@@ -203,18 +202,6 @@ async fn reset_streaming_recovery_retry_counts(
     }
 }
 
-async fn session_has_pending_events(
-    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
-    session_id: &str,
-) -> bool {
-    let active = active_sessions.read().await;
-    if let Some(session) = active.get(session_id) {
-        return session.pending_events.read().await.count() > 0;
-    }
-
-    false
-}
-
 async fn initialize_pending_execution(
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
     session_id: &str,
@@ -395,30 +382,33 @@ pub async fn handle_llm_response(
     if tool_calls.is_empty() {
         reset_streaming_recovery_retry_counts(active_sessions, &session_id).await;
 
-        // Check for pending messages before finishing
-        let has_pending = session_has_pending_events(active_sessions, &session_id).await;
-
-        if has_pending {
+        if crate::agent::workflow::session_has_pending_events(active_sessions, &session_id).await {
             spawn_persist_assistant_message_to_db(msg_for_db);
-            log::info!(
-                "🔄 Pending messages detected for session {}. Continuing workflow.",
-                session_id
-            );
-            // Recursively trigger next turn
-            return request_llm_completion(
+            crate::agent::workflow::continue_workflow_if_pending_events(
                 session_repo,
                 active_sessions,
                 proxy_manager,
                 app_handle,
-                session_id,
+                &session_id,
             )
-            .await
-            .map(|_| ())
-            .map_err(String::from);
+            .await?;
+            return Ok(());
         }
 
         // Ensure the final assistant row is visible before waking terminal waiters.
         persist_assistant_message_to_db(&msg_for_db).await;
+
+        if crate::agent::workflow::continue_workflow_if_pending_events(
+            session_repo,
+            active_sessions,
+            proxy_manager,
+            app_handle,
+            &session_id,
+        )
+        .await?
+        {
+            return Ok(());
+        }
 
         // No pending messages remain, so finish the workflow now.
         crate::agent::lifecycle::update_session_status(

--- a/src-tauri/src/agent/workflow/finish.rs
+++ b/src-tauri/src/agent/workflow/finish.rs
@@ -1,0 +1,145 @@
+use crate::agent::state::AgentSession;
+use crate::mcp::MCPServiceProxyManager;
+use crate::repositories::SessionRepository;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::AppHandle;
+use tokio::sync::RwLock;
+
+pub async fn session_has_pending_events(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+) -> bool {
+    let active = active_sessions.read().await;
+    if let Some(session) = active.get(session_id) {
+        return session.pending_events.read().await.count() > 0;
+    }
+
+    false
+}
+
+/// Re-check `pending_events` immediately before transitioning to Idle.
+///
+/// Returns `true` when pending messages were found and a new LLM turn was
+/// requested. Callers must skip the Idle transition in that case.
+pub async fn continue_workflow_if_pending_events(
+    session_repo: &Arc<dyn SessionRepository>,
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    proxy_manager: &Arc<MCPServiceProxyManager>,
+    app_handle: &AppHandle,
+    session_id: &str,
+) -> Result<bool, String> {
+    if !session_has_pending_events(active_sessions, session_id).await {
+        return Ok(false);
+    }
+
+    log::info!(
+        "Pending messages detected for session {} during workflow finish. Continuing workflow.",
+        session_id
+    );
+
+    crate::agent::llm::request_llm_completion_with_recovery(
+        session_repo,
+        active_sessions,
+        proxy_manager,
+        app_handle,
+        session_id.to_string(),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::context::registry::ContextRegistry;
+    use crate::agent::state::{CompactionRuntimeState, PendingEvent, PendingEventManager};
+    use crate::repositories::{SessionMetadata, SessionStatus};
+    use std::sync::atomic::AtomicBool;
+    use std::time::SystemTime;
+    use tokio_util::sync::CancellationToken;
+
+    fn build_session(session_id: &str) -> AgentSession {
+        let now = chrono::Utc::now().timestamp_millis();
+        AgentSession {
+            metadata: SessionMetadata {
+                id: session_id.to_string(),
+                name: None,
+                status: SessionStatus::Busy,
+                model: "gpt-5.4".to_string(),
+                provider: "openai".to_string(),
+                assistant_id: None,
+                parent_session_id: None,
+                lineage_id: None,
+                depth: None,
+                max_depth: None,
+                max_fanout: None,
+                org_id: None,
+                org_name: None,
+                org_root_session_id: None,
+                created_at: now,
+                updated_at: now,
+                last_viewed_at: None,
+                last_message_at: None,
+                last_attention_at: None,
+                last_attention_reason: None,
+                is_bookmarked: false,
+                yolo_mode: false,
+                unsafe_mode: false,
+                workspace_override: None,
+            },
+            is_running: true,
+            active_permit: None,
+            status_transition: Arc::new(RwLock::new(None)),
+            transition_lock: Arc::new(tokio::sync::Mutex::new(())),
+            cancellation_token: CancellationToken::new(),
+            yolo_mode: Arc::new(AtomicBool::new(false)),
+            unsafe_mode: Arc::new(AtomicBool::new(false)),
+            cancel_pending: Arc::new(AtomicBool::new(false)),
+            pending_execution: None,
+            messages: Arc::new(RwLock::new(Vec::new())),
+            cache_initialized: Arc::new(AtomicBool::new(true)),
+            last_synced_at: Arc::new(RwLock::new(Some(SystemTime::now()))),
+            repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
+            repeated_text_loop_retry_count: Arc::new(RwLock::new(0)),
+            pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
+            pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+            context_registry: Arc::new(ContextRegistry::new()),
+            compact_context: Arc::new(RwLock::new(None)),
+            compaction: CompactionRuntimeState::new(),
+            expected_response_id: Arc::new(RwLock::new(None)),
+            cached_stable_prompt: Arc::new(RwLock::new(None)),
+            last_completion_request: Arc::new(RwLock::new(None)),
+            last_submitted_input_message_id: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_has_pending_events_is_false_when_queue_empty() {
+        let sessions = Arc::new(RwLock::new(HashMap::from([(
+            "sess-1".to_string(),
+            build_session("sess-1"),
+        )])));
+
+        assert!(!session_has_pending_events(&sessions, "sess-1").await);
+    }
+
+    #[tokio::test]
+    async fn session_has_pending_events_is_true_when_queue_has_messages() {
+        let session = build_session("sess-2");
+        session
+            .pending_events
+            .write()
+            .await
+            .add(PendingEvent::Message("msg-1".to_string()));
+
+        let sessions = Arc::new(RwLock::new(HashMap::from([(
+            "sess-2".to_string(),
+            session,
+        )])));
+
+        assert!(session_has_pending_events(&sessions, "sess-2").await);
+    }
+}

--- a/src-tauri/src/agent/workflow/mod.rs
+++ b/src-tauri/src/agent/workflow/mod.rs
@@ -1,9 +1,11 @@
 pub mod cancel;
+pub mod finish;
 pub mod pause_resume;
 pub mod start;
 pub mod tool;
 
 pub use cancel::*;
+pub use finish::{continue_workflow_if_pending_events, session_has_pending_events};
 pub use pause_resume::*;
 pub use start::*;
 pub use tool::*;

--- a/src-tauri/src/agent/workflow/tool.rs
+++ b/src-tauri/src/agent/workflow/tool.rs
@@ -128,6 +128,17 @@ pub async fn continue_workflow_after_tool(
                     "UI interaction detected for session {}. Stopping loop.",
                     session_id
                 );
+                if crate::agent::workflow::continue_workflow_if_pending_events(
+                    session_repo,
+                    active_sessions,
+                    proxy_manager,
+                    app_handle,
+                    &session_id,
+                )
+                .await?
+                {
+                    return Ok(());
+                }
                 if let Err(error) = crate::agent::lifecycle::update_session_status(
                     session_repo,
                     active_sessions,

--- a/src-tauri/src/mcp/builtin/session_api/formatting.rs
+++ b/src-tauri/src/mcp/builtin/session_api/formatting.rs
@@ -55,6 +55,14 @@ pub fn is_terminal_status(status: &str) -> bool {
     )
 }
 
+/// Returns true when a blocking parent wait should stop polling.
+///
+/// `paused` is not a terminal lifecycle status, but cancelled or interrupted
+/// child sessions settle there and must unblock `checkSession(wait=true)`.
+pub fn is_wait_complete_status(status: &str) -> bool {
+    is_terminal_status(status) || status.eq_ignore_ascii_case("paused")
+}
+
 /// Returns true if the last tool-role message in `messages` contains a
 /// content item with `"type": "resource"` — indicating an intentional pause
 /// waiting for user interaction (e.g. a UI resource prompt).
@@ -425,6 +433,15 @@ mod tests {
     #[test]
     fn terminal_status_paused_is_not_terminal() {
         assert!(!is_terminal_status("paused"));
+    }
+
+    #[test]
+    fn wait_complete_status_includes_terminal_and_paused() {
+        assert!(is_wait_complete_status("idle"));
+        assert!(is_wait_complete_status("error"));
+        assert!(is_wait_complete_status("paused"));
+        assert!(is_wait_complete_status("Paused"));
+        assert!(!is_wait_complete_status("busy"));
     }
 
     #[test]

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
 use super::formatting::{
-    extract_session_status, is_terminal_status, latest_session_output, session_output_is_missing,
-    truncate_text,
+    extract_session_status, is_wait_complete_status, latest_session_output,
+    session_output_is_missing, truncate_text,
 };
 use super::types::MessageSummaryOptions;
 use crate::agent::AgentSessionManager;
@@ -482,7 +482,7 @@ pub async fn wait_until_session_terminal(
             .ok_or_else(|| format!("Agent session '{}' not found", session_id))?;
 
         wake_count = wake_count.saturating_add(1);
-        if is_terminal_status(&extract_session_status(&session)) {
+        if is_wait_complete_status(&extract_session_status(&session)) {
             return Ok((session, wake_count));
         }
 

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -102,6 +102,8 @@ pub mod tool_list_tools_tests;
 pub mod tool_loop_fence_tests;
 pub mod tool_result_spillover_tests;
 pub mod ui_interaction_template_tests;
+pub mod wait_session_complete_status_tests;
+pub mod workflow_finish_pending_tests;
 pub mod workflow_restart_state_tests;
 pub mod workspace_file_operation_utils_tests;
 pub mod workspace_guidance_tests;

--- a/src-tauri/tests/integration/wait_session_complete_status_tests.rs
+++ b/src-tauri/tests/integration/wait_session_complete_status_tests.rs
@@ -1,0 +1,31 @@
+use tauri_mcp_agent_lib::mcp::builtin::session_api::formatting::{
+    is_terminal_status, is_wait_complete_status,
+};
+
+/// Regression: cancelled child sessions end in `paused`, which must unblock
+/// `checkSession(wait=true)` instead of sleeping forever in the poll loop.
+#[test]
+fn paused_child_cancel_is_a_wait_complete_outcome() {
+    assert!(
+        !is_terminal_status("paused"),
+        "paused must remain non-terminal for lifecycle semantics"
+    );
+    assert!(
+        is_wait_complete_status("paused"),
+        "parent wait loops must exit when a delegated session settles to paused"
+    );
+}
+
+#[test]
+fn wait_complete_status_preserves_terminal_set() {
+    for status in ["idle", "terminated", "failed", "error"] {
+        assert!(
+            is_wait_complete_status(status),
+            "{status} should still complete a blocking wait"
+        );
+    }
+    assert!(
+        !is_wait_complete_status("busy"),
+        "busy sessions must keep the parent waiting"
+    );
+}

--- a/src-tauri/tests/integration/workflow_finish_pending_tests.rs
+++ b/src-tauri/tests/integration/workflow_finish_pending_tests.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use tauri_mcp_agent_lib::agent::context::registry::ContextRegistry;
+use tauri_mcp_agent_lib::agent::state::{
+    AgentSession, CompactionRuntimeState, PendingEvent, PendingEventManager,
+};
+use tauri_mcp_agent_lib::agent::workflow::session_has_pending_events;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+fn build_session(session_id: &str) -> AgentSession {
+    let now = chrono::Utc::now().timestamp_millis();
+    AgentSession {
+        metadata: SessionMetadata {
+            id: session_id.to_string(),
+            name: None,
+            status: SessionStatus::Busy,
+            model: "gpt-5.4".to_string(),
+            provider: "openai".to_string(),
+            assistant_id: None,
+            parent_session_id: None,
+            lineage_id: None,
+            depth: None,
+            max_depth: None,
+            max_fanout: None,
+            org_id: None,
+            org_name: None,
+            org_root_session_id: None,
+            created_at: now,
+            updated_at: now,
+            last_viewed_at: None,
+            last_message_at: None,
+            last_attention_at: None,
+            last_attention_reason: None,
+            is_bookmarked: false,
+            yolo_mode: false,
+            unsafe_mode: false,
+            workspace_override: None,
+        },
+        is_running: true,
+        active_permit: None,
+        status_transition: Arc::new(RwLock::new(None)),
+        transition_lock: Arc::new(tokio::sync::Mutex::new(())),
+        cancellation_token: CancellationToken::new(),
+        yolo_mode: Arc::new(AtomicBool::new(false)),
+        unsafe_mode: Arc::new(AtomicBool::new(false)),
+        cancel_pending: Arc::new(AtomicBool::new(false)),
+        pending_execution: None,
+        messages: Arc::new(RwLock::new(Vec::new())),
+        cache_initialized: Arc::new(AtomicBool::new(true)),
+        last_synced_at: Arc::new(RwLock::new(Some(SystemTime::now()))),
+        repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
+        repeated_text_loop_retry_count: Arc::new(RwLock::new(0)),
+        pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
+        pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+        context_registry: Arc::new(ContextRegistry::new()),
+        compact_context: Arc::new(RwLock::new(None)),
+        compaction: CompactionRuntimeState::new(),
+        expected_response_id: Arc::new(RwLock::new(None)),
+        cached_stable_prompt: Arc::new(RwLock::new(None)),
+        last_completion_request: Arc::new(RwLock::new(None)),
+        last_submitted_input_message_id: Arc::new(RwLock::new(None)),
+    }
+}
+
+#[tokio::test]
+async fn finish_window_detects_messages_queued_during_busy_to_idle_race() {
+    let session = build_session("sess-finish-race");
+    session
+        .pending_events
+        .write()
+        .await
+        .add(PendingEvent::Message("queued-during-finish".to_string()));
+
+    let sessions = Arc::new(RwLock::new(HashMap::from([(
+        "sess-finish-race".to_string(),
+        session,
+    )])));
+
+    assert!(
+        session_has_pending_events(&sessions, "sess-finish-race").await,
+        "finish-window re-check must observe messages injected while status was still Busy"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `is_wait_complete_status()` so `checkSession(wait=true)` exits when a delegated child settles to `paused` (cancel paths) instead of polling forever.
- Add `continue_workflow_if_pending_events()` and re-check `pending_events` immediately before Idle transitions in `response.rs` and `tool.rs` to close the Busy→Idle TOCTOU race where injected messages were stranded in `pending_events`.

## Test plan

- [x] `cargo test --lib agent::workflow::finish`
- [x] `cargo test --test integration_tests wait_session_complete_status`
- [x] `cargo test --test integration_tests workflow_finish_pending`
- [ ] Manual: cancel a child session while parent is waiting (`checkSession(wait=true)`) and confirm parent returns paused result
- [ ] Manual: send a user message during natural workflow completion and confirm it is processed without requiring a second message


Made with [Cursor](https://cursor.com)