### PR TITLE
🎨 Palette: Add tooltip to Bookmarked Session Row unbookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-06-20 - Icon-Only Buttons Require Tooltips
 **Learning:** While `aria-label` is sufficient for screen readers on icon-only buttons, sighted users navigating with a mouse or keyboard require a visible tooltip to understand the button's action if the icon is not universally understood.
 **Action:** Always wrap icon-only buttons with `<Tooltip>` components, reusing the same translation key used for the `aria-label`.
+## 2025-02-09 - Add tooltip to unbookmark button
+**Learning:** Sighted mouse users lack context for icon-only buttons like "Remove bookmark" without visual tooltips, even when `aria-label` is present for screen readers.
+**Action:** Always wrap icon-only action buttons in `Tooltip` components to ensure parity between visual context and semantic accessibility labels.

--- a/src/features/agent/components/BookmarkedSessionRow.tsx
+++ b/src/features/agent/components/BookmarkedSessionRow.tsx
@@ -1,5 +1,10 @@
 import { StarOff, Clock3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { formatRelativeTime } from '@/lib/date-utils';
 import type { AgentSession } from '@/models/agent';
 import { getLatestSessionActivityTimestamp } from '@/lib/session-metadata';
@@ -65,19 +70,26 @@ export function BookmarkedSessionRow({
           </div>
         </div>
       </Button>
-      <Button
-        type="button"
-        size="icon"
-        variant="ghost"
-        className="h-8 w-8 shrink-0"
-        onClick={() => onToggleBookmark?.(session.id)}
-        aria-label={t(
-          'sessionHistory.actions.unbookmarkAria',
-          'Remove bookmark',
-        )}
-      >
-        <StarOff className="h-4 w-4" aria-hidden="true" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 shrink-0"
+            onClick={() => onToggleBookmark?.(session.id)}
+            aria-label={t(
+              'sessionHistory.actions.unbookmarkAria',
+              'Remove bookmark',
+            )}
+          >
+            <StarOff className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {t('sessionHistory.actions.unbookmarkAria', 'Remove bookmark')}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,7 +5,11 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
+export const EXECUTION_MODE_VALUES = [
+  'normal',
+  'yolo',
+  'unsafe',
+] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
## 💡 What
Added a visual tooltip to the icon-only 'Remove bookmark' button in the `BookmarkedSessionRow` component.

## 🎯 Why
While the button had an `aria-label` for screen readers, sighted users relying on a mouse had no visual indication of what the `StarOff` icon button did. The tooltip provides this essential context, improving usability.

## 📸 Before/After
*Before:* Hovering over the `StarOff` icon button showed no tooltip.
*After:* Hovering over the `StarOff` icon button now displays a tooltip saying 'Remove bookmark' (localized).

## ♿ Accessibility
Improved clarity for sighted users by ensuring the action's intent is visibly communicated alongside its existing semantic label.

---
*PR created automatically by Jules for task [18156155814321039505](https://jules.google.com/task/18156155814321039505) started by @fritzprix*