### PR TITLE
feat: implement OAuth 2.1 authentication flow for remote MCP servers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4095,7 +4095,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/src/commands/mcp_commands.rs
+++ b/src-tauri/src/commands/mcp_commands.rs
@@ -99,3 +99,61 @@ pub async fn revoke_oauth_token(server_id: String) -> Result<String, String> {
         "OAuth token revoked successfully for server: {server_id}"
     ))
 }
+
+/// Starts the OAuth 2.1 authorization flow: opens browser, runs loopback listener,
+/// exchanges code, and saves token in keychain.
+#[tauri::command]
+pub async fn start_oauth_flow(
+    app_handle: tauri::AppHandle,
+    server_id: String,
+    config: crate::mcp::types::OAuthConfig,
+) -> Result<String, String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let oauth_manager = crate::mcp::oauth::OAuthManager::new();
+
+    // Step 1: Start auth flow and get URL + state
+    let (auth_url, state) = oauth_manager
+        .start_authorization_flow(&config, &server_id)
+        .await?;
+
+    // Step 2: Open browser
+    log::info!("Opening authorization URL in browser: {}", auth_url);
+    app_handle
+        .opener()
+        .open_url(&auth_url, Option::<String>::None)
+        .map_err(|e| format!("Failed to open browser: {e}"))?;
+
+    // Step 3: Run temporary loopback server and wait for code
+    let redirect_uri = config
+        .redirect_uri
+        .clone()
+        .unwrap_or_else(|| "http://localhost:14207/callback".to_string());
+
+    // Verify it is a localhost loopback callback
+    if !redirect_uri.starts_with("http://localhost")
+        && !redirect_uri.starts_with("http://127.0.0.1")
+    {
+        return Err(format!(
+            "Unsupported redirect URI: {}. Only http://localhost or http://127.0.0.1 are supported.",
+            redirect_uri
+        ));
+    }
+
+    let code = oauth_manager
+        .wait_for_callback(&redirect_uri, &state)
+        .await?;
+
+    // Step 4: Exchange code for token
+    let access_token = oauth_manager
+        .exchange_code_for_token(&config, &server_id, &code, &state)
+        .await?;
+
+    // Step 5: Save token in keychain
+    crate::mcp::keychain::store_token_securely(&server_id, &access_token).await?;
+
+    Ok(format!(
+        "OAuth integration successful for server: {}",
+        server_id
+    ))
+}

--- a/src-tauri/src/commands/mcp_commands.rs
+++ b/src-tauri/src/commands/mcp_commands.rs
@@ -128,16 +128,28 @@ pub async fn start_oauth_flow(
     let redirect_uri = config
         .redirect_uri
         .clone()
-        .unwrap_or_else(|| "http://localhost:14207/callback".to_string());
+        .unwrap_or_else(|| crate::mcp::oauth::DEFAULT_CALLBACK_URL.to_string());
 
-    // Verify it is a localhost loopback callback
-    if !redirect_uri.starts_with("http://localhost")
-        && !redirect_uri.starts_with("http://127.0.0.1")
-    {
-        return Err(format!(
-            "Unsupported redirect URI: {}. Only http://localhost or http://127.0.0.1 are supported.",
-            redirect_uri
-        ));
+    // Verify it is a localhost loopback callback with a port
+    if let Ok(parsed_url) = url::Url::parse(&redirect_uri) {
+        if parsed_url.scheme() != "http" {
+            return Err("Unsupported redirect URI scheme. Only http:// is supported for loopback listeners.".to_string());
+        }
+        let host = parsed_url.host_str().unwrap_or("");
+        if host != "localhost" && host != "127.0.0.1" {
+            return Err(format!(
+                "Security violation: host '{}' is not allowed for redirect URI. Only 'localhost' or '127.0.0.1' are allowed.",
+                host
+            ));
+        }
+        if parsed_url.port().is_none() {
+            return Err(format!(
+                "Redirect URI must specify a port number (e.g. {}) to bind the loopback listener.",
+                crate::mcp::oauth::DEFAULT_CALLBACK_URL
+            ));
+        }
+    } else {
+        return Err(format!("Invalid redirect URI: {}", redirect_uri));
     }
 
     let code = oauth_manager

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,7 +70,7 @@ use commands::log_commands::{
 use commands::mcp_commands::{
     get_oauth_token, has_oauth_token, list_available_builtin_server_definitions,
     list_builtin_servers, list_builtin_servers_with_metadata, list_builtin_tools, probe_mcp_server,
-    revoke_oauth_token, validate_tool_schema,
+    revoke_oauth_token, start_oauth_flow, validate_tool_schema,
 };
 use commands::mcp_server_config_commands::{
     create_mcp_server_config, delete_mcp_server_config, list_mcp_server_configs,
@@ -237,6 +237,7 @@ pub fn run() {
                 has_oauth_token,
                 get_oauth_token,
                 revoke_oauth_token,
+                start_oauth_flow,
                 // Message management commands
                 messages_get_page,
                 messages_get_messages_before,

--- a/src-tauri/src/mcp/builtin/planning/context.rs
+++ b/src-tauri/src/mcp/builtin/planning/context.rs
@@ -61,13 +61,17 @@ pub async fn get_service_context(
 
     // Goal Section
     parts.push("### Stable Context".to_string());
+    let goal_missing = goal_notice.is_none() && goal.is_none();
     if let Some(notice) = &goal_notice {
         parts.push("- Current Goal: unavailable".to_string());
         parts.push(format!("- {}", notice.hint));
     } else if let Some(g) = &goal {
         parts.push(format!("- Current Goal: \"{}\"", g));
     } else {
-        parts.push("- No goal set".to_string());
+        parts.push(
+            "- Current Goal: missing — required: call planning__createGoal before task work"
+                .to_string(),
+        );
     }
 
     // Todos Section
@@ -153,6 +157,11 @@ pub async fn get_service_context(
                 parts.push(format!("- [✓] (Todo ID {}) {}{}", t.id, t.content, summary));
             }
         }
+    } else if goal_missing {
+        parts.push(
+            "- Tasks: none yet (add todos with planning__addTodo after planning__createGoal)"
+                .to_string(),
+        );
     } else {
         parts.push("- Tasks: None".to_string());
     }

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -3,7 +3,7 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::builtin::service_id::BuiltinServiceId;
 use crate::mcp::builtin::utils::load_session_tool_access;
-use crate::mcp::types::{MCPResult, MCPServerConfig, TransportConfig};
+use crate::mcp::types::{MCPResult, MCPServerConfig, OAuthConfig, TransportConfig};
 use crate::repositories::mcp_server_repository::MCPServerRepository;
 use crate::state::get_mcp_server_repository;
 use serde_json::{json, Value};
@@ -176,10 +176,14 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
             version: None,
         });
 
+    let authentication = args
+        .get("authentication")
+        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+
     let config = MCPServerConfig {
         name: Some(name.clone()),
         transport,
-        authentication: None,
+        authentication,
         metadata,
     };
 
@@ -341,10 +345,14 @@ pub async fn update_server(_server: &ToolServer, args: Value) -> Result<MCPResul
             version: None,
         });
 
+    let authentication = args
+        .get("authentication")
+        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+
     let config = MCPServerConfig {
         name: Some(name.to_string()),
         transport: transport_config,
-        authentication: None,
+        authentication,
         metadata,
     };
 

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -176,9 +176,20 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
             version: None,
         });
 
-    let authentication = args
-        .get("authentication")
-        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+    let authentication = match args.get("authentication") {
+        Some(v) => match serde_json::from_value::<OAuthConfig>(v.clone()) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Invalid authentication config: {}", e),
+                    ToolGroup::Tool,
+                )
+                .to_mcp_result())
+            }
+        },
+        None => None,
+    };
 
     let config = MCPServerConfig {
         name: Some(name.clone()),
@@ -345,9 +356,20 @@ pub async fn update_server(_server: &ToolServer, args: Value) -> Result<MCPResul
             version: None,
         });
 
