### PR TITLE
🎨 Palette: Replace native title with Tooltip in attached files bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2025-02-09 - Add tooltip to unbookmark button
 **Learning:** Sighted mouse users lack context for icon-only buttons like "Remove bookmark" without visual tooltips, even when `aria-label` is present for screen readers.
 **Action:** Always wrap icon-only action buttons in `Tooltip` components to ensure parity between visual context and semantic accessibility labels.
+## 2024-07-07 - Replace native title with Tooltip for icon buttons
+**Learning:** Using native `title` attributes on icon-only buttons provides poor visibility and inconsistent feedback across browsers/OS. Screen reader support can also be inconsistent compared to ARIA patterns used by the design system's Tooltip component.
+**Action:** Always replace native `title` attributes with the design system's `<Tooltip>` component on icon-only buttons for immediate, visually consistent, and keyboard-accessible feedback.

--- a/src/features/agent/components/AgentAttachedFilesBar.tsx
+++ b/src/features/agent/components/AgentAttachedFilesBar.tsx
@@ -1,5 +1,11 @@
 import { Paperclip, X } from 'lucide-react';
-import { Button } from '@/components/ui';
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui';
 
 interface AgentAttachedFileItem {
   id: string;
@@ -31,17 +37,23 @@ export function AgentAttachedFilesBar({
             className="flex items-center rounded-md border border-border/45 bg-background/45 px-2 py-1"
           >
             <span className="max-w-36 truncate text-xs">{file.name}</span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={file.onRemove}
-              className="ml-1 h-6 w-6"
-              title={`Remove ${file.name}`}
-              aria-label={`Remove ${file.name}`}
-            >
-              <X className="h-4 w-4" />
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={file.onRemove}
+                    className="ml-1 h-6 w-6"
+                    aria-label={`Remove ${file.name}`}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Remove {file.name}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
### 💡 What
Replaced the native HTML `title` attribute with the design system's `<Tooltip>` component for the remove file icon button in `AgentAttachedFilesBar`.

### 🎯 Why
Native tooltips have unpredictable display delays, vary wildly across operating systems and browsers, and can be inaccessible to keyboard users. The design system's Tooltip provides immediate, styled feedback that follows accessibility guidelines.

### 📸 Before/After
No visual change to the static UI, but hovering/focusing the 'X' button now displays a consistent, styled tooltip instead of the native OS tooltip.

### ♿ Accessibility
- Maintains `aria-label` for screen readers.
- Tooltip provides visible context for keyboard users navigating via Tab.

---
*PR created automatically by Jules for task [17551808252506001618](https://jules.google.com/task/17551808252506001618) started by @fritzprix*