### PR TITLE
fix(mcp): align telegram preset with bot api requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
       - name: 📥 Checkout
@@ -78,6 +78,10 @@ jobs:
       - name: 🦀 Check Rust
         run: cd src-tauri && cargo check
 
+      - name: 🍎 Fix macOS SDKROOT for Rust linker
+        if: runner.os == 'macOS'
+        run: echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
+
       - name: 🧪 Run Rust integration tests
         run: pnpm rust:test
 
@@ -113,7 +117,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
       - name: 📥 Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.20] - 2026-06-25
+
+### 🚀 Features
+
+- **Slack MCP Integration**: Add official Slack MCP server preset (`https://mcp.slack.com/mcp`) supporting standard OAuth 2.1 authorization with custom query parameters (`customParams` containing the exact 25 scopes for Slack tools).
+- **OAuth Security Hardening**: Mitigate potential OAuth security risks by implementing constant-time CSRF token comparison, strict redirect URI whitelisting (`http://localhost:14207/callback`), exact domain matching for the token endpoint, and Cache-Control headers on the callback page.
+
+### 🐛 Fixes
+
+- **Telegram Preset & CLI Hardening**: Add missing `TELEGRAM_BOT_TOKEN` definition to the Telegram preset, bypass Windows PowerShell command encoding limits via file-based args, and secure the `telegram-cli` script with strict path/size validation.
+- **Slash Command Trigger**: Correct the lookbehind regex for the slash command dropdown in the chat input.
+- **Session Cache & Database Fallback**: Prevent stale session states by falling back to the SQLite database during session checks if the in-memory cache is out of sync.
+- **Windows UNC Path Crashes**: Automatically strip UNC prefixes from TEMP and TMP environment variables, preventing `pnpm` command failures on Windows.
+
 ## [0.8.19] - 2026-06-23
 
 ### 🚀 Features

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.de.md
+++ b/README.de.md
@@ -205,11 +205,10 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **Alle Release-Artefakte:** [Releases-Seite](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **Alle Release-Artefakte:** [Releases-Seite](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Entwickler-Setup:**

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,11 +205,10 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **Todos los archivos de la release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **Todos los archivos de la release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuración para desarrolladores:**

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,11 +205,10 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows :** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon) :** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux :** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **Tous les fichiers de release :** [page des Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows :** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon) :** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux :** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **Tous les fichiers de release :** [page des Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuration développeur :**

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,11 +205,10 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **すべてのリリース資産:** [リリースページ](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **すべてのリリース資産:** [リリースページ](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **開発者セットアップ：**

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,11 +205,10 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **전체 릴리스 자산:** [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **전체 릴리스 자산:** [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **개발자 설정:**

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,11 +209,10 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Developer Setup:**

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,11 +205,10 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **Todos os artefatos da release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **Todos os artefatos da release:** [página de Releases](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **Configuração para programadores:**

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,11 +205,10 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows：** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS（Apple Silicon）：** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux：** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **完整发布资源：** [发布页面](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows：** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS（Apple Silicon）：** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux：** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **完整发布资源：** [发布页面](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->
 
 **开发者设置：**

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Fritz Prix <fritzprix@gmail.com>
 pkgname=libragent
-pkgver=0.8.19
+pkgver=0.8.20
 pkgrel=1
 pkgdesc="A desktop app for AI agents with built-in tools"
 arch=('x86_64')

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -295,7 +295,8 @@
       "args": ["-y", "@fre4x/telegram"],
       "env": {
         "TELEGRAM_MCP_SESSION": "~/.libragent/telegram_mcp",
-        "TELEGRAM_BOT_TOKEN": ""
+        "TELEGRAM_BOT_TOKEN": "",
+        "ALLOWED_USER_ID": ""
       },
       "variableDefinitions": {
         "TELEGRAM_MCP_SESSION": {
@@ -309,6 +310,12 @@
           "label": "Telegram Bot Token",
           "description": "Get your bot token from @BotFather on Telegram.",
           "type": "password"
+        },
+        "ALLOWED_USER_ID": {
+          "required": false,
+          "label": "Allowed Telegram User ID",
+          "description": "Telegram user ID allowed to interact with the bot.",
+          "type": "text"
         }
       }
     },

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -295,7 +295,7 @@
       "args": ["-y", "@fre4x/telegram"],
       "env": {
         "TELEGRAM_MCP_SESSION": "~/.libragent/telegram_mcp",
-        "MOCK": "false"
+        "TELEGRAM_BOT_TOKEN": ""
       },
       "variableDefinitions": {
         "TELEGRAM_MCP_SESSION": {
@@ -303,6 +303,12 @@
           "label": "Telegram MCP Session Path",
           "description": "GramJS StringSession path. Default: ~/.libragent/telegram_mcp",
           "type": "text"
+        },
+        "TELEGRAM_BOT_TOKEN": {
+          "required": true,
+          "label": "Telegram Bot Token",
+          "description": "Get your bot token from @BotFather on Telegram.",
+          "type": "password"
         }
       }
     },

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -336,7 +336,7 @@
         "clientId": "YOUR_SLACK_CLIENT_ID",
         "clientSecret": "YOUR_SLACK_CLIENT_SECRET",
         "customParams": {
-          "user_scope": "channels:read,channels:history,chat:write,users:read"
+          "user_scope": "search:read.public,search:read.private,search:read.mpim,search:read.im,search:read.files,files:read,emoji:read,search:read.users,chat:write,channels:history,groups:history,mpim:history,im:history,channels:write,groups:write,im:write,mpim:write,reactions:write,canvases:read,canvases:write,users:read,users:read.email,channels:read,groups:read,mpim:read"
         }
       }
     }

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -322,6 +322,23 @@
           "type": "text"
         }
       }
+    },
+    "slack": {
+      "category": "messaging",
+      "description": "Connect to Slack to search channels, read history, send messages, and manage canvases.",
+      "logo": "https://a.slack-edge.com/80588/img/services/api_256.png",
+      "url": "https://mcp.slack.com/mcp",
+      "authentication": {
+        "type": "oauth2.1",
+        "authorizationEndpoint": "https://slack.com/oauth/v2_user/authorize",
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "usePkce": true,
+        "clientId": "YOUR_SLACK_CLIENT_ID",
+        "clientSecret": "YOUR_SLACK_CLIENT_SECRET",
+        "customParams": {
+          "user_scope": "channels:read,channels:history,chat:write,users:read"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libragent",
   "private": true,
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "A desktop app for AI agents with built-in tools",
   "author": "fritzprix",
   "license": "MIT",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: libragent
 base: core22
-version: '0.8.19'
+version: '0.8.20'
 summary: A desktop app for AI agents with built-in tools
 description: |
   LibrAgent is a next-generation desktop AI agent platform that combines the lightness of Tauri with the intuitiveness of React. Users can automate all daily tasks by giving AI agents their own unique personalities and abilities.
@@ -25,7 +25,7 @@ apps:
 parts:
   libragent:
     plugin: dump
-    source: src-tauri/target/release/bundle/deb/libragent_0.8.19_amd64.deb
+    source: src-tauri/target/release/bundle/deb/libragent_0.8.20_amd64.deb
     source-type: deb
     stage-packages:
       - libwebkit2gtk-4.1-0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4095,7 +4095,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libragent"
-version = "0.8.19"
+version = "0.8.20"
 description = "A desktop app for AI agents with built-in tools"
 authors = ["fritzprix"]
 license = "MIT"

--- a/src-tauri/bundled_skills/telegram-cli/SKILL.md
+++ b/src-tauri/bundled_skills/telegram-cli/SKILL.md
@@ -167,6 +167,36 @@ When `--output` is set, stdout prints a compact summary (`status`, `output` path
 
 All CLI output uses UTF-8 (`ensure_ascii=False`). Errors go to stderr as UTF-8 JSON.
 
+### Input encoding (Windows / Unicode workaround)
+
+On Windows, passing Unicode characters (like Korean) as command-line arguments can cause character corruption (mojibake) due to PowerShell's default encoding (`cp949`).
+
+To bypass this bottleneck, **always** write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query`:
+
+#### Send Message (Windows Recommended)
+```powershell
+# 1. Write the message to a UTF-8 file in the workspace
+$msg = "안녕하세요, 텔레그램 메시지 테스트입니다."
+$msg | Out-File -Encoding utf8 "<workspace>/tg_message.txt"
+
+# 2. Call the CLI with --message-file
+python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
+  --chat "<chat_id_or_username>" `
+  --message-file "<workspace>/tg_message.txt"
+```
+
+#### Search Messages (Windows Recommended)
+```powershell
+# 1. Write the query to a UTF-8 file in the workspace
+$query = "테스트"
+$query | Out-File -Encoding utf8 "<workspace>/tg_query.txt"
+
+# 2. Call the CLI with --query-file
+python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
+  --query-file "<workspace>/tg_query.txt" `
+  --output "<workspace>/telegram_search.json"
+```
+
 ### Dispatch CLI Actions
 
 Classify the user's request into one of the actions (`send_message`, `get_messages`, `list_chats`, `search_messages`, `download_file`, `get_chat_info`) and execute the CLI. For a detailed reference of CLI parameters, JSON output schemas, and pagination strategies, see the [cli-reference.md](references/cli-reference.md) guide.

--- a/src-tauri/bundled_skills/telegram-cli/SKILL.md
+++ b/src-tauri/bundled_skills/telegram-cli/SKILL.md
@@ -167,11 +167,18 @@ When `--output` is set, stdout prints a compact summary (`status`, `output` path
 
 All CLI output uses UTF-8 (`ensure_ascii=False`). Errors go to stderr as UTF-8 JSON.
 
+### Output handling (Windows 필수)
+On Windows, always set these before invoking any CLI command:
+```powershell
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$env:PYTHONUTF8 = "1"
+```
+
 ### Input encoding (Windows / Unicode workaround)
 
 On Windows, passing Unicode characters (like Korean) as command-line arguments can cause character corruption (mojibake) due to PowerShell's default encoding (`cp949`).
 
-To bypass this bottleneck, **always** write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query`:
+To bypass this bottleneck, it is highly **recommended** to write the message or query to a UTF-8 file and use `--message-file` or `--query-file` instead of `--message` or `--query` (especially on older Windows PowerShell environments; PowerShell 7+ with `$OutputEncoding` set to UTF-8 may work with inline arguments):
 
 #### Send Message (Windows Recommended)
 ```powershell
@@ -183,6 +190,9 @@ $msg | Out-File -Encoding utf8 "<workspace>/tg_message.txt"
 python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
   --chat "<chat_id_or_username>" `
   --message-file "<workspace>/tg_message.txt"
+
+# 3. Clean up the temporary file (recommended)
+Remove-Item -Path "<workspace>/tg_message.txt" -ErrorAction SilentlyContinue
 ```
 
 #### Search Messages (Windows Recommended)
@@ -195,6 +205,9 @@ $query | Out-File -Encoding utf8 "<workspace>/tg_query.txt"
 python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
   --query-file "<workspace>/tg_query.txt" `
   --output "<workspace>/telegram_search.json"
+
+# 3. Clean up the temporary file (recommended)
+Remove-Item -Path "<workspace>/tg_query.txt" -ErrorAction SilentlyContinue
 ```
 
 ### Dispatch CLI Actions

--- a/src-tauri/bundled_skills/telegram-cli/references/cli-reference.md
+++ b/src-tauri/bundled_skills/telegram-cli/references/cli-reference.md
@@ -12,7 +12,7 @@ Use `telegram_cli.py` to dispatch actions.
 ```powershell
 python "<skill-base-dir>/scripts/telegram_cli.py" --action send_message `
   --chat "<chat_id_or_username>" `
-  --message "메시지 내용" `
+  [--message "메시지 내용" | --message-file "/path/to/message.txt"] `
   [--file "/path/to/attachment"]
 ```
 - Username: `@username` or `username`
@@ -35,7 +35,7 @@ python "<skill-base-dir>/scripts/telegram_cli.py" --action list_chats
 ### Action: `search_messages` — Search messages
 ```powershell
 python "<skill-base-dir>/scripts/telegram_cli.py" --action search_messages `
-  --query "검색어" `
+  [--query "검색어" | --query-file "/path/to/query.txt"] `
   [--limit N] `
   [--chat "<chat_id_or_username>"] `
   [--offset_id N] `
@@ -177,8 +177,8 @@ python "<skill-base-dir>/scripts/telegram_cli.py" --action get_messages `
 | FloodWait | `"message": "FloodWait: wait N seconds"` (exit `2`) | Wait **N** seconds, retry same command |
 | Not authorized | `"Not authorized. Run setup first."` (exit `1`) | Run `check_config.py`; if not ok, run Step 2 auth flow |
 | Auth restart | `check_config` → `auth_restart_needed` | Delete `~/.libragent/telegram_session.session`, `send_code` → `sign_in` |
-| Missing `--chat` / `--query` | exit `3` | Add required flag and retry |
-| cp949 / garbled stdout | Mojibake in console | Re-run with `--output` and read the UTF-8 file |
+| Missing `--chat` / `--query` | exit `3` | Add required flag (or file-based equivalent) and retry |
+| cp949 / garbled inputs or stdout | Mojibake in console or sent messages | For outputs, re-run with `--output` and read the UTF-8 file. For inputs, write to a UTF-8 file and use `--message-file` or `--query-file` |
 
 ### Error Handling (setup & auth)
 

--- a/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
+++ b/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
@@ -170,12 +170,12 @@ def require_chat_arg(args: argparse.Namespace, action: str) -> bool:
 
 
 def require_query_arg(args: argparse.Namespace) -> bool:
-    """Validate that --query was provided for search_messages."""
-    if args.query:
+    """Validate that --query or --query-file was provided for search_messages."""
+    if args.query or args.query_file:
         return True
 
     emit_error(
-        {"status": "error", "message": "Missing required argument: --query is required for search_messages."}
+        {"status": "error", "message": "Missing required argument: --query or --query-file is required for search_messages."}
     )
     return False
 
@@ -295,10 +295,22 @@ def format_chat(peer: Any) -> dict:
 
 def action_send_message(args: argparse.Namespace, config: dict) -> int:
     """Send a message to a chat."""
-    if not require_chat_arg(args, "send_message") or not args.message:
-        if not args.message:
+    message = args.message
+    if args.message_file:
+        message_file_path = Path(args.message_file)
+        if not message_file_path.exists():
+            emit_error({"status": "error", "message": f"Message file not found: {args.message_file}"})
+            return 3
+        try:
+            message = message_file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            emit_error({"status": "error", "message": f"Failed to read message file: {e}"})
+            return 3
+
+    if not require_chat_arg(args, "send_message") or not message:
+        if not message:
             emit_error(
-                {"status": "error", "message": "Missing required argument: --message is required for send_message."}
+                {"status": "error", "message": "Missing required argument: --message or --message-file is required for send_message."}
             )
         return 3
 
@@ -319,7 +331,7 @@ def action_send_message(args: argparse.Namespace, config: dict) -> int:
                 emit_error({"status": "error", "message": f"File not found: {args.file}"})
                 return 3
             result = client.loop.run_until_complete(
-                client.send_file(peer, str(file_path), caption=args.message)
+                client.send_file(peer, str(file_path), caption=message)
             )
             output = {
                 "status": "ok",
@@ -332,7 +344,7 @@ def action_send_message(args: argparse.Namespace, config: dict) -> int:
             }
         else:
             result = client.loop.run_until_complete(
-                client.send_message(peer, args.message)
+                client.send_message(peer, message)
             )
             output = {
                 "status": "ok",
@@ -451,7 +463,23 @@ def action_list_chats(args: argparse.Namespace, config: dict) -> int:
 
 def action_search_messages(args: argparse.Namespace, config: dict) -> int:
     """Search messages."""
-    if not require_query_arg(args):
+    query = args.query
+    if args.query_file:
+        query_file_path = Path(args.query_file)
+        if not query_file_path.exists():
+            emit_error({"status": "error", "message": f"Query file not found: {args.query_file}"})
+            return 3
+        try:
+            query = query_file_path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            emit_error({"status": "error", "message": f"Failed to read query file: {e}"})
+            return 3
+
+    if not require_query_arg(args) or not query:
+        if not query:
+            emit_error(
+                {"status": "error", "message": "Missing required argument: --query or --query-file is required for search_messages."}
+            )
         return 3
 
     client = create_client(config)
@@ -472,7 +500,7 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
                 client,
                 peer,
                 limit=limit,
-                search=args.query,
+                search=query,
                 offset_id=offset_id,
             )
         )
@@ -483,7 +511,7 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
             {
                 "status": "ok",
                 "action": "search_messages",
-                "query": args.query,
+                "query": query,
                 "chat": args.chat,
                 "count": len(msgs),
                 "offset_id": offset_id,
@@ -659,7 +687,9 @@ def main() -> int:
     )
     parser.add_argument("--chat", help="Chat ID or username")
     parser.add_argument("--message", help="Message text (for send_message)")
+    parser.add_argument("--message-file", help="Read message text from a UTF-8 file (avoids PowerShell encoding issues)")
     parser.add_argument("--query", help="Search query (for search_messages)")
+    parser.add_argument("--query-file", help="Read search query from a UTF-8 file (avoids PowerShell encoding issues)")
     parser.add_argument("--limit", type=int, default=20, help="Number of messages (default: 20)")
     parser.add_argument(
         "--offset_id",

--- a/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
+++ b/src-tauri/bundled_skills/telegram-cli/scripts/telegram_cli.py
@@ -291,20 +291,59 @@ def format_chat(peer: Any) -> dict:
     return {"id": getattr(peer, "id", None), "name": "Unknown", "type": "unknown"}
 
 
+def validate_and_read_file(file_path_str: str, file_type_label: str) -> str | None:
+    """Validate, check size, and read a UTF-8 file, handling errors.
+
+    Returns the file content stripped, or None if an error was emitted.
+    """
+    path = Path(file_path_str)
+    if not path.exists():
+        emit_error({"status": "error", "message": f"{file_type_label} file not found: {file_path_str}"})
+        return None
+
+    # Path traversal validation
+    try:
+        resolved_path = path.resolve()
+        resolved_config_dir = CONFIG_PATH.parent.resolve()
+
+        # Check if the path resides inside the config directory
+        if resolved_path == CONFIG_PATH.resolve() or resolved_config_dir in resolved_path.parents:
+            emit_error({"status": "error", "message": "Access denied: cannot read files from the config directory."})
+            return None
+    except Exception as e:
+        emit_error({"status": "error", "message": f"Path validation failed: {e}"})
+        return None
+
+    # File size limit validation (1 MB)
+    max_file_size = 1024 * 1024  # 1 MB
+    try:
+        if path.stat().st_size > max_file_size:
+            emit_error({"status": "error", "message": f"File size exceeds the limit of {max_file_size} bytes."})
+            return None
+    except OSError as e:
+        emit_error({"status": "error", "message": f"Failed to access file metadata: {e}"})
+        return None
+
+    # Read and strip content
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+        if not content:
+            emit_error({"status": "error", "message": f"The provided {file_type_label.lower()} file is empty."})
+            return None
+        return content
+    except OSError as e:
+        emit_error({"status": "error", "message": f"Failed to read {file_type_label.lower()} file: {e}"})
+        return None
+
+
 # ─── Actions ──────────────────────────────────────────────────────────
 
 def action_send_message(args: argparse.Namespace, config: dict) -> int:
     """Send a message to a chat."""
     message = args.message
     if args.message_file:
-        message_file_path = Path(args.message_file)
-        if not message_file_path.exists():
-            emit_error({"status": "error", "message": f"Message file not found: {args.message_file}"})
-            return 3
-        try:
-            message = message_file_path.read_text(encoding="utf-8")
-        except OSError as e:
-            emit_error({"status": "error", "message": f"Failed to read message file: {e}"})
+        message = validate_and_read_file(args.message_file, "Message")
+        if message is None:
             return 3
 
     if not require_chat_arg(args, "send_message") or not message:
@@ -465,14 +504,8 @@ def action_search_messages(args: argparse.Namespace, config: dict) -> int:
     """Search messages."""
     query = args.query
     if args.query_file:
-        query_file_path = Path(args.query_file)
-        if not query_file_path.exists():
-            emit_error({"status": "error", "message": f"Query file not found: {args.query_file}"})
-            return 3
-        try:
-            query = query_file_path.read_text(encoding="utf-8").strip()
-        except OSError as e:
-            emit_error({"status": "error", "message": f"Failed to read query file: {e}"})
+        query = validate_and_read_file(args.query_file, "Query")
+        if query is None:
             return 3
 
     if not require_query_arg(args) or not query:

--- a/src-tauri/src/mcp/oauth.rs
+++ b/src-tauri/src/mcp/oauth.rs
@@ -56,6 +56,21 @@ fn validate_oauth_https_endpoint(url_str: &str, label: &str) -> Result<(), Strin
     Ok(())
 }
 
+/// Constant-time byte comparison to prevent timing attacks.
+/// Note: Early return on length mismatch is acceptable here because
+/// the CSRF token length is fixed and public knowledge, meaning
+/// it does not leak any secret information.
+fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        result |= x ^ y;
+    }
+    result == 0
+}
+
 /// Manages OAuth 2.1 flows for MCP servers
 #[derive(Debug)]
 pub struct OAuthManager {
@@ -150,10 +165,17 @@ impl OAuthManager {
             auth_request = auth_request.set_pkce_challenge(pkce_challenge);
         }
 
-        // Add scopes if configured
+        // Add scopes if configured using standard OAuth2 scope parameter
         if let Some(scopes) = &config.scopes {
             for scope in scopes {
                 auth_request = auth_request.add_scope(Scope::new(scope.clone()));
+            }
+        }
+
+        // Add any custom parameters (e.g., user_scope for Slack)
+        if let Some(custom_params) = &config.custom_params {
+            for (key, value) in custom_params {
+                auth_request = auth_request.add_extra_param(key.clone(), value.clone());
             }
         }
 
@@ -188,14 +210,14 @@ impl OAuthManager {
     ) -> Result<String, String> {
         log::info!("Exchanging authorization code for token: {server_id}");
 
-        // Step 1: Validate CSRF token
+        // Step 1: Validate CSRF token (constant-time comparison to prevent timing attacks)
         {
             let mut tokens = self.csrf_tokens.lock().await;
             let stored_csrf = tokens
                 .remove(server_id)
                 .ok_or("No CSRF token found for server")?;
 
-            if stored_csrf.secret() != state {
+            if !constant_time_compare(stored_csrf.secret().as_bytes(), state.as_bytes()) {
                 return Err("CSRF token mismatch - potential security issue".to_string());
             }
         }
@@ -214,9 +236,12 @@ impl OAuthManager {
             .clone()
             .unwrap_or_else(|| DEFAULT_CALLBACK_URL.to_string());
 
+        let is_slack_token_exchange =
+            endpoints.token_endpoint == "https://slack.com/api/oauth.v2.user.access";
+
         let client_secret = config.client_secret.clone().map(ClientSecret::new);
 
-        let client = BasicClient::new(
+        let mut client = BasicClient::new(
             ClientId::new(client_id),
             client_secret,
             AuthUrl::new(endpoints.authorization_endpoint)
@@ -229,6 +254,10 @@ impl OAuthManager {
         .set_redirect_uri(
             RedirectUrl::new(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?,
         );
+
+        if is_slack_token_exchange {
+            client = client.set_auth_type(oauth2::AuthType::RequestBody);
+        }
 
         let mut exchange =
             client.exchange_code(AuthorizationCode::new(authorization_code.to_string()));
@@ -331,6 +360,25 @@ impl OAuthManager {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
 
+        // Security validation: redirect_uri must be whitelisted
+        let parsed_uri =
+            url::Url::parse(redirect_uri).map_err(|e| format!("Invalid redirect URI: {e}"))?;
+
+        let host = parsed_uri.host_str().unwrap_or("");
+        if host != "localhost" && host != "127.0.0.1" {
+            return Err(
+                "Security violation: redirect_uri host must be localhost or 127.0.0.1".to_string(),
+            );
+        }
+
+        if parsed_uri.scheme() != "http" {
+            return Err("Security violation: redirect_uri scheme must be http".to_string());
+        }
+
+        if parsed_uri.path() != "/callback" {
+            return Err("Security violation: redirect_uri path must be /callback".to_string());
+        }
+
         let port = Self::parse_port_from_uri(redirect_uri);
         log::info!("Starting temporary OAuth callback listener on port {port}");
 
@@ -387,12 +435,15 @@ impl OAuthManager {
                                                              </html>";
                                                          let response = format!(
                                                              "HTTP/1.1 200 OK\r\n\
-                                                             Content-Type: text/html; charset=utf-8\r\n\
-                                                             Content-Length: {}\r\n\
-                                                             Connection: close\r\n\r\n\
-                                                             {}",
-                                                             html.len(),
-                                                             html
+                                                              Content-Type: text/html; charset=utf-8\r\n\
+                                                              Content-Length: {}\r\n\
+                                                              Cache-Control: no-store, no-cache, must-revalidate\r\n\
+                                                              Pragma: no-cache\r\n\
+                                                              Expires: 0\r\n\
+                                                              Connection: close\r\n\r\n\
+                                                              {}",
+                                                              html.len(),
+                                                              html
                                                          );
                                                          let _ = stream.write_all(response.as_bytes()).await;
                                                          let _ = stream.flush().await;
@@ -477,10 +528,11 @@ mod tests {
             registration_endpoint: None,
             client_id: Some("test-client".to_string()),
             client_secret: None,
-            redirect_uri: Some("libr-agent://oauth/callback".to_string()),
+            redirect_uri: Some("http://localhost:14207/callback".to_string()),
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             use_pkce: true,
             resource_parameter: None,
+            custom_params: None,
         };
 
         let result = manager
@@ -500,5 +552,81 @@ mod tests {
             .lock()
             .await
             .contains_key("test-server"));
+    }
+
+    #[tokio::test]
+    async fn test_slack_authorization_url_construction() {
+        let manager = OAuthManager::new();
+        let mut custom_params = HashMap::new();
+        custom_params.insert(
+            "user_scope".to_string(),
+            "channels:read,chat:write".to_string(),
+        );
+
+        let config = OAuthConfig {
+            oauth_type: "oauth2.1".to_string(),
+            discovery_url: None,
+            authorization_endpoint: Some("https://slack.com/oauth/v2_user/authorize".to_string()),
+            token_endpoint: Some("https://slack.com/api/oauth.v2.user.access".to_string()),
+            registration_endpoint: None,
+            client_id: Some("test-client".to_string()),
+            client_secret: None,
+            redirect_uri: Some("http://localhost:14207/callback".to_string()),
+            scopes: None,
+            use_pkce: true,
+            resource_parameter: None,
+            custom_params: Some(custom_params),
+        };
+
+        let result = manager
+            .start_authorization_flow(&config, "slack-server")
+            .await;
+
+        assert!(result.is_ok());
+        let (url, _state) = result.unwrap();
+
+        // Slack user oauth must contain user_scope with comma-separated scopes
+        assert!(url.contains("user_scope=channels%3Aread%2Cchat%3Awrite"));
+        // Slack user oauth must NOT contain standard scope parameter
+        assert!(!url.contains("scope="));
+    }
+
+    #[test]
+    fn test_constant_time_compare() {
+        assert!(constant_time_compare(b"hello", b"hello"));
+        assert!(!constant_time_compare(b"hello", b"world"));
+        assert!(!constant_time_compare(b"hello", b"helloo"));
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_callback_redirect_uri_whitelist() {
+        let manager = OAuthManager::new();
+
+        // Invalid host
+        let res = manager
+            .wait_for_callback("http://malicious.example.com/callback", "state")
+            .await;
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .contains("Security violation: redirect_uri host"));
+
+        // Invalid scheme
+        let res = manager
+            .wait_for_callback("https://localhost/callback", "state")
+            .await;
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .contains("Security violation: redirect_uri scheme"));
+
+        // Invalid path
+        let res = manager
+            .wait_for_callback("http://localhost/badpath", "state")
+            .await;
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .contains("Security violation: redirect_uri path"));
     }
 }

--- a/src-tauri/src/mcp/presets.rs
+++ b/src-tauri/src/mcp/presets.rs
@@ -15,6 +15,8 @@ pub struct MCPServerPreset {
     pub env: Option<Value>,
     pub variable_definitions: Option<Value>,
     pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<crate::mcp::types::OAuthConfig>,
 }
 
 #[derive(Deserialize)]
@@ -32,6 +34,7 @@ struct RawPresetConfig {
     // common
     description: Option<String>,
     logo: Option<String>,
+    authentication: Option<crate::mcp::types::OAuthConfig>,
 }
 
 pub fn get_recommended_servers() -> Vec<MCPServerPreset> {
@@ -82,6 +85,7 @@ pub fn get_recommended_servers() -> Vec<MCPServerPreset> {
             env: config.env,
             variable_definitions,
             url,
+            authentication: config.authentication,
         });
     }
 

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -87,6 +87,9 @@ pub struct OAuthConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "resourceParameter", alias = "resource_parameter")]
     pub resource_parameter: Option<String>, // RFC 9728
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "customParams", alias = "custom_params")]
+    pub custom_params: Option<HashMap<String, String>>,
 }
 
 fn default_use_pkce() -> bool {
@@ -699,6 +702,7 @@ mod tests {
                 scopes: Some(vec!["read".to_string(), "write".to_string()]),
                 use_pkce: true,
                 resource_parameter: None,
+                custom_params: None,
             }),
             metadata: Some(ServerMetadata {
                 description: Some("Test server with OAuth".to_string()),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibrAgent",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "identifier": "com.fritzprix.libragent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/README.md
+++ b/src/README.md
@@ -268,9 +268,8 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
-
-- **Windows:** [`LibrAgent_0.8.19_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64-setup.exe) · [`LibrAgent_0.8.19_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_x64_en-US.msi)
-- **macOS (Apple Silicon):** [`LibrAgent_0.8.19_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_aarch64.dmg)
-- **Linux:** [`LibrAgent_0.8.19_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.AppImage) · [`LibrAgent_0.8.19_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent_0.8.19_amd64.deb) · [`LibrAgent-0.8.19-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.19/LibrAgent-0.8.19-1.x86_64.rpm)
-- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.19)
+- **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
+- **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
+- **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)
+- **All release assets:** [Releases page](https://github.com/fritzprix/libr-agent/releases/tag/v0.8.20)
 <!-- RELEASE_DOWNLOADS_END -->

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.20_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64-setup.exe) · [`LibrAgent_0.8.20_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.20_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.20_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.AppImage) · [`LibrAgent_0.8.20_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent_0.8.20_amd64.deb) · [`LibrAgent-0.8.20-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.20/LibrAgent-0.8.20-1.x86_64.rpm)

--- a/src/features/agent/hooks/__tests__/useInputToken.test.tsx
+++ b/src/features/agent/hooks/__tests__/useInputToken.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useInputToken } from '../useInputToken';
+
+describe('useInputToken', () => {
+  it('should identify a command when typing starts with /', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('/clear', 6);
+    });
+
+    expect(result.current.stage).toEqual({
+      kind: 'typing-command',
+      query: 'clear',
+      anchorIndex: 0,
+    });
+    expect(result.current.commandResults).toHaveLength(1);
+    expect(result.current.commandResults[0].id).toBe('/clear');
+  });
+
+  it('should identify a command when typing / after a space', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('hello /clear', 12);
+    });
+
+    expect(result.current.stage).toEqual({
+      kind: 'typing-command',
+      query: 'clear',
+      anchorIndex: 6,
+    });
+    expect(result.current.commandResults).toHaveLength(1);
+  });
+
+  it('should not identify a command when / is preceded by a non-whitespace character', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('hello/clear', 11);
+    });
+
+    expect(result.current.stage).toEqual({ kind: 'idle' });
+    expect(result.current.commandResults).toHaveLength(0);
+  });
+
+  it('should not identify a command for path slashes', () => {
+    const { result } = renderHook(() => useInputToken([], []));
+
+    act(() => {
+      result.current.onInputChange('src/features/agent', 18);
+    });
+
+    expect(result.current.stage).toEqual({ kind: 'idle' });
+    expect(result.current.commandResults).toHaveLength(0);
+  });
+});

