### PR TITLE
⚡ Bolt: Replace Array.from().filter() with for...of loops for better performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-05-24 - Avoid Array.from().filter() on Set Iterators
-**Learning:** Calling `Array.from(set).filter()` on hot paths like AI message formatting creates unnecessary intermediate array allocations, increasing garbage collection pressure.
-**Action:** Use a `for...of` loop directly on the `Set` to filter elements into a new array, completely bypassing the intermediate array allocation.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid Array.from().filter() on Set Iterators
+**Learning:** Calling `Array.from(set).filter()` on hot paths like AI message formatting creates unnecessary intermediate array allocations, increasing garbage collection pressure.
+**Action:** Use a `for...of` loop directly on the `Set` to filter elements into a new array, completely bypassing the intermediate array allocation.

--- a/src/lib/ai-service/anthropic/message-converter.ts
+++ b/src/lib/ai-service/anthropic/message-converter.ts
@@ -107,12 +107,20 @@ function logToolChainIntegrity(messages: Message[]): void {
     }
   }
 
-  const unmatchedToolUses = Array.from(toolUseIds).filter(
-    (id) => !toolResultIds.has(id),
-  );
-  const unmatchedToolResults = Array.from(toolResultIds).filter(
-    (id) => !toolUseIds.has(id),
-  );
+  // ⚡ Bolt: Replaced Array.from().filter() with for...of loops to avoid intermediate array allocations
+  const unmatchedToolUses: string[] = [];
+  for (const id of toolUseIds) {
+    if (!toolResultIds.has(id)) {
+      unmatchedToolUses.push(id);
+    }
+  }
+
+  const unmatchedToolResults: string[] = [];
+  for (const id of toolResultIds) {
+    if (!toolUseIds.has(id)) {
+      unmatchedToolResults.push(id);
+    }
+  }
 
   if (unmatchedToolUses.length > 0 || unmatchedToolResults.length > 0) {
     logger.warn('Potential tool chain mismatch detected', {


### PR DESCRIPTION
💡 What: Replaced `Array.from(set).filter(...)` chains with `for...of` loops in `src/lib/ai-service/anthropic/message-converter.ts`.
🎯 Why: Avoiding intermediate array allocations from `Array.from()` before filtering reduces garbage collection pressure on the hot path for processing AI messages.
📊 Impact: Reduces intermediate array allocations, lowering memory overhead and garbage collection pressure when processing AI messages with tool calls.
🔬 Measurement: Verify tests still pass and no memory regressions are observed during tool call generation.

---
*PR created automatically by Jules for task [2621542510161551156](https://jules.google.com/task/2621542510161551156) started by @fritzprix*