### PR TITLE
fix(agent): fix slash command dropdown trigger regex with lookbehind

### DIFF
--- a/src/features/agent/hooks/__tests__/useInputToken.test.tsx
+++ b/src/features/agent/hooks/__tests__/useInputToken.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useInputToken } from '../useInputToken';
+
+describe('useInputToken', () => {
+  it('should identify a command when typing starts with /', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('/clear', 6);
+    });
+
+    expect(result.current.stage).toEqual({
+      kind: 'typing-command',
+      query: 'clear',
+      anchorIndex: 0,
+    });
+    expect(result.current.commandResults).toHaveLength(1);
+    expect(result.current.commandResults[0].id).toBe('/clear');
+  });
+
+  it('should identify a command when typing / after a space', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('hello /clear', 12);
+    });
+
+    expect(result.current.stage).toEqual({
+      kind: 'typing-command',
+      query: 'clear',
+      anchorIndex: 6,
+    });
+    expect(result.current.commandResults).toHaveLength(1);
+  });
+
+  it('should not identify a command when / is preceded by a non-whitespace character', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('hello/clear', 11);
+    });
+
+    expect(result.current.stage).toEqual({ kind: 'idle' });
+    expect(result.current.commandResults).toHaveLength(0);
+  });
+
+  it('should not identify a command for path slashes', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('src/features/agent', 18);
+    });
+
+    expect(result.current.stage).toEqual({ kind: 'idle' });
+    expect(result.current.commandResults).toHaveLength(0);
+  });
+});

--- a/src/features/agent/hooks/useInputToken.ts
+++ b/src/features/agent/hooks/useInputToken.ts
@@ -50,7 +50,7 @@ const TYPE_RE = /@([\w]*)$/;
 /** Regex: matches `@word:rest` (typing arg for a type). */
 const ARG_RE = /@([\w]+):([\S]*)$/;
 /** Regex: matches `/command` with potential spaces. */
-const COMMAND_RE = /\/([\w\s-]*)$/;
+const COMMAND_RE = /(?<!\S)\/([\w\s-]*)$/;
 
 export interface UseInputTokenResult {
   /** Current UX stage. */


### PR DESCRIPTION
Resolves the bug where the slash command dropdown was incorrectly recommended in the middle of a sentence. A negative lookbehind is used to ensure the slash command is only triggered at the start of a line or after a whitespace. Unit tests have been added and verified.