### PR TITLE
fix(windows): strip UNC prefix from TEMP/TMP paths to prevent pnpm crashes

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/docs/audit/code-audit-git-diff-0.8.19.md
+++ b/docs/audit/code-audit-git-diff-0.8.19.md
@@ -1,0 +1,115 @@
+# Code Audit Report: Git Diff Review
+
+## 1. 변경 사항 개요
+
+| Category              | Files | Type           | Impact   |
+| --------------------- | ----- | -------------- | -------- |
+| README 포맷팅         | 8개   | Formatting     | Low      |
+| 버전 업데이트         | 1개   | Metadata       | Low      |
+| Windows 경로 처리     | 1개   | **Core Logic** | **High** |
+| Generated 파일 포맷팅 | 2개   | Formatting     | Low      |
+
+---
+
+## 2. 핵심 변경 분석: `windows.rs` — `simplify_path()`
+
+### 2.1 변경 내용
+
+```rust
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(stripped) = path.strip_prefix(r"\\?\") {
+        if !stripped.starts_with(r"UNC\") {
+            return stripped.to_path_buf();
+        }
+    }
+    path.to_path_buf()
+}
+```
+
+**적용 위치:**
+
+- `cmd.current_dir(&clean_workspace)` — 작업 디렉토리 설정
+- `cmd.env("TEMP", clean_workspace.join(".libragent/tmp"))` — TEMP 환경변수
+- `cmd.env("TMP", clean_workspace.join(".libragent/tmp"))` — TMP 환경변수
+- `clean_workspace.join(".libragent/tmp")` — 스크립트 템프 디렉토리 생성
+
+### 2.2 로직 정확성 평가
+
+| 입력 경로                  | strip_prefix 결과      | UNC\ 체크 | 최종 결과                             |
+| -------------------------- | ---------------------- | --------- | ------------------------------------- |
+| `\\?\C:\Users\dev\project` | `C:\Users\dev\project` | N/A       | `C:\Users\dev\project` ✅             |
+| `\\?\UNC\server\share`     | `UNC\server\share`     | True      | `\\?\UNC\server\share` (원본 유지) ✅ |
+| `C:\Users\dev\project`     | Err                    | —         | `C:\Users\dev\project` ✅             |
+
+**판단: 로직 정확함. 세 가지 케이스 모두 올바르게 처리됨.**
+
+### 2.3 일관성 평가
+
+`simplify_path()`의 호출이 `create_basic_isolated_command()` 함수 내에서 **단 한 번** 수행되고, 그 결과(`clean_workspace`)가 모든 경로 연산에 재사용된다. 이는 **DRY 원칙 준수** 및 **일관성 보장에 우수**.
+
+### 2.4 위험 요소
+
+| 위험도     | 항목                  | 설명                                                                                                       |
+| ---------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Medium** | Long path 지원 손실   | `\\?\` prefix 제거로 260자 초과 경로 지원 불가. 깊게 중첩된 워크스페이스에서 경로 길이 제한 에러 발생 가능 |
+| **Low**    | 테스트 누락           | `simplify_path()` 자체에 대한 unit test 없음. 현재 테스트는 script content와 cleanup wrapper만 검증        |
+| **Low**    | UNC 경로 보존 시 동작 | `\\?\UNC\server\share`가 원본 그대로 전달되지만, 이 경로가 외부 도구에서 여전히 파싱 실패할 가능성         |
+
+### 2.5 개선 제안
+
+```rust
+// 현재: 단순 strip (long path 지원 포기)
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    // ...
+}
+
+// 대안: long path 지원을 유지하면서 UNC 문제를 우회하는 방식 고려
+// (예: workspace 경로를 short path로 변환 후 사용)
+```
+
+**권장 사항:** `simplify_path()`에 대한 unit test 추가. 특히 `\\?\UNC\` 케이스와 일반 케이스 모두 커버.
+
+---
+
+## 3. 부수 변경 분석
+
+### 3.1 README 파일 (8개)
+
+**변경:** `<!-- RELEASE_DOWNLOADS_START -->` HTML comment 뒤에 빈 줄 추가
+
+**판단: 적절함.** Markdown 렌더링을 위해 HTML 블록과 리스트 사이에 빈 줄이 필요함.
+
+### 3.2 Cargo.lock
+
+**변경:** `version = "0.8.18"` → `"0.8.19"`
+
+**판단: 정상적인 버전 업데이트.**
+
+### 3.3 Generated TypeScript 파일 (2개)
+
+| 파일                  | 변경 내용                                                               | 판단                  |
+| --------------------- | ----------------------------------------------------------------------- | --------------------- |
+| `builtin-services.ts` | `(typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number]` — typeof parentheses | Prettier 포맷팅. 무해 |
+| `execution-mode.ts`   | 배열을 단일 라인으로 collapse                                           | Prettier 포맷팅. 무해 |
+
+**판단:** Auto-generated 파일의 포맷팅 변경. Generator 스크립트(`scripts/sync-*.cjs`)의 Prettier 설정 변경으로 보임. 기능적 영향 없음.
+
+---
+
+## 4. 종합 평가
+
+| 항목                 | 점수       | 비고                                                                           |
+| -------------------- | ---------- | ------------------------------------------------------------------------------ |
+| **문제 해결 적절성** | ⭐⭐⭐⭐⭐ | UNC 경로로 인한 외부 도구 크래시를 정확히 지적하고 해결                        |
+| **구현 설계**        | ⭐⭐⭐⭐   | 단일 호출 + 재사용으로 일관성 우수. long path 지원 포기 트레이드오프 명시 필요 |
+| **테스트 커버리지**  | ⭐⭐       | `simplify_path()` 자체 테스트 누락. script/wrapper 테스트는 기존 유지          |
+| **부수 변경 관리**   | ⭐⭐⭐⭐⭐ | README, generated 파일 변경은 모두 포맷팅/메타데이터로 안전                    |
+
+### 결론: **Merge 권장 (단, 테스트 추가 권고)**
+
+`simplify_path()` 변경은 **실제 문제를 정확히 해결**하며, 구현도 깔끔하고 일관성 있게 적용됨.
+
+**Merge 전 권고 사항:**
+
+1. `simplify_path()` unit test 추가 (P0)
+2. `\\?\` prefix 제거로 인한 long path 제한에 대한 문서화 (P1)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4095,7 +4095,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -6,6 +6,22 @@ use tracing::info;
 /// Monotonic counter for unique script filenames within a process lifetime.
 static SCRIPT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Helper to remove Windows UNC path prefix `\\?\` if present.
+/// This prevents crashes in external tools (like node/pnpm) that fail to parse UNC paths.
+///
+/// NOTE: By stripping the `\\?\` prefix from local paths, Windows API support for paths
+/// longer than 260 characters (MAX_PATH) is bypassed unless long path support is enabled
+/// in the Windows registry. However, since the external tools (like node/pnpm) cannot
+/// handle UNC paths anyway, this is a necessary trade-off for compatibility.
+fn simplify_path(path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(stripped) = path.strip_prefix(r"\\?\") {
+        if !stripped.starts_with(r"UNC\") {
+            return stripped.to_path_buf();
+        }
+    }
+    path.to_path_buf()
+}
+
 /// Basic isolation: environment variables and working directory
 pub async fn create_basic_isolated_command(
     config: IsolatedProcessConfig,
@@ -28,8 +44,10 @@ pub async fn create_basic_isolated_command(
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 
+    let clean_workspace = simplify_path(&config.workspace_path);
+
     // Set working directory
-    cmd.current_dir(&config.workspace_path);
+    cmd.current_dir(&clean_workspace);
 
     // Apply environment isolation: clear all inherited environment variables
     cmd.env_clear();
@@ -40,8 +58,8 @@ pub async fn create_basic_isolated_command(
     }
 
     // Keep host home directories so CLI tools can discover their config, but isolate temp files.
-    cmd.env("TEMP", config.workspace_path.join(".libragent/tmp"));
-    cmd.env("TMP", config.workspace_path.join(".libragent/tmp"));
+    cmd.env("TEMP", clean_workspace.join(".libragent/tmp"));
+    cmd.env("TMP", clean_workspace.join(".libragent/tmp"));
 
     // Add user-specified environment variables
     for (key, value) in &config.env_vars {
@@ -72,7 +90,7 @@ pub async fn create_basic_isolated_command(
 
     // Write the command to a temp .ps1 file so AV can inspect it in plaintext.
     // Base64+Invoke-Expression was flagged as malware obfuscation; plain .ps1 is not.
-    let tmp_dir = config.workspace_path.join(".libragent/tmp");
+    let tmp_dir = clean_workspace.join(".libragent/tmp");
     tokio::fs::create_dir_all(&tmp_dir)
         .await
         .map_err(|e| format!("Failed to create tmp dir: {}", e))?;
@@ -183,6 +201,36 @@ pub async fn create_high_isolated_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_simplify_path_local_drive() {
+        let path = std::path::Path::new(r"\\?\C:\Users\SKTelecom\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"C:\Users\SKTelecom\project")
+        );
+    }
+
+    #[test]
+    fn test_simplify_path_unc_share() {
+        let path = std::path::Path::new(r"\\?\UNC\server\share\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"\\?\UNC\server\share\project")
+        );
+    }
+
+    #[test]
+    fn test_simplify_path_no_prefix() {
+        let path = std::path::Path::new(r"C:\Users\SKTelecom\project");
+        let simplified = simplify_path(path);
+        assert_eq!(
+            simplified,
+            std::path::Path::new(r"C:\Users\SKTelecom\project")
+        );
+    }
 
     /// Mirrors the script content format used by `create_basic_isolated_command`.
     fn build_script_content(full_command: &str) -> String {

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
This PR resolves the issue where \pnpm\ (via its internal \	emp-dir\ library) crashes on Windows because \TEMP\ and \TMP\ environment variables are set to a path with the Win32 long path UNC prefix \\\\\?\\\.

### Changes:
- Added a \simplify_path\ helper function to \windows.rs\ that strips \\\\\?\\\ from standard local paths (while preserving UNC network shares starting with \\\\\?\\UNC\\\).
- Configured child command working directory, \TEMP\, \TMP\, and target script paths using the cleaned path.
- Added 3 unit tests covering the local drive, UNC share, and prefix-less path cases.
- Documented the MAX_PATH (260-character limitation) trade-off in the helper's docstring.
- Included the code audit report and formatting improvements.