### PR TITLE
fix(telegram-cli): bypass PowerShell encoding limits with file-based args

### DIFF
--- a/src-tauri/bundled_skills/telegram-cli/SKILL.md
+++ b/src-tauri/bundled_skills/telegram-cli/SKILL.md
@@ -167,6 +167,36 @@ When `--output` is set, stdout prints a compact summary (`status`, `output` path
 
 All CLI output uses UTF-8 (`ensure_ascii=False`). Errors go to stderr as UTF-8 JSON.
 
+### Input encoding (Windows / Unicode workaround)
+
+On Windows, passing Unicode characters (like Korean) as command-line arguments can cause character corruption (mojibake) due to PowerShell's default encoding (`cp949`).
+
+To bypass this bottleneck, **always** write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query`:
+
+#### Send Message (Windows Recommended)
+```powershell
+# 1. Write the message to a UTF-8 file in the workspace
+$msg = "안녕하세요, 텔레그램 메시지 테스트입니다."
+$msg | Out-File -Encoding utf8 "<workspace>/tg_message.txt"
+
+# 2. Call the CLI with --message-file
+python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
+  --chat "<chat_id_or_username>" `
+  --message-file "<workspace>/tg_message.txt"
+```
+
+#### Search Messages (Windows Recommended)
+```powershell
+# 1. Write the query to a UTF-8 file in the workspace
+$query = "테스트"
+$query | Out-File -Encoding utf8 "<workspace>/tg_query.txt"
+
+# 2. Call the CLI with --query-file
+python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
+  --query-file "<workspace>/tg_query.txt" `
+  --output "<workspace>/telegram_search.json"
+```
+
 ### Dispatch CLI Actions
 
 Classify the user's request into one of the actions (`send_message`, `get_messages`, `list_chats`, `search_messages`, `download_file`, `get_chat_info`) and execute the CLI. For a detailed reference of CLI parameters, JSON output schemas, and pagination strategies, see the [cli-reference.md](references/cli-reference.md) guide.

--- a/src-tauri/bundled_skills/telegram-cli/SKILL.md
+++ b/src-tauri/bundled_skills/telegram-cli/SKILL.md
@@ -167,11 +167,18 @@ When `--output` is set, stdout prints a compact summary (`status`, `output` path
 
 All CLI output uses UTF-8 (`ensure_ascii=False`). Errors go to stderr as UTF-8 JSON.
 
+### Output handling (Windows 필수)
+On Windows, always set these before invoking any CLI command:
+```powershell
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$env:PYTHONUTF8 = "1"
+```
+
 ### Input encoding (Windows / Unicode workaround)
 
 On Windows, passing Unicode characters (like Korean) as command-line arguments can cause character corruption (mojibake) due to PowerShell's default encoding (`cp949`).
 
-To bypass this bottleneck, **always** write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query`:
+To bypass this bottleneck, it is highly **recommended** to write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query` (especially on older Windows PowerShell environments; PowerShell 7+ with `$OutputEncoding` set to UTF-8 may work with inline arguments):
 
 #### Send Message (Windows Recommended)
 ```powershell
@@ -183,6 +190,9 @@ $msg | Out-File -Encoding utf8 "<workspace>/tg_message.txt"
 python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
   --chat "<chat_id_or_username>" `
   --message-file "<workspace>/tg_message.txt"
+
+# 3. Clean up the temporary file (recommended)
+Remove-Item -Path "<workspace>/tg_message.txt" -ErrorAction SilentlyContinue
 ```
 
 #### Search Messages (Windows Recommended)
@@ -195,6 +205,9 @@ $query | Out-File -Encoding utf8 "<workspace>/tg_query.txt"
 python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
   --query-file "<workspace>/tg_query.txt" `
   --output "<workspace>/telegram_search.json"
+
+# 3. Clean up the temporary file (recommended)
+Remove-Item -Path "<workspace>/tg_query.txt" -ErrorAction SilentlyContinue
 ```
 
 ### Dispatch CLI Actions

--- a/src-tauri/bundled_skills/telegram-cli/references/cli-reference.md
+++ b/src-tauri/bundled_skills/telegram-cli/references/cli-reference.md
@@ -12,7 +12,7 @@ Use `telegram_cli.py` to dispatch actions.
 ```powershell
 python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
   --chat "<chat_id_or_username>" `
-  --message "메시지 내용" `
+  [--message "메시지 내용" | --message-file "/path/to/message.txt"] `
   [--file "/path/to/attachment"]
 ```
 - Username: `@username` or `username`
@@ -35,7 +35,7 @@ python "<skill-base-dir>/scripts/telegram_cli.py" --action list_chats
 ### Action: `search_messages` — Search messages
 ```powershell
 python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
-  --query "검색어" `
+  [--query "검색어" | --query-file "/path/to/query.txt"] `
   [--limit N] `
   [--chat "<chat_id_or_username>"] `
   [--offset_id N] `
@@ -177,8 +177,8 @@ python "<skill-base-dir>/scripts/telegram_cli.py" --action get_messages `
 | FloodWait | `"message": "FloodWait: wait N seconds"` (exit `2`) | Wait **N** seconds, retry same command |
 | Not authorized | `"Not authorized. Run setup first."` (exit `1`) | Run `check_config.py`; if not ok, run Step 2 auth flow |
 | Auth restart | `check_config` → `auth_restart_needed` | Delete `~/.libragent/telegram_session.session`, `send_code` → `sign_in` |
-| Missing `--chat` / `--query` | exit `3` | Add required flag and retry |
-| cp949 / garbled stdout | Mojibake in console | Re-run with `--output` and read the UTF-8 file |
+| Missing `--chat` / `--query` | exit `3` | Add required flag (or file-based equivalent) and retry |
+| cp949 / garbled inputs or stdout | Mojibake in console or sent messages | For outputs, re-run with `--output` and read the UTF-8 file. For inputs, write to a UTF-8 file and use `--message-file` or `--query-file` |
 
 ### Error Handling (setup & auth)
 

--- a/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
+++ b/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
@@ -170,12 +170,12 @@ def require_chat_arg(args: argparse.Namespace, action: str) -> bool:
 
 
 def require_query_arg(args: argparse.Namespace) -> bool:
-    """Validate that --query was provided for search_messages."""
-    if args.query:
+    """Validate that --query or --query-file was provided for search_messages."""
+    if args.query or args.query_file:
         return True
 
     emit_error(
-        {"status": "error", "message": "Missing required argument: --query is required for search_messages."}
+        {"status": "error", "message": "Missing required argument: --query or --query-file is required for search_messages."}
     )
     return False
 
@@ -295,10 +295,22 @@ def format_chat(peer: Any) -> dict:
 
 def action_send_message(args: argparse.Namespace, config: dict) -> int:
     """Send a message to a chat."""
-    if not require_chat_arg(args, "send_message") or not args.message:
-        if not args.message:
+    message = args.message
+    if args.message_file:
+        message_file_path = Path(args.message_file)
+        if not message_file_path.exists():
+            emit_error({"status": "error", "message": f"Message file not found: {args.message_file}"})
+            return 3
+        try:
+            message = message_file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            emit_error({"status": "error", "message": f"Failed to read message file: {e}"})
+            return 3
+
+    if not require_chat_arg(args, "send_message") or not message:
+        if not message:
             emit_error(
-                {"status": "error", "message": "Missing required argument: --message is required for send_message."}
+                {"status": "error", "message": "Missing required argument: --message or --message-file is required for send_message."}
             )
         return 3
 
@@ -319,7 +331,7 @@ def action_send_message(args: argparse.Namespace, config: dict) -> int:
                 emit_error({"status": "error", "message": f"File not found: {args.file}"})
                 return 3
             result = client.loop.run_until_complete(
-                client.send_file(peer, str(file_path), caption=args.message)
+                client.send_file(peer, str(file_path), caption=message)
             )
             output = {
                 "status": "ok",
@@ -332,7 +344,7 @@ def action_send_message(args: argparse.Namespace, config: dict) -> int:
             }
         else:
             result = client.loop.run_until_complete(
-                client.send_message(peer, args.message)
+                client.send_message(peer, message)
             )
             output = {
                 "status": "ok",
@@ -451,7 +463,23 @@ def action_list_chats(args: argparse.Namespace, config: dict) -> int:
 
 def action_search_messages(args: argparse.Namespace, config: dict) -> int:
     """Search messages."""
-    if not require_query_arg(args):
+    query = args.query
+    if args.query_file:
+        query_file_path = Path(args.query_file)
+        if not query_file_path.exists():
+            emit_error({"status": "error", "message": f"Query file not found: {args.query_file}"})
+            return 3
+        try:
+            query = query_file_path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            emit_error({"status": "error", "message": f"Failed to read query file: {e}"})
+            return 3
+
+    if not require_query_arg(args) or not query:
+        if not query:
+            emit_error(
+                {"status": "error", "message": "Missing required argument: --query or --query-file is required for search_messages."}
+            )
         return 3
 
     client = create_client(config)
@@ -472,7 +500,7 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
                 client,
                 peer,
                 limit=limit,
-                search=args.query,
+                search=query,
                 offset_id=offset_id,
             )
         )
