### PR TITLE
fix(mcp): harden editFile schema, bounds, and anchor errors

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
@@ -1,7 +1,7 @@
 use super::super::super::WorkspaceServer;
 use super::super::utils::{
     compute_line_hash, format_hashline, format_prefix_hash, initial_prefix_hash_state,
-    parse_anchor, read_file_as_string, update_prefix_hash_state,
+    parse_anchor, update_prefix_hash_state,
 };
 use super::types::{EditAction, LineEdit, PreparedFileEdit};
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
@@ -24,7 +24,8 @@ fn validate_edits_do_not_overlap(edits: &[LineEdit]) -> Result<(), MCPResult> {
                 ErrorCategory::InvalidInput,
                 format!(
                     "Conflicting edits: edit #{} and edit #{} both insert at the beginning of the file",
-                    idx_a, idx_b
+                    idx_a + 1,
+                    idx_b + 1
                 ),
                 ToolGroup::Workspace,
             )
@@ -39,7 +40,8 @@ fn validate_edits_do_not_overlap(edits: &[LineEdit]) -> Result<(), MCPResult> {
                 ErrorCategory::InvalidInput,
                 format!(
                     "Overlapping edits: edit #{} overlaps with edit #{}",
-                    idx_a, idx_b
+                    idx_a + 1,
+                    idx_b + 1
                 ),
                 ToolGroup::Workspace,
             )
@@ -129,6 +131,7 @@ fn build_new_hash_sections(edits: &[LineEdit], new_content: &str) -> Vec<String>
 
 fn validate_edit_anchors(
     path_str: &str,
+    edit_index: usize,
     edit: &LineEdit,
     line_count: usize,
     orig_lines: &[&str],
@@ -142,8 +145,11 @@ fn validate_edit_anchors(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "File '{}': line {} does not exist (file has {} lines)",
-                path_str, edit.start_line, line_count
+                "File '{}': edit #{}: line {} does not exist (file has {} lines)",
+                path_str,
+                edit_index + 1,
+                edit.start_line,
+                line_count
             ),
             ToolGroup::Workspace,
         )
@@ -155,8 +161,11 @@ fn validate_edit_anchors(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "File '{}': end line {} does not exist (file has {} lines)",
-                path_str, edit.end_line, line_count
+                "File '{}': edit #{}: end line {} does not exist (file has {} lines)",
+                path_str,
+                edit_index + 1,
+                edit.end_line,
+                line_count
             ),
             ToolGroup::Workspace,
         )
@@ -173,8 +182,10 @@ fn validate_edit_anchors(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "File '{}': invalid anchor for line {}: expected 6-character hexadecimal code",
-                    path_str, edit.start_line
+                    "File '{}': edit #{}: invalid anchor for line {}: expected 6-character hexadecimal code",
+                    path_str,
+                    edit_index + 1,
+                    edit.start_line
                 ),
                 ToolGroup::Workspace,
             )
@@ -194,8 +205,11 @@ fn validate_edit_anchors(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "File '{}': STALE ANCHOR on line {} (current line content changed)",
-                path_str, edit.start_line
+                "File '{}': edit #{}: STALE ANCHOR on line {} (current line content changed; anchor {:?})",
+                path_str,
+                edit_index + 1,
+                edit.start_line,
+                expected_anchor
             ),
             ToolGroup::Workspace,
         )
@@ -211,8 +225,11 @@ fn validate_edit_anchors(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "File '{}': STALE ANCHOR on line {} (earlier content changed before this line)",
-                path_str, edit.start_line
+                "File '{}': edit #{}: STALE ANCHOR on line {} (earlier content changed before this line; anchor {:?})",
+                path_str,
+                edit_index + 1,
+                edit.start_line,
+                expected_anchor
             ),
             ToolGroup::Workspace,
         )
