### PR TITLE
Harden Claude channel security and observability

### DIFF
--- a/src-tauri/src/agent/session_manager/channel.rs
+++ b/src-tauri/src/agent/session_manager/channel.rs
@@ -145,8 +145,64 @@ fn format_channel_payload(
     )
 }
 
+/// Known HTML event-handler attribute names blocked when channel XML may render as HTML.
+const UNSAFE_HTML_EVENT_ATTRS: &[&str] = &[
+    "onclick",
+    "onerror",
+    "onload",
+    "onmouseover",
+    "onfocus",
+    "onblur",
+    "onchange",
+    "onsubmit",
+    "onreset",
+    "onselect",
+    "onkeydown",
+    "onkeypress",
+    "onkeyup",
+    "onabort",
+    "oncanplay",
+    "ontoggle",
+    "onanimationend",
+    "ontransitionend",
+    "onpointerdown",
+    "onpointerup",
+    "onpaste",
+    "oncut",
+    "oncopy",
+    "ondrag",
+    "ondrop",
+    "onscroll",
+    "onwheel",
+    "onresize",
+    "onbeforeunload",
+    "onhashchange",
+    "onmessage",
+    "onoffline",
+    "ononline",
+    "onpagehide",
+    "onpageshow",
+    "onpopstate",
+    "onstorage",
+    "onunload",
+];
+
+fn is_unsafe_html_event_attr(key: &str) -> bool {
+    UNSAFE_HTML_EVENT_ATTRS
+        .iter()
+        .any(|attr| key.eq_ignore_ascii_case(attr))
+}
+
 fn is_safe_channel_attribute_name(key: &str) -> bool {
-    if matches!(key, "source") {
+    if key.eq_ignore_ascii_case("source") {
+        return false;
+    }
+
+    if key.eq_ignore_ascii_case("style") {
+        return false;
+    }
+
+    if is_unsafe_html_event_attr(key) {
         return false;
     }
 

--- a/src-tauri/src/agent/tool_approvals.rs
+++ b/src-tauri/src/agent/tool_approvals.rs
@@ -9,8 +9,6 @@ use crate::mcp::builtin::workspace::code_execution::shell::policy::{
     evaluate_shell_policy, is_shell_tool_name, ShellPolicyAction, ShellPolicyContext,
 };
 
-const CHANNEL_PERMISSION_ID_ALPHABET: &[u8] = b"abcdefghijkmnopqrstuvwxyz";
-const CHANNEL_PERMISSION_ID_LENGTH: usize = 5;
 static TOOL_APPROVALS_CONFIG: OnceCell<ToolApprovalsConfig> = OnceCell::const_new();
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -194,15 +192,7 @@ fn requires_approval_by_config(config: &ToolApprovalsConfig, tool_name: &str) ->
 }
 
 pub fn generate_channel_permission_request_id() -> String {
-    let bytes = uuid::Uuid::new_v4().into_bytes();
-    let mut output = String::with_capacity(CHANNEL_PERMISSION_ID_LENGTH);
-
-    for byte in bytes.iter().take(CHANNEL_PERMISSION_ID_LENGTH) {
-        let index = (*byte as usize) % CHANNEL_PERMISSION_ID_ALPHABET.len();
-        output.push(CHANNEL_PERMISSION_ID_ALPHABET[index] as char);
-    }
-
-    output
+    uuid::Uuid::new_v4().simple().to_string()
 }
 
 pub fn build_channel_permission_description(tool_name: &str, arguments: &str) -> String {

--- a/src-tauri/src/mcp/session_isolation/channel_dispatch.rs
+++ b/src-tauri/src/mcp/session_isolation/channel_dispatch.rs
@@ -54,11 +54,11 @@ pub fn spawn_session_channel_dispatch_task(
                     let approved = match parse_channel_permission_behavior(&verdict.behavior) {
                         Ok(approved) => approved,
                         Err(error) => {
-                            error!(
-                                "Invalid channel permission verdict from '{}': {}",
+                            warn!(
+                                "Invalid channel permission verdict from '{}' (defaulting to deny): {}",
                                 server_name, error
                             );
-                            continue;
+                            false
                         }
                     };
 

--- a/src-tauri/src/mcp/session_isolation/channel_events.rs
+++ b/src-tauri/src/mcp/session_isolation/channel_events.rs
@@ -1,11 +1,95 @@
 use crate::mcp::types::{ChannelNotification, ChannelPermissionVerdict};
 use log::warn;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{self, Sender};
+
+const CHANNEL_DROP_METRICS_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+static CHANNEL_EVENTS_DROPPED_BUFFER_FULL: AtomicU64 = AtomicU64::new(0);
+static CHANNEL_EVENTS_DROPPED_RECEIVER_CLOSED: AtomicU64 = AtomicU64::new(0);
+static CHANNEL_DROP_METRICS_LAST_LOG: LazyLock<Mutex<Instant>> =
+    LazyLock::new(|| Mutex::new(Instant::now()));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelDropKind {
+    BufferFull,
+    ReceiverClosed,
+}
+
+fn record_channel_event_drop(kind: ChannelDropKind, source: &str) {
+    match kind {
+        ChannelDropKind::BufferFull => {
+            CHANNEL_EVENTS_DROPPED_BUFFER_FULL.fetch_add(1, Ordering::Relaxed);
+        }
+        ChannelDropKind::ReceiverClosed => {
+            CHANNEL_EVENTS_DROPPED_RECEIVER_CLOSED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    maybe_log_channel_drop_metrics(source);
+}
+
+fn maybe_log_channel_drop_metrics(trigger_source: &str) {
+    let mut last_log = CHANNEL_DROP_METRICS_LAST_LOG
+        .lock()
+        .expect("channel drop metrics lock poisoned");
+    if last_log.elapsed() < CHANNEL_DROP_METRICS_LOG_INTERVAL {
+        return;
+    }
+
+    let buffer_full = CHANNEL_EVENTS_DROPPED_BUFFER_FULL.swap(0, Ordering::Relaxed);
+    let receiver_closed = CHANNEL_EVENTS_DROPPED_RECEIVER_CLOSED.swap(0, Ordering::Relaxed);
+
+    if buffer_full > 0 || receiver_closed > 0 {
+        warn!(
+            "Channel event drops in last {}s (triggered by '{}'): buffer_full={}, receiver_closed={}",
+            CHANNEL_DROP_METRICS_LOG_INTERVAL.as_secs(),
+            trigger_source,
+            buffer_full,
+            receiver_closed
+        );
+    }
+
+    *last_log = Instant::now();
+}
+
+/// Test-only snapshot of channel event drop counters (not reset).
+#[doc(hidden)]
+pub fn channel_drop_metrics_snapshot_for_test() -> (u64, u64) {
+    (
+        CHANNEL_EVENTS_DROPPED_BUFFER_FULL.load(Ordering::Relaxed),
+        CHANNEL_EVENTS_DROPPED_RECEIVER_CLOSED.load(Ordering::Relaxed),
+    )
+}
+
+/// Test-only reset of channel event drop counters.
+#[doc(hidden)]
+pub fn reset_channel_drop_metrics_for_test() {
+    CHANNEL_EVENTS_DROPPED_BUFFER_FULL.store(0, Ordering::Relaxed);
+    CHANNEL_EVENTS_DROPPED_RECEIVER_CLOSED.store(0, Ordering::Relaxed);
+    if let Ok(mut last_log) = CHANNEL_DROP_METRICS_LAST_LOG.lock() {
+        *last_log = Instant::now();
+    }
+}
+
+/// Test-only: move the drop-metrics log window into the past so the next drop flushes counters.
+#[doc(hidden)]
+pub fn advance_channel_drop_metrics_log_window_for_test() {
+    if let Ok(mut last_log) = CHANNEL_DROP_METRICS_LAST_LOG.lock() {
+        *last_log = Instant::now()
+            .checked_sub(CHANNEL_DROP_METRICS_LOG_INTERVAL + Duration::from_secs(1))
+            .unwrap_or_else(Instant::now);
+    }
+}
 
 /// Bounded buffer for native channel events per session.
 pub const CHANNEL_EVENT_BUFFER_SIZE: usize = 1024;
+
+/// Maximum allowed length for channel message `content` (bytes).
+pub const MAX_CHANNEL_CONTENT_BYTES: usize = 8192;
 
 pub type ChannelEventSender = Sender<SessionChannelEvent>;
 pub type ChannelEventReceiver = mpsc::Receiver<SessionChannelEvent>;
@@ -36,16 +120,10 @@ pub fn try_emit_channel_event(tx: &ChannelEventSender, event: SessionChannelEven
     if let Err(error) = tx.try_send(event) {
         match error {
             mpsc::error::TrySendError::Full(_) => {
-                warn!(
-                    "Channel event buffer full (capacity {}) for '{}'; dropping event",
-                    CHANNEL_EVENT_BUFFER_SIZE, source
-                );
+                record_channel_event_drop(ChannelDropKind::BufferFull, source);
             }
             mpsc::error::TrySendError::Closed(_) => {
-                warn!(
-                    "Channel event receiver dropped for '{}'; dropping event",
-                    source
-                );
+                record_channel_event_drop(ChannelDropKind::ReceiverClosed, source);
             }
         }
     }
@@ -114,7 +192,16 @@ pub fn try_parse_channel_event(line: &[u8], server_name: &str) -> Option<Session
 
     match kind {
         ChannelMethodKind::Message => {
-            let content = params.get("content")?.as_str()?.to_string();
+            let content = params.get("content")?.as_str()?;
+            if content.len() > MAX_CHANNEL_CONTENT_BYTES {
+                warn!(
+                    "Channel message content too large ({} bytes) from '{}'; dropping",
+                    content.len(),
+                    server_name
+                );
+                return None;
+            }
+            let content = content.to_string();
             let meta = params
                 .get("meta")
                 .map(flatten_meta_object)
@@ -170,6 +257,38 @@ mod tests {
                 assert_eq!(notification.content, "hello");
                 assert_eq!(notification.meta.get("chat_id"), Some(&"1".to_string()));
                 assert_eq!(notification.meta.get("sender_id"), Some(&"42".to_string()));
+            }
+            SessionChannelEvent::PermissionVerdict { .. } => {
+                panic!("expected message event");
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_channel_message_content() {
+        let oversized = "x".repeat(MAX_CHANNEL_CONTENT_BYTES + 1);
+        let line = format!(
+            r#"{{"jsonrpc":"2.0","method":"claude/channel","params":{{"content":"{}"}}}}"#,
+            oversized
+        );
+        assert!(
+            try_parse_channel_event(line.as_bytes(), "telegram").is_none(),
+            "oversized channel content should be dropped"
+        );
+    }
+
+    #[test]
+    fn accepts_channel_message_at_content_limit() {
+        let content = "x".repeat(MAX_CHANNEL_CONTENT_BYTES);
+        let line = format!(
+            r#"{{"jsonrpc":"2.0","method":"claude/channel","params":{{"content":"{}"}}}}"#,
+            content
+        );
+        let event = try_parse_channel_event(line.as_bytes(), "telegram")
+            .expect("content at limit should parse");
+        match event {
+            SessionChannelEvent::Message { notification, .. } => {
+                assert_eq!(notification.content.len(), MAX_CHANNEL_CONTENT_BYTES);
             }
             SessionChannelEvent::PermissionVerdict { .. } => {
                 panic!("expected message event");

--- a/src-tauri/tests/integration/channel_drop_metrics_tests.rs
+++ b/src-tauri/tests/integration/channel_drop_metrics_tests.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+
+use tauri_mcp_agent_lib::mcp::session_isolation::channel_events::{
+    advance_channel_drop_metrics_log_window_for_test, channel_drop_metrics_snapshot_for_test,
+    create_channel_event_bus, reset_channel_drop_metrics_for_test, try_emit_channel_event,
+    SessionChannelEvent, CHANNEL_EVENT_BUFFER_SIZE,
+};
+use tauri_mcp_agent_lib::mcp::types::ChannelNotification;
+
+fn sample_message_event() -> SessionChannelEvent {
+    SessionChannelEvent::Message {
+        server_name: "test-server".to_string(),
+        notification: ChannelNotification {
+            content: "hello".to_string(),
+            meta: HashMap::new(),
+        },
+    }
+}
+
+#[test]
+fn channel_drop_metrics_count_buffer_full_events() {
+    reset_channel_drop_metrics_for_test();
+
+    let (tx, _rx) = create_channel_event_bus();
+    let event = sample_message_event();
+
+    for _ in 0..=CHANNEL_EVENT_BUFFER_SIZE {
+        try_emit_channel_event(&tx, event.clone(), "buffer-full-test");
+    }
+
+    let (buffer_full, receiver_closed) = channel_drop_metrics_snapshot_for_test();
+    assert!(buffer_full >= 1, "expected at least one buffer-full drop");
+    assert_eq!(receiver_closed, 0);
+}
+
+#[test]
+fn channel_drop_metrics_count_receiver_closed_events() {
+    reset_channel_drop_metrics_for_test();
+
+    let (tx, rx) = create_channel_event_bus();
+    drop(rx);
+
+    try_emit_channel_event(&tx, sample_message_event(), "receiver-closed-test");
+
+    let (buffer_full, receiver_closed) = channel_drop_metrics_snapshot_for_test();
+    assert_eq!(buffer_full, 0);
+    assert_eq!(receiver_closed, 1);
+}
+
+#[test]
+fn channel_drop_metrics_throttles_periodic_counter_flush() {
+    reset_channel_drop_metrics_for_test();
+
+    let (tx, _rx) = create_channel_event_bus();
+    let event = sample_message_event();
+
+    for _ in 0..=CHANNEL_EVENT_BUFFER_SIZE {
+        try_emit_channel_event(&tx, event.clone(), "throttle-test");
+    }
+
+    let (buffer_full_before_flush, _) = channel_drop_metrics_snapshot_for_test();
+    assert!(
+        buffer_full_before_flush >= 1,
+        "expected drops to accumulate while log window is active"
+    );
+
+    advance_channel_drop_metrics_log_window_for_test();
+    try_emit_channel_event(&tx, event, "throttle-flush");
+
+    let (buffer_full_after_flush, receiver_closed_after_flush) =
+        channel_drop_metrics_snapshot_for_test();
+    assert_eq!(
+        buffer_full_after_flush, 0,
+        "expired log window should flush buffer-full counter"
+    );
+    assert_eq!(receiver_closed_after_flush, 0);
+}

--- a/src-tauri/tests/integration/channel_event_parsing_tests.rs
+++ b/src-tauri/tests/integration/channel_event_parsing_tests.rs
@@ -1,0 +1,35 @@
+use tauri_mcp_agent_lib::mcp::session_isolation::channel_events::{
+    try_parse_channel_event, SessionChannelEvent, MAX_CHANNEL_CONTENT_BYTES,
+};
+
+#[test]
+fn rejects_oversized_channel_message_content() {
+    let oversized = "x".repeat(MAX_CHANNEL_CONTENT_BYTES + 1);
+    let line = format!(
+        r#"{{"jsonrpc":"2.0","method":"claude/channel","params":{{"content":"{}"}}}}"#,
+        oversized
+    );
+    assert!(
+        try_parse_channel_event(line.as_bytes(), "telegram").is_none(),
+        "oversized channel content should be dropped"
+    );
+}
+
+#[test]
+fn accepts_channel_message_at_content_limit() {
+    let content = "x".repeat(MAX_CHANNEL_CONTENT_BYTES);
+    let line = format!(
+        r#"{{"jsonrpc":"2.0","method":"claude/channel","params":{{"content":"{}"}}}}"#,
+        content
+    );
+    let event = try_parse_channel_event(line.as_bytes(), "telegram")
+        .expect("content at limit should parse");
+    match event {
+        SessionChannelEvent::Message { notification, .. } => {
+            assert_eq!(notification.content.len(), MAX_CHANNEL_CONTENT_BYTES);
+        }
+        SessionChannelEvent::PermissionVerdict { .. } => {
+            panic!("expected message event");
+        }
+    }
+}

--- a/src-tauri/tests/integration/channel_payload_format_tests.rs
+++ b/src-tauri/tests/integration/channel_payload_format_tests.rs
@@ -21,3 +21,60 @@ fn channel_payload_filters_unsafe_meta_keys_and_preserves_them_in_body() {
     assert!(payload.contains("bad key=&lt;bad&gt;"));
     assert!(payload.contains("9starts_wrong=value"));
 }
+
+#[test]
+fn channel_payload_filters_dangerous_html_meta_attribute_names() {
+    let mut meta = HashMap::new();
+    meta.insert("onclick".to_string(), "alert(1)".to_string());
+    meta.insert("onerror".to_string(), "alert(1)".to_string());
+    meta.insert("style".to_string(), "color:red".to_string());
+    meta.insert("safe_meta".to_string(), "ok".to_string());
+
+    let payload = format_channel_payload_for_test("bridge", "hello", &meta);
+
+    assert!(payload.contains(r#"<channel source="bridge" safe_meta="ok">"#));
+    assert!(!payload.contains(r#"onclick="#));
+    assert!(!payload.contains(r#"onerror="#));
+    assert!(!payload.contains(r#"style="#));
+    assert!(payload.contains("[channel_meta]"));
+    assert!(payload.contains("onclick=alert(1)"));
+    assert!(payload.contains("onerror=alert(1)"));
+    assert!(payload.contains("style=color:red"));
+}
+
+#[test]
+fn channel_payload_allows_legitimate_on_prefixed_meta_keys() {
+    let mut meta = HashMap::new();
+    meta.insert("one".to_string(), "1".to_string());
+    meta.insert("online".to_string(), "true".to_string());
+    meta.insert("oncall".to_string(), "alice".to_string());
+    meta.insert("ongoing".to_string(), "yes".to_string());
+
+    let payload = format_channel_payload_for_test("bridge", "hello", &meta);
+
+    assert!(payload.contains(r#"one="1""#));
+    assert!(payload.contains(r#"online="true""#));
+    assert!(payload.contains(r#"oncall="alice""#));
+    assert!(payload.contains(r#"ongoing="yes""#));
+    assert!(!payload.contains("[channel_meta]"));
+}
+
+#[test]
+fn channel_payload_filters_reserved_names_case_insensitively() {
+    let mut meta = HashMap::new();
+    meta.insert("SOURCE".to_string(), "override".to_string());
+    meta.insert("STYLE".to_string(), "color:red".to_string());
+    meta.insert("OnClick".to_string(), "alert(1)".to_string());
+    meta.insert("safe_meta".to_string(), "ok".to_string());
+
+    let payload = format_channel_payload_for_test("bridge", "hello", &meta);
+
+    assert!(payload.contains(r#"<channel source="bridge" safe_meta="ok">"#));
+    assert!(!payload.contains(r#"SOURCE="#));
+    assert!(!payload.contains(r#"STYLE="#));
+    assert!(!payload.contains(r#"OnClick="#));
+    assert!(payload.contains("[channel_meta]"));
+    assert!(payload.contains("SOURCE=override"));
+    assert!(payload.contains("STYLE=color:red"));
+    assert!(payload.contains("OnClick=alert(1)"));
+}

--- a/src-tauri/tests/integration/channel_permission_id_tests.rs
+++ b/src-tauri/tests/integration/channel_permission_id_tests.rs
@@ -4,14 +4,12 @@ use tauri_mcp_agent_lib::agent::tool_approvals::{
 };
 
 #[test]
-fn channel_permission_request_ids_match_claude_constraints() {
+fn channel_permission_request_ids_are_32_char_uuid_hex() {
     let request_id = generate_channel_permission_request_id();
 
-    assert_eq!(request_id.len(), 5);
-    assert!(request_id
-        .chars()
-        .all(|ch| matches!(ch, 'a'..='k' | 'm'..='z')));
-    assert!(!request_id.contains('l'));
+    assert_eq!(request_id.len(), 32);
+    assert!(request_id.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert!(request_id.chars().all(|ch| !ch.is_ascii_uppercase()));
 }
 
 #[test]

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -17,6 +17,8 @@ pub mod builtin_service_registry_tests;
 pub mod bundled_skills_build_mirror_tests;
 pub mod cancel_logic;
 pub mod channel_auto_routing_tests;
+pub mod channel_drop_metrics_tests;
+pub mod channel_event_parsing_tests;
 pub mod channel_payload_format_tests;
 pub mod channel_permission_id_tests;
 pub mod channel_permission_resolution_tests;


### PR DESCRIPTION
## Summary

- Strengthen channel permission request IDs with full UUIDs
- Tighten channel meta attribute filtering (case-insensitive reserved keys, explicit HTML event handler blocklist, style degradation)
- Default invalid permission verdicts to deny instead of skipping
- Cap inbound channel content size and add throttled drop metrics
- Add integration tests for filtering, parsing, metrics, and permission IDs

## Test plan

- [x] cargo check --tests
- [x] pnpm refactor:validate
- [ ] CI integration tests on Linux (Windows integration suite is gated)

Made with [Cursor](https://cursor.com)