### PR TITLE
fix: support bootstrap alias for SetupWizard and use setup-wizard in default config

### DIFF
--- a/src-tauri/src/mcp/builtin/service_id.rs
+++ b/src-tauri/src/mcp/builtin/service_id.rs
@@ -18,7 +18,7 @@ pub enum BuiltinServiceId {
     Ui,
     Browser,
     ScheduledTask,
-    #[serde(rename = "setup-wizard", alias = "setup_wizard")]
+    #[serde(rename = "setup-wizard", alias = "setup_wizard", alias = "bootstrap")]
     SetupWizard,
     Tool, // Unified Tool Domain
     Media,

--- a/src-tauri/src/services/assistant_init.rs
+++ b/src-tauri/src/services/assistant_init.rs
@@ -307,7 +307,7 @@ ATTENTION ECONOMY:
             "deletionProtected": true,
             "localServices": [],
             "allowedBuiltInServiceAliases": [
-                "bootstrap",
+                "setup-wizard",
                 "tool",
                 "agent",
                 "workspace",


### PR DESCRIPTION
This PR adds 'bootstrap' as an alias for the SetupWizard builtin service in Rust to ensure backward compatibility with existing databases, and updates the default assistant initialization to use the canonical 'setup-wizard' alias.