@@ -234,8 +251,10 @@ fn validate_edit_anchors(
                 return Err(guided_error(
                     ErrorCategory::InvalidInput,
                     format!(
-                        "File '{}': invalid endAnchor for line {}: expected 6-character hexadecimal code",
-                        path_str, edit.end_line
+                        "File '{}': edit #{}: invalid endAnchor for line {}: expected 6-character hexadecimal code",
+                        path_str,
+                        edit_index + 1,
+                        edit.end_line
                     ),
                     ToolGroup::Workspace,
                 )
@@ -254,8 +273,11 @@ fn validate_edit_anchors(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "File '{}': STALE END ANCHOR on line {} (range boundary changed)",
-                    path_str, edit.end_line
+                    "File '{}': edit #{}: STALE END ANCHOR on line {} (range boundary changed; endAnchor {:?})",
+                    path_str,
+                    edit_index + 1,
+                    edit.end_line,
+                    expected_end_anchor
                 ),
                 ToolGroup::Workspace,
             )
@@ -271,8 +293,11 @@ fn validate_edit_anchors(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "File '{}': STALE END ANCHOR on line {} (earlier content changed before range boundary)",
-                    path_str, edit.end_line
+                    "File '{}': edit #{}: STALE END ANCHOR on line {} (earlier content changed before range boundary; endAnchor {:?})",
+                    path_str,
+                    edit_index + 1,
+                    edit.end_line,
+                    expected_end_anchor
                 ),
                 ToolGroup::Workspace,
             )
@@ -295,23 +320,21 @@ pub(super) async fn prepare_file_edit_batch(
 ) -> Result<PreparedFileEdit, MCPResult> {
     validate_edits_do_not_overlap(&edits)?;
 
-    let safe_path = match server.validate_path_with_error_for_write(path_str, session_id) {
-        Ok(path) => path,
-        Err(error) => {
-            return Err(guided_error(
-                ErrorCategory::PermissionDenied,
-                format!("Path validation failed for '{}': {}", path_str, error),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
-                "Use a normal file path without '..' traversal segments".to_string(),
-                "Use listDirectory to inspect valid target paths".to_string(),
-            ])
-            .to_mcp_result());
-        }
-    };
+    if let Err(error) = server.validate_path_with_error_for_write(path_str, session_id.clone()) {
+        return Err(guided_error(
+            ErrorCategory::PermissionDenied,
+            format!("Path validation failed for '{}': {}", path_str, error),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Use a normal file path without '..' traversal segments".to_string(),
+            "Use listDirectory to inspect valid target paths".to_string(),
+        ])
+        .to_mcp_result());
+    }
 
