### PR TITLE
feat(mcp): enrich checkSession/messageToSession timeout response and stopSession description

### DIFF
--- a/src-tauri/src/agent/llm/completion/request.rs
+++ b/src-tauri/src/agent/llm/completion/request.rs
@@ -4,8 +4,9 @@ mod formatting;
 mod orchestration;
 
 pub use compact::{
-    build_compact_summary_message, build_compact_summary_message_for_messages,
-    build_compact_summary_text, summarize_recent_tool_calls,
+    apply_compact_summary_projection, build_compact_summary_message,
+    build_compact_summary_message_for_messages, build_compact_summary_text,
+    summarize_recent_tool_calls,
 };
 pub use context_selection::{
     build_compact_context_selection_options, resolve_preserved_calibration_ratio,

--- a/src-tauri/src/agent/llm/completion/request/compact.rs
+++ b/src-tauri/src/agent/llm/completion/request/compact.rs
@@ -1,5 +1,6 @@
 use crate::mcp::types::MCPContent;
 use crate::models::chat::Message;
+use crate::repositories::CompactContextRecord;
 use std::collections::HashMap;
 
 const COMPACT_TOOL_SNAPSHOT_LIMIT: usize = 5;
@@ -29,6 +30,33 @@ pub fn build_compact_summary_message_for_messages(
         build_compact_summary_text(summary, compacted_messages),
         created_at,
     )
+}
+
+/// Builds the message list used for token projection, mirroring preflight compact injection.
+pub fn apply_compact_summary_projection(
+    session_id: &str,
+    messages: &[Message],
+    compact_record: Option<&CompactContextRecord>,
+) -> Vec<Message> {
+    let Some(record) = compact_record else {
+        return messages.to_vec();
+    };
+
+    let Some(to_idx) = messages
+        .iter()
+        .position(|message| message.id == record.to_id)
+    else {
+        return messages.to_vec();
+    };
+
+    let summary_msg = build_compact_summary_message_for_messages(
+        session_id,
+        &record.summary,
+        &messages[..=to_idx],
+        chrono::Utc::now().timestamp_millis(),
+    );
+    let tail = messages[(to_idx + 1)..].to_vec();
+    [vec![summary_msg], tail].concat()
 }
 
 pub fn build_compact_summary_text(summary: &str, compacted_messages: &[Message]) -> String {

--- a/src-tauri/src/agent/llm/response_circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/response_circuit_breaker.rs
@@ -1,11 +1,12 @@
 use crate::agent::llm::circuit_breaker;
-use crate::agent::llm::completion::{load_context_management_settings, uses_compaction_strategy};
+use crate::agent::llm::completion::load_context_management_settings;
+use crate::agent::llm::completion::request::apply_compact_summary_projection;
 use crate::agent::llm::token_utils::{
-    calculate_conservative_preflight_prompt_tokens, calculate_effective_input_budget,
-    calculate_prompt_anchored_total_tokens, derive_measured_output_tokens_reserve,
-    estimate_text_tokens, try_derive_bpe_calibration_ratio,
+    calculate_conservative_preflight_prompt_tokens, calculate_context_safety_margin,
+    calculate_effective_input_budget, calculate_prompt_anchored_total_tokens,
+    derive_measured_output_tokens_reserve, estimate_text_tokens, try_derive_bpe_calibration_ratio,
 };
-use crate::agent::state::AgentSession;
+use crate::agent::state::{AgentSession, CompactionRecoveryPhase};
 use crate::agent::tools::{
     create_tool_result_message, tool_result_inline_limit_bytes,
     tool_result_preview_content_limit_bytes,
@@ -276,28 +277,31 @@ async fn apply_tool_loop_token_fence(
         return;
     }
 
-    let context_settings = load_context_management_settings().await;
-    if !uses_compaction_strategy(context_settings.context_strategy()) {
-        return;
-    }
-
-    // Clone Arc handles while holding the sessions read-lock (no async ops, fast).
-    // The guard is dropped at the end of this block so writers are not stalled
-    // during the subsequent inner async reads.
-    let (messages_lock, last_request_lock, session_metadata) = {
+    // Tool-loop token fence is a last-resort fallback after compaction hard failure
+    // (DegradedTools recovery phase). Normal compact-mode sessions rely on compaction
+    // and preflight context selection instead of redacting parallel tool batches here.
+    let (messages_lock, last_request_lock, compact_context_lock, session_metadata) = {
         let sessions = active_sessions.read().await;
         let Some(session) = sessions.get(session_id) else {
             return;
         };
+        if session.compaction.recovery_phase().await != CompactionRecoveryPhase::DegradedTools {
+            return;
+        }
         (
             Arc::clone(&session.messages),
             Arc::clone(&session.last_completion_request),
+            Arc::clone(&session.compact_context),
             session.metadata.clone(),
         )
     };
-    // sessions guard is dropped here — writers can now acquire active_sessions
+
+    let context_settings = load_context_management_settings().await;
 
     let history_messages = messages_lock.read().await.clone();
+    let compact_record = compact_context_lock.read().await.clone();
+    let projection_history =
+        apply_compact_summary_projection(session_id, &history_messages, compact_record.as_ref());
     let last_completion_request = last_request_lock.read().await.clone();
     let configured_max_output_tokens = crate::agent::resolve_agent_config(&session_metadata)
         .await
@@ -306,10 +310,10 @@ async fn apply_tool_loop_token_fence(
     let (system_prompt_tokens, tools_tokens) =
         estimate_parent_request_prefix_tokens(last_completion_request.as_ref());
     let fallback_calibration_ratio =
-        try_derive_bpe_calibration_ratio(&history_messages, system_prompt_tokens, tools_tokens);
+        try_derive_bpe_calibration_ratio(&projection_history, system_prompt_tokens, tools_tokens);
 
     let output_reserve_tokens =
-        derive_measured_output_tokens_reserve(&history_messages, configured_max_output_tokens);
+        derive_measured_output_tokens_reserve(&projection_history, configured_max_output_tokens);
     let safe_input_token_limit = context_settings
         .max_input_context()
         .min(context_settings.model_max_limit());
@@ -329,7 +333,7 @@ async fn apply_tool_loop_token_fence(
 
     for prefix_len in 1..=original_tool_calls.len() {
         let projected_messages = build_projected_messages_for_prefix(
-            &history_messages,
+            &projection_history,
             assistant_message,
             &original_tool_calls,
             prefix_len,
@@ -366,7 +370,7 @@ async fn apply_tool_loop_token_fence(
     assistant_message.tool_calls = Some(original_tool_calls.into_iter().take(kept_count).collect());
 
     let persisted_messages = build_projected_messages_for_prefix(
-        &history_messages,
+        &projection_history,
         assistant_message,
         assistant_message
             .tool_calls
@@ -382,7 +386,7 @@ async fn apply_tool_loop_token_fence(
     );
 
     log::warn!(
-        "Tool-loop token fence redacted assistant tool calls for session {}: kept={} dropped={} projected_prompt_tokens={} projected_total_budget_tokens={} persisted_prompt_tokens={} guarded_total_budget_limit={} output_reserve_tokens={}",
+        "Tool-loop token fence (compaction degraded-tools fallback) redacted assistant tool calls for session {}: kept={} dropped={} projected_prompt_tokens={} projected_total_budget_tokens={} persisted_prompt_tokens={} guarded_total_budget_limit={} output_reserve_tokens={} compact_summary_applied={}",
         session_id,
         kept_count,
         dropped_count,
@@ -390,7 +394,8 @@ async fn apply_tool_loop_token_fence(
         kept_projection_total,
         persisted_prompt_tokens,
         guarded_total_budget_limit,
-        output_reserve_tokens
+        output_reserve_tokens,
+        compact_record.is_some()
     );
 }
 
@@ -446,8 +451,4 @@ fn estimate_parent_request_prefix_tokens(
         .unwrap_or(0);
 
     (system_prompt_tokens, tools_tokens)
-}
-
-fn calculate_context_safety_margin(effective_input_budget: usize) -> usize {
-    ((effective_input_budget as f64) * 0.03).ceil() as usize
 }

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -392,15 +392,17 @@ fn stop_session_tool() -> MCPTool {
         name: "stopSession".to_string(),
         title: Some("Stop Agent Session".to_string()),
         description: tool_description(
-            "Forcefully terminate an active sub-agent session.",
+            "Forcefully terminate an active sub-agent session when a critical problem is confirmed.",
             &["Session ID from agent__checkSession or agent__listAgents(type='sessions')."],
             &[
-                "Use when delegation is no longer needed or the child appears stuck.",
+                "CRITICAL: Do NOT stop a session simply because checkSession or messageToSession timed out. Timeouts only mean the child is busy working.",
+                "Always check the child session's current status and latest messages via checkSession(wait=false) to confirm it is actually stuck before stopping.",
+                "Use ONLY when there is a confirmed critical error, infinite loop, or the delegation is explicitly no longer needed.",
                 "No-op if the session is already non-running.",
             ],
             &[
+                "Check session status and messages first with agent__checkSession.",
                 "Delete session data with agent__deleteSession if permanent removal is needed.",
-                "Start fresh delegation with agent__startSession.",
             ],
         ),
         input_schema: object_prop(

--- a/src-tauri/src/mcp/builtin/agent/utils.rs
+++ b/src-tauri/src/mcp/builtin/agent/utils.rs
@@ -422,6 +422,55 @@ pub async fn wait_until_session_terminal(
     }
 }
 
+fn format_message_summary(msg: &crate::models::chat::Message) -> String {
+    let mut text_parts = Vec::new();
+    for content in &msg.content {
+        match content {
+            MCPContent::Text { text, .. } => {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    text_parts.push(trimmed.to_string());
+                }
+            }
+            MCPContent::Thinking { thinking, .. } => {
+                let trimmed = thinking.trim();
+                if !trimmed.is_empty() {
+                    text_parts.push(format!("[Thinking: {}]", trimmed));
+                }
+            }
+            MCPContent::Image { .. } => {
+                text_parts.push("[Image]".to_string());
+            }
+            MCPContent::Audio { .. } => {
+                text_parts.push("[Audio]".to_string());
+            }
+            MCPContent::Resource { .. } => {
+                text_parts.push("[Resource]".to_string());
+            }
+            _ => {}
+        }
+    }
+
+    if text_parts.is_empty() {
+        if let Some(tool_calls) = &msg.tool_calls {
+            let names: Vec<String> = tool_calls
+                .iter()
+                .map(|tc| tc.function.name.clone())
+                .collect();
+            text_parts.push(format!("[Tool Call: {}]", names.join(", ")));
+        }
+    }
+
+    let joined = text_parts.join(" ");
+    if joined.chars().count() > 150 {
+        let mut truncated: String = joined.chars().take(150).collect();
+        truncated.push_str("...");
+        truncated
+    } else {
+        joined
+    }
+}
+
 pub async fn handle_wait_timeout_result(
     wait_result: Result<(Value, u64), String>,
     manager: Option<&AgentSessionManager>,
@@ -438,27 +487,53 @@ pub async fn handle_wait_timeout_result(
                 category,
                 crate::mcp::error_normalization::ExternalMcpErrorCategory::Timeout
             ) {
-                let text = if is_spawn {
-                    format!(
-                        "Child session created (ID: {}) but waiting for completion timed out after {}s.\n\nThe agent is likely still working. Use checkSession(sessionId=\"{}\", wait=true) later to fetch the final result.",
-                        session_id, timeout_seconds, session_id
-                    )
-                } else {
-                    format!(
-                        "Waiting for session {} timed out after {}s. The agent is likely still working.\n\nYou can call checkSession(sessionId=\"{}\", wait=true) again to continue waiting, or use list(type=\"sessions\") to confirm it is still active.",
-                        session_id, timeout_seconds, session_id
-                    )
-                };
-
-                let (session_status, turn_count) = match manager {
+                let (session_status, turn_count, latest_msgs_str, latest_msgs_json) = match manager
+                {
                     Some(manager) => {
                         let session_status = match fetch_session_value(manager, session_id).await {
                             Ok(Some(session)) => extract_session_status(&session),
                             Ok(None) | Err(_) => "unknown".to_string(),
                         };
-                        (session_status, count_session_turns(session_id).await)
+                        let turn_count = count_session_turns(session_id).await;
+
+                        let repo = crate::state::get_message_repository();
+                        let mut messages = repo
+                            .get_messages_by_session(session_id, 5)
+                            .await
+                            .unwrap_or_default();
+                        messages.reverse();
+
+                        let mut msgs_str = String::new();
+                        let mut msgs_json = Vec::new();
+
+                        if !messages.is_empty() {
+                            msgs_str.push_str("\n\nLatest workflow messages:\n");
+                            for msg in &messages {
+                                let summary = format_message_summary(msg);
+                                msgs_str.push_str(&format!("  - [{}]: {}\n", msg.role, summary));
+                                msgs_json.push(json!({
+                                    "role": msg.role,
+                                    "summary": summary,
+                                    "createdAt": msg.created_at,
+                                }));
+                            }
+                        }
+
+                        (session_status, turn_count, msgs_str, msgs_json)
                     }
-                    None => ("unknown".to_string(), 0),
+                    None => ("unknown".to_string(), 0, String::new(), Vec::new()),
+                };
+
+                let text = if is_spawn {
+                    format!(
+                        "Child session created (ID: {}) but waiting for completion timed out after {}s.\n\nThe agent is likely still working. Use checkSession(sessionId=\"{}\", wait=true) later to fetch the final result.{}\n\nCurrent status: {}",
+                        session_id, timeout_seconds, session_id, latest_msgs_str, session_status
+                    )
+                } else {
+                    format!(
+                        "Waiting for session {} timed out after {}s. The agent is likely still working.\n\nYou can call checkSession(sessionId=\"{}\", wait=true) again to continue waiting, or use list(type=\"sessions\") to confirm it is still active.{}\n\nCurrent status: {}",
+                        session_id, timeout_seconds, session_id, latest_msgs_str, session_status
+                    )
                 };
 
                 let mut data = build_agent_session_tool_data(
@@ -477,6 +552,7 @@ pub async fn handle_wait_timeout_result(
                     Value::String("timeout".to_string()),
                 );
                 data.insert("error".to_string(), Value::String(e));
+                data.insert("latestMessages".to_string(), json!(latest_msgs_json));
 
                 if is_spawn {
                     data.insert("id".to_string(), Value::String(session_id.to_string()));

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -397,7 +397,9 @@ impl SessionRepository for InMemorySessionRepository {
 #[cfg(test)]
 mod tests {
     use super::InMemorySessionRepository;
-    use crate::repositories::session_repository::{SessionMetadata, SessionRepository, SessionStatus};
+    use crate::repositories::session_repository::{
+        SessionMetadata, SessionRepository, SessionStatus,
+    };
 
     #[tokio::test]
     async fn test_new_repository_is_empty() {

--- a/src-tauri/src/repositories/in_memory_session_repository.rs
+++ b/src-tauri/src/repositories/in_memory_session_repository.rs
@@ -397,10 +397,7 @@ impl SessionRepository for InMemorySessionRepository {
 #[cfg(test)]
 mod tests {
     use super::InMemorySessionRepository;
-    use crate::execution_mode::ExecutionMode;
-    use crate::repositories::session_repository::{
-        SessionMetadata, SessionRepository, SessionStatus,
-    };
+    use crate::repositories::session_repository::{SessionMetadata, SessionRepository, SessionStatus};
 
     #[tokio::test]
     async fn test_new_repository_is_empty() {
@@ -411,37 +408,11 @@ mod tests {
     #[tokio::test]
     async fn test_upsert_and_get_session() {
         let repo = InMemorySessionRepository::new();
-        let session = SessionMetadata {
-            id: "test-session".to_string(),
-            name: Some("Test Session".to_string()),
-            status: SessionStatus::Idle,
-            model: "gpt-4".to_string(),
-            provider: "openai".to_string(),
-            assistant_id: None,
-            is_bookmarked: false,
-            parent_session_id: None,
-            lineage_id: None,
-            depth: None,
-            max_depth: None,
-            max_fanout: None,
-            org_id: None,
-            org_name: None,
-            org_root_session_id: None,
-            created_at: 1234567890,
-            updated_at: 1234567890,
-            last_viewed_at: None,
-            last_message_at: None,
-            last_attention_at: None,
-            last_attention_reason: None,
-            execution_mode: ExecutionMode::Normal,
-            workspace_override: None,
-        };
+        let session = SessionMetadata::test_fixture("test-session");
 
-        // Upsert session
         repo.upsert_session(&session).await.unwrap();
         assert_eq!(repo.count().await, 1);
 
-        // Get session
         let retrieved = repo.get_session("test-session").await.unwrap();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().id, "test-session");
@@ -451,49 +422,24 @@ mod tests {
     async fn test_update_status() {
         let repo = InMemorySessionRepository::new();
         let session = SessionMetadata {
-            id: "test-session".to_string(),
-            name: Some("Test".to_string()),
-            status: SessionStatus::Idle,
-            model: "gpt-4".to_string(),
-            provider: "openai".to_string(),
-            assistant_id: None,
-            is_bookmarked: false,
-            parent_session_id: None,
-            lineage_id: None,
-            depth: None,
-            max_depth: None,
-            max_fanout: None,
-            org_id: None,
-            org_name: None,
-            org_root_session_id: None,
             created_at: 100,
             updated_at: 100,
-            last_viewed_at: None,
-            last_message_at: None,
-            last_attention_at: None,
-            last_attention_reason: None,
-            execution_mode: ExecutionMode::Normal,
-            workspace_override: None,
+            ..SessionMetadata::test_fixture("test-session")
         };
 
         repo.upsert_session(&session).await.unwrap();
-
-        // Update status
         repo.update_status("test-session", SessionStatus::Busy)
             .await
             .unwrap();
 
-        // Verify status changed
         let updated = repo.get_session("test-session").await.unwrap().unwrap();
         assert_eq!(updated.status, SessionStatus::Busy);
-        assert!(updated.updated_at > 100); // Timestamp should be updated
+        assert!(updated.updated_at > 100);
     }
 
     #[tokio::test]
     async fn test_update_status_nonexistent_session_is_idempotent() {
         let repo = InMemorySessionRepository::new();
-
-        // Should not fail even if session doesn't exist
         let result = repo.update_status("nonexistent", SessionStatus::Busy).await;
         assert!(result.is_ok());
     }
@@ -502,39 +448,17 @@ mod tests {
     async fn test_delete_session() {
         let repo = InMemorySessionRepository::new();
         let session = SessionMetadata {
-            id: "test-session".to_string(),
             name: None,
-            status: SessionStatus::Idle,
-            model: "gpt-4".to_string(),
-            provider: "openai".to_string(),
-            assistant_id: None,
-            is_bookmarked: false,
-            parent_session_id: None,
-            lineage_id: None,
-            depth: None,
-            max_depth: None,
-            max_fanout: None,
-            org_id: None,
-            org_name: None,
-            org_root_session_id: None,
             created_at: 100,
             updated_at: 100,
-            last_viewed_at: None,
-            last_message_at: None,
-            last_attention_at: None,
-            last_attention_reason: None,
-            execution_mode: ExecutionMode::Normal,
-            workspace_override: None,
+            ..SessionMetadata::test_fixture("test-session")
         };
 
         repo.upsert_session(&session).await.unwrap();
         assert_eq!(repo.count().await, 1);
-
-        // Delete session
         repo.delete_session("test-session").await.unwrap();
         assert_eq!(repo.count().await, 0);
 
-        // Verify session is gone
         let retrieved = repo.get_session("test-session").await.unwrap();
         assert!(retrieved.is_none());
     }
@@ -543,37 +467,17 @@ mod tests {
     async fn test_get_all_sessions() {
         let repo = InMemorySessionRepository::new();
 
-        // Add multiple sessions
         for i in 0..3 {
             let session = SessionMetadata {
-                id: format!("session-{}", i),
-                name: Some(format!("Session {}", i)),
-                status: SessionStatus::Idle,
-                model: "gpt-4".to_string(),
-                provider: "openai".to_string(),
-                is_bookmarked: false,
-                assistant_id: None,
-                parent_session_id: None,
-                lineage_id: None,
-                depth: None,
-                max_depth: None,
-                max_fanout: None,
-                org_id: None,
-                org_name: None,
-                org_root_session_id: None,
+                id: format!("session-{i}"),
+                name: Some(format!("Session {i}")),
                 created_at: 100,
                 updated_at: 100,
-                last_viewed_at: None,
-                last_message_at: None,
-                last_attention_at: None,
-                last_attention_reason: None,
-                execution_mode: ExecutionMode::Normal,
-                workspace_override: None,
+                ..SessionMetadata::test_fixture(format!("session-{i}"))
             };
             repo.upsert_session(&session).await.unwrap();
         }
 
-        // Get all sessions
         let all = repo.get_all_sessions().await.unwrap();
         assert_eq!(all.len(), 3);
     }
@@ -582,39 +486,18 @@ mod tests {
     async fn test_clear() {
         let repo = InMemorySessionRepository::new();
 
-        // Add sessions
         for i in 0..5 {
             let session = SessionMetadata {
-                id: format!("session-{}", i),
+                id: format!("session-{i}"),
                 name: None,
-                status: SessionStatus::Idle,
-                model: "gpt-4".to_string(),
-                provider: "openai".to_string(),
-                is_bookmarked: false,
-                assistant_id: None,
-                parent_session_id: None,
-                lineage_id: None,
-                depth: None,
-                max_depth: None,
-                max_fanout: None,
-                org_id: None,
-                org_name: None,
-                org_root_session_id: None,
                 created_at: 100,
                 updated_at: 100,
-                last_viewed_at: None,
-                last_message_at: None,
-                last_attention_at: None,
-                last_attention_reason: None,
-                execution_mode: ExecutionMode::Normal,
-                workspace_override: None,
+                ..SessionMetadata::test_fixture(format!("session-{i}"))
             };
             repo.upsert_session(&session).await.unwrap();
         }
 
         assert_eq!(repo.count().await, 5);
-
-        // Clear all
         repo.clear().await;
         assert_eq!(repo.count().await, 0);
     }
@@ -625,48 +508,27 @@ mod tests {
         use tokio::task;
 
         let repo = Arc::new(InMemorySessionRepository::new());
-
-        // Spawn multiple tasks to upsert sessions concurrently
         let mut handles = vec![];
+
         for i in 0..10 {
             let repo_clone = repo.clone();
             let handle = task::spawn(async move {
                 let session = SessionMetadata {
-                    id: format!("session-{}", i),
+                    id: format!("session-{i}"),
                     name: None,
-                    status: SessionStatus::Idle,
-                    model: "gpt-4".to_string(),
-                    provider: "openai".to_string(),
-                    is_bookmarked: false,
                     created_at: 100,
                     updated_at: 100,
-                    last_viewed_at: None,
-                    last_message_at: None,
-                    last_attention_at: None,
-                    last_attention_reason: None,
-                    assistant_id: None,
-                    parent_session_id: None,
-                    lineage_id: None,
-                    depth: None,
-                    max_depth: None,
-                    max_fanout: None,
-                    org_id: None,
-                    org_name: None,
-                    org_root_session_id: None,
-                    execution_mode: ExecutionMode::Normal,
-                    workspace_override: None,
+                    ..SessionMetadata::test_fixture(format!("session-{i}"))
                 };
                 repo_clone.upsert_session(&session).await.unwrap();
             });
             handles.push(handle);
         }
 
-        // Wait for all tasks to complete
         for handle in handles {
             handle.await.unwrap();
         }
 
-        // Verify all sessions were added
         assert_eq!(repo.count().await, 10);
     }
 }

--- a/src-tauri/src/repositories/session_repository.rs
+++ b/src-tauri/src/repositories/session_repository.rs
@@ -721,3 +721,39 @@ impl SessionRepository for SqliteSessionRepository {
         Ok(())
     }
 }
+
+#[cfg(test)]
+impl SessionMetadata {
+    pub fn test_fixture(id: impl Into<String>) -> Self {
+        let id = id.into();
+        Self {
+            id: id.clone(),
+            name: Some(format!("Test {id}")),
+            status: SessionStatus::Idle,
+            model: "gpt-4".to_string(),
+            provider: "openai".to_string(),
+            assistant_id: None,
+            parent_session_id: None,
+            lineage_id: None,
+            depth: None,
+            max_depth: None,
+            max_fanout: None,
+            org_id: None,
+            org_name: None,
+            org_root_session_id: None,
+            created_at: 1234567890,
+            updated_at: 1234567890,
+            last_viewed_at: None,
+            last_message_at: None,
+            last_attention_at: None,
+            last_attention_reason: None,
+            is_bookmarked: false,
+            execution_mode: ExecutionMode::Normal,
+            workspace_override: None,
+            workspace_isolation: WorkspaceIsolationMode::default(),
+            docker_config: None,
+            docker_container_name: None,
+            docker_host_workspace_path: None,
+        }
+    }
+}

--- a/src-tauri/tests/integration/tool_loop_fence_tests.rs
+++ b/src-tauri/tests/integration/tool_loop_fence_tests.rs
@@ -261,12 +261,8 @@ async fn assert_tool_calls_unchanged(
     original_tool_call_count: usize,
     phase_label: &str,
 ) {
-    preprocess_assistant_tool_calls_for_testing(
-        active_sessions,
-        session_id,
-        assistant_message,
-    )
-    .await;
+    preprocess_assistant_tool_calls_for_testing(active_sessions, session_id, assistant_message)
+        .await;
 
     let kept_tool_calls = assistant_message
         .tool_calls

--- a/src-tauri/tests/integration/tool_loop_fence_tests.rs
+++ b/src-tauri/tests/integration/tool_loop_fence_tests.rs
@@ -11,7 +11,7 @@ use tauri_mcp_agent_lib::agent::llm::{
     CompactionParentRequest,
 };
 use tauri_mcp_agent_lib::agent::state::{
-    AgentSession, CompactionRuntimeState, PendingEventManager,
+    AgentSession, CompactionRecoveryPhase, CompactionRuntimeState, PendingEventManager,
 };
 use tauri_mcp_agent_lib::agent::types::{ToolCall, ToolCallFunction};
 use tauri_mcp_agent_lib::agent::ExecutionMode;
@@ -20,11 +20,8 @@ use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 use tauri_mcp_agent_lib::repositories::{
     SessionMetadata, SessionStatus, SettingsRepository, SqliteSettingsRepository,
 };
-use tauri_mcp_agent_lib::{
-    init_active_sessions, set_settings_repository, try_get_active_sessions,
-    try_get_settings_repository,
-};
-use tokio::sync::{Mutex, RwLock};
+use tauri_mcp_agent_lib::{init_active_sessions, set_settings_repository, try_get_active_sessions};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use tokio_util::sync::CancellationToken;
 
 fn build_session_metadata(session_id: &str) -> SessionMetadata {
@@ -191,14 +188,17 @@ fn build_assistant_message(session_id: &str, tool_call_count: usize) -> Message 
 }
 
 async fn ensure_settings_repo() -> SqliteSettingsRepository {
-    if let Some(repo) = try_get_settings_repository() {
-        return repo.clone();
-    }
+    static SETTINGS_REPO: OnceCell<SqliteSettingsRepository> = OnceCell::const_new();
 
-    let db = common::setup_test_db_with_migrations().await;
-    let repo = SqliteSettingsRepository::new(db);
-    set_settings_repository(repo.clone());
-    repo
+    SETTINGS_REPO
+        .get_or_init(|| async {
+            let db = common::setup_test_db_with_migrations().await;
+            let repo = SqliteSettingsRepository::new(db);
+            set_settings_repository(repo.clone());
+            repo
+        })
+        .await
+        .clone()
 }
 
 async fn upsert_tool_loop_settings() {
@@ -220,6 +220,13 @@ async fn upsert_tool_loop_settings() {
 }
 
 async fn register_session(session_id: &str) -> Arc<RwLock<HashMap<String, AgentSession>>> {
+    register_session_with_compaction_phase(session_id, CompactionRecoveryPhase::DegradedTools).await
+}
+
+async fn register_session_with_compaction_phase(
+    session_id: &str,
+    recovery_phase: CompactionRecoveryPhase,
+) -> Arc<RwLock<HashMap<String, AgentSession>>> {
     let active_sessions = if let Some(existing) = try_get_active_sessions() {
         existing.clone()
     } else {
@@ -228,12 +235,48 @@ async fn register_session(session_id: &str) -> Arc<RwLock<HashMap<String, AgentS
         sessions
     };
 
-    active_sessions.write().await.insert(
-        session_id.to_string(),
-        build_active_session(session_id, build_history(session_id)),
-    );
+    let session = build_active_session(session_id, build_history(session_id));
+    match recovery_phase {
+        CompactionRecoveryPhase::DegradedTools => {
+            session.compaction.transition_to_degraded_tools().await;
+        }
+        CompactionRecoveryPhase::OverflowRecovery => {
+            session.compaction.transition_to_overflow_recovery().await;
+        }
+        CompactionRecoveryPhase::CacheAligned => {}
+    }
 
     active_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), session);
+
+    active_sessions
+}
+
+async fn assert_tool_calls_unchanged(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+    assistant_message: &mut Message,
+    original_tool_call_count: usize,
+    phase_label: &str,
+) {
+    preprocess_assistant_tool_calls_for_testing(
+        active_sessions,
+        session_id,
+        assistant_message,
+    )
+    .await;
+
+    let kept_tool_calls = assistant_message
+        .tool_calls
+        .as_ref()
+        .expect("tool calls should remain untouched");
+    assert_eq!(
+        kept_tool_calls.len(),
+        original_tool_call_count,
+        "tool-loop fence must not run outside compaction degraded-tools fallback ({phase_label})"
+    );
 }
 
 #[tokio::test]
@@ -307,4 +350,52 @@ async fn tool_loop_fence_redacts_before_pending_execution_initialization() {
         !session.cancel_pending.load(Ordering::Relaxed),
         "tool-loop fence should redact, not mark the session as cancelled"
     );
+}
+
+#[tokio::test]
+async fn tool_loop_fence_skips_when_compaction_not_in_degraded_tools_phase() {
+    let session_id = "tool-loop-fence-cache-aligned-session";
+    let active_sessions =
+        register_session_with_compaction_phase(session_id, CompactionRecoveryPhase::CacheAligned)
+            .await;
+    let mut assistant_message = build_assistant_message(session_id, 6);
+    let original_tool_call_count = assistant_message
+        .tool_calls
+        .as_ref()
+        .expect("tool calls present")
+        .len();
+
+    assert_tool_calls_unchanged(
+        &active_sessions,
+        session_id,
+        &mut assistant_message,
+        original_tool_call_count,
+        "CacheAligned",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn tool_loop_fence_skips_during_overflow_recovery_phase() {
+    let session_id = "tool-loop-fence-overflow-recovery-session";
+    let active_sessions = register_session_with_compaction_phase(
+        session_id,
+        CompactionRecoveryPhase::OverflowRecovery,
+    )
+    .await;
+    let mut assistant_message = build_assistant_message(session_id, 6);
+    let original_tool_call_count = assistant_message
+        .tool_calls
+        .as_ref()
+        .expect("tool calls present")
+        .len();
+
+    assert_tool_calls_unchanged(
+        &active_sessions,
+        session_id,
+        &mut assistant_message,
+        original_tool_call_count,
+        "OverflowRecovery",
+    )
+    .await;
 }

--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -46,6 +46,10 @@ function DraftChatInner() {
     pendingFiles,
     workspaceOverride,
     setWorkspaceOverride,
+    workspaceIsolation,
+    setWorkspaceIsolation,
+    dockerImage,
+    setDockerImage,
     dragState,
     profileDragState,
     isAttachmentLoading,
@@ -118,6 +122,10 @@ function DraftChatInner() {
       {workspaceOverride && (
         <AgentDraftWorkspacePreviewPanel
           workspacePath={workspaceOverride}
+          workspaceIsolation={workspaceIsolation}
+          setWorkspaceIsolation={setWorkspaceIsolation}
+          dockerImage={dockerImage}
+          setDockerImage={setDockerImage}
           onClear={() => setWorkspaceOverride(null)}
         />
       )}

--- a/src/features/agent/components/AgentDraftWorkspacePreviewPanel.tsx
+++ b/src/features/agent/components/AgentDraftWorkspacePreviewPanel.tsx
@@ -1,22 +1,31 @@
-import { Button } from '@/components/ui';
+import { Button, Input, Label } from '@/components/ui';
+import { Switch } from '@/components/ui/switch';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, RefreshCw, X } from 'lucide-react';
+import { FolderOpen, RefreshCw, X, Shield, HelpCircle } from 'lucide-react';
 
 import { FileTreeNode } from './workspace-panel/FileTreeNode';
 import { useDraftWorkspacePreviewTree } from './workspace-panel/useDraftWorkspacePreviewTree';
 
 interface AgentDraftWorkspacePreviewPanelProps {
   workspacePath: string;
+  workspaceIsolation: 'host' | 'docker';
+  setWorkspaceIsolation: (val: 'host' | 'docker') => void;
+  dockerImage: string;
+  setDockerImage: (val: string) => void;
   onClear: () => void;
 }
 
 export function AgentDraftWorkspacePreviewPanel({
   workspacePath,
+  workspaceIsolation,
+  setWorkspaceIsolation,
+  dockerImage,
+  setDockerImage,
   onClear,
 }: AgentDraftWorkspacePreviewPanelProps) {
   const { t } = useTranslation();
@@ -78,6 +87,87 @@ export function AgentDraftWorkspacePreviewPanel({
             <div className="rounded-md border border-border/50 bg-muted/50 p-2 font-mono text-[10px] break-all">
               {workspacePath}
             </div>
+          </div>
+
+          {/* Environment Isolation Settings */}
+          <div className="rounded-lg border border-border/40 bg-muted/[0.08] p-3 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-foreground/80">
+                <Shield className="h-3.5 w-3.5 text-primary/80" />
+                <span>
+                  {t('agent.workspace.isolationSettings', 'Isolation Settings')}
+                </span>
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="cursor-help text-muted-foreground/50 hover:text-muted-foreground">
+                    <HelpCircle className="h-3.5 w-3.5" />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[220px] text-xs">
+                  {t(
+                    'agent.workspace.isolationTip',
+                    'Docker workspace runs your workspace commands safely inside a container rather than directly on your host machine.',
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+
+            <div className="flex items-center justify-between pt-1">
+              <Label
+                htmlFor="docker-isolation"
+                className="text-xs font-medium cursor-pointer text-muted-foreground"
+              >
+                {t(
+                  'agent.workspace.useDockerContainer',
+                  'Use Docker Container',
+                )}
+              </Label>
+              <Switch
+                id="docker-isolation"
+                checked={workspaceIsolation === 'docker'}
+                onCheckedChange={(checked) =>
+                  setWorkspaceIsolation(checked ? 'docker' : 'host')
+                }
+              />
+            </div>
+
+            {workspaceIsolation === 'docker' && (
+              <div className="space-y-2 pt-2 border-t border-border/20 animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="space-y-1">
+                  <Label className="text-[10px] font-bold text-muted-foreground uppercase">
+                    {t('agent.workspace.dockerImage', 'Docker Image')}
+                  </Label>
+                  <Input
+                    value={dockerImage}
+                    onChange={(e) => setDockerImage(e.target.value)}
+                    placeholder="e.g. python:3.11-slim"
+                    className="h-8 text-xs font-mono bg-background"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-1 pt-1">
+                  {[
+                    { label: 'Python 3', val: 'python:3.11-slim' },
+                    { label: 'Node 20', val: 'node:20-alpine' },
+                    { label: 'Ubuntu', val: 'ubuntu:latest' },
+                    { label: 'Go 1.22', val: 'golang:1.22-alpine' },
+                  ].map((preset) => (
+                    <button
+                      key={preset.val}
+                      onClick={() => setDockerImage(preset.val)}
+                      type="button"
+                      className={`text-[9px] px-2 py-0.5 rounded-full border transition-all ${
+                        dockerImage === preset.val
+                          ? 'border-primary bg-primary/10 text-primary font-medium'
+                          : 'border-border bg-muted/40 hover:bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="rounded-lg border border-border/40 bg-muted/[0.18] p-3 text-xs text-muted-foreground">

--- a/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
+++ b/src/features/agent/components/__tests__/AgentDraftWorkspacePreviewPanel.test.tsx
@@ -59,6 +59,10 @@ describe('AgentDraftWorkspacePreviewPanel', () => {
     render(
       <AgentDraftWorkspacePreviewPanel
         workspacePath={workspacePath}
+        workspaceIsolation="host"
+        setWorkspaceIsolation={vi.fn()}
+        dockerImage="python:3.11-slim"
+        setDockerImage={vi.fn()}
         onClear={vi.fn()}
       />,
     );
@@ -91,6 +95,10 @@ describe('AgentDraftWorkspacePreviewPanel', () => {
     render(
       <AgentDraftWorkspacePreviewPanel
         workspacePath={workspacePath}
+        workspaceIsolation="host"
+        setWorkspaceIsolation={vi.fn()}
+        dockerImage="python:3.11-slim"
+        setDockerImage={vi.fn()}
         onClear={onClear}
       />,
     );

--- a/src/features/agent/hooks/useAgentDraftChat.ts
+++ b/src/features/agent/hooks/useAgentDraftChat.ts
@@ -75,6 +75,10 @@ export function useAgentDraftChat() {
   const [workspaceOverride, setWorkspaceOverride] = useState<string | null>(
     null,
   );
+  const [workspaceIsolation, setWorkspaceIsolation] = useState<
+    'host' | 'docker'
+  >('host');
+  const [dockerImage, setDockerImage] = useState<string>('python:3.11-slim');
   const [dragState, setDragState] = useState<'none' | 'valid' | 'invalid'>(
     'none',
   );
@@ -369,6 +373,13 @@ export function useAgentDraftChat() {
             agentConfig,
             isEphemeral: false,
             workspacePath: workspaceOverride || undefined,
+            workspaceIsolation: workspaceOverride ? workspaceIsolation : 'host',
+            dockerConfig:
+              workspaceOverride && workspaceIsolation === 'docker'
+                ? {
+                    image: dockerImage,
+                  }
+                : undefined,
           },
         });
 
@@ -513,6 +524,10 @@ export function useAgentDraftChat() {
     pendingFiles,
     workspaceOverride,
     setWorkspaceOverride,
+    workspaceIsolation,
+    setWorkspaceIsolation,
+    dockerImage,
+    setDockerImage,
     dragState,
     profileDragState,
     isAttachmentLoading,

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -889,6 +889,10 @@
       "renameEmptyError": "Session title cannot be empty"
     },
     "workspace": {
+      "isolationSettings": "Isolation Settings",
+      "isolationTip": "Docker workspace runs your workspace commands safely inside a container rather than directly on your host machine.",
+      "useDockerContainer": "Use Docker Container",
+      "dockerImage": "Docker Image",
       "loadError": "Failed to load directory",
       "importFileError": "Failed to import file",
       "setOverrideSuccess": "Workspace override set successfully",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -889,6 +889,10 @@
       "renameEmptyError": "세션 제목은 비워 둘 수 없습니다"
     },
     "workspace": {
+      "isolationSettings": "격리 환경 설정",
+      "isolationTip": "도커 워크스페이스는 명령어를 호스트 환경이 아닌 안전한 컨테이너 내부에서 격리 실행합니다.",
+      "useDockerContainer": "도커 컨테이너 사용",
+      "dockerImage": "도커 이미지",
       "loadError": "디렉토리 로드에 실패했습니다",
       "importFileError": "파일 가져오기 실패",
       "setOverrideSuccess": "워크스페이스가 성공적으로 재설정되었습니다",


### PR DESCRIPTION
## Summary

MCP builtin agent 도구(`checkSession`, `messageToSession`)의 timeout 응답을 보강하고, `stopSession` 도구의 설명을 개선합니다.

## Problem

- `checkSession` / `messageToSession` 호출 시 timeout이 발생하면 기존에는 단순한 에러만 반환되어, AI 에이전트가 상황을 정확히 파악하기 어려웠습니다.
- `stopSession` 도구의 설명이 불충분하여 에이전트가 적절한 시점에 활용하기 힘들었습니다.

## Changes

### Backend (Rust)
- **Timeout 응답 보강** (`mcp/builtin/agent/utils.rs`): timeout 발생 시 세션 상태·경과 시간 등 컨텍스트 정보를 포함한 구조화된 응답 반환
- **stopSession 설명 개선** (`mcp/builtin/agent/tools.rs`): 도구 설명을 더 명확하고 구체적으로 갱신
- **Response Circuit Breaker 리팩토링** (`agent/llm/response_circuit_breaker.rs`): 로직 정리
- **Compact request 모듈 추가** (`agent/llm/completion/request/compact.rs`): 서브모듈 분리
- **SessionRepository 정리**: `InMemorySessionRepository` 코드 정리 및 trait 보강

### Frontend
- `builtin-services.ts`, `execution-mode.ts`: 자동 생성 파일 동기화

### Tests
- `tool_loop_fence_tests.rs`: 통합 테스트 보강

## Validation
- `pnpm refactor:validate` 전체 16단계 통과 완료