### PR TITLE
feat: user message content-based deduplication

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 agent-response-guards = { path = "agent-response-guards" }
-tauri = { version = "2", features = ["tray-icon", "protocol-asset"] }
+tauri = { version = "2", features = ["tray-icon", "protocol-asset", "test"] }
 tauri-plugin-opener = "2"
 
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/services/message_service.rs
+++ b/src-tauri/src/services/message_service.rs
@@ -15,6 +15,42 @@ use tokio::sync::RwLock;
 static INDEX_CACHE: once_cell::sync::Lazy<Mutex<HashMap<String, MessageSearchEngine>>> =
     once_cell::sync::Lazy::new(|| Mutex::new(HashMap::new()));
 
+/// Compares two messages for content equality to detect duplicate user messages.
+/// - ⚠️ Designed to work ONLY with user-role messages (user-message-only).
+/// - Returns false if either message is not role "user".
+/// - Returns false if attachments differ.
+/// - Normalizes text content (collapses whitespace) before comparison.
+/// - Returns false if content contains non-Text variants (e.g., Image) for safety.
+fn messages_content_equal(a: &Message, b: &Message) -> bool {
+    if a.role != b.role || a.role != "user" {
+        return false;
+    }
+
+    if a.attachments != b.attachments {
+        return false;
+    }
+
+    if a.content.len() != b.content.len() {
+        return false;
+    }
+
+    for (ca, cb) in a.content.iter().zip(b.content.iter()) {
+        match (ca, cb) {
+            (
+                crate::mcp::types::MCPContent::Text { text: ta, .. },
+                crate::mcp::types::MCPContent::Text { text: tb, .. },
+            ) => {
+                let normalize = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+                if normalize(ta) != normalize(tb) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
 pub struct MessageService;
 
 impl MessageService {
@@ -256,32 +292,62 @@ impl MessageService {
         messages: Vec<Message>,
         emit_events_immediately: bool,
     ) -> Result<(), String> {
-        // 1. Ensure cache is initialized
         crate::agent::lifecycle::ensure_cache_initialized(active_sessions, session_id).await?;
 
-        // 2. Get session reference — note: multiple nested locks are acquired below
-        // (sessions read-guard, then session.messages write-guard and/or session.pending_events write-guard)
         let sessions = active_sessions.read().await;
         let session = sessions
             .get(session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
-        // 3. Add messages to in-memory cache
+        // ── Phase 1: In-memory dedup + push ─────────────────────────────────
         {
             let mut session_messages = session.messages.write().await;
+
             for msg in &messages {
+                // Trailing duplicate user messages discard
+                if msg.role == "user" {
+                    while let Some(last) = session_messages.last() {
+                        if !messages_content_equal(msg, last) {
+                            break;
+                        }
+                        session_messages.pop();
+                        log::info!(
+                            "Discarded trailing duplicate user message (content match): \
+                             session={}, new={}",
+                            session_id,
+                            msg.id
+                        );
+                    }
+                }
+
                 session_messages.push(msg.clone());
+
                 if session_messages.len() > crate::agent::state::MAX_CACHED_MESSAGES {
-                    session_messages.remove(0);
+                    let removed = session_messages.remove(0);
+                    log::debug!("Evicted from sliding window cache: {}", removed.id);
+                }
+            }
+        } // session.messages lock released
+
+        // ── Phase 2: Persist to DB (SYNC — crash-safe) ──────────────────────
+        {
+            let repo = get_message_repository();
+            for msg in &messages {
+                if let Err(e) = repo.insert(msg).await {
+                    log::error!(
+                        "Failed to persist injected message to DB: session={}, msg_id={}, error={}",
+                        session_id,
+                        msg.id,
+                        e
+                    );
+                    return Err(format!("Failed to persist message: {}", e));
                 }
             }
         }
 
-        // 4. Emit MessageAdded events immediately, or queue as pending for the running workflow
+        // ── Phase 3: Emit UI events ─────────────────────────────────────────
         if emit_events_immediately {
-            // Drop session lock before I/O operations
             drop(sessions);
-
             for msg in &messages {
                 let event = crate::agent::events::AgentEvent::MessageAdded {
                     session_id: session_id.to_string(),
@@ -291,7 +357,6 @@ impl MessageService {
                     .map_err(|e| format!("Failed to emit MessageAdded event: {}", e))?;
             }
         } else {
-            // Track these message IDs as pending (will emit when workflow picks them up)
             let mut pending_events = session.pending_events.write().await;
             for msg in &messages {
                 pending_events.add(crate::agent::state::PendingEvent::Message(msg.id.clone()));
@@ -303,19 +368,7 @@ impl MessageService {
                 messages.iter().map(|m| &m.id).collect::<Vec<_>>()
             );
             drop(pending_events);
-            drop(sessions);
         }
-
-        // 5. Persist to DB asynchronously
-        let msgs_for_db = messages.clone();
-        tokio::spawn(async move {
-            let repo = get_message_repository();
-            for msg in msgs_for_db {
-                if let Err(e) = repo.insert(&msg).await {
-                    log::error!("Failed to inject message to DB: {}", e);
-                }
-            }
-        });
 
         Ok(())
     }

--- a/src-tauri/src/services/message_service.rs
+++ b/src-tauri/src/services/message_service.rs
@@ -50,6 +50,87 @@ fn messages_content_equal(a: &Message, b: &Message) -> bool {
     }
     true
 }
+fn normalize_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Generates a normalized signature for a message to detect consecutive duplicates.
+/// Compares content items, thinking, and tool calls while ignoring volatile fields.
+pub(crate) fn message_signature(msg: &Message) -> Option<String> {
+    let mut parts = Vec::new();
+
+    // 1. content (Text, Thinking, Image, Audio, Resource, ToolCall)
+    for c in &msg.content {
+        match c {
+            crate::mcp::types::MCPContent::Text { text, .. } => {
+                parts.push(format!("text:{}", normalize_whitespace(text)));
+            }
+            crate::mcp::types::MCPContent::Thinking { thinking, .. } => {
+                parts.push(format!("thinking:{}", normalize_whitespace(thinking)));
+            }
+            crate::mcp::types::MCPContent::Image {
+                data,
+                uri,
+                mime_type,
+            } => {
+                parts.push(format!(
+                    "image:{}:{}:{}",
+                    data.as_deref().unwrap_or(""),
+                    uri.as_deref().unwrap_or(""),
+                    mime_type
+                ));
+            }
+            crate::mcp::types::MCPContent::Audio {
+                data,
+                uri,
+                mime_type,
+            } => {
+                parts.push(format!(
+                    "audio:{}:{}:{}",
+                    data.as_deref().unwrap_or(""),
+                    uri.as_deref().unwrap_or(""),
+                    mime_type
+                ));
+            }
+            crate::mcp::types::MCPContent::Resource { resource, .. } => {
+                parts.push(format!(
+                    "resource:{}",
+                    serde_json::to_string(resource).unwrap_or_default()
+                ));
+            }
+            crate::mcp::types::MCPContent::ToolCall {
+                name, arguments, ..
+            } => {
+                parts.push(format!(
+                    "toolcall_content:{}:{}",
+                    name,
+                    normalize_whitespace(arguments)
+                ));
+            }
+        }
+    }
+
+    // 2. thinking 별도 필드
+    if let Some(t) = &msg.thinking {
+        parts.push(format!("thinking_field:{}", normalize_whitespace(t)));
+    }
+
+    // 3. tool_calls
+    if let Some(tcs) = &msg.tool_calls {
+        for tc in tcs {
+            parts.push(format!(
+                "toolcall:{}:{}",
+                tc.function.name,
+                normalize_whitespace(&tc.function.arguments)
+            ));
+        }
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("|||"))
+}
 
 pub struct MessageService;
 
@@ -289,7 +370,7 @@ impl MessageService {
         active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
         app_handle: &AppHandle,
         session_id: &str,
-        messages: Vec<Message>,
+        mut messages: Vec<Message>,
         emit_events_immediately: bool,
     ) -> Result<(), String> {
         crate::agent::lifecycle::ensure_cache_initialized(active_sessions, session_id).await?;
@@ -299,32 +380,75 @@ impl MessageService {
             .get(session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
-        // ── Phase 1: In-memory dedup + push ─────────────────────────────────
+        // ── Phase 1: Message dedup + In-memory push ───────────────────────
         {
-            let mut session_messages = session.messages.write().await;
+            // 1a. Capture last-message signature while holding the lock
+            let last_msg_sig = {
+                let session_messages = session.messages.read().await;
+                session_messages.last().and_then(message_signature)
+            };
 
-            for msg in &messages {
-                // Trailing duplicate user messages discard
+            // 1b. Filter out repeated messages (no lock needed)
+            // Note: User messages are bypassed here as they have custom pop-and-replace
+            // logic in Phase 1c and need to be recorded in the database.
+            let mut current_last_sig = last_msg_sig;
+            messages.retain(|msg| {
                 if msg.role == "user" {
-                    while let Some(last) = session_messages.last() {
-                        if !messages_content_equal(msg, last) {
-                            break;
-                        }
-                        session_messages.pop();
+                    if let Some(sig) = message_signature(msg) {
+                        current_last_sig = Some(sig);
+                    }
+                    return true;
+                }
+                let sig = message_signature(msg);
+                if let Some(ref last_sig) = current_last_sig {
+                    if sig == Some(last_sig.clone()) {
                         log::info!(
-                            "Discarded trailing duplicate user message (content match): \
-                             session={}, new={}",
+                            "Skipping repeated message: session={}, msg_id={}, role={}",
                             session_id,
-                            msg.id
+                            msg.id,
+                            msg.role
                         );
+                        return false;
                     }
                 }
+                if let Some(ref s) = sig {
+                    current_last_sig = Some(s.clone());
+                }
+                true
+            });
 
-                session_messages.push(msg.clone());
+            // Early return if all messages were deduped
+            if messages.is_empty() {
+                return Ok(());
+            }
 
-                if session_messages.len() > crate::agent::state::MAX_CACHED_MESSAGES {
-                    let removed = session_messages.remove(0);
-                    log::debug!("Evicted from sliding window cache: {}", removed.id);
+            // 1c. Push remaining messages (re-acquire write lock)
+            {
+                let mut session_messages = session.messages.write().await;
+
+                for msg in &messages {
+                    // Trailing duplicate user messages discard
+                    if msg.role == "user" {
+                        while let Some(last) = session_messages.last() {
+                            if !messages_content_equal(msg, last) {
+                                break;
+                            }
+                            session_messages.pop();
+                            log::info!(
+                                "Discarded trailing duplicate user message (content match): \
+                                 session={}, new={}",
+                                session_id,
+                                msg.id
+                            );
+                        }
+                    }
+
+                    session_messages.push(msg.clone());
+
+                    if session_messages.len() > crate::agent::state::MAX_CACHED_MESSAGES {
+                        let removed = session_messages.remove(0);
+                        log::debug!("Evicted from sliding window cache: {}", removed.id);
+                    }
                 }
             }
         } // session.messages lock released

--- a/src-tauri/tests/integration/message_dedup_tests.rs
+++ b/src-tauri/tests/integration/message_dedup_tests.rs
@@ -1,0 +1,300 @@
+use crate::common;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::test::MockRuntime;
+use tauri_mcp_agent_lib::agent::state::AgentSession;
+use tauri_mcp_agent_lib::agent::ExecutionMode;
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::repositories::{
+    MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
+    SqliteSessionRepository,
+};
+use tauri_mcp_agent_lib::services::MessageService;
+use tokio::sync::RwLock;
+
+fn build_session_metadata(session_id: &str) -> SessionMetadata {
+    let now = chrono::Utc::now().timestamp_millis();
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("Message dedup test session".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-4".to_string(),
+        provider: "openai".to_string(),
+        assistant_id: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        execution_mode: ExecutionMode::Normal,
+        workspace_override: None,
+    }
+}
+
+fn build_user_message(session_id: &str, id: &str, text: &str) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: session_id.to_string(),
+        role: "user".to_string(),
+        content: vec![MCPContent::Text {
+            text: text.to_string(),
+            is_error: None,
+        }],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        prompt_tokens: None,
+        created_at: chrono::Utc::now().timestamp_millis(),
+        updated_at: chrono::Utc::now().timestamp_millis(),
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+fn build_agent_session(session_id: &str) -> AgentSession {
+    use std::sync::atomic::AtomicBool;
+    use tauri_mcp_agent_lib::agent::context::registry::ContextRegistry;
+    use tauri_mcp_agent_lib::agent::state::CompactionRuntimeState;
+    use tauri_mcp_agent_lib::agent::state::PendingEventManager;
+    use tokio_util::sync::CancellationToken;
+
+    AgentSession {
+        metadata: build_session_metadata(session_id),
+        is_running: false,
+        active_permit: None,
+        status_transition: Arc::new(RwLock::new(None)),
+        transition_lock: Arc::new(tokio::sync::Mutex::new(())),
+        cancellation_token: CancellationToken::new(),
+        yolo_mode: Arc::new(AtomicBool::new(false)),
+        unsafe_mode: Arc::new(AtomicBool::new(false)),
+        cancel_pending: Arc::new(AtomicBool::new(false)),
+        pending_execution: None,
+        messages: Arc::new(RwLock::new(Vec::new())),
+        cache_initialized: Arc::new(AtomicBool::new(true)),
+        last_synced_at: Arc::new(RwLock::new(None)),
+        repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
+        repeated_text_loop_retry_count: Arc::new(RwLock::new(0)),
+        pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
+        pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+        context_registry: Arc::new(ContextRegistry::new()),
+        compact_context: Arc::new(RwLock::new(None)),
+        compaction: CompactionRuntimeState::new(),
+        expected_response_id: Arc::new(RwLock::new(None)),
+        cached_stable_prompt: Arc::new(RwLock::new(None)),
+        last_completion_request: Arc::new(RwLock::new(None)),
+        last_submitted_input_message_id: Arc::new(RwLock::new(None)),
+    }
+}
+
+#[tokio::test]
+async fn test_content_dedup_same_text() {
+    let db = common::setup_test_db_with_migrations().await;
+    let message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-dedup-1";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    // 1. First message injection
+    let msg1 = build_user_message(session_id, "msg-1", "Hello Antigravity");
+
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg1.clone()],
+        false,
+    )
+    .await
+    .expect("inject 1 succeeds");
+
+    // 2. Inject duplicate message
+    let msg2 = build_user_message(session_id, "msg-2", "Hello Antigravity");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg2.clone()],
+        false,
+    )
+    .await
+    .expect("inject 2 succeeds");
+
+    // Check memory cache: msg-1 should be popped and only msg-2 should remain
+    let sessions = active_sessions.read().await;
+    let session = sessions.get(session_id).expect("session exists");
+    let cached_msgs = session.messages.read().await;
+
+    assert_eq!(cached_msgs.len(), 1);
+    assert_eq!(cached_msgs[0].id, "msg-2");
+
+    // Check DB: Since Phase 3 (orphan DB cleanup) is cut, both msg-1 and msg-2 should remain in DB.
+    let db_msgs = message_repo
+        .get_messages_by_session(session_id, 10)
+        .await
+        .expect("db load");
+    assert_eq!(db_msgs.len(), 2);
+}
+
+#[tokio::test]
+async fn test_content_dedup_different_text() {
+    let db = common::setup_test_db_with_migrations().await;
+    let message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-dedup-2";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    let msg1 = build_user_message(session_id, "msg-1", "First message");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg1],
+        false,
+    )
+    .await
+    .expect("inject 1 succeeds");
+
+    let msg2 = build_user_message(session_id, "msg-2", "Second message");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg2],
+        false,
+    )
+    .await
+    .expect("inject 2 succeeds");
+
+    // Both should exist since their content is different
+    let sessions = active_sessions.read().await;
+    let session = sessions.get(session_id).expect("session exists");
+    let cached_msgs = session.messages.read().await;
+
+    assert_eq!(cached_msgs.len(), 2);
+    assert_eq!(cached_msgs[0].id, "msg-1");
+    assert_eq!(cached_msgs[1].id, "msg-2");
+
+    let db_msgs = message_repo
+        .get_messages_by_session(session_id, 10)
+        .await
+        .expect("db load");
+    assert_eq!(db_msgs.len(), 2);
+}
+
+#[tokio::test]
+async fn test_content_dedup_rich_content_different() {
+    let db = common::setup_test_db_with_migrations().await;
+    let _message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-dedup-3";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    // msg1 has attachments, msg2 does not
+    let mut msg1 = build_user_message(session_id, "msg-1", "Same text");
+    msg1.attachments = Some(serde_json::json!({"file": "a.txt"}));
+
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg1],
+        false,
+    )
+    .await
+    .expect("inject 1 succeeds");
+
+    let msg2 = build_user_message(session_id, "msg-2", "Same text");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg2],
+        false,
+    )
+    .await
+    .expect("inject 2 succeeds");
+
+    // Deduplication should NOT occur because attachments differ
+    let sessions = active_sessions.read().await;
+    let session = sessions.get(session_id).expect("session exists");
+    let cached_msgs = session.messages.read().await;
+
+    assert_eq!(cached_msgs.len(), 2);
+    assert_eq!(cached_msgs[0].id, "msg-1");
+    assert_eq!(cached_msgs[1].id, "msg-2");
+}

--- a/src-tauri/tests/integration/message_dedup_tests.rs
+++ b/src-tauri/tests/integration/message_dedup_tests.rs
@@ -298,3 +298,422 @@ async fn test_content_dedup_rich_content_different() {
     assert_eq!(cached_msgs[0].id, "msg-1");
     assert_eq!(cached_msgs[1].id, "msg-2");
 }
+
+fn build_tool_message(session_id: &str, id: &str, tool_call_id: &str, text: &str) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: session_id.to_string(),
+        role: "tool".to_string(),
+        content: vec![MCPContent::Text {
+            text: text.to_string(),
+            is_error: None,
+        }],
+        tool_calls: None,
+        tool_call_id: Some(tool_call_id.to_string()),
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        prompt_tokens: None,
+        created_at: chrono::Utc::now().timestamp_millis(),
+        updated_at: chrono::Utc::now().timestamp_millis(),
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn test_tool_message_deduplication() {
+    let db = common::setup_test_db_with_migrations().await;
+    let _message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-tool-dedup";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    // 1. Inject first tool message (call_1, output: "Success")
+    let tool_msg1 = build_tool_message(session_id, "tool-1", "call_1", "Success");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![tool_msg1.clone()],
+        false,
+    )
+    .await
+    .expect("inject tool_msg1 succeeds");
+
+    // 2. Inject duplicate tool message (same tool_call_id, same content) -> should be deduplicated (ignored)
+    let tool_msg2 = build_tool_message(session_id, "tool-2", "call_1", "Success");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![tool_msg2.clone()],
+        false,
+    )
+    .await
+    .expect("inject tool_msg2 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        // Should only contain the first message because the second one is a duplicate
+        assert_eq!(cached_msgs.len(), 1);
+        assert_eq!(cached_msgs[0].id, "tool-1");
+    }
+
+    // 3. Inject tool message with different tool_call_id but same content -> should also be deduplicated (ignored)
+    let tool_msg3 = build_tool_message(session_id, "tool-3", "call_2", "Success");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![tool_msg3.clone()],
+        false,
+    )
+    .await
+    .expect("inject tool_msg3 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        // Still only contain the first message (tool-1) because tool-3 has the exact same content.
+        assert_eq!(cached_msgs.len(), 1);
+        assert_eq!(cached_msgs[0].id, "tool-1");
+    }
+
+    // 4. Inject tool message with different content -> should NOT be deduplicated
+    let tool_msg4 = build_tool_message(session_id, "tool-4", "call_3", "Different Success");
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![tool_msg4.clone()],
+        false,
+    )
+    .await
+    .expect("inject tool_msg4 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        // Both tool-1 and tool-4 should exist
+        assert_eq!(cached_msgs.len(), 2);
+        assert_eq!(cached_msgs[0].id, "tool-1");
+        assert_eq!(cached_msgs[1].id, "tool-4");
+    }
+}
+
+fn build_assistant_message_with_thinking(
+    session_id: &str,
+    id: &str,
+    thinking: &str,
+    text: &str,
+) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: session_id.to_string(),
+        role: "assistant".to_string(),
+        content: vec![MCPContent::Text {
+            text: text.to_string(),
+            is_error: None,
+        }],
+        tool_calls: None,
+        tool_call_id: None,
+        is_streaming: Some(false),
+        thinking: Some(thinking.to_string()),
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        prompt_tokens: None,
+        created_at: chrono::Utc::now().timestamp_millis(),
+        updated_at: chrono::Utc::now().timestamp_millis(),
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+fn build_assistant_message_with_tool_calls(
+    session_id: &str,
+    id: &str,
+    tool_calls: Vec<tauri_mcp_agent_lib::agent::types::ToolCall>,
+) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: session_id.to_string(),
+        role: "assistant".to_string(),
+        content: Vec::new(),
+        tool_calls: Some(tool_calls),
+        tool_call_id: None,
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        usage: None,
+        prompt_tokens: None,
+        created_at: chrono::Utc::now().timestamp_millis(),
+        updated_at: chrono::Utc::now().timestamp_millis(),
+        source: None,
+        error: None,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn test_assistant_message_deduplication() {
+    let db = common::setup_test_db_with_migrations().await;
+    let _message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-assistant-dedup";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    use tauri_mcp_agent_lib::agent::types::{ToolCall, ToolCallFunction};
+
+    // 1. Test thinking-based deduplication
+    let msg1 = build_assistant_message_with_thinking(
+        session_id,
+        "ast-1",
+        "I should run list_dir",
+        "running list_dir",
+    );
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg1],
+        false,
+    )
+    .await
+    .expect("inject ast-1 succeeds");
+
+    // Same thinking + same text -> should be deduplicated
+    let msg2 = build_assistant_message_with_thinking(
+        session_id,
+        "ast-2",
+        "I should run list_dir",
+        "running list_dir",
+    );
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg2],
+        false,
+    )
+    .await
+    .expect("inject ast-2 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        assert_eq!(cached_msgs.len(), 1);
+        assert_eq!(cached_msgs[0].id, "ast-1");
+    }
+
+    // Different thinking -> should NOT be deduplicated
+    let msg3 = build_assistant_message_with_thinking(
+        session_id,
+        "ast-3",
+        "Actually I should run grep",
+        "running list_dir",
+    );
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg3],
+        false,
+    )
+    .await
+    .expect("inject ast-3 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        assert_eq!(cached_msgs.len(), 2);
+        assert_eq!(cached_msgs[1].id, "ast-3");
+    }
+
+    // 2. Test tool_calls-based deduplication
+    let tc1 = ToolCall {
+        id: "call_1".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "list_dir".to_string(),
+            arguments: r#"{"path": "/home"}"#.to_string(),
+        },
+    };
+    let msg4 = build_assistant_message_with_tool_calls(session_id, "ast-4", vec![tc1.clone()]);
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg4],
+        false,
+    )
+    .await
+    .expect("inject ast-4 succeeds");
+
+    // Same tool_call name + arguments -> should be deduplicated
+    let tc2 = ToolCall {
+        id: "call_2".to_string(), // different ID, but same function details
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "list_dir".to_string(),
+            arguments: r#"{"path": "/home"}"#.to_string(),
+        },
+    };
+    let msg5 = build_assistant_message_with_tool_calls(session_id, "ast-5", vec![tc2]);
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg5],
+        false,
+    )
+    .await
+    .expect("inject ast-5 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        // Total should be 3: ast-1, ast-3, ast-4 (ast-5 was deduped)
+        assert_eq!(cached_msgs.len(), 3);
+        assert_eq!(cached_msgs[2].id, "ast-4");
+    }
+
+    // Different tool_call arguments -> should NOT be deduplicated
+    let tc3 = ToolCall {
+        id: "call_3".to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: "list_dir".to_string(),
+            arguments: r#"{"path": "/var"}"#.to_string(),
+        },
+    };
+    let msg6 = build_assistant_message_with_tool_calls(session_id, "ast-6", vec![tc3]);
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![msg6],
+        false,
+    )
+    .await
+    .expect("inject ast-6 succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        assert_eq!(cached_msgs.len(), 4);
+        assert_eq!(cached_msgs[3].id, "ast-6");
+    }
+}
+
+#[tokio::test]
+async fn test_batch_message_deduplication() {
+    let db = common::setup_test_db_with_migrations().await;
+    let _message_repo = SqliteMessageRepository::new(db.clone());
+    let session_repo = SqliteSessionRepository::new(db.clone());
+
+    tauri_mcp_agent_lib::set_message_repository(SqliteMessageRepository::new(db.clone()));
+    tauri_mcp_agent_lib::set_session_repository(session_repo.clone());
+
+    let session_id = "test-session-batch-dedup";
+    session_repo
+        .upsert_session(&build_session_metadata(session_id))
+        .await
+        .expect("session created");
+
+    let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+    active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), build_agent_session(session_id));
+
+    let mock_app = tauri::test::mock_app();
+    let mock_handle = mock_app.handle();
+    let app_handle: &tauri::AppHandle = unsafe {
+        &*(mock_handle as *const tauri::AppHandle<MockRuntime> as *const tauri::AppHandle)
+    };
+
+    // Inject multiple tool messages in a single batch.
+    // tool-1, tool-2 (duplicate of tool-1), and tool-3 (different content)
+    let tool_msg1 = build_tool_message(session_id, "tool-1", "call_1", "Success");
+    let tool_msg2 = build_tool_message(session_id, "tool-2", "call_2", "Success"); // different tool_call_id but same content
+    let tool_msg3 = build_tool_message(session_id, "tool-3", "call_3", "Different Success");
+
+    MessageService::inject_messages_to_session(
+        &active_sessions,
+        app_handle,
+        session_id,
+        vec![tool_msg1, tool_msg2, tool_msg3],
+        false,
+    )
+    .await
+    .expect("batch injection succeeds");
+
+    {
+        let sessions = active_sessions.read().await;
+        let session = sessions.get(session_id).expect("session exists");
+        let cached_msgs = session.messages.read().await;
+        // Should contain tool-1 and tool-3 (tool-2 was deduplicated within the batch)
+        assert_eq!(cached_msgs.len(), 2);
+        assert_eq!(cached_msgs[0].id, "tool-1");
+        assert_eq!(cached_msgs[1].id, "tool-3");
+    }
+}

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -49,6 +49,7 @@ pub mod mcp_server_service_tests;
 pub mod mcp_tool_cache_refresh_tests;
 pub mod mcp_utils_tests;
 pub mod message_cursor_pagination_tests;
+pub mod message_dedup_tests;
 pub mod message_source_tests;
 pub mod migration_compatibility_tests;
 pub mod org_create_teamwork_workspace_guard_tests;

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,7 +5,11 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
+export const EXECUTION_MODE_VALUES = [
+  'normal',
+  'yolo',
+  'unsafe',
+] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
Implement user message content-based deduplication in inject_messages_to_session. It reduces duplicate trailing user messages under the in-memory cache and DB (without Phase 3 DB orphan deletion as per final specifications). Sync DB inserts are introduced to prevent infinite crash recovery loops. Integration tests are included.