-    let original_content = match read_file_as_string(&safe_path).await {
+    let file_manager = server.get_file_manager(session_id);
+    let original_content = match file_manager.read_file_as_string(path_str).await {
         Ok(content) => content,
         Err(error) => {
             return Err(
@@ -332,8 +355,15 @@ pub(super) async fn prepare_file_edit_batch(
         })
         .collect();
 
-    for edit in &edits {
-        validate_edit_anchors(path_str, edit, line_count, &orig_lines, &prefix_hashes)?;
+    for (edit_index, edit) in edits.iter().enumerate() {
+        validate_edit_anchors(
+            path_str,
+            edit_index,
+            edit,
+            line_count,
+            &orig_lines,
+            &prefix_hashes,
+        )?;
     }
 
     let modified_lines = apply_edits(&orig_lines, &edits);

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
@@ -121,6 +121,24 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
         }
     }
 
+    if !canonical.contains_key("startLine") {
+        let is_insert_after = canonical
+            .get("op")
+            .and_then(|value| value.as_str())
+            .is_some_and(|op| op == "insert_after");
+        let touches_existing_line = canonical.contains_key("startAnchor")
+            || canonical.contains_key("endAnchor")
+            || canonical.contains_key("endLine");
+        let has_non_empty_content = canonical
+            .get("content")
+            .and_then(|value| value.as_str())
+            .is_some_and(|content| !content.is_empty());
+
+        if has_non_empty_content && !is_insert_after && !touches_existing_line {
+            canonical.insert("startLine".to_string(), Value::Number(0.into()));
+        }
+    }
+
     Value::Object(canonical)
 }
 
@@ -403,7 +421,7 @@ pub(super) fn parse_line_edit(
     if requires_anchor && start_anchor.is_none() {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!("{edit_label} targets existing content and requires 'startAnchor'"),
+            format!("{edit_label} targets existing content and requires 'anchor' (or 'startAnchor')"),
             ToolGroup::Workspace,
         )
         .guidance(vec![

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -1,3 +1,4 @@
+use super::super::tools::file_tools::EDIT_FILE_MAX_EDITS;
 use super::super::WorkspaceServer;
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
 use crate::mcp::types::MCPResult;
@@ -262,10 +263,10 @@ impl WorkspaceServer {
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Replace: {\"path\": \"src/a.ts\", \"edits\": [{\"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
-                "Insert top: {\"path\": \"src/a.ts\", \"edits\": [{\"startLine\": 0, \"content\": \"header\"}]}".to_string(),
-                "Insert below a line: {\"path\": \"src/a.ts\", \"edits\": [{\"op\": \"insert_after\", \"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
-                "Delete range: {\"path\": \"src/b.ts\", \"edits\": [{\"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]}".to_string(),
+                "Replace: {\"path\": \"src/a.ts\", \"edits\": [{\"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
+                "Prepend: {\"path\": \"src/a.ts\", \"edits\": [{\"content\": \"header\"}]}".to_string(),
+                "Insert below a line: {\"path\": \"src/a.ts\", \"edits\": [{\"op\": \"insert_after\", \"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
+                "Delete range: {\"path\": \"src/b.ts\", \"edits\": [{\"startLine\": 10, \"endLine\": 15, \"anchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]}".to_string(),
                 "Existing lines are 1-based; use startLine=0 only to prepend at the top".to_string(),
                 "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
             ])
@@ -308,6 +309,22 @@ impl WorkspaceServer {
             }
         };
 
+        if edits_array.len() > EDIT_FILE_MAX_EDITS as usize {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Parameter 'edits' exceeds the maximum of {EDIT_FILE_MAX_EDITS} operations per call (got {})",
+                    edits_array.len()
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                format!("Split the work into multiple editFile calls with at most {EDIT_FILE_MAX_EDITS} edits each"),
+                "Combine adjacent line replacements into a single range edit when possible".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
         if let Err(result) = validate_edit_target_path(self, &path, session_id.clone()) {
             return Ok(result);
         }
@@ -323,8 +340,8 @@ impl WorkspaceServer {
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
-                        "Single-line: {\"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
-                        "Range: {\"startLine\": 10, \"endLine\": 15, \"startAnchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}".to_string(),
+                        "Single-line: {\"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
+                        "Range: {\"startLine\": 10, \"endLine\": 15, \"anchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}".to_string(),
                     ])
                     .to_mcp_result());
                 }

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -563,25 +563,110 @@ Use flat params (line/anchor) for a single deletion, or the `edits` array for mu
     }
 }
 
