### PR TITLE
⚡ Bolt: Optimize tool chain integrity checking

### DIFF
--- a/src/lib/ai-service/anthropic/message-converter.ts
+++ b/src/lib/ai-service/anthropic/message-converter.ts
@@ -107,12 +107,21 @@ function logToolChainIntegrity(messages: Message[]): void {
     }
   }
 
-  const unmatchedToolUses = Array.from(toolUseIds).filter(
-    (id) => !toolResultIds.has(id),
-  );
-  const unmatchedToolResults = Array.from(toolResultIds).filter(
-    (id) => !toolUseIds.has(id),
-  );
+  // ⚡ Bolt: Replaced Array.from().filter() with for...of loops directly on the Sets
+  // to avoid intermediate array allocations and reduce garbage collection pressure.
+  const unmatchedToolUses: string[] = [];
+  for (const id of toolUseIds) {
+    if (!toolResultIds.has(id)) {
+      unmatchedToolUses.push(id);
+    }
+  }
+
+  const unmatchedToolResults: string[] = [];
+  for (const id of toolResultIds) {
+    if (!toolUseIds.has(id)) {
+      unmatchedToolResults.push(id);
+    }
+  }
 
   if (unmatchedToolUses.length > 0 || unmatchedToolResults.length > 0) {
     logger.warn('Potential tool chain mismatch detected', {


### PR DESCRIPTION
## 💡 What
Replaced `Array.from(set).filter(...)` chains with `for...of` loops in `logToolChainIntegrity` for Anthropic message conversion.

## 🎯 Why
The previous implementation allocated two intermediate arrays on every Anthropic API call just to check for tool chain mismatches. This creates unnecessary garbage collection pressure on a hot path.

## 📊 Impact
Avoids intermediate array allocations and reduces GC pressure during Anthropic message conversion.

## 🔬 Measurement
Run the test suite (`pnpm test:run`) to ensure tool chain logic behaves identically. Profile memory allocations during heavy Anthropic usage.

---
*PR created automatically by Jules for task [1270809965767908200](https://jules.google.com/task/1270809965767908200) started by @fritzprix*