### PR TITLE
refactor(assistant): skip default assistant config reconciliation to preserve user changes

### DIFF
--- a/src-tauri/src/services/assistant_init.rs
+++ b/src-tauri/src/services/assistant_init.rs
@@ -62,48 +62,7 @@ fn missing_default_assistant_names(assistants: &[BundledAssistant]) -> Vec<&'sta
         .collect()
 }
 
-fn json_string_array(value: &Value, key: &str) -> Vec<String> {
-    value
-        .get(key)
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn sorted_string_slices_equal(a: &[String], b: &[String]) -> bool {
-    let mut a_sorted = a.to_vec();
-    let mut b_sorted = b.to_vec();
-    a_sorted.sort();
-    b_sorted.sort();
-    a_sorted == b_sorted
-}
-
-fn bundled_config_needs_update(config_val: &Value, assistant: &BundledAssistant) -> bool {
-    config_val.get("description").and_then(|v| v.as_str())
-        != Some(assistant.config.description.as_str())
-        || config_val.get("systemPrompt").and_then(|v| v.as_str())
-            != Some(assistant.prompt.as_str())
-        || config_val
-            .get("deletionProtected")
-            .and_then(|v| v.as_bool())
-            != Some(assistant.config.deletion_protected)
-        || !sorted_string_slices_equal(
-            &json_string_array(config_val, "mcpServerIds"),
-            &assistant.config.mcp_server_ids,
-        )
-        || !sorted_string_slices_equal(
-            &json_string_array(config_val, "localServices"),
-            &assistant.config.local_services,
-        )
-        || !sorted_string_slices_equal(
-            &json_string_array(config_val, "allowedBuiltInServiceAliases"),
-            &assistant.config.allowed_builtin_service_aliases,
-        )
-}
+// Helper functions for checking config updates are removed because we do not reconcile existing configurations.
 
 #[derive(Debug, Clone)]
 pub struct BundledAssistant {
@@ -294,45 +253,12 @@ pub async fn ensure_default_assistants(resource_dir: Option<&Path>) -> Result<()
     for assistant in &bundled {
         log::info!("Ensuring assistant: {}", assistant.name);
 
-        if let Some(existing) = existing_map.remove(&assistant.name) {
-            let mut config_val =
-                serde_json::from_str::<Value>(&existing.config).unwrap_or_else(|_| json!({}));
-
-            if !bundled_config_needs_update(&config_val, assistant) {
-                continue;
-            }
-
-            config_val["description"] = Value::String(assistant.config.description.clone());
-            config_val["systemPrompt"] = Value::String(assistant.prompt.clone());
-            config_val["mcpServerIds"] = Value::Array(
-                assistant
-                    .config
-                    .mcp_server_ids
-                    .iter()
-                    .map(|s| Value::String(s.clone()))
-                    .collect(),
+        if let Some(_existing) = existing_map.remove(&assistant.name) {
+            log::info!(
+                "Assistant '{}' already exists, skipping initialization to preserve user changes.",
+                assistant.name
             );
-            config_val["deletionProtected"] = Value::Bool(assistant.config.deletion_protected);
-            config_val["localServices"] = Value::Array(
-                assistant
-                    .config
-                    .local_services
-                    .iter()
-                    .map(|s| Value::String(s.clone()))
-                    .collect(),
-            );
-            config_val["allowedBuiltInServiceAliases"] = Value::Array(
-                assistant
-                    .config
-                    .allowed_builtin_service_aliases
-                    .iter()
-                    .map(|s| Value::String(s.clone()))
-                    .collect(),
-            );
-
-            repo.update_assistant(&existing.id, None, Some(config_val.to_string()))
-                .await
-                .map_err(|e| format!("Failed to update assistant '{}': {}", assistant.name, e))?;
+            continue;
         } else {
             let mut config_val = json!({});
             config_val["description"] = Value::String(assistant.config.description.clone());
@@ -426,32 +352,10 @@ pub async fn ensure_default_assistants_hardcoded() -> Result<(), String> {
                 .await
                 .map_err(|e| format!("Failed to create {}: {}", name, e))?;
         } else {
-            // Reconcile if exists
-            let assistants = repo
-                .list_assistants()
-                .await
-                .map_err(|e| format!("Failed to list assistants: {}", e))?;
-            if let Some(existing) = assistants.into_iter().find(|a| a.name == name) {
-                let existing_config =
-                    serde_json::from_str::<Value>(&existing.config).unwrap_or_else(|_| json!({}));
-
-                let temp_config: BundledAssistantConfig =
-                    serde_json::from_value(config_val.clone())
-                        .map_err(|e| format!("Failed to parse config for comparison: {}", e))?;
-
-                let temp_bundled = BundledAssistant {
-                    name: name.to_string(),
-                    prompt: prompt.to_string(),
-                    config: temp_config,
-                };
-
-                if bundled_config_needs_update(&existing_config, &temp_bundled) {
-                    log::info!("Updating default '{}'...", name);
-                    repo.update_assistant(&existing.id, None, Some(config_val.to_string()))
-                        .await
-                        .map_err(|e| format!("Failed to update {}: {}", name, e))?;
-                }
-            }
+            log::info!(
+                "Default assistant '{}' already exists, skipping initialization.",
+                name
+            );
         }
     }
 

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
### Description
This pull request modifies the application startup initialization logic for default assistants (such as `Master Mind`, `Libr Assistant`, `Coding Expert`, and `App Wizard`). It resolves the issue where any user-customized configurations (e.g., adding MCP servers/tools, updating system prompts, or modifying descriptions) on default assistants were automatically overwritten and reset back to their hardcoded/bundled defaults upon application restart.

### Key Changes
- **`src-tauri/src/services/assistant_init.rs`**:
  - Completely removed the configuration comparison helper functions (`bundled_config_needs_update`, `json_string_array`, and `sorted_string_slices_equal`).
  - Simplified the startup reconciliation logic in both `ensure_default_assistants` and `ensure_default_assistants_hardcoded` functions:
    - Instead of checking for differences and updating the existing database record with default values, the application now skips initialization for any default assistant that already exists in the database.
    - Default assistant settings are now only populated on first startup (when the database is completely empty/missing the assistant records) or when a factory reset is executed.

### Benefits
- **Preserved Customizations**: Users can now customize system prompts and add/remove MCP tools from the default assistants, and these changes will persist reliably across application restarts.
- **Improved Performance**: Eliminates unnecessary database queries and config comparison checks for existing default assistants on every app startup.
- **Restoration via Factory Reset**: Default configurations can still be restored at any time by performing a factory reset, which clears the database and triggers the initial population.