-    let authentication = args
-        .get("authentication")
-        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+    let authentication = match args.get("authentication") {
+        Some(v) => match serde_json::from_value::<OAuthConfig>(v.clone()) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Invalid authentication config: {}", e),
+                    ToolGroup::Tool,
+                )
+                .to_mcp_result())
+            }
+        },
+        None => None,
+    };
 
     let config = MCPServerConfig {
         name: Some(name.to_string()),

--- a/src-tauri/src/mcp/builtin/tool/tools.rs
+++ b/src-tauri/src/mcp/builtin/tool/tools.rs
@@ -2,6 +2,66 @@ use crate::mcp::builtin::tool_description::tool_description;
 use crate::mcp::types::MCPTool;
 use crate::mcp::utils::schema_builder::*;
 
+fn oauth_config_schema(description: Option<&str>) -> crate::mcp::schema::JSONSchema {
+    object_prop(
+        vec![
+            (
+                "type".to_string(),
+                string_const_prop("oauth2.1", Some("Authentication type (always 'oauth2.1')")),
+            ),
+            (
+                "discoveryUrl".to_string(),
+                string_prop(
+                    None,
+                    None,
+                    Some("RFC 8414 OAuth 2.0 Authorization Server Metadata discovery endpoint."),
+                ),
+            ),
+            (
+                "authorizationEndpoint".to_string(),
+                string_prop(None, None, Some("Authorization endpoint URL.")),
+            ),
+            (
+                "tokenEndpoint".to_string(),
+                string_prop(None, None, Some("Token endpoint URL.")),
+            ),
+            (
+                "registrationEndpoint".to_string(),
+                string_prop(None, None, Some("Client registration endpoint URL.")),
+            ),
+            (
+                "clientId".to_string(),
+                string_prop(None, None, Some("OAuth client ID.")),
+            ),
+            (
+                "redirectUri".to_string(),
+                string_prop(None, None, Some("OAuth redirect URI.")),
+            ),
+            (
+                "scopes".to_string(),
+                array_schema(
+                    string_prop(None, None, None),
+                    Some("List of OAuth scopes to request."),
+                ),
+            ),
+            (
+                "usePkce".to_string(),
+                boolean_prop(Some("Whether to use PKCE. Default is true.")),
+            ),
+            (
+                "resourceParameter".to_string(),
+                string_prop(
+                    None,
+                    None,
+                    Some("Resource parameter for target audience/endpoint."),
+                ),
+            ),
+        ],
+        vec!["type".to_string()],
+        description,
+    )
+}
+
 fn transport_config_schema(description: Option<&str>) -> crate::mcp::schema::JSONSchema {
     object_prop(
         vec![
@@ -71,6 +131,7 @@ fn transport_config_schema(description: Option<&str>) -> crate::mcp::schema::JSO
 /// Register a new MCP server configuration
 pub fn register_server_tool() -> MCPTool {
     let transport_schema = transport_config_schema(Some("Transport configuration"));
+    let oauth_schema = oauth_config_schema(Some("Optional OAuth 2.1 authentication configuration"));
 
     MCPTool {
         name: "registerServer".to_string(),
@@ -105,6 +166,7 @@ pub fn register_server_tool() -> MCPTool {
                     string_prop_required("Short purpose statement describing when this server should be used."),
                 ),
                 ("transport".to_string(), transport_schema),
+                ("authentication".to_string(), oauth_schema),
             ],
             vec!["name".to_string(), "description".to_string(), "transport".to_string()],
             None,
@@ -119,6 +181,8 @@ pub fn update_server_tool() -> MCPTool {
     let transport_schema = transport_config_schema(Some(
         "Replacement transport configuration. Set type to stdio (command, args, env) or http/http-sse (url, headers, enableSSE). Supply the full transport object for the target type.",
     ));
+    let oauth_schema =
+        oauth_config_schema(Some("Replacement OAuth 2.1 authentication configuration"));
 
     MCPTool {
         name: "updateServer".to_string(),
@@ -143,6 +207,7 @@ pub fn update_server_tool() -> MCPTool {
                     string_prop_required("Target server name (slug) to update"),
                 ),
                 ("transport".to_string(), transport_schema),
+                ("authentication".to_string(), oauth_schema),
                 (
                     "description".to_string(),
                     string_prop(

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -3,14 +3,61 @@ use oauth2::reqwest::async_http_client;
 ///
 /// Implements RFC 7636 (PKCE), RFC 8414 (Discovery), and RFC 7591 (Dynamic Registration)
 use oauth2::{
-    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, CsrfToken, PkceCodeChallenge,
-    PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, TokenUrl,
+    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, TokenUrl,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::mcp::types::OAuthConfig;
+
+pub const DEFAULT_CALLBACK_PORT: u16 = 14207;
+pub const DEFAULT_CALLBACK_URL: &str = "http://localhost:14207/callback";
+
+fn is_private_or_local_host(host: &str) -> bool {
+    if host.is_empty() || host == "localhost" || host == "127.0.0.1" {
+        return true;
+    }
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return ip.is_loopback()
+            || ip.is_unspecified()
+            || ip.is_multicast()
+            || match ip {
+                std::net::IpAddr::V4(ipv4) => ipv4.is_private() || ipv4.is_link_local(),
+                std::net::IpAddr::V6(ipv6) => {
+                    let octets = ipv6.octets();
+                    let first = octets[0];
+                    // ULA (fc00::/7) or link-local unicast (fe80::/10)
+                    first == 0xfc
+                        || first == 0xfd
+                        || (first == 0xfe && (octets[1] & 0xc0) == 0x80)
+                }
+            };
+    }
+
+    false
+}
+
+/// Rejects non-HTTPS OAuth endpoints and hosts on private/local networks.
+fn validate_oauth_https_endpoint(url_str: &str, label: &str) -> Result<(), String> {
+    let parsed =
+        url::Url::parse(url_str).map_err(|e| format!("Invalid {label} URL: {e}"))?;
+
+    if parsed.scheme() != "https" {
+        return Err(format!("{label} must use HTTPS scheme for security"));
+    }
+
+    let host = parsed.host_str().unwrap_or("");
+    if is_private_or_local_host(host) {
+        return Err(format!(
+            "Security violation: Local/private {label} is not allowed"
+        ));
+    }
+
+    Ok(())
+}
 
 /// Manages OAuth 2.1 flows for MCP servers
 #[derive(Debug)]
@@ -63,35 +110,11 @@ impl OAuthManager {
         log::info!("Starting OAuth flow for server: {server_id}");
 
         // Step 1: Discover or use configured endpoints
-        let endpoints = if let Some(discovery_url) = &config.discovery_url {
-            log::debug!("Using RFC 8414 discovery: {discovery_url}");
-            self.discover_endpoints(discovery_url).await?
-        } else {
-            // Use fallback endpoints from config
-            OAuthEndpoints {
-                authorization_endpoint: config
-                    .authorization_endpoint
-                    .clone()
-                    .ok_or("Missing authorization_endpoint")?,
-                token_endpoint: config
-                    .token_endpoint
-                    .clone()
-                    .ok_or("Missing token_endpoint")?,
-            }
-        };
+        let endpoints = self.resolve_endpoints(config).await?;
 
         log::debug!("OAuth endpoints: {endpoints:?}");
 
-        // Step 2: Create PKCE challenge
-        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
-
-        // Store verifier for later use in token exchange
-        {
-            let mut verifiers = self.pkce_verifiers.lock().await;
-            verifiers.insert(server_id.to_string(), pkce_verifier);
-        }
-
-        // Step 3: Build OAuth client
+        // Step 2: Build OAuth client
         let client_id = config
             .client_id
             .clone()
@@ -100,11 +123,13 @@ impl OAuthManager {
         let redirect_uri = config
             .redirect_uri
             .clone()
-            .unwrap_or_else(|| "libr-agent://oauth/callback".to_string());
+            .unwrap_or_else(|| DEFAULT_CALLBACK_URL.to_string());
+
+        let client_secret = config.client_secret.clone().map(ClientSecret::new);
 
         let client = BasicClient::new(
             ClientId::new(client_id),
-            None, // Client secret not used with PKCE
+            client_secret,
             AuthUrl::new(endpoints.authorization_endpoint)
                 .map_err(|e| format!("Invalid authorization URL: {e}"))?,
             Some(
@@ -116,10 +141,17 @@ impl OAuthManager {
             RedirectUrl::new(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?,
         );
 
-        // Step 4: Generate authorization URL with PKCE
-        let mut auth_request = client
-            .authorize_url(CsrfToken::new_random)
-            .set_pkce_challenge(pkce_challenge);
+        // Step 3: Generate authorization URL
+        let mut auth_request = client.authorize_url(CsrfToken::new_random);
+
+        if config.use_pkce {
+            let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+            {
+                let mut verifiers = self.pkce_verifiers.lock().await;
+                verifiers.insert(server_id.to_string(), pkce_verifier);
+            }
+            auth_request = auth_request.set_pkce_challenge(pkce_challenge);
+        }
 
         // Add scopes if configured
         if let Some(scopes) = &config.scopes {
@@ -171,31 +203,10 @@ impl OAuthManager {
             }
         }
 
-        // Step 2: Retrieve PKCE verifier
-        let verifier = {
-            let mut verifiers = self.pkce_verifiers.lock().await;
-            verifiers
-                .remove(server_id)
-                .ok_or("No PKCE verifier found for server")?
-        };
+        // Step 2: Get endpoints
+        let endpoints = self.resolve_endpoints(config).await?;
 
-        // Step 3: Get endpoints
-        let endpoints = if let Some(discovery_url) = &config.discovery_url {
-            self.discover_endpoints(discovery_url).await?
-        } else {
-            OAuthEndpoints {
-                authorization_endpoint: config
-                    .authorization_endpoint
-                    .clone()
-                    .ok_or("Missing authorization_endpoint")?,
-                token_endpoint: config
-                    .token_endpoint
-                    .clone()
-                    .ok_or("Missing token_endpoint")?,
-            }
-        };
-
-        // Step 4: Build client and exchange code
+        // Step 3: Build client and exchange code
         let client_id = config
             .client_id
             .clone()
@@ -204,11 +215,13 @@ impl OAuthManager {
         let redirect_uri = config
             .redirect_uri
             .clone()
-            .unwrap_or_else(|| "libr-agent://oauth/callback".to_string());
+            .unwrap_or_else(|| DEFAULT_CALLBACK_URL.to_string());
+
+        let client_secret = config.client_secret.clone().map(ClientSecret::new);
 
         let client = BasicClient::new(
             ClientId::new(client_id),
-            None,
+            client_secret,
             AuthUrl::new(endpoints.authorization_endpoint)
                 .map_err(|e| format!("Invalid authorization URL: {e}"))?,
             Some(
@@ -220,9 +233,21 @@ impl OAuthManager {
             RedirectUrl::new(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?,
         );
 
-        let token_result = client
-            .exchange_code(AuthorizationCode::new(authorization_code.to_string()))
-            .set_pkce_verifier(verifier)
+        let mut exchange =
+            client.exchange_code(AuthorizationCode::new(authorization_code.to_string()));
+
+        if config.use_pkce {
+            // Retrieve PKCE verifier
+            let verifier = {
+                let mut verifiers = self.pkce_verifiers.lock().await;
+                verifiers
+                    .remove(server_id)
+                    .ok_or("No PKCE verifier found for server")?
+            };
+            exchange = exchange.set_pkce_verifier(verifier);
+        }
+
+        let token_result = exchange
             .request_async(async_http_client)
             .await
             .map_err(|e| format!("Token exchange failed: {e}"))?;
@@ -231,6 +256,28 @@ impl OAuthManager {
 
         log::info!("Successfully obtained access token for {server_id}");
         Ok(access_token)
+    }
+
+    async fn resolve_endpoints(&self, config: &OAuthConfig) -> Result<OAuthEndpoints, String> {
+        if let Some(discovery_url) = &config.discovery_url {
+            log::debug!("Using RFC 8414 discovery: {discovery_url}");
+            self.discover_endpoints(discovery_url).await
+        } else {
+            let authorization_endpoint = config
+                .authorization_endpoint
+                .clone()
+                .ok_or("Missing authorization_endpoint")?;
+            let token_endpoint = config
+                .token_endpoint
+                .clone()
+                .ok_or("Missing token_endpoint")?;
+            validate_oauth_https_endpoint(&authorization_endpoint, "authorization endpoint")?;
+            validate_oauth_https_endpoint(&token_endpoint, "token endpoint")?;
+            Ok(OAuthEndpoints {
+                authorization_endpoint,
+                token_endpoint,
+            })
+        }
     }
 
     /// Discovers OAuth endpoints using RFC 8414
@@ -242,6 +289,8 @@ impl OAuthManager {
     /// The discovered OAuth endpoints
     async fn discover_endpoints(&self, discovery_url: &str) -> Result<OAuthEndpoints, String> {
         log::debug!("Discovering OAuth endpoints from: {discovery_url}");
+
+        validate_oauth_https_endpoint(discovery_url, "discovery URL")?;
 
         let client = reqwest::Client::new();
         let metadata: AuthServerMetadata = client
@@ -255,6 +304,12 @@ impl OAuthManager {
 
         log::debug!("Discovered endpoints: {metadata:?}");
 
+        validate_oauth_https_endpoint(
+            &metadata.authorization_endpoint,
+            "authorization endpoint",
+        )?;
+        validate_oauth_https_endpoint(&metadata.token_endpoint, "token endpoint")?;
+
         Ok(OAuthEndpoints {
             authorization_endpoint: metadata.authorization_endpoint,
             token_endpoint: metadata.token_endpoint,
@@ -263,12 +318,12 @@ impl OAuthManager {
 
     /// Parses port from a redirect URI string.
     /// E.g. "http://localhost:14207/callback" -> 14207
-    /// Defaults to 14207 if parsing fails.
+    /// Defaults to DEFAULT_CALLBACK_PORT if parsing fails.
     fn parse_port_from_uri(uri_str: &str) -> u16 {
         if let Ok(u) = url::Url::parse(uri_str) {
-            u.port().unwrap_or(14207)
+            u.port().unwrap_or(DEFAULT_CALLBACK_PORT)
         } else {
-            14207
+            DEFAULT_CALLBACK_PORT
         }
     }
 
@@ -318,31 +373,39 @@ impl OAuthManager {
 
                                                 if let (Some(code), Some(state)) = (code, state) {
                                                     if state == expected_state {
-                                                        // Send success HTML page response
-                                                        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\
-                                                            <html>\
-                                                            <head>\
-                                                                <title>LibrAgent - Authentication Successful</title>\
-                                                                <style>\
-                                                                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
-                                                                    .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
-                                                                    h1 { color: #2ea043; margin-top: 0; }\
-                                                                    p { color: #8b949e; line-height: 1.5; }\
-                                                                </style>\
-                                                            </head>\
-                                                            <body>\
-                                                                <div class='card'>\
-                                                                    <h1>✓ Authentication Successful</h1>\
-                                                                    <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
-                                                                </div>\
-                                                            </body>\
-                                                            </html>";
-                                                        let _ = stream.write_all(response.as_bytes()).await;
-                                                        let _ = stream.flush().await;
-                                                        return Ok(code.clone());
-                                                    } else {
-                                                        log::warn!("OAuth state mismatch. Expected {}, got {:?}", expected_state, state);
-                                                    }
+                                                         // Send success HTML page response
+                                                         let html = "<html>\
+                                                             <head>\
+                                                                 <title>LibrAgent - Authentication Successful</title>\
+                                                                 <style>\
+                                                                     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
+                                                                     .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
+                                                                     h1 { color: #2ea043; margin-top: 0; }\
+                                                                     p { color: #8b949e; line-height: 1.5; }\
+                                                                 </style>\
+                                                             </head>\
+                                                             <body>\
+                                                                 <div class='card'>\
+                                                                     <h1>✓ Authentication Successful</h1>\
+                                                                     <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
+                                                                 </div>\
+                                                             </body>\
+                                                             </html>";
+                                                         let response = format!(
+                                                             "HTTP/1.1 200 OK\r\n\
+                                                             Content-Type: text/html; charset=utf-8\r\n\
+                                                             Content-Length: {}\r\n\
+                                                             Connection: close\r\n\r\n\
+                                                             {}",
+                                                             html.len(),
+                                                             html
+                                                         );
+                                                         let _ = stream.write_all(response.as_bytes()).await;
+                                                         let _ = stream.flush().await;
+                                                         return Ok(code.clone());
+                                                     } else {
+                                                         log::warn!("OAuth state mismatch detected during callback processing");
+                                                     }
                                                 }
                                             }
                                         }
@@ -386,6 +449,30 @@ mod tests {
         assert!(manager.csrf_tokens.lock().await.is_empty());
     }
 
+    #[test]
+    fn validate_oauth_https_endpoint_rejects_private_hosts() {
+        assert!(validate_oauth_https_endpoint(
+            "http://auth.example.com/authorize",
+            "authorization endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://127.0.0.1/authorize",
+            "authorization endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://169.254.169.254/token",
+            "token endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://auth.example.com/authorize",
+            "authorization endpoint"
+        )
+        .is_ok());
+    }
+
     #[tokio::test]
     async fn test_start_authorization_flow() {
         let manager = OAuthManager::new();
@@ -396,6 +483,7 @@ mod tests {
             token_endpoint: Some("https://auth.example.com/token".to_string()),
             registration_endpoint: None,
             client_id: Some("test-client".to_string()),
+            client_secret: None,
             redirect_uri: Some("libr-agent://oauth/callback".to_string()),
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             use_pkce: true,

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -260,6 +260,113 @@ impl OAuthManager {
             token_endpoint: metadata.token_endpoint,
         })
     }
+
+    /// Parses port from a redirect URI string.
+    /// E.g. "http://localhost:14207/callback" -> 14207
+    /// Defaults to 14207 if parsing fails.
+    fn parse_port_from_uri(uri_str: &str) -> u16 {
+        if let Ok(u) = url::Url::parse(uri_str) {
+            u.port().unwrap_or(14207)
+        } else {
+            14207
+        }
+    }
+
+    /// Starts a temporary localhost listener to wait for the OAuth authorization code.
+    /// This runs asynchronously and times out after 2 minutes.
+    pub async fn wait_for_callback(
+        &self,
+        redirect_uri: &str,
+        expected_state: &str,
+    ) -> Result<String, String> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let port = Self::parse_port_from_uri(redirect_uri);
+        log::info!("Starting temporary OAuth callback listener on port {port}");
+
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+            .await
+            .map_err(|e| format!("Failed to bind OAuth listener to port {port}: {e}"))?;
+
+        let timeout_dur = std::time::Duration::from_secs(120);
+        let timeout = tokio::time::sleep(timeout_dur);
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                accept_res = listener.accept() => {
+                    match accept_res {
+                        Ok((mut stream, _)) => {
+                            let mut buffer = [0; 1024];
+                            match stream.read(&mut buffer).await {
+                                Ok(n) if n > 0 => {
+                                    let request = String::from_utf8_lossy(&buffer[..n]);
+                                    if request.starts_with("GET ") {
+                                        let first_line = request.lines().next().unwrap_or("");
+                                        let parts: Vec<&str> = first_line.split_whitespace().collect();
+                                        if parts.len() >= 2 {
+                                            let path = parts[1];
+                                            if let Some(query_start) = path.find('?') {
+                                                let query = &path[query_start + 1..];
+                                                let params: HashMap<String, String> = url::form_urlencoded::parse(query.as_bytes())
+                                                    .into_owned()
+                                                    .collect();
+
+                                                let code = params.get("code");
+                                                let state = params.get("state");
+
+                                                if let (Some(code), Some(state)) = (code, state) {
+                                                    if state == expected_state {
+                                                        // Send success HTML page response
+                                                        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\
+                                                            <html>\
+                                                            <head>\
+                                                                <title>LibrAgent - Authentication Successful</title>\
+                                                                <style>\
+                                                                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
+                                                                    .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
+                                                                    h1 { color: #2ea043; margin-top: 0; }\
+                                                                    p { color: #8b949e; line-height: 1.5; }\
+                                                                </style>\
+                                                            </head>\
+                                                            <body>\
+                                                                <div class='card'>\
+                                                                    <h1>✓ Authentication Successful</h1>\
+                                                                    <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
+                                                                </div>\
+                                                            </body>\
+                                                            </html>";
+                                                        let _ = stream.write_all(response.as_bytes()).await;
+                                                        let _ = stream.flush().await;
+                                                        return Ok(code.clone());
+                                                    } else {
+                                                        log::warn!("OAuth state mismatch. Expected {}, got {:?}", expected_state, state);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Invalid request fall-through
+                                    let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\nConnection: close\r\n\r\nFailed to authenticate. State mismatch or missing code.";
+                                    let _ = stream.write_all(response.as_bytes()).await;
+                                    let _ = stream.flush().await;
+                                }
+                                _ => {}
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Error accepting connection in OAuth callback listener: {e}");
+                        }
+                    }
+                }
+                _ = &mut timeout => {
+                    return Err("OAuth authorization timed out after 2 minutes".to_string());
+                }
+            }
+        }
+    }
 }
 
 impl Default for OAuthManager {

--- a/src-tauri/src/mcp/server/lifecycle.rs
+++ b/src-tauri/src/mcp/server/lifecycle.rs
@@ -1,5 +1,6 @@
 use super::MCPServerManager;
 use crate::mcp::types::{MCPConnection, MCPServerConfig, TransportConfig};
+use crate::repositories::mcp_server_repository::MCPServerRepository;
 use anyhow::Result;
 use log::{debug, error, info};
 use rmcp::{
@@ -147,6 +148,28 @@ async fn start_http_server(
             } else {
                 error!("Invalid header ignored: {}: {}", k, v);
             }
+        }
+    }
+
+    // Attempt to load OAuth token from OS keychain
+    let mut oauth_token = None;
+    // Step 1: Check using server name (slug)
+    if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
+        oauth_token = Some(tok);
+    } else {
+        // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
+        let repo = crate::state::get_mcp_server_repository();
+        if let Ok(Some(model)) = repo.get_by_name(&name).await {
+            if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
+                oauth_token = Some(tok);
+            }
+        }
+    }
+
+    if let Some(token) = oauth_token {
+        if let Ok(auth_val) = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
+            header_map.insert(reqwest::header::AUTHORIZATION, auth_val);
+            log::info!("Injected OAuth Bearer token for HTTP MCP server '{}'", name);
         }
     }
 

--- a/src-tauri/src/mcp/server/lifecycle.rs
+++ b/src-tauri/src/mcp/server/lifecycle.rs
@@ -151,17 +151,19 @@ async fn start_http_server(
         }
     }
 
-    // Attempt to load OAuth token from OS keychain
+    // Attempt to load OAuth token from OS keychain if authentication is configured
     let mut oauth_token = None;
-    // Step 1: Check using server name (slug)
-    if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
-        oauth_token = Some(tok);
-    } else {
-        // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
-        let repo = crate::state::get_mcp_server_repository();
-        if let Ok(Some(model)) = repo.get_by_name(&name).await {
-            if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
-                oauth_token = Some(tok);
+    if config.authentication.is_some() {
+        // Step 1: Check using server name (slug)
+        if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
+            oauth_token = Some(tok);
+        } else {
+            // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
+            let repo = crate::state::get_mcp_server_repository();
+            if let Ok(Some(model)) = repo.get_by_name(&name).await {
+                if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
+                    oauth_token = Some(tok);
+                }
             }
         }
     }

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -56,25 +56,36 @@ pub struct SecurityConfig {
 /// OAuth 2.1 authentication configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthConfig {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "oauth_type", alias = "oauthType")]
     pub oauth_type: String, // Always "oauth2.1"
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "discoveryUrl", alias = "discovery_url")]
     pub discovery_url: Option<String>, // RFC 8414 discovery endpoint
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "authorizationEndpoint", alias = "authorization_endpoint")]
     pub authorization_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "tokenEndpoint", alias = "token_endpoint")]
     pub token_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "registrationEndpoint", alias = "registration_endpoint")]
     pub registration_endpoint: Option<String>, // RFC 7591
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "clientId", alias = "client_id")]
     pub client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "clientSecret", alias = "client_secret")]
+    pub client_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "redirectUri", alias = "redirect_uri")]
     pub redirect_uri: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
     #[serde(default = "default_use_pkce")]
+    #[serde(rename = "usePkce", alias = "use_pkce", alias = "usePKCE")]
     pub use_pkce: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "resourceParameter", alias = "resource_parameter")]
     pub resource_parameter: Option<String>, // RFC 9728
 }
 
@@ -683,6 +694,7 @@ mod tests {
                 token_endpoint: None,
                 registration_endpoint: None,
                 client_id: Some("test-client".to_string()),
+                client_secret: None,
                 redirect_uri: Some("libr-agent://oauth/callback".to_string()),
                 scopes: Some(vec!["read".to_string(), "write".to_string()]),
                 use_pkce: true,

--- a/src-tauri/src/services/mcp_server_service.rs
+++ b/src-tauri/src/services/mcp_server_service.rs
@@ -27,6 +27,10 @@ pub(crate) fn summarize_tool_names(tools: &[MCPTool]) -> String {
     }
 }
 
+fn is_oauth_auth_required_error(err: &str) -> bool {
+    err.contains("Auth required") || err.contains("AuthRequired")
+}
+
 impl McpServerService {
     fn requires_reverification(existing_config: &Value, incoming_config: &Value) -> bool {
         let existing_transport = existing_config.get("transport");
@@ -100,31 +104,46 @@ impl McpServerService {
         config.name = Some(server_name.clone());
 
         // 3. Verify config
-        let tools = Self::verify_config(config).await?;
+        let verify_result = Self::verify_config(config).await;
 
-        log::info!(
-            "[probe] '{}' ({}) → {} tool(s): [{}]",
-            server_name,
-            server_id,
-            tools.len(),
-            summarize_tool_names(&tools)
-        );
+        match verify_result {
+            Ok(tools) => {
+                log::info!(
+                    "[probe] '{}' ({}) → {} tool(s): [{}]",
+                    server_name,
+                    server_id,
+                    tools.len(),
+                    summarize_tool_names(&tools)
+                );
 
-        // 4. Persist tool list (names + descriptions) to DB (best-effort)
-        let tools_json_str = crate::mcp::utils::serialize_mcp_tools(&tools);
+                // 4. Persist tool list (names + descriptions) to DB (best-effort)
+                let tools_json_str = crate::mcp::utils::serialize_mcp_tools(&tools);
 
-        if let Err(e) = repo
-            .update_cached_tools(server_id, tools.len() as i32, tools_json_str)
-            .await
-        {
-            log::warn!(
-                "[probe] Failed to cache tool list for '{}': {}",
-                server_id,
-                e
-            );
+                if let Err(e) = repo
+                    .update_cached_tools(server_id, tools.len() as i32, tools_json_str)
+                    .await
+                {
+                    log::warn!(
+                        "[probe] Failed to cache tool list for '{}': {}",
+                        server_id,
+                        e
+                    );
+                }
+
+                Ok(tools)
+            }
+            Err(err) => {
+                // Set verification status to error so it doesn't get stuck in pending
+                if let Err(e) = repo.set_verification_error(server_id, err.clone()).await {
+                    log::warn!(
+                        "[probe] Failed to update verification error status for '{}': {}",
+                        server_id,
+                        e
+                    );
+                }
+                Err(err)
+            }
         }
-
-        Ok(tools)
     }
 
     async fn persist_verified_tools(
@@ -138,7 +157,8 @@ impl McpServerService {
             .map_err(|e| format!("Failed to persist verification result: {}", e))
     }
 
-    async fn reload_server(
+    /// Reloads the server row from the database after a write. Does not re-verify connectivity.
+    async fn fetch_server_model(
         repo: &dyn MCPServerRepository,
         server_id: &str,
     ) -> Result<crate::entity::mcp_server::Model, String> {
@@ -169,29 +189,55 @@ impl McpServerService {
         mcp_config.name = Some(name.clone());
 
         // 2. Verify the configuration connects and provides tools before saving
-        let tools = Self::verify_config(mcp_config)
-            .await
-            .map_err(|e| format!("Verification failed: {}", e))?;
+        let verify_result = Self::verify_config(mcp_config).await;
 
-        // 3. Save to database
-        let model = repo
-            .create(&name, config)
-            .await
-            .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
+        match verify_result {
+            Ok(tools) => {
+                // 3. Save to database
+                let model = repo
+                    .create(&name, config)
+                    .await
+                    .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
 
-        Self::persist_verified_tools(repo, &model.id, &tools).await?;
+                Self::persist_verified_tools(repo, &model.id, &tools).await?;
 
-        let model = Self::reload_server(repo, &model.id).await?;
+                let model = Self::fetch_server_model(repo, &model.id).await?;
 
-        log::info!(
-            "'{}' ({}) saved after verification with {} tool(s): [{}]",
-            model.name,
-            model.id,
-            tools.len(),
-            summarize_tool_names(&tools)
-        );
+                log::info!(
+                    "'{}' ({}) saved after verification with {} tool(s): [{}]",
+                    model.name,
+                    model.id,
+                    tools.len(),
+                    summarize_tool_names(&tools)
+                );
 
-        Ok(model)
+                Ok(model)
+            }
+            Err(err) if is_oauth_auth_required_error(&err) =>
+            {
+                // Save config even if verification failed with AuthRequired, but mark status as error/auth required
+                let model = repo
+                    .create(&name, config)
+                    .await
+                    .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
+
+                let auth_err_msg = format!("Authentication required: {}", err);
+                repo.set_verification_error(&model.id, auth_err_msg.clone())
+                    .await
+                    .map_err(|e| format!("Failed to set verification error: {}", e))?;
+
+                let model = Self::fetch_server_model(repo, &model.id).await?;
+                log::info!(
+                    "'{}' ({}) saved with pending authentication status: {}",
+                    model.name,
+                    model.id,
+                    auth_err_msg
+                );
+
+                Ok(model)
+            }
+            Err(err) => Err(format!("Verification failed: {}", err)),
+        }
     }
 
     pub async fn update_server_config(
@@ -236,28 +282,55 @@ impl McpServerService {
             Self::requires_reverification(&existing_config_val, &final_config_val);
 
         if requires_reverification {
-            let tools = Self::verify_config(mcp_config)
-                .await
-                .map_err(|e| format!("Verification failed: {}", e))?;
+            let verify_result = Self::verify_config(mcp_config).await;
 
-            let updated = repo
-                .update(&id, name.as_deref(), config)
-                .await
-                .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
+            match verify_result {
+                Ok(tools) => {
+                    let updated = repo
+                        .update(&id, name.as_deref(), config)
+                        .await
+                        .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
 
-            Self::persist_verified_tools(repo, &updated.id, &tools).await?;
+                    Self::persist_verified_tools(repo, &updated.id, &tools).await?;
 
-            let updated = Self::reload_server(repo, &updated.id).await?;
+                    let updated = Self::fetch_server_model(repo, &updated.id).await?;
 
-            log::info!(
-                "'{}' ({}) updated after verification with {} tool(s): [{}]",
-                updated.name,
-                updated.id,
-                tools.len(),
-                summarize_tool_names(&tools)
-            );
+                    log::info!(
+                        "'{}' ({}) updated after verification with {} tool(s): [{}]",
+                        updated.name,
+                        updated.id,
+                        tools.len(),
+                        summarize_tool_names(&tools)
+                    );
 
-            return Ok(updated);
+                    return Ok(updated);
+                }
+                Err(err) if is_oauth_auth_required_error(&err) =>
+                {
+                    let updated = repo
+                        .update(&id, name.as_deref(), config)
+                        .await
+                        .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
+
+                    let auth_err_msg = format!("Authentication required: {}", err);
+                    repo.set_verification_error(&updated.id, auth_err_msg.clone())
+                        .await
+                        .map_err(|e| format!("Failed to set verification error: {}", e))?;
+
+                    let updated = Self::fetch_server_model(repo, &updated.id).await?;
+                    log::info!(
+                        "'{}' ({}) updated with pending authentication status: {}",
+                        updated.name,
+                        updated.id,
+                        auth_err_msg
+                    );
+
+                    return Ok(updated);
+                }
+                Err(err) => {
+                    return Err(format!("Verification failed: {}", err));
+                }
+            }
         }
 
         // Name-only or metadata-only updates do not require transport re-verification.
@@ -273,6 +346,15 @@ impl McpServerService {
         repo: &dyn MCPServerRepository,
         id: &str,
     ) -> Result<(), String> {
+        // Cleanup token from keychain if present
+        if let Err(e) = crate::mcp::keychain::delete_token(id).await {
+            log::warn!(
+                "Failed to delete OAuth token from keychain for server '{}': {}",
+                id,
+                e
+            );
+        }
+
         repo.delete(id)
             .await
             .map_err(|e| format!("Failed to delete MCP server config: {}", e))?;

--- a/src/features/mcp-servers/MCPServerDialog.tsx
+++ b/src/features/mcp-servers/MCPServerDialog.tsx
@@ -65,6 +65,22 @@ function MCPServerDialogComponent({
     handleRemoveHeader,
     handleUpdateHeader,
     submit,
+    authType,
+    setAuthType,
+    discoveryUrl,
+    setDiscoveryUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    clientId,
+    setClientId,
+    clientSecret,
+    setClientSecret,
+    scopes,
+    setScopes,
+    usePkce,
+    setUsePkce,
   } = useMCPServerForm(server);
 
   return (
@@ -249,6 +265,22 @@ function MCPServerDialogComponent({
               handleAddHeader={handleAddHeader}
               handleRemoveHeader={handleRemoveHeader}
               handleUpdateHeader={handleUpdateHeader}
+              authType={authType}
+              setAuthType={setAuthType}
+              discoveryUrl={discoveryUrl}
+              setDiscoveryUrl={setDiscoveryUrl}
+              authorizationEndpoint={authorizationEndpoint}
+              setAuthorizationEndpoint={setAuthorizationEndpoint}
+              tokenEndpoint={tokenEndpoint}
+              setTokenEndpoint={setTokenEndpoint}
+              clientId={clientId}
+              setClientId={setClientId}
+              clientSecret={clientSecret}
+              setClientSecret={setClientSecret}
+              scopes={scopes}
+              setScopes={setScopes}
+              usePkce={usePkce}
+              setUsePkce={setUsePkce}
             />
           )}
         </div>

--- a/src/features/mcp-servers/MCPServerManagement.tsx
+++ b/src/features/mcp-servers/MCPServerManagement.tsx
@@ -49,6 +49,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
     handleDelete,
     confirmDelete,
     handleToggleActive,
+    mutateServers,
   } = useMCPServerManagement(service);
 
   return (
@@ -104,6 +105,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
                   onDelete={handleDelete}
                   onToggleActive={handleToggleActive}
                   isToggling={!!togglingStatus[server.id]}
+                  onRevalidate={mutateServers}
                 />
               ))}
             </div>

--- a/src/features/mcp-servers/components/HttpForm.tsx
+++ b/src/features/mcp-servers/components/HttpForm.tsx
@@ -12,6 +12,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
 
 interface HttpFormProps {
   draft: MCPServerEntity;
@@ -34,6 +41,22 @@ interface HttpFormProps {
     field: 'key' | 'value',
     value: string,
   ) => void;
+  authType: 'none' | 'oauth2.1';
+  setAuthType: (type: 'none' | 'oauth2.1') => void;
+  discoveryUrl: string;
+  setDiscoveryUrl: (url: string) => void;
+  authorizationEndpoint: string;
+  setAuthorizationEndpoint: (url: string) => void;
+  tokenEndpoint: string;
+  setTokenEndpoint: (url: string) => void;
+  clientId: string;
+  setClientId: (id: string) => void;
+  clientSecret: string;
+  setClientSecret: (secret: string) => void;
+  scopes: string;
+  setScopes: (scopes: string) => void;
+  usePkce: boolean;
+  setUsePkce: (use: boolean) => void;
 }
 
 export function HttpForm({
@@ -53,6 +76,22 @@ export function HttpForm({
   handleAddHeader,
   handleRemoveHeader,
   handleUpdateHeader,
+  authType,
+  setAuthType,
+  discoveryUrl,
+  setDiscoveryUrl,
+  authorizationEndpoint,
+  setAuthorizationEndpoint,
+  tokenEndpoint,
+  setTokenEndpoint,
+  clientId,
+  setClientId,
+  clientSecret,
+  setClientSecret,
+  scopes,
+  setScopes,
+  usePkce,
+  setUsePkce,
 }: HttpFormProps) {
   const { t } = useTranslation('common');
   const advancedPanelId = useId();
@@ -170,33 +209,196 @@ export function HttpForm({
         </div>
       )}
 
-      {/* Only show the generic API Key field if no variableDefinitions are defined for this server.
-                  When variableDefinitions exist, all credentials are handled through that section above. */}
-      {!(server.metadata as MCPServerMetadata | undefined)
-        ?.variableDefinitions && (
-        <div className="space-y-2">
-          <Label htmlFor="http-api-key">
-            {t('mcpServer.dialog.apiKeyLabel', 'API Key / Token')}{' '}
-            <span className="text-muted-foreground text-xs">
-              {t('mcpServer.dialog.apiKeyOptional', '(Optional)')}
-            </span>
-          </Label>
-          <Input
-            id="http-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder={t(
-              'mcpServer.dialog.apiKeyPlaceholder',
-              'Secret Token',
-            )}
-          />
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'mcpServer.dialog.apiKeyDesc',
-              "Automatically adds 'Authorization: Bearer <token>' header.",
-            )}
-          </p>
+      {/* Authentication Method Selector */}
+      <div className="space-y-2">
+        <Label htmlFor="auth-method">
+          {t('mcpServer.dialog.authMethodLabel', 'Authentication Method')}
+        </Label>
+        <Select
+          value={authType}
+          onValueChange={(val: 'none' | 'oauth2.1') => setAuthType(val)}
+        >
+          <SelectTrigger id="auth-method">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">
+              {t('mcpServer.dialog.authMethodNone', 'None / Token (Bearer)')}
+            </SelectItem>
+            <SelectItem value="oauth2.1">
+              {t('mcpServer.dialog.authMethodOAuth', 'OAuth 2.1')}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Render generic API Key field ONLY when authType is 'none' and no variableDefinitions are defined */}
+      {authType === 'none' &&
+        !(server.metadata as MCPServerMetadata | undefined)
+          ?.variableDefinitions && (
+          <div className="space-y-2">
+            <Label htmlFor="http-api-key">
+              {t('mcpServer.dialog.apiKeyLabel', 'API Key / Token')}{' '}
+              <span className="text-muted-foreground text-xs">
+                {t('mcpServer.dialog.apiKeyOptional', '(Optional)')}
+              </span>
+            </Label>
+            <Input
+              id="http-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder={t(
+                'mcpServer.dialog.apiKeyPlaceholder',
+                'Secret Token',
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'mcpServer.dialog.apiKeyDesc',
+                "Automatically adds 'Authorization: Bearer <token>' header.",
+              )}
+            </p>
+          </div>
+        )}
+
+      {/* Render OAuth 2.1 Configuration Card */}
+      {authType === 'oauth2.1' && (
+        <div className="space-y-4 p-4 border rounded-md bg-muted/10">
+          <h4 className="text-sm font-semibold flex items-center gap-2">
+            🔑{' '}
+            {t('mcpServer.dialog.oauthConfigHeader', 'OAuth 2.1 Configuration')}
+          </h4>
+
+          {/* Client ID / Client Key */}
+          <div className="space-y-2">
+            <Label htmlFor="oauth-client-id">
+              {t('mcpServer.dialog.clientIdLabel', 'Client Key (Client ID)')}{' '}
+              <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="oauth-client-id"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder="e.g. slack-mcp-client-id"
+            />
+          </div>
+
+          {/* Client Secret */}
+          <div className="space-y-2">
+            <Label htmlFor="oauth-client-secret">
+              {t('mcpServer.dialog.clientSecretLabel', 'Client Secret')}{' '}
+              <span className="text-muted-foreground text-xs">
+                {t('mcpServer.dialog.clientSecretOptional', '(Optional)')}
+              </span>
+            </Label>
+            <Input
+              id="oauth-client-secret"
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              placeholder="Enter client secret if using a confidential client"
+            />
+          </div>
+
+          {/* Configuration Mode: Discovery URL or Manual Endpoints */}
+          <div className="space-y-4 pt-2 border-t border-border/50">
+            <div className="space-y-2">
+              <Label htmlFor="oauth-discovery-url">
+                {t('mcpServer.dialog.discoveryUrlLabel', 'Discovery URL')}
+              </Label>
+              <Input
+                id="oauth-discovery-url"
+                value={discoveryUrl}
+                onChange={(e) => setDiscoveryUrl(e.target.value)}
+                placeholder="https://mcp.example.com/.well-known/oauth-authorization-server"
+              />
+              <p className="text-xs text-muted-foreground">
+                RFC 8414 OAuth Authorization Server metadata endpoint (takes
+                precedence).
+              </p>
+            </div>
+
+            <div className="text-xs text-center text-muted-foreground font-medium py-1">
+              — {t('mcpServer.dialog.or', 'OR')} —
+            </div>
+
+            {/* Manual Endpoints */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="oauth-auth-endpoint">
+                  {t(
+                    'mcpServer.dialog.authEndpointLabel',
+                    'Authorization Endpoint',
+                  )}
+                </Label>
+                <Input
+                  id="oauth-auth-endpoint"
+                  value={authorizationEndpoint}
+                  onChange={(e) => setAuthorizationEndpoint(e.target.value)}
+                  placeholder="https://slack.com/oauth/v2_user/authorize"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="oauth-token-endpoint">
+                  {t('mcpServer.dialog.tokenEndpointLabel', 'Token Endpoint')}
+                </Label>
+                <Input
+                  id="oauth-token-endpoint"
+                  value={tokenEndpoint}
+                  onChange={(e) => setTokenEndpoint(e.target.value)}
+                  placeholder="https://slack.com/api/oauth.v2.user.access"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Scopes */}
+          <div className="space-y-2 pt-2 border-t border-border/50">
+            <Label htmlFor="oauth-scopes">
+              {t('mcpServer.dialog.scopesLabel', 'Scopes')}
+            </Label>
+            <Input
+              id="oauth-scopes"
+              value={scopes}
+              onChange={(e) => setScopes(e.target.value)}
+              placeholder="e.g. search:read.public, chat:write"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'mcpServer.dialog.scopesDesc',
+                'Comma-separated scopes. Scope names cannot contain commas.',
+              )}
+            </p>
+          </div>
+
+          {/* PKCE Toggle */}
+          <div className="flex items-center justify-between pt-2">
+            <div className="space-y-0.5">
+              <Label htmlFor="oauth-use-pkce">
+                {t(
+                  'mcpServer.dialog.usePkceLabel',
+                  'Use PKCE (Proof Key for Code Exchange)',
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground font-light">
+                {usePkce
+                  ? t(
+                      'mcpServer.dialog.usePkceEnabledDesc',
+                      'Recommended for public clients without a client secret.',
+                    )
+                  : t(
+                      'mcpServer.dialog.usePkceDisabledDesc',
+                      'Only disable PKCE for providers that do not support it. Confidential clients should use a client secret instead.',
+                    )}
+              </p>
+            </div>
+            <Switch
+              id="oauth-use-pkce"
+              checked={usePkce}
+              onCheckedChange={setUsePkce}
+            />
+          </div>
         </div>
       )}
 

--- a/src/features/mcp-servers/components/ServerCard.tsx
+++ b/src/features/mcp-servers/components/ServerCard.tsx
@@ -1,5 +1,13 @@
-import React, { useState } from 'react';
-import { Server, CheckCircle2, XCircle, Loader2, Wrench } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Server,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Wrench,
+  ShieldCheck,
+  ShieldAlert,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { MCPServerEntity } from '@/models/chat';
 import {
@@ -12,6 +20,9 @@ import {
 import { Switch } from '@/components/ui/switch';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { ServerToolsModal } from './ServerToolsModal';
+import { hasOAuthToken, startOAuthFlow, revokeOAuthToken } from '@/lib/backend';
+import { safeInvoke } from '@/lib/backend/core';
+import { toast } from 'sonner';
 
 interface ServerCardProps {
   server: MCPServerEntity;
@@ -19,6 +30,7 @@ interface ServerCardProps {
   onDelete: (server: MCPServerEntity) => void;
   onToggleActive: (server: MCPServerEntity, checked: boolean) => void;
   isToggling?: boolean;
+  onRevalidate?: () => void;
 }
 
 export const ServerCard = React.memo(
@@ -28,11 +40,63 @@ export const ServerCard = React.memo(
     onDelete,
     onToggleActive,
     isToggling,
+    onRevalidate,
   }: ServerCardProps) => {
     const { t } = useTranslation('common');
     const serverName = server.name || t('mcpServer.unnamed', 'Unnamed Server');
     const [isToolsOpen, setIsToolsOpen] = useState(false);
     const verificationStatus = server.verificationStatus;
+
+    const [hasToken, setHasToken] = useState<boolean>(false);
+    const [isAuthorizing, setIsAuthorizing] = useState<boolean>(false);
+
+    useEffect(() => {
+      if (server.authentication?.type === 'oauth2.1') {
+        hasOAuthToken(server.id)
+          .then(setHasToken)
+          .catch(() => setHasToken(false));
+      }
+    }, [server.id, server.authentication]);
+
+    const handleAuthorize = useCallback(async () => {
+      if (!server.authentication) return;
+      setIsAuthorizing(true);
+      try {
+        await startOAuthFlow(server.id, server.authentication);
+        setHasToken(true);
+        toast.success(
+          t('mcpServer.toasts.authSuccess', 'Successfully authenticated!'),
+        );
+        // Probe to trigger re-verification and fetch tools
+        await safeInvoke('probe_mcp_server', { serverId: server.id });
+        if (onRevalidate) onRevalidate();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        toast.error(
+          t('mcpServer.toasts.authFailed', `Authorization failed: ${msg}`),
+        );
+      } finally {
+        setIsAuthorizing(false);
+      }
+    }, [server.id, server.authentication, t, onRevalidate]);
+
+    const handleDisconnect = useCallback(async () => {
+      try {
+        await revokeOAuthToken(server.id);
+        setHasToken(false);
+        toast.success(
+          t('mcpServer.toasts.disconnectSuccess', 'Successfully disconnected.'),
+        );
+        // Probe to reset status to connection failed/AuthRequired
+        await safeInvoke('probe_mcp_server', { serverId: server.id });
+        if (onRevalidate) onRevalidate();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        toast.error(
+          t('mcpServer.toasts.disconnectFailed', `Disconnect failed: ${msg}`),
+        );
+      }
+    }, [server.id, t, onRevalidate]);
 
     return (
       <Card className="relative overflow-hidden">
@@ -117,7 +181,27 @@ export const ServerCard = React.memo(
                   })()}`}
               </p>
               {/* Tool count / verification status — mutually exclusive display */}
-              <div className="mt-1">
+              <div className="mt-1 flex flex-col gap-1">
+                {server.authentication?.type === 'oauth2.1' && (
+                  <span
+                    className={`inline-flex items-center gap-1 text-xs font-semibold ${hasToken ? 'text-blue-600 dark:text-blue-400' : 'text-amber-600 dark:text-amber-500'}`}
+                  >
+                    {hasToken ? (
+                      <>
+                        <ShieldCheck className="w-3.5 h-3.5" />
+                        {t('mcpServer.authorizedStatus', 'Authorized')}
+                      </>
+                    ) : (
+                      <>
+                        <ShieldAlert className="w-3.5 h-3.5 text-amber-500" />
+                        {t(
+                          'mcpServer.unauthorizedStatus',
+                          'Authorization Required',
+                        )}
+                      </>
+                    )}
+                  </span>
+                )}
                 {verificationStatus === 'pending' && (
                   <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                     <Loader2 className="w-3 h-3 animate-spin" />
@@ -225,6 +309,31 @@ export const ServerCard = React.memo(
               >
                 {t('mcpServer.edit', 'Edit')}
               </Button>
+
+              {server.authentication?.type === 'oauth2.1' &&
+                (hasToken ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDisconnect}
+                    className="text-amber-600 hover:text-amber-700 border-amber-200 hover:bg-amber-50 dark:hover:bg-amber-950/20"
+                  >
+                    {t('mcpServer.disconnect', 'Disconnect')}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="default"
+                    size="sm"
+                    disabled={isAuthorizing}
+                    onClick={handleAuthorize}
+                    className="bg-blue-600 hover:bg-blue-700 text-white font-semibold"
+                  >
+                    {isAuthorizing && (
+                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    )}
+                    {t('mcpServer.authorize', 'Authorize')}
+                  </Button>
+                ))}
             </div>
             <Button
               variant="destructive"

--- a/src/features/mcp-servers/hooks/useMCPServerForm.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerForm.ts
@@ -194,6 +194,32 @@ export function useMCPServerForm(server: MCPServerEntity) {
 
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  // OAuth specific state
+  const [authType, setAuthType] = useState<'none' | 'oauth2.1'>(() => {
+    return server.authentication?.type === 'oauth2.1' ? 'oauth2.1' : 'none';
+  });
+  const [discoveryUrl, setDiscoveryUrl] = useState(() => {
+    return server.authentication?.discoveryUrl || '';
+  });
+  const [authorizationEndpoint, setAuthorizationEndpoint] = useState(() => {
+    return server.authentication?.authorizationEndpoint || '';
+  });
+  const [tokenEndpoint, setTokenEndpoint] = useState(() => {
+    return server.authentication?.tokenEndpoint || '';
+  });
+  const [clientId, setClientId] = useState(() => {
+    return server.authentication?.clientId || '';
+  });
+  const [clientSecret, setClientSecret] = useState(() => {
+    return server.authentication?.clientSecret || '';
+  });
+  const [scopes, setScopes] = useState(() => {
+    return server.authentication?.scopes?.join(', ') || '';
+  });
+  const [usePkce, setUsePkce] = useState(() => {
+    return server.authentication?.usePKCE ?? true;
+  });
+
   const isNewServer = !server.createdAt || draft.name === '';
 
   const isReservedName = () =>
@@ -229,6 +255,18 @@ export function useMCPServerForm(server: MCPServerEntity) {
       draft.transport.type === 'http-sse'
     ) {
       if (!draft.transport.url.trim()) return false;
+
+      // If OAuth 2.1 is enabled, clientId is required and we need either discoveryUrl OR authorization & token endpoints
+      if (authType === 'oauth2.1') {
+        if (!clientId.trim()) return false;
+        if (
+          !discoveryUrl.trim() &&
+          (!authorizationEndpoint.trim() || !tokenEndpoint.trim())
+        ) {
+          return false;
+        }
+      }
+
       const httpDefs = (server.metadata as MCPServerMetadata | undefined)
         ?.variableDefinitions;
       if (httpDefs) {
@@ -378,6 +416,25 @@ export function useMCPServerForm(server: MCPServerEntity) {
             headers,
             enableSSE: enableSSE,
           } as TransportConfig,
+          authentication:
+            authType === 'oauth2.1'
+              ? {
+                  type: 'oauth2.1',
+                  discoveryUrl: discoveryUrl.trim() || undefined,
+                  authorizationEndpoint:
+                    authorizationEndpoint.trim() || undefined,
+                  tokenEndpoint: tokenEndpoint.trim() || undefined,
+                  clientId: clientId.trim() || undefined,
+                  clientSecret: clientSecret.trim() || undefined,
+                  scopes: scopes.trim()
+                    ? scopes
+                        .split(',')
+                        .map((s) => s.trim())
+                        .filter(Boolean)
+                    : undefined,
+                  usePKCE: usePkce,
+                }
+              : undefined,
         };
 
         await onSave(updatedDraft);
@@ -416,5 +473,21 @@ export function useMCPServerForm(server: MCPServerEntity) {
     handleRemoveHeader,
     handleUpdateHeader,
     submit,
+    authType,
+    setAuthType,
+    discoveryUrl,
+    setDiscoveryUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    clientId,
+    setClientId,
+    clientSecret,
+    setClientSecret,
+    scopes,
+    setScopes,
+    usePkce,
+    setUsePkce,
   };
 }

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -249,5 +249,6 @@ export function useMCPServerManagement(service?: McpServerService) {
     handleDelete,
     confirmDelete,
     handleToggleActive,
+    mutateServers,
   };
 }

--- a/src/lib/backend/core.ts
+++ b/src/lib/backend/core.ts
@@ -49,6 +49,6 @@ export async function safeInvoke<T>(
     } else {
       logger.error('invoke failed', { cmd, err });
     }
-    throw err;
+    throw err instanceof Error ? err : new Error(typeof err === 'string' ? err : String(err));
   }
 }

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -40,6 +40,7 @@ export {
   hasOAuthToken,
   getOAuthToken,
   revokeOAuthToken,
+  startOAuthFlow,
   sampleFromModel,
   validateToolSchema,
 } from './mcp-server';

--- a/src/lib/backend/mcp-server.ts
+++ b/src/lib/backend/mcp-server.ts
@@ -4,6 +4,7 @@ import type {
   MCPResponse,
   SamplingOptions,
   SamplingResponse,
+  OAuthConfig,
 } from '@/lib/mcp';
 import { createId } from '@paralleldrive/cuid2';
 
@@ -66,6 +67,21 @@ export async function getOAuthToken(serverId: string): Promise<string | null> {
  */
 export async function revokeOAuthToken(serverId: string): Promise<string> {
   return safeInvoke<string>('revoke_oauth_token', { serverId });
+}
+
+/**
+ * Starts the OAuth 2.1 authorization flow: opens browser, runs loopback listener,
+ * exchanges code, and saves token in keychain.
+ *
+ * @param serverId - Unique identifier for the MCP server
+ * @param config - The OAuthConfig object
+ * @returns Success message
+ */
+export async function startOAuthFlow(
+  serverId: string,
+  config: OAuthConfig,
+): Promise<string> {
+  return safeInvoke<string>('start_oauth_flow', { serverId, config });
 }
 
 /**

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,7 +5,11 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
+export const EXECUTION_MODE_VALUES = [
+  'normal',
+  'yolo',
+  'unsafe',
+] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 

--- a/src/lib/mcp/config/transport.ts
+++ b/src/lib/mcp/config/transport.ts
@@ -36,6 +36,7 @@ export interface OAuthConfig {
   tokenEndpoint?: string;
   registrationEndpoint?: string; // RFC 7591 Dynamic Client Registration
   clientId?: string;
+  clientSecret?: string;
   redirectUri?: string;
   scopes?: string[];
   usePKCE?: boolean; // Default: true


### PR DESCRIPTION
Implements standard OAuth 2.1 authentication flow compliance (under the MCP 2025-06-18 spec) for Remote/HTTP MCP servers, resolving integration blockages for servers that enforce OAuth (like Slack).