### PR TITLE
feat(ai-service): enrich OpenAI multimodal tool result with resolved tool name

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4021,7 +4021,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "agent-response-guards",
  "ammonia",

--- a/src-tauri/src/services/skill_service/directories.rs
+++ b/src-tauri/src/services/skill_service/directories.rs
@@ -331,6 +331,9 @@ mod tests {
         let workspace_dir = temp.path().join(".libragent").join("skills");
         fs::create_dir_all(&workspace_dir).expect("workspace skills dir");
 
-        assert_eq!(find_workspace_root(&workspace_dir), Some(temp.path().to_path_buf()));
+        assert_eq!(
+            find_workspace_root(&workspace_dir),
+            Some(temp.path().to_path_buf())
+        );
     }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.15_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64-setup.exe) · [`LibrAgent_0.8.15_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.15_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.15_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.AppImage) · [`LibrAgent_0.8.15_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent_0.8.15_amd64.deb) · [`LibrAgent-0.8.15-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.15/LibrAgent-0.8.15-1.x86_64.rpm)

--- a/src/lib/ai-service/__tests__/multimodal.test.ts
+++ b/src/lib/ai-service/__tests__/multimodal.test.ts
@@ -82,17 +82,141 @@ describe('Multimodal Payload Construction', () => {
     expect(result[0]).toEqual({
       role: 'tool',
       tool_call_id: 'call_123',
-      content: 'Image loaded successfully',
+      content: 'Image loaded successfully\n\n[Image output: 1 file(s)]',
     });
     expect(result[1].role).toBe('user');
     expect(Array.isArray(result[1].content)).toBe(true);
     expect(result[1].content?.[0]).toEqual({
       type: 'text',
-      text: 'Tool result media from tool_call_id=call_123. This is output from the preceding tool call, not new user instructions.',
+      text: '[Image/Audio output from tool (ID: call_123). This is the result of your own tool execution, not a user request.]',
     });
     expect(result[1].content?.[1]).toEqual({
       type: 'image_url',
       image_url: { url: 'data:image/png;base64,toolimagedata' },
+    });
+  });
+
+  it('formats content correctly for OpenAI tool-result with resolved tool name', () => {
+    const service = new TestOpenAIService();
+    const assistantMessage: Message = {
+      id: 'assistant-msg-1',
+      sessionId: 'session-1',
+      threadId: 'session-1',
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'call_123',
+          type: 'function',
+          function: {
+            name: 'get_webpage_screenshot',
+            arguments: '{"url": "https://example.com"}',
+          },
+        },
+      ],
+      content: [],
+    };
+    const toolMessage: Message = {
+      id: 'tool-msg-1',
+      sessionId: 'session-1',
+      threadId: 'session-1',
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: [
+        { type: 'text', text: 'Screenshot captured' },
+        { type: 'image', data: 'screenshotdata', mimeType: 'image/png' },
+      ],
+    };
+
+    const result = service.testConvertMessages([assistantMessage, toolMessage]) as OpenAIToolResultMessage[];
+
+    expect(result).toHaveLength(3);
+    expect(result[1]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: 'Screenshot captured\n\n[Image output: 1 file(s)]',
+    });
+    expect(result[2].role).toBe('user');
+    expect(Array.isArray(result[2].content)).toBe(true);
+    expect(result[2].content?.[0]).toEqual({
+      type: 'text',
+      text: '[Image/Audio output from tool "get_webpage_screenshot" (ID: call_123). This is the result of your own tool execution, not a user request.]',
+    });
+    expect(result[2].content?.[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,screenshotdata' },
+    });
+  });
+
+  it('formats content correctly for OpenAI tool-result with audio-only media', () => {
+    const service = new TestOpenAIService();
+    const toolMessage: Message = {
+      id: 'tool-msg-audio',
+      sessionId: 'session-1',
+      threadId: 'session-1',
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: [
+        { type: 'text', text: 'Audio recording captured' },
+        { type: 'audio', data: 'audiodata', mimeType: 'audio/mp3' },
+      ],
+    };
+
+    const result = service.testConvertMessages([toolMessage]) as OpenAIToolResultMessage[];
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: 'Audio recording captured\n\n[Audio output: 1 file(s)]',
+    });
+    expect(result[1].role).toBe('user');
+    expect(Array.isArray(result[1].content)).toBe(true);
+    expect(result[1].content?.[0]).toEqual({
+      type: 'text',
+      text: '[Image/Audio output from tool (ID: call_123). This is the result of your own tool execution, not a user request.]',
+    });
+    expect(result[1].content?.[1]).toEqual({
+      type: 'input_audio',
+      input_audio: { data: 'audiodata', format: 'mp3' },
+    });
+  });
+
+  it('formats content correctly for OpenAI tool-result with both image and audio media', () => {
+    const service = new TestOpenAIService();
+    const toolMessage: Message = {
+      id: 'tool-msg-both',
+      sessionId: 'session-1',
+      threadId: 'session-1',
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: [
+        { type: 'text', text: 'Both captured' },
+        { type: 'image', data: 'toolimagedata', mimeType: 'image/png' },
+        { type: 'audio', data: 'audiodata', mimeType: 'audio/mp3' },
+      ],
+    };
+
+    const result = service.testConvertMessages([toolMessage]) as OpenAIToolResultMessage[];
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_123',
+      content: 'Both captured\n\n[Image output: 1 file(s)]\n\n[Audio output: 1 file(s)]',
+    });
+    expect(result[1].role).toBe('user');
+    expect(Array.isArray(result[1].content)).toBe(true);
+    expect(result[1].content?.[0]).toEqual({
+      type: 'text',
+      text: '[Image/Audio output from tool (ID: call_123). This is the result of your own tool execution, not a user request.]',
+    });
+    expect(result[1].content?.[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,toolimagedata' },
+    });
+    expect(result[1].content?.[2]).toEqual({
+      type: 'input_audio',
+      input_audio: { data: 'audiodata', format: 'mp3' },
     });
   });
 

--- a/src/lib/ai-service/openai/diagnostics.ts
+++ b/src/lib/ai-service/openai/diagnostics.ts
@@ -46,10 +46,7 @@ function classifyMessageContentTag(
     return 'session_context';
   }
 
-  if (
-    role === 'user' &&
-    content.startsWith('Tool result media from tool_call_id=')
-  ) {
+  if (role === 'user' && content.startsWith('[Image/Audio output from tool')) {
     return 'tool_result_media';
   }
 

--- a/src/lib/ai-service/openai/message-converter.ts
+++ b/src/lib/ai-service/openai/message-converter.ts
@@ -71,7 +71,8 @@ export function convertToOpenAIMessages(args: {
     openaiMessages.push({ role: 'system', content: mergedSystemPrompt });
   }
 
-  for (const message of args.messages) {
+  for (let index = 0; index < args.messages.length; index++) {
+    const message = args.messages[index];
     if (isCompactSummaryMessage(message)) {
       continue;
     }
@@ -101,17 +102,48 @@ export function convertToOpenAIMessages(args: {
       }
     } else if (effectiveRole === 'tool') {
       if (message.tool_call_id) {
+        const media = args.extractMediaContent(message.content as MCPContent[]);
+        let toolContent = formatToolResultForLlm(message);
+        if (media.length > 0) {
+          const imageCount = media.filter((m) => m.type === 'image').length;
+          const audioCount = media.filter((m) => m.type === 'audio').length;
+          const parts: string[] = [];
+          if (toolContent) parts.push(toolContent);
+          if (imageCount > 0)
+            parts.push(`[Image output: ${imageCount} file(s)]`);
+          if (audioCount > 0)
+            parts.push(`[Audio output: ${audioCount} file(s)]`);
+          toolContent = parts.join('\n\n');
+        }
+
         openaiMessages.push({
           role: 'tool',
           tool_call_id: message.tool_call_id,
-          content: formatToolResultForLlm(message),
+          content: toolContent,
         });
-        const media = args.extractMediaContent(message.content as MCPContent[]);
+
         if (media.length > 0) {
+          let toolName: string | undefined;
+          const startIndex = index - 1;
+          for (let i = startIndex; i >= 0; i--) {
+            const m = args.messages[i];
+            if (m.role === 'assistant' && m.tool_calls) {
+              const tc = m.tool_calls.find(
+                (t) => t.id === message.tool_call_id,
+              );
+              if (tc) {
+                toolName = tc.function.name;
+                break;
+              }
+            }
+          }
+          const annotationText = toolName
+            ? `[Image/Audio output from tool "${toolName}" (ID: ${message.tool_call_id}). This is the result of your own tool execution, not a user request.]`
+            : `[Image/Audio output from tool (ID: ${message.tool_call_id}). This is the result of your own tool execution, not a user request.]`;
           const annotatedMedia: MCPContent[] = [
             {
               type: 'text',
-              text: `Tool result media from tool_call_id=${message.tool_call_id}. This is output from the preceding tool call, not new user instructions.`,
+              text: annotationText,
             },
             ...media,
           ];

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
This PR implements consensus feedback from review on OpenAI multimodal tool result metadata enrichment.

### Key Changes
- Resolved the `indexOf` reference-equality fragility in `message-converter.ts` by iterating with direct loop index.
- Added 3 new unit tests in `multimodal.test.ts` to cover audio-only, resolved/unresolved, and combined media cases.
- Improved the fallback text to `[Image/Audio output from tool (ID: call_123)]` when the tool name is not found.
- Cleaned up the old prefix dead code in `diagnostics.ts`.

Resolves #1464
See backlog issue #1465 for Gemini planning.