--- a/src/features/agent/hooks/useInputToken.ts
+++ b/src/features/agent/hooks/useInputToken.ts
@@ -50,7 +50,7 @@ const TYPE_RE = /@([\w]*)$/;
 /** Regex: matches `@word:rest` (typing arg for a type). */
 const ARG_RE = /@([\w]+):([\S]*)$/;
 /** Regex: matches `/command` with potential spaces. */
-const COMMAND_RE = /\/([\w\s-]*)$/;
+const COMMAND_RE = /(?<!\S)\/([\w\s-]*)$/;
 
 export interface UseInputTokenResult {
   /** Current UX stage. */

--- a/src/features/mcp-servers/hooks/useMCPServerManagement.ts
+++ b/src/features/mcp-servers/hooks/useMCPServerManagement.ts
@@ -129,6 +129,7 @@ export function useMCPServerManagement(service?: McpServerService) {
       updatedAt: new Date(),
       metadata: buildPresetMetadata(preset),
       transport,
+      authentication: preset.authentication,
     };
     setEditingServer(newServer);
   }, []);

--- a/src/lib/backend/mcp-server-config.ts
+++ b/src/lib/backend/mcp-server-config.ts
@@ -1,6 +1,7 @@
 import { safeInvoke } from './core';
 import type { MCPServerEntity } from '@/models/chat';
 import type { Page } from '@/lib/db/types';
+import type { OAuthConfig } from '@/lib/mcp';
 
 /**
  * Backend DTO for MCP Server Config
@@ -194,6 +195,7 @@ export interface MCPServerPreset {
     }
   >;
   url?: string;
+  authentication?: OAuthConfig;
 }
 
 export async function listMCPServerPresets(): Promise<MCPServerPreset[]> {

--- a/src/lib/mcp/config/transport.ts
+++ b/src/lib/mcp/config/transport.ts
@@ -41,4 +41,5 @@ export interface OAuthConfig {
   scopes?: string[];
   usePKCE?: boolean; // Default: true
   resourceParameter?: string; // RFC 9728 Protected Resource Metadata
+  customParams?: Record<string, string>; // Arbitrary custom query parameters for OAuth URL
 }


### PR DESCRIPTION
This PR resolves the Telegram MCP verification failure by:
1. Removing the redundant and unexposed 'MOCK' environment variable from mcp-server.json.
2. Adding TELEGRAM_BOT_TOKEN to env and ariableDefinitions in mcp-server.json to expose a password input field in the UI.

This ensures the server can be successfully configured and verified using a bot token without throwing startup exceptions.