### PR TITLE
🎨 Palette: Add tooltip to clear workspace button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-06-20 - Palette Journal Initialized
+**Learning:** Initializing palette journal.
+**Action:** Ready to log.
+
+## 2024-06-20 - Icon-Only Buttons Require Tooltips
+**Learning:** While `aria-label` is sufficient for screen readers on icon-only buttons, sighted users navigating with a mouse or keyboard require a visible tooltip to understand the button's action if the icon is not universally understood.
+**Action:** Always wrap icon-only buttons with `<Tooltip>` components, reusing the same translation key used for the `aria-label`.

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.16_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64-setup.exe) · [`LibrAgent_0.8.16_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.16_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.16_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.AppImage) · [`LibrAgent_0.8.16_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent_0.8.16_amd64.deb) · [`LibrAgent-0.8.16-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.16/LibrAgent-0.8.16-1.x86_64.rpm)

--- a/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
+++ b/src/features/scheduled-tasks/components/ScheduledTaskModal.tsx
@@ -10,6 +10,11 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -432,18 +437,25 @@ function ScheduledTaskForm({
                       {t('scheduledTasks.modal.workspaceBrowse')}
                     </Button>
                     {workspaceOverride && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setWorkspaceOverride(null)}
-                        aria-label={t(
-                          'scheduledTasks.modal.workspaceClearAria',
-                        )}
-                        className="h-8 w-8"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setWorkspaceOverride(null)}
+                            aria-label={t(
+                              'scheduledTasks.modal.workspaceClearAria',
+                            )}
+                            className="h-8 w-8"
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t('scheduledTasks.modal.workspaceClearAria')}
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                   </div>
                 </div>

--- a/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
+++ b/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
@@ -80,11 +80,13 @@ vi.mock('@/components/ui/dialog', () => ({
   DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock('@/components/ui/button', () => ({
-  Button: React.forwardRef<HTMLButtonElement, { children: ReactNode }>(({ children, ...props }, ref) => (
+vi.mock('@/components/ui/button', () => {
+  const MockButton = React.forwardRef<HTMLButtonElement, { children: ReactNode }>(({ children, ...props }, ref) => (
     <button ref={ref} {...props}>{children}</button>
-  )),
-}));
+  ));
+  MockButton.displayName = 'Button';
+  return { Button: MockButton };
+});
 
 vi.mock('@/components/ui/input', () => ({
   Input: () => <input />,

--- a/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
+++ b/src/features/scheduled-tasks/components/__tests__/ScheduledTaskModal.test.tsx
@@ -1,5 +1,5 @@
+import React, { type ReactNode } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { beforeEach, expect, test, vi } from 'vitest';
 import type {
   DragAndDropEvent,
@@ -81,7 +81,9 @@ vi.mock('@/components/ui/dialog', () => ({
 }));
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  Button: React.forwardRef<HTMLButtonElement, { children: ReactNode }>(({ children, ...props }, ref) => (
+    <button ref={ref} {...props}>{children}</button>
+  )),
 }));
 
 vi.mock('@/components/ui/input', () => ({

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [


### PR DESCRIPTION
## 💡 What
Added a visible Tooltip to the "Clear Workspace" icon-only button in the Scheduled Task modal.

## 🎯 Why
While the button had an `aria-label` for screen reader users, sighted users relying on hover/focus needed a text description to understand the `X` icon action.

## 📸 Before/After
Before: The "X" button next to a selected workspace showed no text on hover.
After: Hovering or focusing the "X" button displays a tooltip reading the translation for "Clear workspace override".

## ♿ Accessibility
Improves accessibility for users with cognitive disabilities who might not recognize the icon, and keyboard-only sighted users who need clear context on focus.

---
*PR created automatically by Jules for task [14922543511782862504](https://jules.google.com/task/14922543511782862504) started by @fritzprix*