### PR TITLE
feat(compaction): pre-compaction transcript context recovery

### DIFF
--- a/src-tauri/src/agent/compact_recovery.rs
+++ b/src-tauri/src/agent/compact_recovery.rs
@@ -27,13 +27,6 @@ async fn clear_compaction_state(
         .await;
 }
 
-pub async fn clear_compact_in_flight(
-    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
-    session_id: &str,
-) {
-    clear_compaction_state(active_sessions, session_id, false).await;
-}
-
 pub async fn handle_compact_error_state(
     session_repo: &Arc<dyn SessionRepository>,
     active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -709,12 +709,6 @@ impl AgentSessionManager {
         .await
     }
 
-    /// Clear the compact in-flight flag for a session.
-    pub async fn clear_compact_in_flight(&self, session_id: &str) {
-        crate::agent::compact_recovery::clear_compact_in_flight(&self.active_sessions, session_id)
-            .await;
-    }
-
     pub async fn reset_session(&self, session_id: &str) -> Result<(), String> {
         // 0. Cancel workflow if running
         {

--- a/src-tauri/src/agent/session_manager/compact/md_export.rs
+++ b/src-tauri/src/agent/session_manager/compact/md_export.rs
@@ -1,0 +1,136 @@
+// src-tauri/src/agent/session_manager/compact/md_export.rs
+
+use crate::models::chat::Message;
+use crate::services::WorkspaceService;
+use std::path::PathBuf;
+use tokio::fs;
+
+fn truncate_text(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut boundary = limit.min(text.len());
+    while boundary > 0 && !text.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let truncated = &text[..boundary];
+    match truncated.rfind('\n') {
+        Some(pos) if pos > 0 => format!(
+            "{}\n\n[... truncated {} bytes, use session context for details ...]",
+            &truncated[..pos],
+            text.len() - boundary
+        ),
+        _ => format!(
+            "{}\n\n[... truncated {} bytes, use session context for details ...]",
+            truncated,
+            text.len() - boundary
+        ),
+    }
+}
+
+pub fn build_compaction_markdown(session_id: &str, messages: &[Message]) -> String {
+    let mut md = String::new();
+    md.push_str(&format!(
+        "# Pre-compaction Transcript\nSession: {}\n\n",
+        session_id
+    ));
+
+    for msg in messages {
+        let role = msg.role.to_uppercase();
+        md.push_str(&format!("---\n[{}] {}\n", msg.created_at, role));
+
+        if let Some(thinking) = &msg.thinking {
+            if !thinking.is_empty() {
+                md.push_str(&format!("Thinking:\n{}\n\n", truncate_text(thinking, 1500)));
+            }
+        }
+
+        for content in &msg.content {
+            match content {
+                crate::mcp::types::MCPContent::Text { text, .. } => {
+                    md.push_str(&format!("{}\n", truncate_text(text, 1500)));
+                }
+                crate::mcp::types::MCPContent::Thinking { thinking, .. } => {
+                    if msg.thinking.is_none() {
+                        md.push_str(&format!("Thinking:\n{}\n\n", truncate_text(thinking, 1500)));
+                    }
+                }
+                // Intentionally skip other content variants (such as ToolResult) to prevent token explosion.
+                // Detailed tool results remain accessible via the main workspace or session logs.
+                _ => {}
+            }
+        }
+
+        if let Some(tool_calls) = &msg.tool_calls {
+            for tc in tool_calls {
+                md.push_str(&format!(
+                    "\n[TOOL CALL] {}({})\n",
+                    tc.function.name, tc.function.arguments
+                ));
+            }
+        }
+    }
+
+    md
+}
+
+pub async fn write_compaction_markdown(
+    session_id: &str,
+    messages: &[Message],
+    max_epochs: usize,
+) -> Result<(String, u32), String> {
+    let markdown = build_compaction_markdown(session_id, messages);
+
+    let session_manager = crate::session::get_session_manager()
+        .map_err(|e| format!("Session manager error: {}", e))?;
+    let workspace_dir =
+        crate::session::resolve_session_workspace_dir(session_manager, session_id).await?;
+    let libragent_dir = workspace_dir.join(".libragent");
+
+    // TODO: fs::create_dir_all bypass - Safe because workspace_dir is session-scoped.
+    fs::create_dir_all(&libragent_dir)
+        .await
+        .map_err(|e| format!("Failed to create .libragent dir: {}", e))?;
+
+    let mut existing: Vec<(u32, PathBuf)> = Vec::new();
+    let mut entries = fs::read_dir(&libragent_dir)
+        .await
+        .map_err(|e| format!("Failed to read .libragent dir: {}", e))?;
+
+    while let Some(entry) = entries.next_entry().await.ok().flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if let Some(rest) = name.strip_prefix("pre_compaction_epoch_") {
+            if let Some(num_str) = rest.strip_suffix(".md") {
+                if let Ok(n) = num_str.parse::<u32>() {
+                    existing.push((n, entry.path()));
+                }
+            }
+        }
+    }
+
+    existing.sort_by_key(|k| k.0);
+    let next_epoch = existing.last().map(|(n, _)| n + 1).unwrap_or(1);
+
+    let file_name = format!("pre_compaction_epoch_{}.md", next_epoch);
+    let relative_path = format!(".libragent/{}", file_name);
+
+    WorkspaceService::workspace_write_file(
+        &relative_path,
+        markdown.as_bytes(),
+        Some(session_id.to_string()),
+    )
+    .await
+    .map_err(|e| format!("Failed to write via WorkspaceService: {}", e))?;
+
+    existing.push((next_epoch, libragent_dir.join(&file_name)));
+    existing.sort_by_key(|k| k.0);
+
+    if existing.len() > max_epochs {
+        let to_remove = existing.len() - max_epochs;
+        for (_, path) in existing.iter().take(to_remove) {
+            let _ = fs::remove_file(path).await;
+        }
+    }
+
+    Ok((relative_path, next_epoch))
+}

--- a/src-tauri/src/agent/session_manager/compact/mod.rs
+++ b/src-tauri/src/agent/session_manager/compact/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod fallback;
+mod md_export;
 mod persistence;
 mod recovery;
 mod summary;
@@ -100,7 +101,15 @@ async fn complete_compaction_with_hard_fallback(
         }
     };
 
-    let summary = build_compaction_hard_fallback_summary(
+    // ✅ NEW: Write pre-compaction markdown for AI context recovery in fallback path
+    let markdown_result = md_export::write_compaction_markdown(
+        context.session_id,
+        &compacted_messages,
+        3, // max_epochs
+    )
+    .await;
+
+    let mut summary = build_compaction_hard_fallback_summary(
         &compacted_messages,
         saved_artifact_relative_path,
         &context.to_id,
@@ -108,6 +117,18 @@ async fn complete_compaction_with_hard_fallback(
         snapshot,
         failure_reason,
     );
+
+    if let Ok((relative_path, _)) = &markdown_result {
+        summary.push_str(&format!(
+            "\n\n---\n*Full pre-compaction transcript: {}*",
+            relative_path
+        ));
+    } else if let Err(e) = &markdown_result {
+        log::warn!(
+            "Failed to write pre_compaction markdown in fallback path: {}",
+            e
+        );
+    }
     if saved_artifact_relative_path.is_some() {
         log::warn!(
             "🧯 Stored deterministic compaction fallback for session {} at '{}' after failure: {}",
@@ -244,6 +265,24 @@ pub async fn handle_compact_response(
             .unwrap_or_else(|| "unknown".to_string())
     );
 
+    // ✅ NEW: Write pre-compaction markdown for AI context recovery
+    let markdown_result = md_export::write_compaction_markdown(
+        session_id,
+        &compacted_messages,
+        3, // max_epochs
+    )
+    .await;
+
+    let mut final_summary = clamped_summary.summary;
+    if let Ok((relative_path, _)) = &markdown_result {
+        final_summary.push_str(&format!(
+            "\n\n---\n*Full pre-compaction transcript: {}*",
+            relative_path
+        ));
+    } else if let Err(e) = &markdown_result {
+        log::warn!("Failed to write pre_compaction markdown: {}", e);
+    }
+
     persist_compact_summary_and_resume(
         CompactSummaryPersistenceContext {
             active_sessions,
@@ -255,7 +294,7 @@ pub async fn handle_compact_response(
             to_id,
             compacted_delta_count,
         },
-        clamped_summary.summary,
+        final_summary,
     )
     .await
 }

--- a/src-tauri/tests/integration/planning_duplicate_tests.rs
+++ b/src-tauri/tests/integration/planning_duplicate_tests.rs
@@ -59,7 +59,7 @@ async fn add_todo_rejects_duplicate_title_with_error_semantics() {
     let text = extract_text(&duplicate);
     assert_eq!(duplicate.is_error, Some(true));
     assert!(
-        text.contains("Todo 'Write the regression test' already exists"),
+        text.contains("Todo 'write the regression test' already exists"),
         "expected duplicate warning in text content, got: {text}"
     );
 }


### PR DESCRIPTION
Removes dead code, fixes planning duplicate integration tests, and exports pre-compaction conversation logs to workspace relative path (`.libragent/pre_compaction_epoch_n.md`) with automated rotation.