-fn create_edit_item_schema() -> JSONSchema {
-    let start_line_desc = "Target start line number. Existing lines are 1-based. Use 0 only to prepend at the file top; to insert below an existing line, keep that line's 1-based number and set op='insert_after'.";
-    let end_line_desc =
-        "Inclusive end line for a multi-line replace/delete range. Omit for a single-line edit.";
+// Note: maximum file size is enforced at runtime (LIBRAGENT_MAX_FILE_SIZE).
+// The input schema cannot call runtime functions; therefore `content` has no hard cap here.
+
+/// Maximum number of edit operations allowed in a single editFile call.
+pub const EDIT_FILE_MAX_EDITS: u32 = 50;
+
+fn edit_anchor_props() -> HashMap<String, JSONSchema> {
     let start_anchor_desc =
         "6-character opaque anchor for the start line from readFile(showLineAnchors=true). Required for edits that touch an existing line. Do not include the line number or '|content'.";
     let end_anchor_desc =
         "6-character opaque anchor for the end line. Required when endLine is set for a multi-line replace/delete range.";
-    let content_desc =
-        "Replacement or inserted content. Omit it to delete. Existing lines stay 1-based; use startLine=0 only for prepend, or keep a 1-based existing line number with op='insert_after' to insert below it.";
 
     let mut props = HashMap::new();
     props.insert(
+        "anchor".to_string(),
+        string_prop(None, None, Some(start_anchor_desc)),
+    );
+    props.insert(
+        "startAnchor".to_string(),
+        string_prop(
+            None,
+            None,
+            Some("Alias for anchor. Prefer anchor for new edits."),
+        ),
+    );
+    props.insert(
+        "endAnchor".to_string(),
+        string_prop(None, None, Some(end_anchor_desc)),
+    );
+    props
+}
+
+fn create_prepend_edit_variant() -> JSONSchema {
+    let content_desc =
+        "Content to insert at the beginning of the file. startLine defaults to 0 when omitted.";
+
+    let mut props = edit_anchor_props();
+    props.insert(
+        "content".to_string(),
+        string_prop(Some(0), None, Some(content_desc)),
+    );
+    props.insert(
+        "startLine".to_string(),
+        integer_const_prop(
+            0,
+            Some("Must be 0 for prepend. Omit startLine to prepend with content only."),
+        ),
+    );
+
+    let mut schema = object_schema(props, vec!["content".to_string()]);
+    schema.description = Some(
+        "Prepend content at the top of the file. Provide content only, or content with startLine: 0. Do not include anchors."
+            .to_string(),
+    );
+    schema
+}
+
+fn create_line_edit_variant() -> JSONSchema {
+    let start_line_desc = "Target start line number (1-based). Use endLine only for multi-line replace/delete ranges.";
+    let end_line_desc =
+        "Inclusive end line for a multi-line replace/delete range. Omit for a single-line edit.";
+    let content_desc =
+        "Replacement content. Omit to delete the targeted line or range. The server infers replace vs delete from content presence when op is omitted.";
+
+    let mut props = edit_anchor_props();
+    props.insert(
+        "startLine".to_string(),
+        integer_prop(Some(1), None, Some(start_line_desc)),
+    );
+    props.insert(
+        "endLine".to_string(),
+        integer_prop(Some(1), None, Some(end_line_desc)),
+    );
+    props.insert(
+        "content".to_string(),
+        string_prop(None, None, Some(content_desc)),
+    );
+    props.insert(
         "op".to_string(),
         enum_prop_optional(
-            vec!["replace", "insert_after", "delete"],
-            Some(
-                "Optional operation hint. The server infers replace when content is present, delete when content is omitted, and top-of-file insert when startLine is 0. Use op='insert_after' for inserting below an existing line.",
-            ),
+            vec!["replace", "delete"],
+            Some("Optional hint for replace or delete. Omit to let the server infer from content."),
+        ),
+    );
+
+    let mut schema = object_schema(props, vec!["startLine".to_string()]);
+    schema.description = Some(
+        "Replace or delete existing lines. Requires startLine plus anchor for existing-line edits."
+            .to_string(),
+    );
+    schema
+}
+
+fn create_insert_after_edit_variant() -> JSONSchema {
+    let start_line_desc =
+        "Line number to insert after (1-based). Use 0 only to prepend at the file top.";
+    let content_desc = "Content to insert after the anchored line.";
+
+    let mut props = edit_anchor_props();
+    props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "insert_after",
+            Some("Must be insert_after for this edit shape."),
         ),
     );
     props.insert(
@@ -589,27 +674,36 @@ fn create_edit_item_schema() -> JSONSchema {
         integer_prop(Some(0), None, Some(start_line_desc)),
     );
     props.insert(
-        "endLine".to_string(),
-        integer_prop(Some(1), None, Some(end_line_desc)),
-    );
-    props.insert(
-        "startAnchor".to_string(),
-        string_prop(None, None, Some(start_anchor_desc)),
-    );
-    props.insert(
-        "endAnchor".to_string(),
-        string_prop(None, None, Some(end_anchor_desc)),
-    );
-    props.insert(
         "content".to_string(),
-        string_prop(None, None, Some(content_desc)),
+        string_prop(Some(0), None, Some(content_desc)),
     );
 
-    let mut schema = object_schema(props, vec!["startLine".to_string()]);
+    let mut schema = object_schema(
+        props,
+        vec![
+            "op".to_string(),
+            "startLine".to_string(),
+            "content".to_string(),
+        ],
+    );
     schema.description = Some(
-        "A single edit operation. Provide startLine plus anchors for existing-line edits. Existing content uses 1-based line numbers; only startLine=0 prepends at the file top. op is optional for common replace/delete flows but still useful for insert_after.".to_string(),
+        "Insert content after an existing line (or prepend when startLine is 0). Requires anchor unless startLine is 0."
+            .to_string(),
     );
     schema
+}
+
+fn create_edit_item_schema() -> JSONSchema {
+    one_of_object_schema(
+        vec![
+            create_prepend_edit_variant(),
+            create_line_edit_variant(),
+            create_insert_after_edit_variant(),
+        ],
+        Some(
+            "A single edit operation. Choose the variant that matches the intent: prepend, replace/delete existing lines, or insert_after.",
+        ),
+    )
 }
 
 pub fn create_edit_file_input_schema() -> JSONSchema {
@@ -624,8 +718,9 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     );
     props.insert(
         "edits".to_string(),
-        array_schema(
+        array_schema_with_max_items(
             create_edit_item_schema(),
+            Some(EDIT_FILE_MAX_EDITS),
             Some("Ordered list of edit operations to apply atomically to one file. All edits are schema-validated and anchor-validated before any write. Edits must not overlap."),
         ),
     );
@@ -641,15 +736,12 @@ pub fn create_edit_file_tool() -> MCPTool {
 
 PREREQUISITE: Obtain anchors from a prior readFile(showLineAnchors=true), writeFile response, or previous editFile response. Anchored lines look like `42:a31f2c|...`; for anchors, pass only the 6-character code such as `a31f2c`, not `42:a31f2c`.
 
-Line numbering is 1-based for existing content. The only valid 0 value is startLine=0, which prepends at the file top.
+Edit shapes (one per array item):
+- Prepend: `{ \"content\": \"...\" }` or `{ \"startLine\": 0, \"content\": \"...\" }`
+- Replace/delete existing lines: `{ \"startLine\": N, \"anchor\": \"...\", \"content\": \"...\" }` (omit content to delete)
+- Insert after a line: `{ \"op\": \"insert_after\", \"startLine\": N, \"anchor\": \"...\", \"content\": \"...\" }`
 
-Keep the payload simple and let the server infer the common cases:
-- replace single line: startLine + startAnchor + content
-- replace range: startLine + startAnchor + endLine + endAnchor + content
-- delete single line: startLine + startAnchor
-- delete range: startLine + startAnchor + endLine + endAnchor
-- prepend at file top: startLine=0 + content
-- insert below an existing line: add op='insert_after' + startLine + startAnchor + content
+Line numbering is 1-based for existing content. The only valid 0 value is startLine=0, which prepends at the file top.
 
 All edits are validated before any write begins."
             .to_string(),

--- a/src-tauri/src/mcp/utils/schema_builder.rs
+++ b/src-tauri/src/mcp/utils/schema_builder.rs
@@ -140,13 +140,22 @@ pub fn object_schema(properties: HashMap<String, JSONSchema>, required: Vec<Stri
     }
 }
 
-/// Creates an array schema with item type
+/// Creates an array schema with item type and optional max length.
 pub fn array_schema(items: JSONSchema, description: Option<&str>) -> JSONSchema {
+    array_schema_with_max_items(items, None, description)
+}
+
+/// Creates an array schema with item type and an optional `maxItems` constraint.
+pub fn array_schema_with_max_items(
+    items: JSONSchema,
+    max_items: Option<u32>,
+    description: Option<&str>,
+) -> JSONSchema {
     JSONSchema {
         schema_type: JSONSchemaType::Array {
             items: Some(Box::new(items)),
             min_items: None,
-            max_items: None,
+            max_items,
             unique_items: None,
         },
         title: None,

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -64,7 +64,7 @@ fn later_prefix_hash_changes_when_earlier_content_changes() {
 }
 
 #[test]
-fn edit_file_schema_uses_single_object_item_contract() {
+fn edit_file_schema_uses_discriminated_edit_variants() {
     let schema_json =
         serde_json::to_value(create_edit_file_input_schema()).expect("serialize editFile schema");
     let root_required = schema_json
@@ -78,42 +78,76 @@ fn edit_file_schema_uses_single_object_item_contract() {
         .iter()
         .any(|value| value.as_str() == Some("edits")));
 
-    let edits_items = schema_json
+    let edits_property = schema_json
         .get("properties")
         .and_then(|properties| properties.get("edits"))
-        .and_then(|edits| edits.get("items"))
-        .expect("edits.items schema");
+        .expect("edits property");
     assert_eq!(
-        edits_items.get("type").and_then(|value| value.as_str()),
-        Some("object")
-    );
-    assert!(
-        edits_items.get("oneOf").is_none(),
-        "model-facing schema should avoid oneOf-heavy edit variants"
+        edits_property
+            .get("maxItems")
+            .and_then(|value| value.as_u64()),
+        Some(50)
     );
 
-    let required = edits_items
+    let edits_items = edits_property.get("items").expect("edits.items schema");
+    let one_of = edits_items
+        .get("oneOf")
+        .and_then(|value| value.as_array())
+        .expect("edits.items.oneOf array");
+    assert_eq!(
+        one_of.len(),
+        3,
+        "expected prepend, line-edit, and insert-after variants"
+    );
+
+    let prepend_variant = &one_of[0];
+    let prepend_required = prepend_variant
         .get("required")
         .and_then(|value| value.as_array())
-        .expect("required array");
-    assert!(required
+        .expect("prepend required");
+    assert!(prepend_required
         .iter()
-        .any(|value| value.as_str() == Some("startLine")));
+        .any(|value| value.as_str() == Some("content")));
     assert!(
-        !required.iter().any(|value| value.as_str() == Some("path")),
-        "edit items should not repeat path; path belongs at the root"
+        !prepend_required
+            .iter()
+            .any(|value| value.as_str() == Some("startLine")),
+        "prepend variant should not require startLine"
     );
 
-    let start_line_description = edits_items
+    let line_edit_variant = &one_of[1];
+    let line_edit_required = line_edit_variant
+        .get("required")
+        .and_then(|value| value.as_array())
+        .expect("line edit required");
+    assert!(line_edit_required
+        .iter()
+        .any(|value| value.as_str() == Some("startLine")));
+
+    let insert_after_variant = &one_of[2];
+    let insert_after_required = insert_after_variant
+        .get("required")
+        .and_then(|value| value.as_array())
+        .expect("insert_after required");
+    assert!(insert_after_required
+        .iter()
+        .any(|value| value.as_str() == Some("op")));
+    assert!(insert_after_required
+        .iter()
+        .any(|value| value.as_str() == Some("startLine")));
+    assert!(insert_after_required
+        .iter()
+        .any(|value| value.as_str() == Some("anchor")));
+
+    let start_line_description = line_edit_variant
         .get("properties")
         .and_then(|properties| properties.get("startLine"))
         .and_then(|value| value.get("description"))
         .and_then(|value| value.as_str())
         .expect("startLine description");
     assert!(
-        start_line_description.contains("Existing lines are 1-based")
-            && start_line_description.contains("Use 0 only to prepend"),
-        "startLine description should make the 1-based/0-based exception explicit: {start_line_description}"
+        start_line_description.contains("Existing lines are 1-based"),
+        "startLine description should make the 1-based rule explicit: {start_line_description}"
     );
 }
 
@@ -146,7 +180,7 @@ async fn edit_file_rejects_hashless_replace_of_existing_line() {
     let text = extract_text_content(&result);
     assert_eq!(result.is_error, Some(true));
     assert!(
-        text.contains("requires 'startAnchor'"),
+        text.contains("requires 'anchor'"),
         "expected missing-anchor error, got: {text}"
     );
 }
@@ -212,7 +246,7 @@ async fn edit_file_missing_target_reports_file_not_found_before_anchor_guidance(
         "expected missing-file guidance, got: {text}"
     );
     assert!(
-        !text.contains("requires 'startAnchor'"),
+        !text.contains("requires 'anchor'"),
         "path errors should be reported before anchor guidance: {text}"
     );
 }
@@ -1020,8 +1054,124 @@ async fn edit_file_rejects_stale_anchor_without_partial_write() {
         text.contains("STALE ANCHOR"),
         "expected stale anchor error, got: {text}"
     );
+    assert!(
+        text.contains("edit #1"),
+        "stale anchor error should identify the edit index, got: {text}"
+    );
     assert_eq!(
         std::fs::read_to_string(workspace_dir.join("b.txt")).expect("read b"),
         "one\ntwo\n"
+    );
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set_temp(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: tests run serially within this module; guard restores on drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+#[tokio::test]
+async fn edit_file_rejects_oversized_target_file() {
+    let _env_guard = EnvVarGuard::set_temp("LIBRAGENT_MAX_FILE_SIZE", "10");
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-size-limit";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("large.txt"), "01234567890123456789").expect("write file");
+
+    let result = server
+        .handle_edit_file(json!({
+            "path": "large.txt",
+            "edits": [{ "content": "x" }]
+        }))
+        .await
+        .expect("editFile should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "oversized file should fail, got: {:?}",
+        result
+    );
+    let text = result_text(&result);
+    assert!(
+        text.contains("exceeds the maximum allowed size") || text.contains("File size error"),
+        "expected size-limit error, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_file_rejects_more_than_max_edits() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-max-edits";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "line\n").expect("write sample file");
+
+    let edits: Vec<serde_json::Value> = (0..51).map(|_| json!({ "content": "x" })).collect();
+
+    let result = server
+        .handle_edit_file(json!({
+            "path": "sample.txt",
+            "edits": edits
+        }))
+        .await
+        .expect("editFile should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "more than 50 edits should fail, got: {:?}",
+        result
+    );
+    let text = result_text(&result);
+    assert!(
+        text.contains("exceeds the maximum of 50"),
+        "expected max-edits error, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn edit_file_content_only_prepends_without_start_line() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-content-prepend";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "body\n").expect("write sample file");
+
+    let result = server
+        .handle_edit_file(json!({
+            "path": "sample.txt",
+            "edits": [{ "content": "header\n" }]
+        }))
+        .await
+        .expect("editFile should return");
+
+    assert!(
+        !result.is_error.unwrap_or(true),
+        "content-only prepend should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read sample"),
+        "header\nbody\n"
     );
 }

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -150,7 +150,7 @@ fn edit_file_schema_uses_discriminated_edit_variants() {
         .and_then(|value| value.as_str())
         .expect("startLine description");
     assert!(
-        start_line_description.contains("Existing lines are 1-based"),
+        start_line_description.contains("1-based"),
         "startLine description should make the 1-based rule explicit: {start_line_description}"
     );
 }
@@ -361,7 +361,7 @@ async fn edit_file_rejects_start_line_zero_for_replace_and_delete() {
         assert_eq!(result.is_error, Some(true));
         assert!(
             text.contains("'startLine' must be >= 1")
-                || text.contains("does not match the declared schema"),
+                || text.contains("do not match the declared schema"),
             "expected invalid startLine guidance for op={op}, got: {text}"
         );
     }
@@ -1146,8 +1146,7 @@ async fn edit_file_rejects_more_than_max_edits() {
     );
     let text = extract_text_content(&result);
     assert!(
-        text.contains("exceeds the maximum of 50")
-            || text.contains("more than 50 items"),
+        text.contains("exceeds the maximum of 50") || text.contains("more than 50 items"),
         "expected max-edits error, got: {text}"
     );
 }

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -1098,10 +1098,13 @@ async fn edit_file_rejects_oversized_target_file() {
     std::fs::write(workspace_dir.join("large.txt"), "01234567890123456789").expect("write file");
 
     let result = server
-        .handle_edit_file(json!({
-            "path": "large.txt",
-            "edits": [{ "content": "x" }]
-        }))
+        .handle_edit_file(
+            json!({
+                "path": "large.txt",
+                "edits": [{ "content": "x" }]
+            }),
+            Some(session_id.to_string()),
+        )
         .await
         .expect("editFile should return");
 
@@ -1110,7 +1113,7 @@ async fn edit_file_rejects_oversized_target_file() {
         "oversized file should fail, got: {:?}",
         result
     );
-    let text = result_text(&result);
+    let text = extract_text_content(&result);
     assert!(
         text.contains("exceeds the maximum allowed size") || text.contains("File size error"),
         "expected size-limit error, got: {text}"
@@ -1129,10 +1132,13 @@ async fn edit_file_rejects_more_than_max_edits() {
     let edits: Vec<serde_json::Value> = (0..51).map(|_| json!({ "content": "x" })).collect();
 
     let result = server
-        .handle_edit_file(json!({
-            "path": "sample.txt",
-            "edits": edits
-        }))
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "edits": edits
+            }),
+            Some(session_id.to_string()),
+        )
         .await
         .expect("editFile should return");
 
@@ -1141,7 +1147,7 @@ async fn edit_file_rejects_more_than_max_edits() {
         "more than 50 edits should fail, got: {:?}",
         result
     );
-    let text = result_text(&result);
+    let text = extract_text_content(&result);
     assert!(
         text.contains("exceeds the maximum of 50"),
         "expected max-edits error, got: {text}"
@@ -1158,10 +1164,13 @@ async fn edit_file_content_only_prepends_without_start_line() {
     std::fs::write(workspace_dir.join("sample.txt"), "body\n").expect("write sample file");
 
     let result = server
-        .handle_edit_file(json!({
-            "path": "sample.txt",
-            "edits": [{ "content": "header\n" }]
-        }))
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "edits": [{ "content": "header\n" }]
+            }),
+            Some(session_id.to_string()),
+        )
         .await
         .expect("editFile should return");
 

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -135,9 +135,13 @@ fn edit_file_schema_uses_discriminated_edit_variants() {
     assert!(insert_after_required
         .iter()
         .any(|value| value.as_str() == Some("startLine")));
-    assert!(insert_after_required
-        .iter()
-        .any(|value| value.as_str() == Some("anchor")));
+    assert!(
+        insert_after_variant
+            .get("properties")
+            .and_then(|properties| properties.get("anchor"))
+            .is_some(),
+        "insert_after variant should expose anchor for existing-line inserts"
+    );
 
     let start_line_description = line_edit_variant
         .get("properties")
@@ -356,7 +360,8 @@ async fn edit_file_rejects_start_line_zero_for_replace_and_delete() {
         let text = extract_text_content(&result);
         assert_eq!(result.is_error, Some(true));
         assert!(
-            text.contains("'startLine' must be >= 1"),
+            text.contains("'startLine' must be >= 1")
+                || text.contains("does not match the declared schema"),
             "expected invalid startLine guidance for op={op}, got: {text}"
         );
     }
@@ -787,14 +792,6 @@ async fn edit_files_error_messages_include_edit_context() {
 
     std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
 
-    let anchors = format_as_hashlines("alpha\nbeta\n");
-    let start_anchor = anchors
-        .lines()
-        .next()
-        .and_then(|line| line.split('|').next())
-        .and_then(|prefix| prefix.split(':').nth(1))
-        .expect("start anchor");
-
     let result = server
         .handle_edit_file(
             json!({
@@ -803,7 +800,7 @@ async fn edit_files_error_messages_include_edit_context() {
                     {
                         "op": "insert_after",
                         "startLine": 1,
-                        "startAnchor": start_anchor
+                        "content": "new line"
                     }
                 ]
             }),
@@ -816,7 +813,7 @@ async fn edit_files_error_messages_include_edit_context() {
     let text = extract_text_content(&result);
     assert!(
         text.contains("Edit at index 0 [op='insert_after', startLine=1]")
-            && text.contains("'content' is required"),
+            && text.contains("requires 'anchor'"),
         "error should include offending edit context: {text}"
     );
 }
@@ -1149,7 +1146,8 @@ async fn edit_file_rejects_more_than_max_edits() {
     );
     let text = extract_text_content(&result);
     assert!(
-        text.contains("exceeds the maximum of 50"),
+        text.contains("exceeds the maximum of 50")
+            || text.contains("more than 50 items"),
         "expected max-edits error, got: {text}"
     );
 }


### PR DESCRIPTION
## Summary

- Cap editFile edits at 50 (JSON schema maxItems + runtime validation)
- Enforce max_file_size on the read path via SecureFileManager
- Add discriminated oneOf edit variants (PrependEdit, LineEdit, InsertAfterEdit) with anchor alias and content-only prepend
- Improve stale-anchor diagnostics with 1-based edit index and anchor value
- Add integration tests for schema variants, oversized files, max edits, and content-only prepend

## Test plan

- [x] pnpm refactor:validate
- [x] Integration tests in workspace_hash_anchor_tests.rs (CI/Linux)
- [ ] Manual editFile calls: prepend-only content, line edit with anchor, insert_after, stale anchor error message

Made with [Cursor](https://cursor.com)