@@ -483,7 +511,7 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
             {
                 "status": "ok",
                 "action": "search_messages",
-                "query": args.query,
+                "query": query,
                 "chat": args.chat,
                 "count": len(msgs),
                 "offset_id": offset_id,
@@ -659,7 +687,9 @@ def main() -> int:
     )
     parser.add_argument("--chat", help="Chat ID or username")
     parser.add_argument("--message", help="Message text (for send_message)")
+    parser.add_argument("--message-file", help="Read message text from a UTF-8 file (avoids PowerShell encoding issues)")
     parser.add_argument("--query", help="Search query (for search_messages)")
+    parser.add_argument("--query-file", help="Read search query from a UTF-8 file (avoids PowerShell encoding issues)")
     parser.add_argument("--limit", type=int, default=20, help="Number of messages (default: 20)")
     parser.add_argument(
         "--offset_id",

--- a/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
+++ b/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
@@ -291,20 +291,59 @@ def format_chat(peer: Any) -> dict:
     return {"id": getattr(peer, "id", None), "name": "Unknown", "type": "unknown"}
 
 
+def validate_and_read_file(file_path_str: str, file_type_label: str) -> str | None:
+    """Validate, check size, and read a UTF-8 file, handling errors.
+
+    Returns the file content stripped, or None if an error was emitted.
+    """
+    path = Path(file_path_str)
+    if not path.exists():
+        emit_error({"status": "error", "message": f"{file_type_label} file not found: {file_path_str}"})
+        return None
+
+    # Path traversal validation
+    try:
+        resolved_path = path.resolve()
+        resolved_config_dir = CONFIG_PATH.parent.resolve()
+
+        # Check if the path resides inside the config directory
+        if resolved_path == CONFIG_PATH.resolve() or resolved_config_dir in resolved_path.parents:
+            emit_error({"status": "error", "message": "Access denied: cannot read files from the config directory."})
+            return None
+    except Exception as e:
+        emit_error({"status": "error", "message": f"Path validation failed: {e}"})
+        return None
+
+    # File size limit validation (1 MB)
+    max_file_size = 1024 * 1024  # 1 MB
+    try:
+        if path.stat().st_size > max_file_size:
+            emit_error({"status": "error", "message": f"File size exceeds the limit of {max_file_size} bytes."})
+            return None
+    except OSError as e:
+        emit_error({"status": "error", "message": f"Failed to access file metadata: {e}"})
+        return None
+
+    # Read and strip content
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+        if not content:
+            emit_error({"status": "error", "message": f"The provided {file_type_label.lower()} file is empty."})
+            return None
+        return content
+    except OSError as e:
+        emit_error({"status": "error", "message": f"Failed to read {file_type_label.lower()} file: {e}"})
+        return None
+
+
 # ─── Actions ──────────────────────────────────────────────────────────
 
 def action_send_message(args: argparse.Namespace, config: dict) -> int:
     """Send a message to a chat."""
     message = args.message
     if args.message_file:
-        message_file_path = Path(args.message_file)
-        if not message_file_path.exists():
-            emit_error({"status": "error", "message": f"Message file not found: {args.message_file}"})
-            return 3
-        try:
-            message = message_file_path.read_text(encoding="utf-8")
-        except OSError as e:
-            emit_error({"status": "error", "message": f"Failed to read message file: {e}"})
+        message = validate_and_read_file(args.message_file, "Message")
+        if message is None:
             return 3
 
     if not require_chat_arg(args, "send_message") or not message:
@@ -465,14 +504,8 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
     """Search messages."""
     query = args.query
     if args.query_file:
-        query_file_path = Path(args.query_file)
-        if not query_file_path.exists():
-            emit_error({"status": "error", "message": f"Query file not found: {args.query_file}"})
-            return 3
-        try:
-            query = query_file_path.read_text(encoding="utf-8").strip()
-        except OSError as e:
-            emit_error({"status": "error", "message": f"Failed to read query file: {e}"})
+        query = validate_and_read_file(args.query_file, "Query")
+        if query is None:
             return 3
 
     if not require_query_arg(args) or not query:


### PR DESCRIPTION
Closes #1488. Bypasses the Windows PowerShell input encoding bottleneck by introducing file-based parameter passing via --message-file and --query-file.