### PR TITLE
Release v0.8.19: OAuth 2.1 MCP auth, session fixes, and 0.8.18 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.19] - 2026-06-23
+
+### 🚀 Features
+
+- **OAuth 2.1 for Remote MCP Servers**: Add OAuth 2.1 authentication flow for HTTP MCP servers, compliant with the 2025-06-18 MCP authorization spec. Includes discovery, authorization, token exchange, and secure token storage via the OS keychain.
+- **MCP Server OAuth UI**: Configure OAuth 2.1 in the MCP server dialog, authorize/disconnect from server cards, and save auth-required server configs before completing the OAuth handshake.
+- **Planning Goal Nudges**: Planning context now frames a missing goal as a required action with explicit tool names, guiding agents to create a goal before proceeding.
+
+### 🐛 Fixes
+
+- **`messageToSession` Stale Output**: When `wait=true`, prefer fresh in-memory session cache over stale database reads so delegated session polling returns the latest assistant output after workflow completion.
+
+### 🔧 Internal
+
+- **OAuth Hardening**: Validate OAuth discovery and endpoint hosts (HTTPS-only, reject private/local networks).
+- **Test Suite Stability**: Repair lib test fixtures, assistant-scoped playbook isolation, and global-state locking for parallel test runs.
+- **CI**: Bump `actions/checkout` from v6 to v7.
+
 ## [0.8.18] - 2026-06-22
 
 ### 🚀 Features

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.de.md
+++ b/README.de.md
@@ -205,10 +205,10 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **Alle Release-Artefakte:** [Releases-Seite](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **Alle Release-Artefakte:** [Releases-Seite](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Entwickler-Setup:**

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,10 +205,10 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **Todos los archivos de la release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **Todos los archivos de la release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuración para desarrolladores:**

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,10 +205,10 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows :** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon) :** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux :** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **Tous les fichiers de release :** [page des Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows :** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon) :** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux :** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **Tous les fichiers de release :** [page des Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuration développeur :**

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,10 +205,10 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **すべてのリリース資産:** [リリースページ](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **すべてのリリース資産:** [リリースページ](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **開発者セットアップ：**

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,10 +205,10 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **전체 릴리스 자산:** [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **전체 릴리스 자산:** [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **개발자 설정:**

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Developer Setup:**

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,10 +205,10 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **Todos os artefatos da release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **Todos os artefatos da release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuração para programadores:**

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,10 +205,10 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows：** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS（Apple Silicon）：** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux：** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **完整发布资源：** [发布页面](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows：** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS（Apple Silicon）：** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux：** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **完整发布资源：** [发布页面](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **开发者设置：**

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Fritz Prix <fritzprix@gmail.com>
 pkgname=libragent
-pkgver=0.8.18
+pkgver=0.8.19
 pkgrel=1
 pkgdesc="A desktop app for AI agents with built-in tools"
 arch=('x86_64')

--- a/docs/audit/code-audit-git-diff-0.8.19.md
+++ b/docs/audit/code-audit-git-diff-0.8.19.md
@@ -1,0 +1,115 @@
+# Code Audit Report: Git Diff Review
+
+## 1. 변경 사항 개요
+
+| Category              | Files | Type           | Impact   |
+| --------------------- | ----- | -------------- | -------- |
+| README 포맷팅         | 8개   | Formatting     | Low      |
+| 버전 업데이트         | 1개   | Metadata       | Low      |
+| Windows 경로 처리     | 1개   | **Core Logic** | **High** |
+| Generated 파일 포맷팅 | 2개   | Formatting     | Low      |
+
+---
+
+## 2. 핵심 변경 분석: `windows.rs` — `simplify_path()`
+
+### 2.1 변경 내용
+
+```rust
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(stripped) = path.strip_prefix(r"\\?\") {
+        if !stripped.starts_with(r"UNC\") {
+            return stripped.to_path_buf();
+        }
+    }
+    path.to_path_buf()
+}
+```
+
+**적용 위치:**
+
+- `cmd.current_dir(&clean_workspace)` — 작업 디렉토리 설정
+- `cmd.env("TEMP", clean_workspace.join(".libragent/tmp"))` — TEMP 환경변수
+- `cmd.env("TMP", clean_workspace.join(".libragent/tmp"))` — TMP 환경변수
+- `clean_workspace.join(".libragent/tmp")` — 스크립트 템프 디렉토리 생성
+
+### 2.2 로직 정확성 평가
+
+| 입력 경로                  | strip_prefix 결과      | UNC\ 체크 | 최종 결과                             |
+| -------------------------- | ---------------------- | --------- | ------------------------------------- |
+| `\\?\C:\Users\dev\project` | `C:\Users\dev\project` | N/A       | `C:\Users\dev\project` ✅             |
+| `\\?\UNC\server\share`     | `UNC\server\share`     | True      | `\\?\UNC\server\share` (원본 유지) ✅ |
+| `C:\Users\dev\project`     | Err                    | —         | `C:\Users\dev\project` ✅             |
+
+**판단: 로직 정확함. 세 가지 케이스 모두 올바르게 처리됨.**
+
+### 2.3 일관성 평가
+
+`simplify_path()`의 호출이 `create_basic_isolated_command()` 함수 내에서 **단 한 번** 수행되고, 그 결과(`clean_workspace`)가 모든 경로 연산에 재사용된다. 이는 **DRY 원칙 준수** 및 **일관성 보장에 우수**.
+
+### 2.4 위험 요소
+
+| 위험도     | 항목                  | 설명                                                                                                       |
+| ---------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Medium** | Long path 지원 손실   | `\\?\` prefix 제거로 260자 초과 경로 지원 불가. 깊게 중첩된 워크스페이스에서 경로 길이 제한 에러 발생 가능 |
+| **Low**    | 테스트 누락           | `simplify_path()` 자체에 대한 unit test 없음. 현재 테스트는 script content와 cleanup wrapper만 검증        |
+| **Low**    | UNC 경로 보존 시 동작 | `\\?\UNC\server\share`가 원본 그대로 전달되지만, 이 경로가 외부 도구에서 여전히 파싱 실패할 가능성         |
+
+### 2.5 개선 제안
+
+```rust
+// 현재: 단순 strip (long path 지원 포기)
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    // ...
+}
+
+// 대안: long path 지원을 유지하면서 UNC 문제를 우회하는 방식 고려
+// (예: workspace 경로를 short path로 변환 후 사용)
+```
+
+**권장 사항:** `simplify_path()`에 대한 unit test 추가. 특히 `\\?\UNC\` 케이스와 일반 케이스 모두 커버.
+
+---
+
+## 3. 부수 변경 분석
+
+### 3.1 README 파일 (8개)
+
+**변경:** `<!-- RELEASE_DOWNLOADS_START -->` HTML comment 뒤에 빈 줄 추가
+
+**판단: 적절함.** Markdown 렌더링을 위해 HTML 블록과 리스트 사이에 빈 줄이 필요함.
+
+### 3.2 Cargo.lock
+
+**변경:** `version = "0.8.18"` → `"0.8.19"`
+
+**판단: 정상적인 버전 업데이트.**
+
+### 3.3 Generated TypeScript 파일 (2개)
+
+| 파일                  | 변경 내용                                                               | 판단                  |
+| --------------------- | ----------------------------------------------------------------------- | --------------------- |
+| `builtin-services.ts` | `(typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number]` — typeof parentheses | Prettier 포맷팅. 무해 |
+| `execution-mode.ts`   | 배열을 단일 라인으로 collapse                                           | Prettier 포맷팅. 무해 |
+
+**판단:** Auto-generated 파일의 포맷팅 변경. Generator 스크립트(`scripts/sync-*.cjs`)의 Prettier 설정 변경으로 보임. 기능적 영향 없음.
+
+---
+
+## 4. 종합 평가
+
+| 항목                 | 점수       | 비고                                                                           |
+| -------------------- | ---------- | ------------------------------------------------------------------------------ |
+| **문제 해결 적절성** | ⭐⭐⭐⭐⭐ | UNC 경로로 인한 외부 도구 크래시를 정확히 지적하고 해결                        |
+| **구현 설계**        | ⭐⭐⭐⭐   | 단일 호출 + 재사용으로 일관성 우수. long path 지원 포기 트레이드오프 명시 필요 |
+| **테스트 커버리지**  | ⭐⭐       | `simplify_path()` 자체 테스트 누락. script/wrapper 테스트는 기존 유지          |
+| **부수 변경 관리**   | ⭐⭐⭐⭐⭐ | README, generated 파일 변경은 모두 포맷팅/메타데이터로 안전                    |
+
+### 결론: **Merge 권장 (단, 테스트 추가 권고)**
+
+`simplify_path()` 변경은 **실제 문제를 정확히 해결**하며, 구현도 깔끔하고 일관성 있게 적용됨.
+
+**Merge 전 권고 사항:**
+
+1. `simplify_path()` unit test 추가 (P0)
+2. `\\?\` prefix 제거로 인한 long path 제한에 대한 문서화 (P1)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libragent",
   "private": true,
-  "version": "0.8.18",
+  "version": "0.8.19",
   "description": "A desktop app for AI agents with built-in tools",
   "author": "fritzprix",
   "license": "MIT",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: libragent
 base: core22
-version: '0.8.18'
+version: '0.8.19'
 summary: A desktop app for AI agents with built-in tools
 description: |
   LibrAgent is a next-generation desktop AI agent platform that combines the lightness of Tauri with the intuitiveness of React. Users can automate all daily tasks by giving AI agents their own unique personalities and abilities.
@@ -25,7 +25,7 @@ apps:
 parts:
   libragent:
     plugin: dump
-    source: src-tauri/target/release/bundle/deb/libragent_0.8.18_amd64.deb
+    source: src-tauri/target/release/bundle/deb/libragent_0.8.19_amd64.deb
     source-type: deb
     stage-packages:
       - libwebkit2gtk-4.1-0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4095,7 +4095,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4095,7 +4095,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libragent"
-version = "0.8.18"
+version = "0.8.19"
 description = "A desktop app for AI agents with built-in tools"
 authors = ["fritzprix"]
 license = "MIT"

--- a/src-tauri/src/agent/llm/prompt.rs
+++ b/src-tauri/src/agent/llm/prompt.rs
@@ -478,7 +478,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(prompt, "Base prompt only.");
+        assert_eq!(prompt, "Base prompt only.\n\n\n## Agent Runtime Identity\n- Agent Name: Default Assistant\n- Agent ID: (unknown)");
         assert!(!prompt.contains("## Session Context"));
         assert!(!prompt.contains("## Workspace Instructions"));
         assert!(!prompt.contains("## Available Tools & Current State"));

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -621,7 +621,14 @@ mod tests {
                 input_preview: None,
             },
         );
-        session.pending_execution = Some("exec-1".to_string());
+        session.pending_execution = Some(PendingToolExecution {
+            message_id: "exec-1".to_string(),
+            total_expected: 0,
+            results: Vec::new(),
+            tool_names: HashMap::new(),
+            expected_tool_call_ids: HashSet::new(),
+            completed_tool_call_ids: HashSet::new(),
+        });
         *session.compact_context.write().await = Some(CompactContextRecord {
             id: "cc-1".to_string(),
             session_id: "test-sess".to_string(),
@@ -659,12 +666,7 @@ mod tests {
         assert!(session.pending_approvals.read().await.is_empty());
         assert!(session.pending_execution.is_none());
         assert!(session.compact_context.read().await.is_none());
-        assert!(session
-            .pending_events
-            .read()
-            .await
-            .drain_messages()
-            .is_empty());
+        assert!(!session.pending_events.read().await.has_pending());
 
         let snapshot = session.compaction.snapshot().await;
         assert!(matches!(snapshot.phase, CompactionPhase::Idle));

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -835,7 +835,7 @@ mod tests {
         // The agent must see the full guided error, not a bare "Unknown error"
         assert!(
             msg.content.iter().any(|c| matches!(c,
-                MCPContent::Text { text, .. } if text.contains("STALE HASH")
+                MCPContent::Text { text, .. } if text.contains("STALE ANCHOR")
             )),
             "guided_error text must be preserved in the tool message"
         );

--- a/src-tauri/src/commands/mcp_commands.rs
+++ b/src-tauri/src/commands/mcp_commands.rs
@@ -99,3 +99,61 @@ pub async fn revoke_oauth_token(server_id: String) -> Result<String, String> {
         "OAuth token revoked successfully for server: {server_id}"
     ))
 }
+
+/// Starts the OAuth 2.1 authorization flow: opens browser, runs loopback listener,
+/// exchanges code, and saves token in keychain.
+#[tauri::command]
+pub async fn start_oauth_flow(
+    app_handle: tauri::AppHandle,
+    server_id: String,
+    config: crate::mcp::types::OAuthConfig,
+) -> Result<String, String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let oauth_manager = crate::mcp::oauth::OAuthManager::new();
+
+    // Step 1: Start auth flow and get URL + state
+    let (auth_url, state) = oauth_manager
+        .start_authorization_flow(&config, &server_id)
+        .await?;
+
+    // Step 2: Open browser
+    log::info!("Opening authorization URL in browser: {}", auth_url);
+    app_handle
+        .opener()
+        .open_url(&auth_url, Option::<String>::None)
+        .map_err(|e| format!("Failed to open browser: {e}"))?;
+
+    // Step 3: Run temporary loopback server and wait for code
+    let redirect_uri = config
+        .redirect_uri
+        .clone()
+        .unwrap_or_else(|| "http://localhost:14207/callback".to_string());
+
+    // Verify it is a localhost loopback callback
+    if !redirect_uri.starts_with("http://localhost")
+        && !redirect_uri.starts_with("http://127.0.0.1")
+    {
+        return Err(format!(
+            "Unsupported redirect URI: {}. Only http://localhost or http://127.0.0.1 are supported.",
+            redirect_uri
+        ));
+    }
+
+    let code = oauth_manager
+        .wait_for_callback(&redirect_uri, &state)
+        .await?;
+
+    // Step 4: Exchange code for token
+    let access_token = oauth_manager
+        .exchange_code_for_token(&config, &server_id, &code, &state)
+        .await?;
+
+    // Step 5: Save token in keychain
+    crate::mcp::keychain::store_token_securely(&server_id, &access_token).await?;
+
+    Ok(format!(
+        "OAuth integration successful for server: {}",
+        server_id
+    ))
+}

--- a/src-tauri/src/commands/mcp_commands.rs
+++ b/src-tauri/src/commands/mcp_commands.rs
@@ -128,16 +128,28 @@ pub async fn start_oauth_flow(
     let redirect_uri = config
         .redirect_uri
         .clone()
-        .unwrap_or_else(|| "http://localhost:14207/callback".to_string());
+        .unwrap_or_else(|| crate::mcp::oauth::DEFAULT_CALLBACK_URL.to_string());
 
-    // Verify it is a localhost loopback callback
-    if !redirect_uri.starts_with("http://localhost")
-        && !redirect_uri.starts_with("http://127.0.0.1")
-    {
-        return Err(format!(
-            "Unsupported redirect URI: {}. Only http://localhost or http://127.0.0.1 are supported.",
-            redirect_uri
-        ));
+    // Verify it is a localhost loopback callback with a port
+    if let Ok(parsed_url) = url::Url::parse(&redirect_uri) {
+        if parsed_url.scheme() != "http" {
+            return Err("Unsupported redirect URI scheme. Only http:// is supported for loopback listeners.".to_string());
+        }
+        let host = parsed_url.host_str().unwrap_or("");
+        if host != "localhost" && host != "127.0.0.1" {
+            return Err(format!(
+                "Security violation: host '{}' is not allowed for redirect URI. Only 'localhost' or '127.0.0.1' are allowed.",
+                host
+            ));
+        }
+        if parsed_url.port().is_none() {
+            return Err(format!(
+                "Redirect URI must specify a port number (e.g. {}) to bind the loopback listener.",
+                crate::mcp::oauth::DEFAULT_CALLBACK_URL
+            ));
+        }
+    } else {
+        return Err(format!("Invalid redirect URI: {}", redirect_uri));
     }
 
     let code = oauth_manager

--- a/src-tauri/src/execution_mode.rs
+++ b/src-tauri/src/execution_mode.rs
@@ -66,7 +66,7 @@ impl std::str::FromStr for ExecutionMode {
 
 #[cfg(test)]
 mod tests {
-    use super::ExecutionMode;
+    use super::{ExecutionMode, EXECUTION_MODE_DB_VALUES};
 
     #[test]
     fn from_runtime_flags_prefers_unsafe_over_yolo() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,7 +70,7 @@ use commands::log_commands::{
 use commands::mcp_commands::{
     get_oauth_token, has_oauth_token, list_available_builtin_server_definitions,
     list_builtin_servers, list_builtin_servers_with_metadata, list_builtin_tools, probe_mcp_server,
-    revoke_oauth_token, validate_tool_schema,
+    revoke_oauth_token, start_oauth_flow, validate_tool_schema,
 };
 use commands::mcp_server_config_commands::{
     create_mcp_server_config, delete_mcp_server_config, list_mcp_server_configs,
@@ -237,6 +237,7 @@ pub fn run() {
                 has_oauth_token,
                 get_oauth_token,
                 revoke_oauth_token,
+                start_oauth_flow,
                 // Message management commands
                 messages_get_page,
                 messages_get_messages_before,

--- a/src-tauri/src/lifecycle/database.rs
+++ b/src-tauri/src/lifecycle/database.rs
@@ -31,7 +31,7 @@ pub fn extract_db_file_path(db_url: &str) -> Option<&str> {
         .and_then(|p| p.split('?').next())
 }
 
-fn register_sqlite_vec() {
+pub(crate) fn register_sqlite_vec() {
     static REGISTER_SQLITE_VEC: Once = Once::new();
 
     REGISTER_SQLITE_VEC.call_once(|| unsafe {

--- a/src-tauri/src/mcp/builtin/attachments/test_functional.rs
+++ b/src-tauri/src/mcp/builtin/attachments/test_functional.rs
@@ -16,6 +16,7 @@ mod tests {
         let url = crate::utils::sqlite::format_sqlite_url(&db_path.to_string_lossy());
 
         // Connect to database and run migrations
+        crate::lifecycle::database::register_sqlite_vec();
         let db = sea_orm::Database::connect(&url)
             .await
             .expect("Failed to connect to database");

--- a/src-tauri/src/mcp/builtin/planning/context.rs
+++ b/src-tauri/src/mcp/builtin/planning/context.rs
@@ -61,13 +61,17 @@ pub async fn get_service_context(
 
     // Goal Section
     parts.push("### Stable Context".to_string());
+    let goal_missing = goal_notice.is_none() && goal.is_none();
     if let Some(notice) = &goal_notice {
         parts.push("- Current Goal: unavailable".to_string());
         parts.push(format!("- {}", notice.hint));
     } else if let Some(g) = &goal {
         parts.push(format!("- Current Goal: \"{}\"", g));
     } else {
-        parts.push("- No goal set".to_string());
+        parts.push(
+            "- Current Goal: missing — required: call planning__createGoal before task work"
+                .to_string(),
+        );
     }
 
     // Todos Section
@@ -153,6 +157,11 @@ pub async fn get_service_context(
                 parts.push(format!("- [✓] (Todo ID {}) {}{}", t.id, t.content, summary));
             }
         }
+    } else if goal_missing {
+        parts.push(
+            "- Tasks: none yet (add todos with planning__addTodo after planning__createGoal)"
+                .to_string(),
+        );
     } else {
         parts.push("- Tasks: None".to_string());
     }

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -347,6 +347,38 @@ async fn fetch_cached_session_messages_newest_first(
     Some(newest_first)
 }
 
+/// Prefer in-memory session messages when SQLite is missing output or lags behind.
+pub(crate) fn select_preferred_session_messages(
+    db_messages: Vec<Value>,
+    cached_messages: Option<Vec<Value>>,
+) -> Vec<Value> {
+    let Some(cached) = cached_messages else {
+        return db_messages;
+    };
+
+    let db_output = latest_session_output(&db_messages);
+    let cached_output = latest_session_output(&cached);
+
+    if session_output_is_missing(&cached_output) {
+        return db_messages;
+    }
+
+    if session_output_is_missing(&db_output) {
+        return cached;
+    }
+
+    if cached.len() > db_messages.len() {
+        return cached;
+    }
+
+    // DB may have the same number of rows but stale assistant text while persistence catches up.
+    if cached_output != db_output && cached.len() >= db_messages.len() {
+        return cached;
+    }
+
+    db_messages
+}
+
 pub async fn fetch_session_messages_for_result(
     session_id: &str,
     limit: u64,
@@ -357,25 +389,15 @@ pub async fn fetch_session_messages_for_result(
         .await
         .map_err(|e| format!("Failed to fetch session messages: {}", e))?;
 
-    let mut messages_value: Vec<Value> = messages
+    let db_messages: Vec<Value> = messages
         .into_iter()
         .map(serde_json::to_value)
         .collect::<Result<Vec<Value>, serde_json::Error>>()
         .map_err(|e| format!("Failed to serialize session messages: {}", e))?;
 
-    let output = latest_session_output(&messages_value);
-    if session_output_is_missing(&output) {
-        if let Some(cached) =
-            fetch_cached_session_messages_newest_first(session_id, limit as usize).await
-        {
-            let cached_output = latest_session_output(&cached);
-            if !session_output_is_missing(&cached_output) {
-                messages_value = cached;
-            }
-        }
-    }
+    let cached = fetch_cached_session_messages_newest_first(session_id, limit as usize).await;
 
-    Ok(messages_value)
+    Ok(select_preferred_session_messages(db_messages, cached))
 }
 
 /// Consolidates timeout handling for spawnAgent, awaitAgent, and checkSession.
@@ -512,5 +534,88 @@ pub async fn wait_until_session_terminal(
             } => {}
             _ = sleep(sleep_cap) => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_preferred_session_messages;
+    use serde_json::json;
+
+    fn assistant_message(id: &str, text: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "role": "assistant",
+            "content": [{ "type": "text", "text": text }]
+        })
+    }
+
+    fn user_message(text: &str) -> serde_json::Value {
+        json!({
+            "role": "user",
+            "content": [{ "type": "text", "text": text }]
+        })
+    }
+
+    #[test]
+    fn prefers_cache_when_db_output_is_missing() {
+        let db = vec![user_message("new task")];
+        let cached = vec![
+            assistant_message("asst-new", "Fresh answer"),
+            user_message("new task"),
+            assistant_message("asst-old", "Old answer"),
+            user_message("old task"),
+        ];
+
+        let selected = select_preferred_session_messages(db, Some(cached.clone()));
+        assert_eq!(selected, cached);
+    }
+
+    #[test]
+    fn prefers_cache_when_it_has_more_messages() {
+        let db = vec![
+            assistant_message("asst-old", "Old answer"),
+            user_message("old task"),
+        ];
+        let cached = vec![
+            assistant_message("asst-new", "Fresh answer"),
+            user_message("new task"),
+            assistant_message("asst-old", "Old answer"),
+            user_message("old task"),
+        ];
+
+        let selected = select_preferred_session_messages(db, Some(cached.clone()));
+        assert_eq!(selected, cached);
+    }
+
+    #[test]
+    fn prefers_cache_when_counts_match_but_assistant_output_differs() {
+        let db = vec![
+            user_message("new task"),
+            assistant_message("asst-old", "Old answer"),
+            user_message("old task"),
+        ];
+        let cached = vec![
+            assistant_message("asst-new", "Fresh answer"),
+            user_message("new task"),
+            assistant_message("asst-old", "Old answer"),
+        ];
+
+        let selected = select_preferred_session_messages(db, Some(cached.clone()));
+        assert_eq!(selected, cached);
+    }
+
+    #[test]
+    fn keeps_db_when_cache_is_unavailable_or_incomplete() {
+        let db = vec![assistant_message("asst-new", "Fresh answer")];
+
+        let selected = select_preferred_session_messages(db.clone(), None);
+        assert_eq!(selected, db);
+
+        let selected = select_preferred_session_messages(
+            db.clone(),
+            Some(vec![user_message("still working")]),
+        );
+        assert_eq!(selected, db);
     }
 }

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -356,6 +356,20 @@ pub(crate) fn select_preferred_session_messages(
         return db_messages;
     };
 
+    // Verify that the database's latest message is actually present in the cache.
+    // If the DB has a newer message ID that is completely missing from the cache,
+    // the cache is stale/out-of-sync, so we must fall back to db_messages.
+    if let Some(db_latest) = db_messages.first() {
+        if let Some(db_id) = db_latest.get("id").and_then(|id| id.as_str()) {
+            let cache_contains_db_latest = cached.iter().any(|m| {
+                m.get("id").and_then(|id| id.as_str()) == Some(db_id)
+            });
+            if !cache_contains_db_latest {
+                return db_messages;
+            }
+        }
+    }
+
     let db_output = latest_session_output(&db_messages);
     let cached_output = latest_session_output(&cached);
 
@@ -616,6 +630,30 @@ mod tests {
             db.clone(),
             Some(vec![user_message("still working")]),
         );
+        assert_eq!(selected, db);
+    }
+
+    fn user_message_with_id(id: &str, text: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "role": "user",
+            "content": [{ "type": "text", "text": text }]
+        })
+    }
+
+    #[test]
+    fn falls_back_to_db_when_cache_is_stale_and_missing_db_latest_id() {
+        let db = vec![
+            assistant_message("asst-new-2", "Updated answer"),
+            user_message_with_id("msg-user-2", "new query"),
+        ];
+        // Cache has different messages and is missing the latest DB ID ("asst-new-2").
+        let cached = vec![
+            assistant_message("asst-old-1", "Stale answer"),
+            user_message_with_id("msg-user-1", "old query"),
+        ];
+
+        let selected = select_preferred_session_messages(db.clone(), Some(cached));
         assert_eq!(selected, db);
     }
 }

--- a/src-tauri/src/mcp/builtin/session_api/utils.rs
+++ b/src-tauri/src/mcp/builtin/session_api/utils.rs
@@ -361,9 +361,9 @@ pub(crate) fn select_preferred_session_messages(
     // the cache is stale/out-of-sync, so we must fall back to db_messages.
     if let Some(db_latest) = db_messages.first() {
         if let Some(db_id) = db_latest.get("id").and_then(|id| id.as_str()) {
-            let cache_contains_db_latest = cached.iter().any(|m| {
-                m.get("id").and_then(|id| id.as_str()) == Some(db_id)
-            });
+            let cache_contains_db_latest = cached
+                .iter()
+                .any(|m| m.get("id").and_then(|id| id.as_str()) == Some(db_id));
             if !cache_contains_db_latest {
                 return db_messages;
             }

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -3,7 +3,7 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::builtin::service_id::BuiltinServiceId;
 use crate::mcp::builtin::utils::load_session_tool_access;
-use crate::mcp::types::{MCPResult, MCPServerConfig, TransportConfig};
+use crate::mcp::types::{MCPResult, MCPServerConfig, OAuthConfig, TransportConfig};
 use crate::repositories::mcp_server_repository::MCPServerRepository;
 use crate::state::get_mcp_server_repository;
 use serde_json::{json, Value};
@@ -176,10 +176,14 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
             version: None,
         });
 
+    let authentication = args
+        .get("authentication")
+        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+
     let config = MCPServerConfig {
         name: Some(name.clone()),
         transport,
-        authentication: None,
+        authentication,
         metadata,
     };
 
@@ -341,10 +345,14 @@ pub async fn update_server(_server: &ToolServer, args: Value) -> Result<MCPResul
             version: None,
         });
 
+    let authentication = args
+        .get("authentication")
+        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+
     let config = MCPServerConfig {
         name: Some(name.to_string()),
         transport: transport_config,
-        authentication: None,
+        authentication,
         metadata,
     };
 

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -176,9 +176,20 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
             version: None,
         });
 
-    let authentication = args
-        .get("authentication")
-        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+    let authentication = match args.get("authentication") {
+        Some(v) => match serde_json::from_value::<OAuthConfig>(v.clone()) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Invalid authentication config: {}", e),
+                    ToolGroup::Tool,
+                )
+                .to_mcp_result())
+            }
+        },
+        None => None,
+    };
 
     let config = MCPServerConfig {
         name: Some(name.clone()),
@@ -345,9 +356,20 @@ pub async fn update_server(_server: &ToolServer, args: Value) -> Result<MCPResul
             version: None,
         });
 
-    let authentication = args
-        .get("authentication")
-        .and_then(|v| serde_json::from_value::<OAuthConfig>(v.clone()).ok());
+    let authentication = match args.get("authentication") {
+        Some(v) => match serde_json::from_value::<OAuthConfig>(v.clone()) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("Invalid authentication config: {}", e),
+                    ToolGroup::Tool,
+                )
+                .to_mcp_result())
+            }
+        },
+        None => None,
+    };
 
     let config = MCPServerConfig {
         name: Some(name.to_string()),

--- a/src-tauri/src/mcp/builtin/tool/tools.rs
+++ b/src-tauri/src/mcp/builtin/tool/tools.rs
@@ -2,6 +2,66 @@ use crate::mcp::builtin::tool_description::tool_description;
 use crate::mcp::types::MCPTool;
 use crate::mcp::utils::schema_builder::*;
 
+fn oauth_config_schema(description: Option<&str>) -> crate::mcp::schema::JSONSchema {
+    object_prop(
+        vec![
+            (
+                "type".to_string(),
+                string_const_prop("oauth2.1", Some("Authentication type (always 'oauth2.1')")),
+            ),
+            (
+                "discoveryUrl".to_string(),
+                string_prop(
+                    None,
+                    None,
+                    Some("RFC 8414 OAuth 2.0 Authorization Server Metadata discovery endpoint."),
+                ),
+            ),
+            (
+                "authorizationEndpoint".to_string(),
+                string_prop(None, None, Some("Authorization endpoint URL.")),
+            ),
+            (
+                "tokenEndpoint".to_string(),
+                string_prop(None, None, Some("Token endpoint URL.")),
+            ),
+            (
+                "registrationEndpoint".to_string(),
+                string_prop(None, None, Some("Client registration endpoint URL.")),
+            ),
+            (
+                "clientId".to_string(),
+                string_prop(None, None, Some("OAuth client ID.")),
+            ),
+            (
+                "redirectUri".to_string(),
+                string_prop(None, None, Some("OAuth redirect URI.")),
+            ),
+            (
+                "scopes".to_string(),
+                array_schema(
+                    string_prop(None, None, None),
+                    Some("List of OAuth scopes to request."),
+                ),
+            ),
+            (
+                "usePkce".to_string(),
+                boolean_prop(Some("Whether to use PKCE. Default is true.")),
+            ),
+            (
+                "resourceParameter".to_string(),
+                string_prop(
+                    None,
+                    None,
+                    Some("Resource parameter for target audience/endpoint."),
+                ),
+            ),
+        ],
+        vec!["type".to_string()],
+        description,
+    )
+}
+
 fn transport_config_schema(description: Option<&str>) -> crate::mcp::schema::JSONSchema {
     object_prop(
         vec![
@@ -71,6 +131,7 @@ fn transport_config_schema(description: Option<&str>) -> crate::mcp::schema::JSO
 /// Register a new MCP server configuration
 pub fn register_server_tool() -> MCPTool {
     let transport_schema = transport_config_schema(Some("Transport configuration"));
+    let oauth_schema = oauth_config_schema(Some("Optional OAuth 2.1 authentication configuration"));
 
     MCPTool {
         name: "registerServer".to_string(),
@@ -105,6 +166,7 @@ pub fn register_server_tool() -> MCPTool {
                     string_prop_required("Short purpose statement describing when this server should be used."),
                 ),
                 ("transport".to_string(), transport_schema),
+                ("authentication".to_string(), oauth_schema),
             ],
             vec!["name".to_string(), "description".to_string(), "transport".to_string()],
             None,
@@ -119,6 +181,8 @@ pub fn update_server_tool() -> MCPTool {
     let transport_schema = transport_config_schema(Some(
         "Replacement transport configuration. Set type to stdio (command, args, env) or http/http-sse (url, headers, enableSSE). Supply the full transport object for the target type.",
     ));
+    let oauth_schema =
+        oauth_config_schema(Some("Replacement OAuth 2.1 authentication configuration"));
 
     MCPTool {
         name: "updateServer".to_string(),
@@ -143,6 +207,7 @@ pub fn update_server_tool() -> MCPTool {
                     string_prop_required("Target server name (slug) to update"),
                 ),
                 ("transport".to_string(), transport_schema),
+                ("authentication".to_string(), oauth_schema),
                 (
                     "description".to_string(),
                     string_prop(

--- a/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
+++ b/src-tauri/src/mcp/builtin/workspace/test_output_visibility.rs
@@ -1,22 +1,53 @@
 #[cfg(test)]
 mod tests {
     use super::super::WorkspaceServer;
+    use crate::entity::settings;
     use crate::session::SessionManager;
+    use sea_orm::{ConnectionTrait, Database, Schema};
     use serde_json::json;
     use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::time::{sleep, Duration};
 
-    async fn create_server() -> WorkspaceServer {
+    struct WorkspaceTestHarness {
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+        server: WorkspaceServer,
+    }
+
+    async fn create_server() -> WorkspaceTestHarness {
+        let guard = crate::state::lock_test_global_state().await;
+        crate::state::reset_state();
+
         let temp_dir = tempdir().unwrap();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("Failed to create settings database");
+        let schema = Schema::new(db.get_database_backend());
+        let stmt = schema.create_table_from_entity(settings::Entity);
+        db.execute(db.get_database_backend().build(&stmt))
+            .await
+            .expect("Failed to create settings table");
+        crate::lifecycle::repositories::init_repositories(&db).await;
+        crate::state::init_session_bus(crate::agent::session_bus::SessionBus::new());
+        crate::state::init_concurrency_gate(crate::agent::concurrency::ConcurrencyGate::new(
+            crate::agent::concurrency::DEFAULT_MAX_ACTIVE_AGENTS,
+            crate::agent::concurrency::DEFAULT_MAX_SUSPENDED_AGENTS,
+            crate::agent::concurrency::DEFAULT_MAX_ACTIVE_PROCESSES,
+            crate::agent::concurrency::DEFAULT_MAX_SUSPENDED_PROCESSES,
+        ));
+
         let session_manager =
             Arc::new(SessionManager::new_with_base_dir(temp_dir.path().to_path_buf()).unwrap());
-        WorkspaceServer::new("test-session".to_string(), session_manager)
+        WorkspaceTestHarness {
+            _guard: guard,
+            server: WorkspaceServer::new("test-session".to_string(), session_manager),
+        }
     }
 
     #[tokio::test]
     async fn test_read_process_output_visibility() {
-        let server = create_server().await;
+        let harness = create_server().await;
+        let server = &harness.server;
 
         // Use handle_spawn_process directly
         let exec_args = json!({
@@ -81,7 +112,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_poll_process_tail_visibility() {
-        let server = create_server().await;
+        let harness = create_server().await;
+        let server = &harness.server;
 
         // Use handle_spawn_process directly
         let exec_args = json!({

--- a/src-tauri/src/mcp/integration_tests.rs
+++ b/src-tauri/src/mcp/integration_tests.rs
@@ -22,6 +22,21 @@ mod tests {
 
     static TEST_DB: OnceLock<Arc<DatabaseConnection>> = OnceLock::new();
 
+    fn test_session_active_model(id: impl Into<String>) -> session::ActiveModel {
+        session::ActiveModel {
+            id: Set(id.into()),
+            name: Set(None),
+            status: Set("idle".to_string()),
+            model: Set("gpt-4".to_string()),
+            provider: Set("openai".to_string()),
+            execution_mode: Set("normal".to_string()),
+            is_bookmarked: Set(false),
+            created_at: Set(0),
+            updated_at: Set(0),
+            ..Default::default()
+        }
+    }
+
     /// Helper to create or get the singleton test database connection
     async fn create_test_db() -> Arc<DatabaseConnection> {
         if let Some(db) = TEST_DB.get() {
@@ -112,8 +127,13 @@ mod tests {
         TEST_DB.get().expect("DB should be set").clone()
     }
 
+    async fn acquire_integration_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        state::lock_test_global_state().await
+    }
+
     #[tokio::test]
     async fn test_proxy_manager_lifecycle() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Create test dependencies
         let db = create_test_db().await;
         let session_manager = Arc::new(
@@ -133,7 +153,9 @@ mod tests {
 
         assert_eq!(proxy.session_id(), "test-session-1");
         assert_eq!(proxy.builtin_server_count(), 1);
-        assert!(proxy.builtin_tool_ids().contains(&"bootstrap".to_string()));
+        assert!(proxy
+            .builtin_tool_ids()
+            .contains(&"setup-wizard".to_string()));
 
         // Test 2: Get existing proxy
         let retrieved_proxy = proxy_manager
@@ -163,11 +185,11 @@ mod tests {
             _ => panic!("Expected ToolCall result"),
         }
 
-        // Test 4: Call getBootstrapGuide tool
+        // Test 4: Call getSetupGuide tool
         let result = proxy_manager
             .call_tool(
                 "test-session-1",
-                "bootstrap__getBootstrapGuide",
+                "setup-wizard__getSetupGuide",
                 json!({
                     "tool": "node",
                     "platform": "auto"
@@ -201,6 +223,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_isolation() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Create test dependencies
         let db = create_test_db().await;
         let session_manager = Arc::new(
@@ -266,6 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_tool_calls() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Create test dependencies
         let db = create_test_db().await;
         let session_manager = Arc::new(
@@ -293,7 +317,7 @@ mod tests {
             let tool = if i % 2 == 0 {
                 "bootstrap__detectPlatform"
             } else {
-                "bootstrap__getBootstrapGuide"
+                "setup-wizard__getSetupGuide"
             };
 
             let args = if i % 2 == 0 {
@@ -332,6 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_handling() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Create test dependencies
         let db = create_test_db().await;
         let session_manager = Arc::new(
@@ -372,19 +397,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_playbook_ui_rendering_integration() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Setup
         let db = create_test_db().await;
 
-        // Insert test session
-        let new_session = session::ActiveModel {
-            id: Set("playbook-ui-test".to_string()),
-            name: Set(Some("Test".to_string())),
-            status: Set("idle".to_string()),
-            assistant_id: Set(Some("asst-s1".to_string())),
-            created_at: Set(0),
-            updated_at: Set(0),
+        // Insert test session with an isolated assistant scope
+        let assistant_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().timestamp();
+        assistant::Entity::insert(assistant::ActiveModel {
+            id: Set(assistant_id.clone()),
+            name: Set("Playbook UI Test Assistant".to_string()),
+            config: Set("{}".to_string()),
+            created_at: Set(now),
+            updated_at: Set(now),
             ..Default::default()
-        };
+        })
+        .exec(db.as_ref())
+        .await
+        .expect("Failed to insert test assistant");
+
+        let mut new_session = test_session_active_model("playbook-ui-test");
+        new_session.name = Set(Some("Test".to_string()));
+        new_session.assistant_id = Set(Some(assistant_id));
         // Defensive cleanup
         let _ = session::Entity::delete_by_id("playbook-ui-test".to_string())
             .exec(db.as_ref())
@@ -481,7 +515,13 @@ mod tests {
 
             let html = resource["text"].as_str().unwrap();
             assert!(html.contains("<!DOCTYPE html>"));
-            assert!(html.contains("📚 Playbooks (2)"));
+
+            let structured = result.structured_content.expect("No structured content");
+            let total_items = structured["page"]["totalItems"]
+                .as_i64()
+                .expect("totalItems in structured content");
+            assert_eq!(total_items, 2);
+            assert!(html.contains(&format!("Playbooks ({total_items})")));
             assert!(html.contains("Data Processing Workflow"));
             assert!(html.contains("API Integration"));
             assert!(html.contains("btn-select"));
@@ -491,29 +531,20 @@ mod tests {
             panic!("Expected Resource content");
         }
 
-        // Verify structured content
-        let structured = result.structured_content.expect("No structured content");
-        assert_eq!(structured["page"]["totalItems"], 2);
-
         // Cleanup
         proxy_manager.destroy_proxy(&session_id).await;
     }
 
     #[tokio::test]
     async fn test_playbook_session_isolation_with_ui() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Setup
         let db = create_test_db().await;
 
         // Insert test sessions
-        let s1 = session::ActiveModel {
-            id: Set("session-ui-1".to_string()),
-            name: Set(Some("S1".to_string())),
-            status: Set("idle".to_string()),
-            assistant_id: Set(Some("asst-ui-test".to_string())),
-            created_at: Set(0),
-            updated_at: Set(0),
-            ..Default::default()
-        };
+        let mut s1 = test_session_active_model("session-ui-1");
+        s1.name = Set(Some("S1".to_string()));
+        s1.assistant_id = Set(Some("asst-ui-test".to_string()));
         // Defensive cleanup
         let _ = session::Entity::delete_by_id("session-ui-1".to_string())
             .exec(db.as_ref())
@@ -523,15 +554,9 @@ mod tests {
             .await
             .expect("Failed to insert session 1");
 
-        let s2 = session::ActiveModel {
-            id: Set("session-ui-2".to_string()),
-            name: Set(Some("S2".to_string())),
-            status: Set("idle".to_string()),
-            assistant_id: Set(Some("asst-s1".to_string())),
-            created_at: Set(0),
-            updated_at: Set(0),
-            ..Default::default()
-        };
+        let mut s2 = test_session_active_model("session-ui-2");
+        s2.name = Set(Some("S2".to_string()));
+        s2.assistant_id = Set(Some("asst-s1".to_string()));
         // Defensive cleanup
         let _ = session::Entity::delete_by_id("session-ui-2".to_string())
             .exec(db.as_ref())
@@ -659,6 +684,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_shell_workspace_path_resolution() {
+        let _integration_test_lock = acquire_integration_test_lock().await;
         // Create test dependencies
         let db = create_test_db().await;
         let session_manager = Arc::new(

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -3,14 +3,61 @@ use oauth2::reqwest::async_http_client;
 ///
 /// Implements RFC 7636 (PKCE), RFC 8414 (Discovery), and RFC 7591 (Dynamic Registration)
 use oauth2::{
-    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, CsrfToken, PkceCodeChallenge,
-    PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, TokenUrl,
+    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, TokenUrl,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::mcp::types::OAuthConfig;
+
+pub const DEFAULT_CALLBACK_PORT: u16 = 14207;
+pub const DEFAULT_CALLBACK_URL: &str = "http://localhost:14207/callback";
+
+fn is_private_or_local_host(host: &str) -> bool {
+    if host.is_empty() || host == "localhost" || host == "127.0.0.1" {
+        return true;
+    }
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return ip.is_loopback()
+            || ip.is_unspecified()
+            || ip.is_multicast()
+            || match ip {
+                std::net::IpAddr::V4(ipv4) => ipv4.is_private() || ipv4.is_link_local(),
+                std::net::IpAddr::V6(ipv6) => {
+                    let octets = ipv6.octets();
+                    let first = octets[0];
+                    // ULA (fc00::/7) or link-local unicast (fe80::/10)
+                    first == 0xfc
+                        || first == 0xfd
+                        || (first == 0xfe && (octets[1] & 0xc0) == 0x80)
+                }
+            };
+    }
+
+    false
+}
+
+/// Rejects non-HTTPS OAuth endpoints and hosts on private/local networks.
+fn validate_oauth_https_endpoint(url_str: &str, label: &str) -> Result<(), String> {
+    let parsed =
+        url::Url::parse(url_str).map_err(|e| format!("Invalid {label} URL: {e}"))?;
+
+    if parsed.scheme() != "https" {
+        return Err(format!("{label} must use HTTPS scheme for security"));
+    }
+
+    let host = parsed.host_str().unwrap_or("");
+    if is_private_or_local_host(host) {
+        return Err(format!(
+            "Security violation: Local/private {label} is not allowed"
+        ));
+    }
+
+    Ok(())
+}
 
 /// Manages OAuth 2.1 flows for MCP servers
 #[derive(Debug)]
@@ -63,35 +110,11 @@ impl OAuthManager {
         log::info!("Starting OAuth flow for server: {server_id}");
 
         // Step 1: Discover or use configured endpoints
-        let endpoints = if let Some(discovery_url) = &config.discovery_url {
-            log::debug!("Using RFC 8414 discovery: {discovery_url}");
-            self.discover_endpoints(discovery_url).await?
-        } else {
-            // Use fallback endpoints from config
-            OAuthEndpoints {
-                authorization_endpoint: config
-                    .authorization_endpoint
-                    .clone()
-                    .ok_or("Missing authorization_endpoint")?,
-                token_endpoint: config
-                    .token_endpoint
-                    .clone()
-                    .ok_or("Missing token_endpoint")?,
-            }
-        };
+        let endpoints = self.resolve_endpoints(config).await?;
 
         log::debug!("OAuth endpoints: {endpoints:?}");
 
-        // Step 2: Create PKCE challenge
-        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
-
-        // Store verifier for later use in token exchange
-        {
-            let mut verifiers = self.pkce_verifiers.lock().await;
-            verifiers.insert(server_id.to_string(), pkce_verifier);
-        }
-
-        // Step 3: Build OAuth client
+        // Step 2: Build OAuth client
         let client_id = config
             .client_id
             .clone()
@@ -100,11 +123,13 @@ impl OAuthManager {
         let redirect_uri = config
             .redirect_uri
             .clone()
-            .unwrap_or_else(|| "libr-agent://oauth/callback".to_string());
+            .unwrap_or_else(|| DEFAULT_CALLBACK_URL.to_string());
+
+        let client_secret = config.client_secret.clone().map(ClientSecret::new);
 
         let client = BasicClient::new(
             ClientId::new(client_id),
-            None, // Client secret not used with PKCE
+            client_secret,
             AuthUrl::new(endpoints.authorization_endpoint)
                 .map_err(|e| format!("Invalid authorization URL: {e}"))?,
             Some(
@@ -116,10 +141,17 @@ impl OAuthManager {
             RedirectUrl::new(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?,
         );
 
-        // Step 4: Generate authorization URL with PKCE
-        let mut auth_request = client
-            .authorize_url(CsrfToken::new_random)
-            .set_pkce_challenge(pkce_challenge);
+        // Step 3: Generate authorization URL
+        let mut auth_request = client.authorize_url(CsrfToken::new_random);
+
+        if config.use_pkce {
+            let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+            {
+                let mut verifiers = self.pkce_verifiers.lock().await;
+                verifiers.insert(server_id.to_string(), pkce_verifier);
+            }
+            auth_request = auth_request.set_pkce_challenge(pkce_challenge);
+        }
 
         // Add scopes if configured
         if let Some(scopes) = &config.scopes {
@@ -171,31 +203,10 @@ impl OAuthManager {
             }
         }
 
-        // Step 2: Retrieve PKCE verifier
-        let verifier = {
-            let mut verifiers = self.pkce_verifiers.lock().await;
-            verifiers
-                .remove(server_id)
-                .ok_or("No PKCE verifier found for server")?
-        };
+        // Step 2: Get endpoints
+        let endpoints = self.resolve_endpoints(config).await?;
 
-        // Step 3: Get endpoints
-        let endpoints = if let Some(discovery_url) = &config.discovery_url {
-            self.discover_endpoints(discovery_url).await?
-        } else {
-            OAuthEndpoints {
-                authorization_endpoint: config
-                    .authorization_endpoint
-                    .clone()
-                    .ok_or("Missing authorization_endpoint")?,
-                token_endpoint: config
-                    .token_endpoint
-                    .clone()
-                    .ok_or("Missing token_endpoint")?,
-            }
-        };
-
-        // Step 4: Build client and exchange code
+        // Step 3: Build client and exchange code
         let client_id = config
             .client_id
             .clone()
@@ -204,11 +215,13 @@ impl OAuthManager {
         let redirect_uri = config
             .redirect_uri
             .clone()
-            .unwrap_or_else(|| "libr-agent://oauth/callback".to_string());
+            .unwrap_or_else(|| DEFAULT_CALLBACK_URL.to_string());
+
+        let client_secret = config.client_secret.clone().map(ClientSecret::new);
 
         let client = BasicClient::new(
             ClientId::new(client_id),
-            None,
+            client_secret,
             AuthUrl::new(endpoints.authorization_endpoint)
                 .map_err(|e| format!("Invalid authorization URL: {e}"))?,
             Some(
@@ -220,9 +233,21 @@ impl OAuthManager {
             RedirectUrl::new(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?,
         );
 
-        let token_result = client
-            .exchange_code(AuthorizationCode::new(authorization_code.to_string()))
-            .set_pkce_verifier(verifier)
+        let mut exchange =
+            client.exchange_code(AuthorizationCode::new(authorization_code.to_string()));
+
+        if config.use_pkce {
+            // Retrieve PKCE verifier
+            let verifier = {
+                let mut verifiers = self.pkce_verifiers.lock().await;
+                verifiers
+                    .remove(server_id)
+                    .ok_or("No PKCE verifier found for server")?
+            };
+            exchange = exchange.set_pkce_verifier(verifier);
+        }
+
+        let token_result = exchange
             .request_async(async_http_client)
             .await
             .map_err(|e| format!("Token exchange failed: {e}"))?;
@@ -231,6 +256,28 @@ impl OAuthManager {
 
         log::info!("Successfully obtained access token for {server_id}");
         Ok(access_token)
+    }
+
+    async fn resolve_endpoints(&self, config: &OAuthConfig) -> Result<OAuthEndpoints, String> {
+        if let Some(discovery_url) = &config.discovery_url {
+            log::debug!("Using RFC 8414 discovery: {discovery_url}");
+            self.discover_endpoints(discovery_url).await
+        } else {
+            let authorization_endpoint = config
+                .authorization_endpoint
+                .clone()
+                .ok_or("Missing authorization_endpoint")?;
+            let token_endpoint = config
+                .token_endpoint
+                .clone()
+                .ok_or("Missing token_endpoint")?;
+            validate_oauth_https_endpoint(&authorization_endpoint, "authorization endpoint")?;
+            validate_oauth_https_endpoint(&token_endpoint, "token endpoint")?;
+            Ok(OAuthEndpoints {
+                authorization_endpoint,
+                token_endpoint,
+            })
+        }
     }
 
     /// Discovers OAuth endpoints using RFC 8414
@@ -242,6 +289,8 @@ impl OAuthManager {
     /// The discovered OAuth endpoints
     async fn discover_endpoints(&self, discovery_url: &str) -> Result<OAuthEndpoints, String> {
         log::debug!("Discovering OAuth endpoints from: {discovery_url}");
+
+        validate_oauth_https_endpoint(discovery_url, "discovery URL")?;
 
         let client = reqwest::Client::new();
         let metadata: AuthServerMetadata = client
@@ -255,6 +304,12 @@ impl OAuthManager {
 
         log::debug!("Discovered endpoints: {metadata:?}");
 
+        validate_oauth_https_endpoint(
+            &metadata.authorization_endpoint,
+            "authorization endpoint",
+        )?;
+        validate_oauth_https_endpoint(&metadata.token_endpoint, "token endpoint")?;
+
         Ok(OAuthEndpoints {
             authorization_endpoint: metadata.authorization_endpoint,
             token_endpoint: metadata.token_endpoint,
@@ -263,12 +318,12 @@ impl OAuthManager {
 
     /// Parses port from a redirect URI string.
     /// E.g. "http://localhost:14207/callback" -> 14207
-    /// Defaults to 14207 if parsing fails.
+    /// Defaults to DEFAULT_CALLBACK_PORT if parsing fails.
     fn parse_port_from_uri(uri_str: &str) -> u16 {
         if let Ok(u) = url::Url::parse(uri_str) {
-            u.port().unwrap_or(14207)
+            u.port().unwrap_or(DEFAULT_CALLBACK_PORT)
         } else {
-            14207
+            DEFAULT_CALLBACK_PORT
         }
     }
 
@@ -318,31 +373,39 @@ impl OAuthManager {
 
                                                 if let (Some(code), Some(state)) = (code, state) {
                                                     if state == expected_state {
-                                                        // Send success HTML page response
-                                                        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\
-                                                            <html>\
-                                                            <head>\
-                                                                <title>LibrAgent - Authentication Successful</title>\
-                                                                <style>\
-                                                                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
-                                                                    .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
-                                                                    h1 { color: #2ea043; margin-top: 0; }\
-                                                                    p { color: #8b949e; line-height: 1.5; }\
-                                                                </style>\
-                                                            </head>\
-                                                            <body>\
-                                                                <div class='card'>\
-                                                                    <h1>✓ Authentication Successful</h1>\
-                                                                    <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
-                                                                </div>\
-                                                            </body>\
-                                                            </html>";
-                                                        let _ = stream.write_all(response.as_bytes()).await;
-                                                        let _ = stream.flush().await;
-                                                        return Ok(code.clone());
-                                                    } else {
-                                                        log::warn!("OAuth state mismatch. Expected {}, got {:?}", expected_state, state);
-                                                    }
+                                                         // Send success HTML page response
+                                                         let html = "<html>\
+                                                             <head>\
+                                                                 <title>LibrAgent - Authentication Successful</title>\
+                                                                 <style>\
+                                                                     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
+                                                                     .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
+                                                                     h1 { color: #2ea043; margin-top: 0; }\
+                                                                     p { color: #8b949e; line-height: 1.5; }\
+                                                                 </style>\
+                                                             </head>\
+                                                             <body>\
+                                                                 <div class='card'>\
+                                                                     <h1>✓ Authentication Successful</h1>\
+                                                                     <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
+                                                                 </div>\
+                                                             </body>\
+                                                             </html>";
+                                                         let response = format!(
+                                                             "HTTP/1.1 200 OK\r\n\
+                                                             Content-Type: text/html; charset=utf-8\r\n\
+                                                             Content-Length: {}\r\n\
+                                                             Connection: close\r\n\r\n\
+                                                             {}",
+                                                             html.len(),
+                                                             html
+                                                         );
+                                                         let _ = stream.write_all(response.as_bytes()).await;
+                                                         let _ = stream.flush().await;
+                                                         return Ok(code.clone());
+                                                     } else {
+                                                         log::warn!("OAuth state mismatch detected during callback processing");
+                                                     }
                                                 }
                                             }
                                         }
@@ -386,6 +449,30 @@ mod tests {
         assert!(manager.csrf_tokens.lock().await.is_empty());
     }
 
+    #[test]
+    fn validate_oauth_https_endpoint_rejects_private_hosts() {
+        assert!(validate_oauth_https_endpoint(
+            "http://auth.example.com/authorize",
+            "authorization endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://127.0.0.1/authorize",
+            "authorization endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://169.254.169.254/token",
+            "token endpoint"
+        )
+        .is_err());
+        assert!(validate_oauth_https_endpoint(
+            "https://auth.example.com/authorize",
+            "authorization endpoint"
+        )
+        .is_ok());
+    }
+
     #[tokio::test]
     async fn test_start_authorization_flow() {
         let manager = OAuthManager::new();
@@ -396,6 +483,7 @@ mod tests {
             token_endpoint: Some("https://auth.example.com/token".to_string()),
             registration_endpoint: None,
             client_id: Some("test-client".to_string()),
+            client_secret: None,
             redirect_uri: Some("libr-agent://oauth/callback".to_string()),
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             use_pkce: true,

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -260,6 +260,113 @@ impl OAuthManager {
             token_endpoint: metadata.token_endpoint,
         })
     }
+
+    /// Parses port from a redirect URI string.
+    /// E.g. "http://localhost:14207/callback" -> 14207
+    /// Defaults to 14207 if parsing fails.
+    fn parse_port_from_uri(uri_str: &str) -> u16 {
+        if let Ok(u) = url::Url::parse(uri_str) {
+            u.port().unwrap_or(14207)
+        } else {
+            14207
+        }
+    }
+
+    /// Starts a temporary localhost listener to wait for the OAuth authorization code.
+    /// This runs asynchronously and times out after 2 minutes.
+    pub async fn wait_for_callback(
+        &self,
+        redirect_uri: &str,
+        expected_state: &str,
+    ) -> Result<String, String> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let port = Self::parse_port_from_uri(redirect_uri);
+        log::info!("Starting temporary OAuth callback listener on port {port}");
+
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+            .await
+            .map_err(|e| format!("Failed to bind OAuth listener to port {port}: {e}"))?;
+
+        let timeout_dur = std::time::Duration::from_secs(120);
+        let timeout = tokio::time::sleep(timeout_dur);
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                accept_res = listener.accept() => {
+                    match accept_res {
+                        Ok((mut stream, _)) => {
+                            let mut buffer = [0; 1024];
+                            match stream.read(&mut buffer).await {
+                                Ok(n) if n > 0 => {
+                                    let request = String::from_utf8_lossy(&buffer[..n]);
+                                    if request.starts_with("GET ") {
+                                        let first_line = request.lines().next().unwrap_or("");
+                                        let parts: Vec<&str> = first_line.split_whitespace().collect();
+                                        if parts.len() >= 2 {
+                                            let path = parts[1];
+                                            if let Some(query_start) = path.find('?') {
+                                                let query = &path[query_start + 1..];
+                                                let params: HashMap<String, String> = url::form_urlencoded::parse(query.as_bytes())
+                                                    .into_owned()
+                                                    .collect();
+
+                                                let code = params.get("code");
+                                                let state = params.get("state");
+
+                                                if let (Some(code), Some(state)) = (code, state) {
+                                                    if state == expected_state {
+                                                        // Send success HTML page response
+                                                        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\
+                                                            <html>\
+                                                            <head>\
+                                                                <title>LibrAgent - Authentication Successful</title>\
+                                                                <style>\
+                                                                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; text-align: center; padding-top: 100px; background-color: #0d1117; color: #c9d1d9; }\
+                                                                    .card { background: #161b22; padding: 40px; border-radius: 12px; border: 1px solid #30363d; display: inline-block; max-width: 400px; box-shadow: 0 4px 20px rgba(0,0,0,0.3); }\
+                                                                    h1 { color: #2ea043; margin-top: 0; }\
+                                                                    p { color: #8b949e; line-height: 1.5; }\
+                                                                </style>\
+                                                            </head>\
+                                                            <body>\
+                                                                <div class='card'>\
+                                                                    <h1>✓ Authentication Successful</h1>\
+                                                                    <p>LibrAgent has been authorized successfully. You can now close this browser tab and return to the application.</p>\
+                                                                </div>\
+                                                            </body>\
+                                                            </html>";
+                                                        let _ = stream.write_all(response.as_bytes()).await;
+                                                        let _ = stream.flush().await;
+                                                        return Ok(code.clone());
+                                                    } else {
+                                                        log::warn!("OAuth state mismatch. Expected {}, got {:?}", expected_state, state);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Invalid request fall-through
+                                    let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\nConnection: close\r\n\r\nFailed to authenticate. State mismatch or missing code.";
+                                    let _ = stream.write_all(response.as_bytes()).await;
+                                    let _ = stream.flush().await;
+                                }
+                                _ => {}
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Error accepting connection in OAuth callback listener: {e}");
+                        }
+                    }
+                }
+                _ = &mut timeout => {
+                    return Err("OAuth authorization timed out after 2 minutes".to_string());
+                }
+            }
+        }
+    }
 }
 
 impl Default for OAuthManager {

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -30,9 +30,7 @@ fn is_private_or_local_host(host: &str) -> bool {
                     let octets = ipv6.octets();
                     let first = octets[0];
                     // ULA (fc00::/7) or link-local unicast (fe80::/10)
-                    first == 0xfc
-                        || first == 0xfd
-                        || (first == 0xfe && (octets[1] & 0xc0) == 0x80)
+                    first == 0xfc || first == 0xfd || (first == 0xfe && (octets[1] & 0xc0) == 0x80)
                 }
             };
     }
@@ -42,8 +40,7 @@ fn is_private_or_local_host(host: &str) -> bool {
 
 /// Rejects non-HTTPS OAuth endpoints and hosts on private/local networks.
 fn validate_oauth_https_endpoint(url_str: &str, label: &str) -> Result<(), String> {
-    let parsed =
-        url::Url::parse(url_str).map_err(|e| format!("Invalid {label} URL: {e}"))?;
+    let parsed = url::Url::parse(url_str).map_err(|e| format!("Invalid {label} URL: {e}"))?;
 
     if parsed.scheme() != "https" {
         return Err(format!("{label} must use HTTPS scheme for security"));
@@ -304,10 +301,7 @@ impl OAuthManager {
 
         log::debug!("Discovered endpoints: {metadata:?}");
 
-        validate_oauth_https_endpoint(
-            &metadata.authorization_endpoint,
-            "authorization endpoint",
-        )?;
+        validate_oauth_https_endpoint(&metadata.authorization_endpoint, "authorization endpoint")?;
         validate_oauth_https_endpoint(&metadata.token_endpoint, "token endpoint")?;
 
         Ok(OAuthEndpoints {
@@ -461,11 +455,10 @@ mod tests {
             "authorization endpoint"
         )
         .is_err());
-        assert!(validate_oauth_https_endpoint(
-            "https://169.254.169.254/token",
-            "token endpoint"
-        )
-        .is_err());
+        assert!(
+            validate_oauth_https_endpoint("https://169.254.169.254/token", "token endpoint")
+                .is_err()
+        );
         assert!(validate_oauth_https_endpoint(
             "https://auth.example.com/authorize",
             "authorization endpoint"

--- a/src-tauri/src/mcp/server/lifecycle.rs
+++ b/src-tauri/src/mcp/server/lifecycle.rs
@@ -1,5 +1,6 @@
 use super::MCPServerManager;
 use crate::mcp::types::{MCPConnection, MCPServerConfig, TransportConfig};
+use crate::repositories::mcp_server_repository::MCPServerRepository;
 use anyhow::Result;
 use log::{debug, error, info};
 use rmcp::{
@@ -147,6 +148,28 @@ async fn start_http_server(
             } else {
                 error!("Invalid header ignored: {}: {}", k, v);
             }
+        }
+    }
+
+    // Attempt to load OAuth token from OS keychain
+    let mut oauth_token = None;
+    // Step 1: Check using server name (slug)
+    if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
+        oauth_token = Some(tok);
+    } else {
+        // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
+        let repo = crate::state::get_mcp_server_repository();
+        if let Ok(Some(model)) = repo.get_by_name(&name).await {
+            if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
+                oauth_token = Some(tok);
+            }
+        }
+    }
+
+    if let Some(token) = oauth_token {
+        if let Ok(auth_val) = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
+            header_map.insert(reqwest::header::AUTHORIZATION, auth_val);
+            log::info!("Injected OAuth Bearer token for HTTP MCP server '{}'", name);
         }
     }
 

--- a/src-tauri/src/mcp/server/lifecycle.rs
+++ b/src-tauri/src/mcp/server/lifecycle.rs
@@ -151,17 +151,19 @@ async fn start_http_server(
         }
     }
 
-    // Attempt to load OAuth token from OS keychain
+    // Attempt to load OAuth token from OS keychain if authentication is configured
     let mut oauth_token = None;
-    // Step 1: Check using server name (slug)
-    if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
-        oauth_token = Some(tok);
-    } else {
-        // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
-        let repo = crate::state::get_mcp_server_repository();
-        if let Ok(Some(model)) = repo.get_by_name(&name).await {
-            if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
-                oauth_token = Some(tok);
+    if config.authentication.is_some() {
+        // Step 1: Check using server name (slug)
+        if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&name).await {
+            oauth_token = Some(tok);
+        } else {
+            // Step 2: Fallback to DB query to retrieve UUID, then check keychain using UUID
+            let repo = crate::state::get_mcp_server_repository();
+            if let Ok(Some(model)) = repo.get_by_name(&name).await {
+                if let Ok(Some(tok)) = crate::mcp::keychain::get_cached_token(&model.id).await {
+                    oauth_token = Some(tok);
+                }
             }
         }
     }

--- a/src-tauri/src/mcp/service_proxy/mod.rs
+++ b/src-tauri/src/mcp/service_proxy/mod.rs
@@ -9,6 +9,7 @@ use super::builtin::BuiltinMCPServer;
 use super::error_normalization::{external_tool_error_result, ExternalMcpErrorCategory};
 use super::session_isolation::{HttpSessionManager, SessionMCPManager};
 use super::types::{ContextVolatility, MCPResponse, MCPTool, ServiceContext};
+use crate::mcp::builtin::service_id::BuiltinServiceId;
 use crate::session::SessionManager;
 
 pub mod builder;
@@ -148,7 +149,10 @@ impl MCPServiceProxy {
             )
             .await?
             {
-                builtin_servers.insert(tool_id.to_string(), server);
+                let storage_key = BuiltinServiceId::from_alias(tool_id)
+                    .map(|service_id| service_id.name().to_string())
+                    .unwrap_or_else(|| tool_id.to_string());
+                builtin_servers.insert(storage_key, server);
                 log::debug!(
                     "Initialized builtin server '{}' for session '{}'",
                     tool_id,

--- a/src-tauri/src/mcp/service_proxy_manager/management.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/management.rs
@@ -362,3 +362,12 @@ impl MCPServiceProxyManager {
             .map_err(|error| error.to_string())
     }
 }
+
+#[cfg(test)]
+impl MCPServiceProxyManager {
+    pub(crate) async fn mark_runtime_proxy_not_ready_for_test(&self, session_id: &str) {
+        let mut state = self.get_runtime_state(session_id).await;
+        state.proxy.ready = false;
+        self.set_runtime_state(session_id, state, None).await;
+    }
+}

--- a/src-tauri/src/mcp/service_proxy_manager/tests.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/tests.rs
@@ -1,79 +1,111 @@
 use super::*;
 use crate::entity::{
-    assistant, knowledge, planning_goal, planning_scratchpad, planning_todo, playbook, session,
+    assistant, knowledge, mcp_server, planning_goal, planning_scratchpad, planning_todo, playbook,
+    session,
 };
 use sea_orm::{ConnectionTrait, Database, EntityTrait, Schema, Set};
 use serde_json::json;
+use std::sync::Arc;
 
-async fn create_test_manager() -> Arc<MCPServiceProxyManager> {
+struct TestHarness {
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+    manager: Arc<MCPServiceProxyManager>,
+}
+
+fn test_session_active_model(id: impl Into<String>) -> session::ActiveModel {
+    session::ActiveModel {
+        id: Set(id.into()),
+        created_at: Set(chrono::Utc::now().timestamp()),
+        updated_at: Set(0),
+        status: Set("idle".to_string()),
+        model: Set("gpt-4".to_string()),
+        provider: Set("openai".to_string()),
+        execution_mode: Set("normal".to_string()),
+        is_bookmarked: Set(false),
+        ..Default::default()
+    }
+}
+
+async fn insert_test_session(manager: &MCPServiceProxyManager, session_id: &str) {
+    let assistant_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().timestamp();
+
+    assistant::Entity::insert(assistant::ActiveModel {
+        id: Set(assistant_id.clone()),
+        name: Set(format!("Test Assistant for {session_id}")),
+        config: Set("{}".to_string()),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    })
+    .exec(&*manager.db)
+    .await
+    .expect("failed to insert test assistant");
+
+    let mut model = test_session_active_model(session_id);
+    model.assistant_id = Set(Some(assistant_id));
+
+    session::Entity::insert(model)
+        .exec(&*manager.db)
+        .await
+        .expect("failed to insert test session");
+}
+
+async fn create_test_harness() -> TestHarness {
+    let guard = crate::state::lock_test_global_state().await;
+    crate::state::reset_state();
+
     let db = Database::connect("sqlite::memory:")
         .await
         .expect("Failed to connect to in-memory database");
 
     let schema = Schema::new(db.get_database_backend());
 
-    // Create tables
-    let stmt = schema.create_table_from_entity(session::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create session table");
+    for create in [
+        schema.create_table_from_entity(session::Entity),
+        schema.create_table_from_entity(playbook::Entity),
+        schema.create_table_from_entity(assistant::Entity),
+        schema.create_table_from_entity(knowledge::Entity),
+        schema.create_table_from_entity(planning_goal::Entity),
+        schema.create_table_from_entity(planning_todo::Entity),
+        schema.create_table_from_entity(planning_scratchpad::Entity),
+        schema.create_table_from_entity(crate::entity::settings::Entity),
+        schema.create_table_from_entity(mcp_server::Entity),
+    ] {
+        db.execute(db.get_database_backend().build(&create))
+            .await
+            .expect("Failed to create test table");
+    }
 
-    let stmt = schema.create_table_from_entity(playbook::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create playbook table");
-
-    let stmt = schema.create_table_from_entity(assistant::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create assistant table");
-
-    let stmt = schema.create_table_from_entity(knowledge::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create knowledge table");
-
-    let stmt = schema.create_table_from_entity(planning_goal::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create planning_goal table");
-
-    let stmt = schema.create_table_from_entity(planning_todo::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create planning_todo table");
-
-    let stmt = schema.create_table_from_entity(planning_scratchpad::Entity);
-    db.execute(db.get_database_backend().build(&stmt))
-        .await
-        .expect("Failed to create planning_scratchpad table");
+    crate::lifecycle::repositories::init_repositories(&db).await;
+    crate::state::init_session_bus(crate::agent::session_bus::SessionBus::new());
+    crate::state::init_concurrency_gate(crate::agent::concurrency::ConcurrencyGate::new(
+        crate::agent::concurrency::DEFAULT_MAX_ACTIVE_AGENTS,
+        crate::agent::concurrency::DEFAULT_MAX_SUSPENDED_AGENTS,
+        crate::agent::concurrency::DEFAULT_MAX_ACTIVE_PROCESSES,
+        crate::agent::concurrency::DEFAULT_MAX_SUSPENDED_PROCESSES,
+    ));
 
     // Create a minimal SessionManager
     let session_manager = Arc::new(crate::session::SessionManager::new().unwrap());
 
-    Arc::new(MCPServiceProxyManager::new(Arc::new(db), session_manager))
+    TestHarness {
+        _guard: guard,
+        manager: Arc::new(MCPServiceProxyManager::new(Arc::new(db), session_manager)),
+    }
 }
 
 #[tokio::test]
 async fn test_phase3_playbook_and_assistant_integration() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
 
     // Create session 1 with all Phase 3 tools
     let session1 = "test-session-1".to_string();
-    let tool_ids1 = vec!["playbook".to_string(), "assistant".to_string()];
+    let tool_ids1 = vec!["playbook".to_string(), "agent".to_string()];
 
     // Insert session 1 into sessions table
-    let new_session = session::ActiveModel {
-        id: Set(session1.clone()),
-        created_at: Set(chrono::Utc::now().timestamp()),
-        updated_at: Set(0),
-        status: Set("idle".to_string()),
-        ..Default::default()
-    };
-    session::Entity::insert(new_session)
-        .exec(&*manager.db)
-        .await
-        .unwrap();
+    insert_test_session(&manager, &session1).await;
 
     manager
         .create_proxy(session1.clone(), tool_ids1, vec![], None)
@@ -112,7 +144,7 @@ async fn test_phase3_playbook_and_assistant_integration() {
     let assistant_result = manager
         .call_tool(
             &session1,
-            "assistant__createAssistant",
+            "agent__createAssistant",
             json!({
                 "id": "assistant1",
                 "name": "Test Assistant",
@@ -129,23 +161,26 @@ async fn test_phase3_playbook_and_assistant_integration() {
         assistant_result.error.is_none(),
         "Assistant create should succeed"
     );
+    let created_assistant_id = assistant_result
+        .result
+        .as_ref()
+        .and_then(|result| match result {
+            crate::mcp::types::MCPResponseResult::ToolCall(tool_result) => tool_result
+                .structured_content
+                .as_ref()
+                .and_then(|data| data.get("id"))
+                .and_then(|id| id.as_str())
+                .map(str::to_string),
+            _ => None,
+        })
+        .expect("createAssistant should return structured assistant id");
 
     // Create session 2 with same tools
     let session2 = "test-session-2".to_string();
-    let tool_ids2 = vec!["playbook".to_string(), "assistant".to_string()];
+    let tool_ids2 = vec!["playbook".to_string(), "agent".to_string()];
 
     // Insert session 2 into sessions table
-    let new_session = session::ActiveModel {
-        id: Set(session2.clone()),
-        created_at: Set(chrono::Utc::now().timestamp()),
-        updated_at: Set(0),
-        status: Set("idle".to_string()),
-        ..Default::default()
-    };
-    session::Entity::insert(new_session)
-        .exec(&*manager.db)
-        .await
-        .unwrap();
+    insert_test_session(&manager, &session2).await;
 
     manager
         .create_proxy(session2.clone(), tool_ids2, vec![], None)
@@ -186,9 +221,9 @@ async fn test_phase3_playbook_and_assistant_integration() {
     let get_assistant_result = manager
         .call_tool(
             &session2,
-            "assistant__getAssistant",
+            "agent__getAssistant",
             json!({
-                "id": "assistant1"
+                "id": created_assistant_id
             }),
         )
         .await
@@ -301,7 +336,8 @@ async fn test_phase3_playbook_and_assistant_integration() {
 
 #[tokio::test]
 async fn test_phase3_concurrent_operations() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
 
     // Create 3 concurrent sessions
     let sessions = vec![
@@ -312,20 +348,9 @@ async fn test_phase3_concurrent_operations() {
 
     // Insert sessions into database and create proxies
     for session_id in &sessions {
-        let new_session = session::ActiveModel {
-            id: Set(session_id.clone()),
-            model: Set("test_model".to_string()),
-            created_at: Set(chrono::Utc::now().timestamp()),
-            updated_at: Set(0),
-            status: Set("idle".to_string()),
-            ..Default::default()
-        };
-        session::Entity::insert(new_session)
-            .exec(&*manager.db)
-            .await
-            .unwrap();
+        insert_test_session(&manager, session_id).await;
 
-        let tool_ids = vec!["playbook".to_string(), "assistant".to_string()];
+        let tool_ids = vec!["playbook".to_string(), "agent".to_string()];
         manager
             .create_proxy(session_id.clone(), tool_ids, vec![], None)
             .await
@@ -412,33 +437,20 @@ async fn test_phase3_concurrent_operations() {
 
 #[tokio::test]
 async fn test_phase3_all_servers_integration() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
 
     let session_id = "integration-test".to_string();
 
-    // Insert session into database
-    use crate::entity::session;
-    use sea_orm::Set;
-
-    let new_session = session::ActiveModel {
-        id: Set(session_id.clone()),
-        created_at: Set(chrono::Utc::now().timestamp()),
-        updated_at: Set(0),
-        status: Set("idle".to_string()),
-        ..Default::default()
-    };
-    session::Entity::insert(new_session)
-        .exec(&*manager.db)
-        .await
-        .unwrap();
+    insert_test_session(&manager, &session_id).await;
 
     // Create proxy with ALL builtin servers
     let all_tools = vec![
         "bootstrap".to_string(),
-        "knowledge".to_string(),
+        "attachments".to_string(),
         "planning".to_string(),
         "playbook".to_string(),
-        "assistant".to_string(),
+        "agent".to_string(),
     ];
 
     manager
@@ -448,7 +460,7 @@ async fn test_phase3_all_servers_integration() {
 
     // Test Bootstrap (stateless)
     let bootstrap_result = manager
-        .call_tool(&session_id, "bootstrap__detectPlatform", json!({}))
+        .call_tool(&session_id, "setup-wizard__detectPlatform", json!({}))
         .await
         .unwrap();
     assert!(bootstrap_result.error.is_none(), "Bootstrap should work");
@@ -512,7 +524,7 @@ async fn test_phase3_all_servers_integration() {
     let assistant_result = manager
         .call_tool(
             &session_id,
-            "assistant__createAssistant",
+            "agent__createAssistant",
             json!({
                 "id": "integration-assistant",
                 "name": "Integration Test Assistant",
@@ -542,25 +554,12 @@ async fn test_phase3_all_servers_integration() {
 
 #[tokio::test]
 async fn test_empty_mcp_server_ids_means_no_external_servers() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
 
     let session_id = "no-external-test".to_string();
 
-    // Insert session into database
-    use crate::entity::session;
-    use sea_orm::Set;
-
-    let new_session = session::ActiveModel {
-        id: Set(session_id.clone()),
-        created_at: Set(chrono::Utc::now().timestamp()),
-        updated_at: Set(0),
-        status: Set("idle".to_string()),
-        ..Default::default()
-    };
-    session::Entity::insert(new_session)
-        .exec(&*manager.db)
-        .await
-        .unwrap();
+    insert_test_session(&manager, &session_id).await;
 
     // Create proxy with builtin tools but EMPTY mcp_server_ids
     // This should result in NO external MCP servers being loaded
@@ -610,26 +609,17 @@ async fn test_empty_mcp_server_ids_means_no_external_servers() {
 /// The method should treat that as ready and return `Ok(())` without blocking.
 #[tokio::test]
 async fn test_proxy_ready_immediately_for_builtin_only_sessions() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
     let session_id = "readiness-builtin-only";
 
-    let new_session = session::ActiveModel {
-        id: Set(session_id.to_string()),
-        created_at: Set(chrono::Utc::now().timestamp()),
-        updated_at: Set(0),
-        status: Set("idle".to_string()),
-        ..Default::default()
-    };
-    session::Entity::insert(new_session)
-        .exec(&*manager.db)
-        .await
-        .unwrap();
+    insert_test_session(&manager, session_id).await;
 
     // No external MCP server IDs → background task is never spawned.
     manager
         .create_proxy(
             session_id.to_string(),
-            vec!["bootstrap".to_string()],
+            vec!["setup-wizard".to_string()],
             vec![],
             None,
         )
@@ -670,7 +660,8 @@ async fn test_proxy_ready_immediately_for_builtin_only_sessions() {
 /// MCP managers.
 #[tokio::test]
 async fn test_wait_fails_when_proxy_does_not_exist() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
     let session_id = "readiness-missing-proxy";
 
     let result = tokio::time::timeout(
@@ -698,8 +689,23 @@ async fn test_wait_fails_when_proxy_does_not_exist() {
 /// completes before proceeding.
 #[tokio::test]
 async fn test_wait_blocks_until_ready_signal_fires() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
     let session_id = "readiness-signal-test";
+
+    insert_test_session(&manager, session_id).await;
+    manager
+        .create_proxy(
+            session_id.to_string(),
+            vec!["playbook".to_string()],
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
+    manager
+        .mark_runtime_proxy_not_ready_for_test(session_id)
+        .await;
 
     // Inject a pending (false) entry simulating a session with external servers
     // whose background loading has not finished yet.
@@ -739,8 +745,23 @@ async fn test_wait_blocks_until_ready_signal_fires() {
 /// during tool discovery — the workflow start must not block forever.
 #[tokio::test]
 async fn test_wait_times_out_if_never_signaled() {
-    let manager = create_test_manager().await;
+    let harness = create_test_harness().await;
+    let manager = &harness.manager;
     let session_id = "readiness-timeout-test";
+
+    insert_test_session(&manager, session_id).await;
+    manager
+        .create_proxy(
+            session_id.to_string(),
+            vec!["playbook".to_string()],
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
+    manager
+        .mark_runtime_proxy_not_ready_for_test(session_id)
+        .await;
 
     // Inject a pending entry but intentionally never send true.
     let _tx = manager.inject_pending_readiness_for_test(session_id).await;

--- a/src-tauri/src/mcp/session_isolation/stdio_manager/tests.rs
+++ b/src-tauri/src/mcp/session_isolation/stdio_manager/tests.rs
@@ -341,10 +341,10 @@ fn test_env_clear_in_spawn_logic() {
         "stdio_manager MUST call env_clear() to isolate process environment"
     );
 
-    // Verify that we are whitelisting PATH
+    // Verify that isolated env vars are applied after env_clear()
     assert!(
-        source.contains("\"PATH\""),
-        "stdio_manager must whitelist PATH"
+        source.contains("get_isolated_env"),
+        "stdio_manager must apply whitelisted env via get_isolated_env()"
     );
 
     assert!(

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -56,25 +56,36 @@ pub struct SecurityConfig {
 /// OAuth 2.1 authentication configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthConfig {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "oauth_type", alias = "oauthType")]
     pub oauth_type: String, // Always "oauth2.1"
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "discoveryUrl", alias = "discovery_url")]
     pub discovery_url: Option<String>, // RFC 8414 discovery endpoint
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "authorizationEndpoint", alias = "authorization_endpoint")]
     pub authorization_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "tokenEndpoint", alias = "token_endpoint")]
     pub token_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "registrationEndpoint", alias = "registration_endpoint")]
     pub registration_endpoint: Option<String>, // RFC 7591
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "clientId", alias = "client_id")]
     pub client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "clientSecret", alias = "client_secret")]
+    pub client_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "redirectUri", alias = "redirect_uri")]
     pub redirect_uri: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
     #[serde(default = "default_use_pkce")]
+    #[serde(rename = "usePkce", alias = "use_pkce", alias = "usePKCE")]
     pub use_pkce: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "resourceParameter", alias = "resource_parameter")]
     pub resource_parameter: Option<String>, // RFC 9728
 }
 
@@ -683,6 +694,7 @@ mod tests {
                 token_endpoint: None,
                 registration_endpoint: None,
                 client_id: Some("test-client".to_string()),
+                client_secret: None,
                 redirect_uri: Some("libr-agent://oauth/callback".to_string()),
                 scopes: Some(vec!["read".to_string(), "write".to_string()]),
                 use_pkce: true,

--- a/src-tauri/src/mcp/utils/schema_builder.rs
+++ b/src-tauri/src/mcp/utils/schema_builder.rs
@@ -271,7 +271,11 @@ pub fn object_prop(
     JSONSchema {
         schema_type: JSONSchemaType::Object {
             properties: Some(props),
-            required: Some(required),
+            required: if required.is_empty() {
+                None
+            } else {
+                Some(required)
+            },
             additional_properties: Some(JSONSchemaAdditionalProperties::Boolean(false)),
             property_names: None,
             min_properties: None,

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -397,6 +397,7 @@ impl SessionRepository for InMemorySessionRepository {
 #[cfg(test)]
 mod tests {
     use super::InMemorySessionRepository;
+    use crate::execution_mode::ExecutionMode;
     use crate::repositories::session_repository::{
         SessionMetadata, SessionRepository, SessionStatus,
     };

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -747,6 +747,7 @@ mod tests {
     use crate::mcp::types::MCPContent;
 
     async fn setup_test_db() -> SqliteMessageRepository {
+        crate::lifecycle::database::register_sqlite_vec();
         let db = sea_orm::Database::connect("sqlite::memory:")
             .await
             .expect("Failed to create in-memory database");
@@ -766,6 +767,10 @@ mod tests {
             id: Set(session_id.to_string()),
             name: Set(Some("Test Session".to_string())),
             status: Set("idle".to_string()),
+            model: Set("gpt-4".to_string()),
+            provider: Set("openai".to_string()),
+            execution_mode: Set("normal".to_string()),
+            is_bookmarked: Set(false),
             created_at: Set(now),
             updated_at: Set(now),
             ..Default::default()

--- a/src-tauri/src/services/mcp_server_service.rs
+++ b/src-tauri/src/services/mcp_server_service.rs
@@ -27,6 +27,10 @@ pub(crate) fn summarize_tool_names(tools: &[MCPTool]) -> String {
     }
 }
 
+fn is_oauth_auth_required_error(err: &str) -> bool {
+    err.contains("Auth required") || err.contains("AuthRequired")
+}
+
 impl McpServerService {
     fn requires_reverification(existing_config: &Value, incoming_config: &Value) -> bool {
         let existing_transport = existing_config.get("transport");
@@ -100,31 +104,46 @@ impl McpServerService {
         config.name = Some(server_name.clone());
 
         // 3. Verify config
-        let tools = Self::verify_config(config).await?;
+        let verify_result = Self::verify_config(config).await;
 
-        log::info!(
-            "[probe] '{}' ({}) → {} tool(s): [{}]",
-            server_name,
-            server_id,
-            tools.len(),
-            summarize_tool_names(&tools)
-        );
+        match verify_result {
+            Ok(tools) => {
+                log::info!(
+                    "[probe] '{}' ({}) → {} tool(s): [{}]",
+                    server_name,
+                    server_id,
+                    tools.len(),
+                    summarize_tool_names(&tools)
+                );
 
-        // 4. Persist tool list (names + descriptions) to DB (best-effort)
-        let tools_json_str = crate::mcp::utils::serialize_mcp_tools(&tools);
+                // 4. Persist tool list (names + descriptions) to DB (best-effort)
+                let tools_json_str = crate::mcp::utils::serialize_mcp_tools(&tools);
 
-        if let Err(e) = repo
-            .update_cached_tools(server_id, tools.len() as i32, tools_json_str)
-            .await
-        {
-            log::warn!(
-                "[probe] Failed to cache tool list for '{}': {}",
-                server_id,
-                e
-            );
+                if let Err(e) = repo
+                    .update_cached_tools(server_id, tools.len() as i32, tools_json_str)
+                    .await
+                {
+                    log::warn!(
+                        "[probe] Failed to cache tool list for '{}': {}",
+                        server_id,
+                        e
+                    );
+                }
+
+                Ok(tools)
+            }
+            Err(err) => {
+                // Set verification status to error so it doesn't get stuck in pending
+                if let Err(e) = repo.set_verification_error(server_id, err.clone()).await {
+                    log::warn!(
+                        "[probe] Failed to update verification error status for '{}': {}",
+                        server_id,
+                        e
+                    );
+                }
+                Err(err)
+            }
         }
-
-        Ok(tools)
     }
 
     async fn persist_verified_tools(
@@ -138,7 +157,8 @@ impl McpServerService {
             .map_err(|e| format!("Failed to persist verification result: {}", e))
     }
 
-    async fn reload_server(
+    /// Reloads the server row from the database after a write. Does not re-verify connectivity.
+    async fn fetch_server_model(
         repo: &dyn MCPServerRepository,
         server_id: &str,
     ) -> Result<crate::entity::mcp_server::Model, String> {
@@ -169,29 +189,55 @@ impl McpServerService {
         mcp_config.name = Some(name.clone());
 
         // 2. Verify the configuration connects and provides tools before saving
-        let tools = Self::verify_config(mcp_config)
-            .await
-            .map_err(|e| format!("Verification failed: {}", e))?;
+        let verify_result = Self::verify_config(mcp_config).await;
 
-        // 3. Save to database
-        let model = repo
-            .create(&name, config)
-            .await
-            .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
+        match verify_result {
+            Ok(tools) => {
+                // 3. Save to database
+                let model = repo
+                    .create(&name, config)
+                    .await
+                    .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
 
-        Self::persist_verified_tools(repo, &model.id, &tools).await?;
+                Self::persist_verified_tools(repo, &model.id, &tools).await?;
 
-        let model = Self::reload_server(repo, &model.id).await?;
+                let model = Self::fetch_server_model(repo, &model.id).await?;
 
-        log::info!(
-            "'{}' ({}) saved after verification with {} tool(s): [{}]",
-            model.name,
-            model.id,
-            tools.len(),
-            summarize_tool_names(&tools)
-        );
+                log::info!(
+                    "'{}' ({}) saved after verification with {} tool(s): [{}]",
+                    model.name,
+                    model.id,
+                    tools.len(),
+                    summarize_tool_names(&tools)
+                );
 
-        Ok(model)
+                Ok(model)
+            }
+            Err(err) if is_oauth_auth_required_error(&err) =>
+            {
+                // Save config even if verification failed with AuthRequired, but mark status as error/auth required
+                let model = repo
+                    .create(&name, config)
+                    .await
+                    .map_err(|e| format!("Failed to create MCP server config: {}", e))?;
+
+                let auth_err_msg = format!("Authentication required: {}", err);
+                repo.set_verification_error(&model.id, auth_err_msg.clone())
+                    .await
+                    .map_err(|e| format!("Failed to set verification error: {}", e))?;
+
+                let model = Self::fetch_server_model(repo, &model.id).await?;
+                log::info!(
+                    "'{}' ({}) saved with pending authentication status: {}",
+                    model.name,
+                    model.id,
+                    auth_err_msg
+                );
+
+                Ok(model)
+            }
+            Err(err) => Err(format!("Verification failed: {}", err)),
+        }
     }
 
     pub async fn update_server_config(
@@ -236,28 +282,55 @@ impl McpServerService {
             Self::requires_reverification(&existing_config_val, &final_config_val);
 
         if requires_reverification {
-            let tools = Self::verify_config(mcp_config)
-                .await
-                .map_err(|e| format!("Verification failed: {}", e))?;
+            let verify_result = Self::verify_config(mcp_config).await;
 
-            let updated = repo
-                .update(&id, name.as_deref(), config)
-                .await
-                .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
+            match verify_result {
+                Ok(tools) => {
+                    let updated = repo
+                        .update(&id, name.as_deref(), config)
+                        .await
+                        .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
 
-            Self::persist_verified_tools(repo, &updated.id, &tools).await?;
+                    Self::persist_verified_tools(repo, &updated.id, &tools).await?;
 
-            let updated = Self::reload_server(repo, &updated.id).await?;
+                    let updated = Self::fetch_server_model(repo, &updated.id).await?;
 
-            log::info!(
-                "'{}' ({}) updated after verification with {} tool(s): [{}]",
-                updated.name,
-                updated.id,
-                tools.len(),
-                summarize_tool_names(&tools)
-            );
+                    log::info!(
+                        "'{}' ({}) updated after verification with {} tool(s): [{}]",
+                        updated.name,
+                        updated.id,
+                        tools.len(),
+                        summarize_tool_names(&tools)
+                    );
 
-            return Ok(updated);
+                    return Ok(updated);
+                }
+                Err(err) if is_oauth_auth_required_error(&err) =>
+                {
+                    let updated = repo
+                        .update(&id, name.as_deref(), config)
+                        .await
+                        .map_err(|e| format!("Failed to update MCP server config: {}", e))?;
+
+                    let auth_err_msg = format!("Authentication required: {}", err);
+                    repo.set_verification_error(&updated.id, auth_err_msg.clone())
+                        .await
+                        .map_err(|e| format!("Failed to set verification error: {}", e))?;
+
+                    let updated = Self::fetch_server_model(repo, &updated.id).await?;
+                    log::info!(
+                        "'{}' ({}) updated with pending authentication status: {}",
+                        updated.name,
+                        updated.id,
+                        auth_err_msg
+                    );
+
+                    return Ok(updated);
+                }
+                Err(err) => {
+                    return Err(format!("Verification failed: {}", err));
+                }
+            }
         }
 
         // Name-only or metadata-only updates do not require transport re-verification.
@@ -273,6 +346,15 @@ impl McpServerService {
         repo: &dyn MCPServerRepository,
         id: &str,
     ) -> Result<(), String> {
+        // Cleanup token from keychain if present
+        if let Err(e) = crate::mcp::keychain::delete_token(id).await {
+            log::warn!(
+                "Failed to delete OAuth token from keychain for server '{}': {}",
+                id,
+                e
+            );
+        }
+
         repo.delete(id)
             .await
             .map_err(|e| format!("Failed to delete MCP server config: {}", e))?;

--- a/src-tauri/src/services/mcp_server_service.rs
+++ b/src-tauri/src/services/mcp_server_service.rs
@@ -213,8 +213,7 @@ impl McpServerService {
 
                 Ok(model)
             }
-            Err(err) if is_oauth_auth_required_error(&err) =>
-            {
+            Err(err) if is_oauth_auth_required_error(&err) => {
                 // Save config even if verification failed with AuthRequired, but mark status as error/auth required
                 let model = repo
                     .create(&name, config)
@@ -305,8 +304,7 @@ impl McpServerService {
 
                     return Ok(updated);
                 }
-                Err(err) if is_oauth_auth_required_error(&err) =>
-                {
+                Err(err) if is_oauth_auth_required_error(&err) => {
                     let updated = repo
                         .update(&id, name.as_deref(), config)
                         .await

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -6,6 +6,22 @@ use tracing::info;
 /// Monotonic counter for unique script filenames within a process lifetime.
 static SCRIPT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Helper to remove Windows UNC path prefix `\\?\` if present.
+/// This prevents crashes in external tools (like node/pnpm) that fail to parse UNC paths.
+///
+/// NOTE: By stripping the `\\?\` prefix from local paths, Windows API support for paths
+/// longer than 260 characters (MAX_PATH) is bypassed unless long path support is enabled
+/// in the Windows registry. However, since the external tools (like node/pnpm) cannot
+/// handle UNC paths anyway, this is a necessary trade-off for compatibility.
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(stripped) = path.strip_prefix(r"\\?\") {
+        if !stripped.starts_with(r"UNC\") {
+            return stripped.to_path_buf();
+        }
+    }
+    path.to_path_buf()
+}
+
 /// Basic isolation: environment variables and working directory
 pub async fn create_basic_isolated_command(
     config: IsolatedProcessConfig,
@@ -28,8 +44,10 @@ pub async fn create_basic_isolated_command(
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 
+    let clean_workspace = simplify_path(&config.workspace_path);
+
     // Set working directory
-    cmd.current_dir(&config.workspace_path);
+    cmd.current_dir(&clean_workspace);
 
     // Apply environment isolation: clear all inherited environment variables
     cmd.env_clear();
@@ -40,8 +58,8 @@ pub async fn create_basic_isolated_command(
     }
 
     // Keep host home directories so CLI tools can discover their config, but isolate temp files.
-    cmd.env("TEMP", config.workspace_path.join(".libragent/tmp"));
-    cmd.env("TMP", config.workspace_path.join(".libragent/tmp"));
+    cmd.env("TEMP", clean_workspace.join(".libragent/tmp"));
+    cmd.env("TMP", clean_workspace.join(".libragent/tmp"));
 
     // Add user-specified environment variables
     for (key, value) in &config.env_vars {
@@ -72,7 +90,7 @@ pub async fn create_basic_isolated_command(
 
     // Write the command to a temp .ps1 file so AV can inspect it in plaintext.
     // Base64+Invoke-Expression was flagged as malware obfuscation; plain .ps1 is not.
-    let tmp_dir = config.workspace_path.join(".libragent/tmp");
+    let tmp_dir = clean_workspace.join(".libragent/tmp");
     tokio::fs::create_dir_all(&tmp_dir)
         .await
         .map_err(|e| format!("Failed to create tmp dir: {}", e))?;
@@ -183,6 +201,36 @@ pub async fn create_high_isolated_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_simplify_path_local_drive() {
+        let path = std::path::Path::new(r"\\?\C:\Users\SKTelecom\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"C:\Users\SKTelecom\project")
+        );
+    }
+
+    #[test]
+    fn test_simplify_path_unc_share() {
+        let path = std::path::Path::new(r"\\?\UNC\server\share\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"\\?\UNC\server\share\project")
+        );
+    }
+
+    #[test]
+    fn test_simplify_path_no_prefix() {
+        let path = std::path::Path::new(r"C:\Users\SKTelecom\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"C:\Users\SKTelecom\project")
+        );
+    }
 
     /// Mirrors the script content format used by `create_basic_isolated_command`.
     fn build_script_content(full_command: &str) -> String {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -609,3 +609,11 @@ pub fn reset_state() {
         reset_lock(&STARTUP_TIMER);
     }
 }
+
+#[cfg(test)]
+pub static TEST_GLOBAL_STATE_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(test)]
+pub async fn lock_test_global_state() -> tokio::sync::MutexGuard<'static, ()> {
+    TEST_GLOBAL_STATE_MUTEX.lock().await
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibrAgent",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "identifier": "com.fritzprix.libragent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/src/README.md
+++ b/src/README.md
@@ -268,8 +268,8 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
-- **Windows:** [`LibrAgent_0.8.18_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64-setup.exe) · [`LibrAgent_0.8.18_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.18_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.18_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.AppImage) · [`LibrAgent_0.8.18_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent_0.8.18_amd64.deb) · [`LibrAgent-0.8.18-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.18/LibrAgent-0.8.18-1.x86_64.rpm)
-- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.18)
+- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
+- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
 <!-- RELEASE_DOWNLOADS_END -->

--- a/src/features/mcp-servers/MCPServerDialog.tsx
+++ b/src/features/mcp-servers/MCPServerDialog.tsx
@@ -65,6 +65,22 @@ function MCPServerDialogComponent({
     handleRemoveHeader,
     handleUpdateHeader,
     submit,
+    authType,
+    setAuthType,
+    discoveryUrl,
+    setDiscoveryUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    clientId,
+    setClientId,
+    clientSecret,
+    setClientSecret,
+    scopes,
+    setScopes,
+    usePkce,
+    setUsePkce,
   } = useMCPServerForm(server);
 
   return (
@@ -249,6 +265,22 @@ function MCPServerDialogComponent({
               handleAddHeader={handleAddHeader}
               handleRemoveHeader={handleRemoveHeader}
               handleUpdateHeader={handleUpdateHeader}
+              authType={authType}
+              setAuthType={setAuthType}
+              discoveryUrl={discoveryUrl}
+              setDiscoveryUrl={setDiscoveryUrl}
+              authorizationEndpoint={authorizationEndpoint}
+              setAuthorizationEndpoint={setAuthorizationEndpoint}
+              tokenEndpoint={tokenEndpoint}
+              setTokenEndpoint={setTokenEndpoint}
+              clientId={clientId}
+              setClientId={setClientId}
+              clientSecret={clientSecret}
+              setClientSecret={setClientSecret}
+              scopes={scopes}
+              setScopes={setScopes}
+              usePkce={usePkce}
+              setUsePkce={setUsePkce}
             />
           )}
         </div>

--- a/src/features/mcp-servers/MCPServerManagement.tsx
+++ b/src/features/mcp-servers/MCPServerManagement.tsx
@@ -49,6 +49,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
     handleDelete,
     confirmDelete,
     handleToggleActive,
+    mutateServers,
   } = useMCPServerManagement(service);
 
   return (
@@ -104,6 +105,7 @@ function MCPServerManagementComponent({ service }: MCPServerManagementProps) {
                   onDelete={handleDelete}
                   onToggleActive={handleToggleActive}
                   isToggling={!!togglingStatus[server.id]}
+                  onRevalidate={mutateServers}
                 />
               ))}
             </div>

--- a/src/features/mcp-servers/components/HttpForm.tsx
+++ b/src/features/mcp-servers/components/HttpForm.tsx
@@ -12,6 +12,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
 
 interface HttpFormProps {
   draft: MCPServerEntity;
@@ -34,6 +41,22 @@ interface HttpFormProps {
     field: 'key' | 'value',
     value: string,
   ) => void;
+  authType: 'none' | 'oauth2.1';
+  setAuthType: (type: 'none' | 'oauth2.1') => void;
+  discoveryUrl: string;
+  setDiscoveryUrl: (url: string) => void;
+  authorizationEndpoint: string;
+  setAuthorizationEndpoint: (url: string) => void;
+  tokenEndpoint: string;
+  setTokenEndpoint: (url: string) => void;
+  clientId: string;
+  setClientId: (id: string) => void;
+  clientSecret: string;
+  setClientSecret: (secret: string) => void;
+  scopes: string;
+  setScopes: (scopes: string) => void;
+  usePkce: boolean;
+  setUsePkce: (use: boolean) => void;
 }
 
 export function HttpForm({
@@ -53,6 +76,22 @@ export function HttpForm({
   handleAddHeader,
   handleRemoveHeader,
   handleUpdateHeader,
+  authType,
+  setAuthType,
+  discoveryUrl,
+  setDiscoveryUrl,
+  authorizationEndpoint,
+  setAuthorizationEndpoint,
+  tokenEndpoint,
+  setTokenEndpoint,
+  clientId,
+  setClientId,
+  clientSecret,
+  setClientSecret,
+  scopes,
+  setScopes,
+  usePkce,
+  setUsePkce,
 }: HttpFormProps) {
   const { t } = useTranslation('common');
   const advancedPanelId = useId();
@@ -170,33 +209,196 @@ export function HttpForm({
         </div>
       )}
 
-      {/* Only show the generic API Key field if no variableDefinitions are defined for this server.
-                  When variableDefinitions exist, all credentials are handled through that section above. */}
-      {!(server.metadata as MCPServerMetadata | undefined)
-        ?.variableDefinitions && (
-        <div className="space-y-2">
-          <Label htmlFor="http-api-key">
-            {t('mcpServer.dialog.apiKeyLabel', 'API Key / Token')}{' '}
-            <span className="text-muted-foreground text-xs">
-              {t('mcpServer.dialog.apiKeyOptional', '(Optional)')}
-            </span>
-          </Label>
-          <Input
-            id="http-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder={t(
-              'mcpServer.dialog.apiKeyPlaceholder',
-              'Secret Token',
-            )}
-          />
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'mcpServer.dialog.apiKeyDesc',
-              "Automatically adds 'Authorization: Bearer <token>' header.",
-            )}
-          </p>
+      {/* Authentication Method Selector */}
+      <div className="space-y-2">
+        <Label htmlFor="auth-method">
+          {t('mcpServer.dialog.authMethodLabel', 'Authentication Method')}
+        </Label>
+        <Select
+          value={authType}
+          onValueChange={(val: 'none' | 'oauth2.1') => setAuthType(val)}
+        >
+          <SelectTrigger id="auth-method">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">
+              {t('mcpServer.dialog.authMethodNone', 'None / Token (Bearer)')}
+            </SelectItem>
+            <SelectItem value="oauth2.1">
+              {t('mcpServer.dialog.authMethodOAuth', 'OAuth 2.1')}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Render generic API Key field ONLY when authType is 'none' and no variableDefinitions are defined */}
+      {authType === 'none' &&
+        !(server.metadata as MCPServerMetadata | undefined)
+          ?.variableDefinitions && (
+          <div className="space-y-2">
+            <Label htmlFor="http-api-key">
+              {t('mcpServer.dialog.apiKeyLabel', 'API Key / Token')}{' '}
+              <span className="text-muted-foreground text-xs">
+                {t('mcpServer.dialog.apiKeyOptional', '(Optional)')}
+              </span>
+            </Label>
+            <Input
+              id="http-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder={t(
+                'mcpServer.dialog.apiKeyPlaceholder',
+                'Secret Token',
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'mcpServer.dialog.apiKeyDesc',
+                "Automatically adds 'Authorization: Bearer <token>' header.",
+              )}
+            </p>
+          </div>
+        )}
+
+      {/* Render OAuth 2.1 Configuration Card */}
+      {authType === 'oauth2.1' && (
+        <div className="space-y-4 p-4 border rounded-md bg-muted/10">
+          <h4 className="text-sm font-semibold flex items-center gap-2">
+            🔑{' '}
+            {t('mcpServer.dialog.oauthConfigHeader', 'OAuth 2.1 Configuration')}
+          </h4>
+
+          {/* Client ID / Client Key */}
+          <div className="space-y-2">
+            <Label htmlFor="oauth-client-id">
+              {t('mcpServer.dialog.clientIdLabel', 'Client Key (Client ID)')}{' '}
+              <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="oauth-client-id"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder="e.g. slack-mcp-client-id"
+            />
+          </div>
+
+          {/* Client Secret */}
+          <div className="space-y-2">
+            <Label htmlFor="oauth-client-secret">
+              {t('mcpServer.dialog.clientSecretLabel', 'Client Secret')}{' '}
+              <span className="text-muted-foreground text-xs">
+                {t('mcpServer.dialog.clientSecretOptional', '(Optional)')}
+              </span>
+            </Label>
+            <Input
+              id="oauth-client-secret"
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              placeholder="Enter client secret if using a confidential client"
+            />
+          </div>
+
+          {/* Configuration Mode: Discovery URL or Manual Endpoints */}
+          <div className="space-y-4 pt-2 border-t border-border/50">
+            <div className="space-y-2">
+              <Label htmlFor="oauth-discovery-url">
+                {t('mcpServer.dialog.discoveryUrlLabel', 'Discovery URL')}
+              </Label>
+              <Input
+                id="oauth-discovery-url"
+                value={discoveryUrl}
+                onChange={(e) => setDiscoveryUrl(e.target.value)}
+                placeholder="https://mcp.example.com/.well-known/oauth-authorization-server"
+              />
+              <p className="text-xs text-muted-foreground">
+                RFC 8414 OAuth Authorization Server metadata endpoint (takes
+                precedence).
+              </p>
+            </div>
+
+            <div className="text-xs text-center text-muted-foreground font-medium py-1">
+              — {t('mcpServer.dialog.or', 'OR')} —
+            </div>
+
+            {/* Manual Endpoints */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="oauth-auth-endpoint">
+                  {t(
+                    'mcpServer.dialog.authEndpointLabel',
+                    'Authorization Endpoint',
+                  )}
+                </Label>
+                <Input
+                  id="oauth-auth-endpoint"
+                  value={authorizationEndpoint}
+                  onChange={(e) => setAuthorizationEndpoint(e.target.value)}
+                  placeholder="https://slack.com/oauth/v2_user/authorize"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="oauth-token-endpoint">
+                  {t('mcpServer.dialog.tokenEndpointLabel', 'Token Endpoint')}
+                </Label>
+                <Input
+                  id="oauth-token-endpoint"
+                  value={tokenEndpoint}
+                  onChange={(e) => setTokenEndpoint(e.target.value)}
+                  placeholder="https://slack.com/api/oauth.v2.user.access"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Scopes */}
+          <div className="space-y-2 pt-2 border-t border-border/50">
+            <Label htmlFor="oauth-scopes">
+              {t('mcpServer.dialog.scopesLabel', 'Scopes')}
+            </Label>
+            <Input
+              id="oauth-scopes"
+              value={scopes}
+              onChange={(e) => setScopes(e.target.value)}
+              placeholder="e.g. search:read.public, chat:write"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'mcpServer.dialog.scopesDesc',
+                'Comma-separated scopes. Scope names cannot contain commas.',
+              )}
+            </p>
+          </div>
+
+          {/* PKCE Toggle */}
+          <div className="flex items-center justify-between pt-2">
+            <div className="space-y-0.5">
+              <Label htmlFor="oauth-use-pkce">
+                {t(
+                  'mcpServer.dialog.usePkceLabel',
+                  'Use PKCE (Proof Key for Code Exchange)',
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground font-light">
+                {usePkce
+                  ? t(
+                      'mcpServer.dialog.usePkceEnabledDesc',
+                      'Recommended for public clients without a client secret.',
+                    )
+                  : t(
+                      'mcpServer.dialog.usePkceDisabledDesc',
+                      'Only disable PKCE for providers that do not support it. Confidential clients should use a client secret instead.',
+                    )}
+              </p>
+            </div>
+            <Switch
+              id="oauth-use-pkce"
+              checked={usePkce}
+              onCheckedChange={setUsePkce}
+            />
+          </div>
         </div>
       )}
 

--- a/src/features/mcp-servers/components/ServerCard.tsx
+++ b/src/features/mcp-servers/components/ServerCard.tsx
@@ -1,5 +1,13 @@
-import React, { useState } from 'react';
-import { Server, CheckCircle2, XCircle, Loader2, Wrench } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Server,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Wrench,
+  ShieldCheck,
+  ShieldAlert,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { MCPServerEntity } from '@/models/chat';
 import {
@@ -12,6 +20,9 @@ import {
 import { Switch } from '@/components/ui/switch';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { ServerToolsModal } from './ServerToolsModal';
+import { hasOAuthToken, startOAuthFlow, revokeOAuthToken } from '@/lib/backend';
+import { safeInvoke } from '@/lib/backend/core';
+import { toast } from 'sonner';
 
 interface ServerCardProps {
   server: MCPServerEntity;
@@ -19,6 +30,7 @@ interface ServerCardProps {
   onDelete: (server: MCPServerEntity) => void;
   onToggleActive: (server: MCPServerEntity, checked: boolean) => void;
   isToggling?: boolean;
+  onRevalidate?: () => void;
 }
 
 export const ServerCard = React.memo(
@@ -28,11 +40,63 @@ export const ServerCard = React.memo(
     onDelete,
     onToggleActive,
     isToggling,
+    onRevalidate,
   }: ServerCardProps) => {
     const { t } = useTranslation('common');
     const serverName = server.name || t('mcpServer.unnamed', 'Unnamed Server');
     const [isToolsOpen, setIsToolsOpen] = useState(false);
     const verificationStatus = server.verificationStatus;
+
+    const [hasToken, setHasToken] = useState<boolean>(false);
+    const [isAuthorizing, setIsAuthorizing] = useState<boolean>(false);
+
+    useEffect(() => {
+      if (server.authentication?.type === 'oauth2.1') {
+        hasOAuthToken(server.id)
+          .then(setHasToken)
+          .catch(() => setHasToken(false));
+      }
+    }, [server.id, server.authentication]);
+
+    const handleAuthorize = useCallback(async () => {
+      if (!server.authentication) return;
+      setIsAuthorizing(true);
+      try {
+        await startOAuthFlow(server.id, server.authentication);
+        setHasToken(true);
+        toast.success(
+          t('mcpServer.toasts.authSuccess', 'Successfully authenticated!'),
+        );
+        // Probe to trigger re-verification and fetch tools
+        await safeInvoke('probe_mcp_server', { serverId: server.id });
+        if (onRevalidate) onRevalidate();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        toast.error(
+          t('mcpServer.toasts.authFailed', `Authorization failed: ${msg}`),
+        );
+      } finally {
+        setIsAuthorizing(false);
+      }
+    }, [server.id, server.authentication, t, onRevalidate]);
+
+    const handleDisconnect = useCallback(async () => {
+      try {
+        await revokeOAuthToken(server.id);
+        setHasToken(false);
+        toast.success(
+          t('mcpServer.toasts.disconnectSuccess', 'Successfully disconnected.'),
+        );
+        // Probe to reset status to connection failed/AuthRequired
+        await safeInvoke('probe_mcp_server', { serverId: server.id });
+        if (onRevalidate) onRevalidate();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        toast.error(
+          t('mcpServer.toasts.disconnectFailed', `Disconnect failed: ${msg}`),
+        );
+      }
+    }, [server.id, t, onRevalidate]);
 
     return (
       <Card className="relative overflow-hidden">
@@ -117,7 +181,27 @@ export const ServerCard = React.memo(
                   })()}`}
               </p>
               {/* Tool count / verification status — mutually exclusive display */}
-              <div className="mt-1">
+              <div className="mt-1 flex flex-col gap-1">
+                {server.authentication?.type === 'oauth2.1' && (
+                  <span
+                    className={`inline-flex items-center gap-1 text-xs font-semibold ${hasToken ? 'text-blue-600 dark:text-blue-400' : 'text-amber-600 dark:text-amber-500'}`}
+                  >
+                    {hasToken ? (
+                      <>
+                        <ShieldCheck className="w-3.5 h-3.5" />
+                        {t('mcpServer.authorizedStatus', 'Authorized')}
+                      </>
+                    ) : (
+                      <>
+                        <ShieldAlert className="w-3.5 h-3.5 text-amber-500" />
+                        {t(
+                          'mcpServer.unauthorizedStatus',
+                          'Authorization Required',
+                        )}
+                      </>
+                    )}
+                  </span>
+                )}
                 {verificationStatus === 'pending' && (
                   <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                     <Loader2 className="w-3 h-3 animate-spin" />
@@ -225,6 +309,31 @@ export const ServerCard = React.memo(
               >
                 {t('mcpServer.edit', 'Edit')}
               </Button>
+
+              {server.authentication?.type === 'oauth2.1' &&
+                (hasToken ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDisconnect}
+                    className="text-amber-600 hover:text-amber-700 border-amber-200 hover:bg-amber-50 dark:hover:bg-amber-950/20"
+                  >
+                    {t('mcpServer.disconnect', 'Disconnect')}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="default"
+                    size="sm"
+                    disabled={isAuthorizing}
+                    onClick={handleAuthorize}
+                    className="bg-blue-600 hover:bg-blue-700 text-white font-semibold"
+                  >
+                    {isAuthorizing && (
+                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    )}
+                    {t('mcpServer.authorize', 'Authorize')}
+                  </Button>
+                ))}
             </div>
             <Button
               variant="destructive"

--- a/src/features/mcp-servers/hooks/useMCPServerForm.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerForm.ts
@@ -194,6 +194,32 @@ export function useMCPServerForm(server: MCPServerEntity) {
 
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  // OAuth specific state
+  const [authType, setAuthType] = useState<'none' | 'oauth2.1'>(() => {
+    return server.authentication?.type === 'oauth2.1' ? 'oauth2.1' : 'none';
+  });
+  const [discoveryUrl, setDiscoveryUrl] = useState(() => {
+    return server.authentication?.discoveryUrl || '';
+  });
+  const [authorizationEndpoint, setAuthorizationEndpoint] = useState(() => {
+    return server.authentication?.authorizationEndpoint || '';
+  });
+  const [tokenEndpoint, setTokenEndpoint] = useState(() => {
+    return server.authentication?.tokenEndpoint || '';
+  });
+  const [clientId, setClientId] = useState(() => {
+    return server.authentication?.clientId || '';
+  });
+  const [clientSecret, setClientSecret] = useState(() => {
+    return server.authentication?.clientSecret || '';
+  });
+  const [scopes, setScopes] = useState(() => {
+    return server.authentication?.scopes?.join(', ') || '';
+  });
+  const [usePkce, setUsePkce] = useState(() => {
+    return server.authentication?.usePKCE ?? true;
+  });
+
   const isNewServer = !server.createdAt || draft.name === '';
 
   const isReservedName = () =>
@@ -229,6 +255,18 @@ export function useMCPServerForm(server: MCPServerEntity) {
       draft.transport.type === 'http-sse'
     ) {
       if (!draft.transport.url.trim()) return false;
+
+      // If OAuth 2.1 is enabled, clientId is required and we need either discoveryUrl OR authorization & token endpoints
+      if (authType === 'oauth2.1') {
+        if (!clientId.trim()) return false;
+        if (
+          !discoveryUrl.trim() &&
+          (!authorizationEndpoint.trim() || !tokenEndpoint.trim())
+        ) {
+          return false;
+        }
+      }
+
       const httpDefs = (server.metadata as MCPServerMetadata | undefined)
         ?.variableDefinitions;
       if (httpDefs) {
@@ -378,6 +416,25 @@ export function useMCPServerForm(server: MCPServerEntity) {
             headers,
             enableSSE: enableSSE,
           } as TransportConfig,
+          authentication:
+            authType === 'oauth2.1'
+              ? {
+                  type: 'oauth2.1',
+                  discoveryUrl: discoveryUrl.trim() || undefined,
+                  authorizationEndpoint:
+                    authorizationEndpoint.trim() || undefined,
+                  tokenEndpoint: tokenEndpoint.trim() || undefined,
+                  clientId: clientId.trim() || undefined,
+                  clientSecret: clientSecret.trim() || undefined,
+                  scopes: scopes.trim()
+                    ? scopes
+                        .split(',')
+                        .map((s) => s.trim())
+                        .filter(Boolean)
+                    : undefined,
+                  usePKCE: usePkce,
+                }
+              : undefined,
         };
 
         await onSave(updatedDraft);
@@ -416,5 +473,21 @@ export function useMCPServerForm(server: MCPServerEntity) {
     handleRemoveHeader,
     handleUpdateHeader,
     submit,
+    authType,
+    setAuthType,
+    discoveryUrl,
+    setDiscoveryUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    clientId,
+    setClientId,
+    clientSecret,
+    setClientSecret,
+    scopes,
+    setScopes,
+    usePkce,
+    setUsePkce,
   };
 }

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -249,5 +249,6 @@ export function useMCPServerManagement(service?: McpServerService) {
     handleDelete,
     confirmDelete,
     handleToggleActive,
+    mutateServers,
   };
 }

--- a/src/lib/backend/core.ts
+++ b/src/lib/backend/core.ts
@@ -49,6 +49,8 @@ export async function safeInvoke<T>(
     } else {
       logger.error('invoke failed', { cmd, err });
     }
-    throw err instanceof Error ? err : new Error(typeof err === 'string' ? err : String(err));
+    throw err instanceof Error
+      ? err
+      : new Error(typeof err === 'string' ? err : String(err));
   }
 }

--- a/src/lib/backend/core.ts
+++ b/src/lib/backend/core.ts
@@ -49,6 +49,6 @@ export async function safeInvoke<T>(
     } else {
       logger.error('invoke failed', { cmd, err });
     }
-    throw err;
+    throw err instanceof Error ? err : new Error(typeof err === 'string' ? err : String(err));
   }
 }

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -40,6 +40,7 @@ export {
   hasOAuthToken,
   getOAuthToken,
   revokeOAuthToken,
+  startOAuthFlow,
   sampleFromModel,
   validateToolSchema,
 } from './mcp-server';

--- a/src/lib/backend/mcp-server.ts
+++ b/src/lib/backend/mcp-server.ts
@@ -4,6 +4,7 @@ import type {
   MCPResponse,
   SamplingOptions,
   SamplingResponse,
+  OAuthConfig,
 } from '@/lib/mcp';
 import { createId } from '@paralleldrive/cuid2';
 
@@ -66,6 +67,21 @@ export async function getOAuthToken(serverId: string): Promise<string | null> {
  */
 export async function revokeOAuthToken(serverId: string): Promise<string> {
   return safeInvoke<string>('revoke_oauth_token', { serverId });
+}
+
+/**
+ * Starts the OAuth 2.1 authorization flow: opens browser, runs loopback listener,
+ * exchanges code, and saves token in keychain.
+ *
+ * @param serverId - Unique identifier for the MCP server
+ * @param config - The OAuthConfig object
+ * @returns Success message
+ */
+export async function startOAuthFlow(
+  serverId: string,
+  config: OAuthConfig,
+): Promise<string> {
+  return safeInvoke<string>('start_oauth_flow', { serverId, config });
 }
 
 /**

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,7 +5,11 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
+export const EXECUTION_MODE_VALUES = [
+  'normal',
+  'yolo',
+  'unsafe',
+] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 

--- a/src/lib/mcp/config/transport.ts
+++ b/src/lib/mcp/config/transport.ts
@@ -36,6 +36,7 @@ export interface OAuthConfig {
   tokenEndpoint?: string;
   registrationEndpoint?: string; // RFC 7591 Dynamic Client Registration
   clientId?: string;
+  clientSecret?: string;
   redirectUri?: string;
   scopes?: string[];
   usePKCE?: boolean; // Default: true


### PR DESCRIPTION
## Summary

- **v0.8.19**: OAuth 2.1 authentication for remote HTTP MCP servers (2025-06-18 spec), MCP server OAuth UI (configure/authorize/disconnect), planning goal nudges, and `messageToSession(wait=true)` stale-output fix
- **v0.8.18**: Reset session race-condition fixes, clipboard image paste, secure encrypted backups, session context HTML comment headers, and `executionMode` schema alignment
- **Refactors**: Builtin MCP tool name standardization, `executionMode` type unification, scheduled task group removal, and migration backup/import support

## Test plan

- [x] `pnpm refactor:validate` passed on `dev/0.8.x`
- [x] Release script completed for `v0.8.19` (frontend/backend tests, build, tag push)
- [x] GitHub Actions release workflow triggered for `v0.8.19`
- [ ] Merge with **Create a merge commit** (do not squash)
- [ ] After merge, sync `main` back into `dev/0.8.x`


Made with [Cursor](https://cursor.com)