### PR TITLE
feat(mcp): clarify edit anchors and line numbers in tool output

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4129,7 +4129,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -386,10 +386,7 @@ impl SuccessHint {
             ],
 
             // Workspace tools
-            ("runShell" | "runPowerShell", ToolGroup::Workspace) => vec![
-                "Use listDirectory to verify created files".to_string(),
-                "Use readFile to verify file contents".to_string(),
-            ],
+            ("runShell" | "runPowerShell", ToolGroup::Workspace) => vec![],
             ("runInPersistentShell" | "runInPersistentPowerShell", ToolGroup::Workspace) => vec![
                 "Command state (CWD, env vars) is preserved for the next call".to_string(),
                 "With requireUserInput=true, the same synchronous call can pause for a human prompt and then resume to a final result".to_string(),
@@ -403,7 +400,6 @@ impl SuccessHint {
             ],
             ("waitForProcess" | "pollProcess", ToolGroup::Workspace) => vec![
                 "Use readProcessOutput to see the final results".to_string(),
-                "Use listDirectory to check for any generated artifacts".to_string(),
             ],
             ("readProcessOutput", ToolGroup::Workspace) => vec![
                 "Analyze the output to verify command success".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
@@ -471,10 +471,9 @@ impl WorkspaceServer {
                     return Ok(hint.to_mcp_result_with_data(Some(response)));
                 }
 
-                let hint = SuccessHint::new(
-                    text_message,
-                    SuccessHint::for_tool(tool_name, ToolGroup::Workspace),
-                );
+                // Omit generic next-action hints (e.g. listDirectory/readFile) — they are
+                // irrelevant for most commands and waste tokens on successful runs.
+                let hint = SuccessHint::new(text_message, vec![]);
                 Ok(hint.to_mcp_result_with_data(Some(response)))
             }
             None => {

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
@@ -133,12 +133,7 @@ impl WorkspaceServer {
                     };
 
                     let next_actions = if display_cwd == "." {
-                        vec![
-                            "Command state (CWD, env vars) is preserved for the next call"
-                                .to_string(),
-                            "Use listDirectory to inspect workspace-root file changes".to_string(),
-                            "Use readFile to inspect workspace-root file contents".to_string(),
-                        ]
+                        vec![]
                     } else {
                         vec![
                             format!(

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
@@ -404,20 +404,11 @@ pub(super) fn parse_line_edit(
         .map(|anchor| anchor.to_string());
 
     let requires_anchor = !(action == EditAction::InsertAfter && start_line == 0);
-    if !requires_anchor && (start_anchor.is_some() || end_anchor.is_some()) {
-        return Err(guided_error(
-            ErrorCategory::InvalidInput,
-            format!(
-                "{edit_label}: prepend edits with startLine 0 must omit 'startAnchor' and 'endAnchor'"
-            ),
-            ToolGroup::Workspace,
-        )
-        .guidance(vec![
-            "When startLine is 0, the edit inserts before the first line and does not target existing content".to_string(),
-            "Remove startAnchor/endAnchor and keep only startLine: 0 plus content".to_string(),
-        ])
-        .to_mcp_result());
-    }
+    let (start_anchor, end_anchor) = if !requires_anchor {
+        (None, None)
+    } else {
+        (start_anchor, end_anchor)
+    };
     if requires_anchor && start_anchor.is_none() {
         return Err(guided_error(
             ErrorCategory::InvalidInput,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
@@ -8,6 +8,7 @@ const MAX_DIFF_PREVIEW_LINES: usize = 50;
 const DIFF_CONTEXT_LINES: usize = 1;
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct AnchoredLine {
     line_number: usize,
     content: String,
@@ -25,23 +26,14 @@ enum DiffPreviewKind {
 struct DiffPreviewLine {
     kind: DiffPreviewKind,
     content: String,
-    line_number: usize,
-    anchor: Option<String>,
 }
 
 impl DiffPreviewLine {
-    fn render_hashline(&self) -> String {
-        match self.anchor.as_deref() {
-            Some(anchor) => format!("{}:{}|{}", self.line_number, anchor, self.content),
-            None => format!("{}|{}", self.line_number, self.content),
-        }
-    }
-
     fn render(&self) -> String {
         match self.kind {
-            DiffPreviewKind::Context => format!("  {}", self.render_hashline()),
-            DiffPreviewKind::Added => format!("+ {}", self.render_hashline()),
-            DiffPreviewKind::Removed => format!("- {}", self.render_hashline()),
+            DiffPreviewKind::Context => format!("  {}", self.content),
+            DiffPreviewKind::Added => format!("+ {}", self.content),
+            DiffPreviewKind::Removed => format!("- {}", self.content),
         }
     }
 }
@@ -64,8 +56,6 @@ fn push_context_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Context,
         content: line.content.clone(),
-        line_number: line.line_number,
-        anchor: Some(line.anchor.clone()),
     });
 }
 
@@ -73,8 +63,6 @@ fn push_added_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Added,
         content: line.content.clone(),
-        line_number: line.line_number,
-        anchor: Some(line.anchor.clone()),
     });
 }
 
@@ -82,8 +70,6 @@ fn push_removed_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Removed,
         content: line.content.clone(),
-        line_number: line.line_number,
-        anchor: Some(line.anchor.clone()),
     });
 }
 
@@ -310,7 +296,7 @@ pub(super) fn build_edit_file_success(prepared_batches: &[PreparedFileEdit]) -> 
             "\n\nAnchor refresh: no new anchors were generated because these edits only removed existing lines.".to_string()
         } else {
             format!(
-                "\n\nNew anchors:\n```\n{}\n```",
+                "\n\nNew anchors:\n*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n```\n{}\n```",
                 batch.new_hash_sections.join("\n...\n")
             )
         };

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/response.rs
@@ -1,4 +1,3 @@
-use super::super::utils::{compute_anchor, initial_prefix_hash_state};
 use super::types::{EditAction, PreparedFileEdit};
 use crate::mcp::builtin::error_guidance::SuccessHint;
 use crate::mcp::types::MCPResult;
@@ -6,14 +5,6 @@ use serde_json::json;
 
 const MAX_DIFF_PREVIEW_LINES: usize = 50;
 const DIFF_CONTEXT_LINES: usize = 1;
-
-#[derive(Clone)]
-#[allow(dead_code)]
-struct AnchoredLine {
-    line_number: usize,
-    content: String,
-    anchor: String,
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DiffPreviewKind {
@@ -38,45 +29,35 @@ impl DiffPreviewLine {
     }
 }
 
-fn build_anchored_lines(content: &str) -> Vec<AnchoredLine> {
-    let mut prefix_state = initial_prefix_hash_state();
-
-    content
-        .lines()
-        .enumerate()
-        .map(|(idx, line)| AnchoredLine {
-            line_number: idx + 1,
-            content: line.to_string(),
-            anchor: compute_anchor(line, &mut prefix_state),
-        })
-        .collect()
+fn build_content_lines(content: &str) -> Vec<String> {
+    content.lines().map(|line| line.to_string()).collect()
 }
 
-fn push_context_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+fn push_context_line(lines: &mut Vec<DiffPreviewLine>, content: &str) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Context,
-        content: line.content.clone(),
+        content: content.to_string(),
     });
 }
 
-fn push_added_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+fn push_added_line(lines: &mut Vec<DiffPreviewLine>, content: &str) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Added,
-        content: line.content.clone(),
+        content: content.to_string(),
     });
 }
 
-fn push_removed_line(lines: &mut Vec<DiffPreviewLine>, line: &AnchoredLine) {
+fn push_removed_line(lines: &mut Vec<DiffPreviewLine>, content: &str) {
     lines.push(DiffPreviewLine {
         kind: DiffPreviewKind::Removed,
-        content: line.content.clone(),
+        content: content.to_string(),
     });
 }
 
 fn build_preview_lines(
     batch: &PreparedFileEdit,
-    original_lines: &[AnchoredLine],
-    new_lines: &[AnchoredLine],
+    original_lines: &[String],
+    new_lines: &[String],
 ) -> Vec<DiffPreviewLine> {
     let mut preview_lines = Vec::new();
     let mut sorted_edits = batch.edits.clone();
@@ -125,7 +106,7 @@ fn build_preview_lines(
             && original_slice
                 .iter()
                 .zip(new_slice.iter())
-                .all(|(original_line, new_line)| original_line.content == new_line.content);
+                .all(|(original_line, new_line)| original_line == new_line);
 
         if slices_match {
             for new_line in new_slice {
@@ -178,10 +159,10 @@ fn build_preview_ranges(preview_lines: &[DiffPreviewLine]) -> Vec<(usize, usize)
     ranges
 }
 
-/// Generate a git-style diff preview with anchor annotations for changed lines.
-fn build_diff_with_anchors(batch: &PreparedFileEdit) -> String {
-    let original_lines = build_anchored_lines(&batch.original_content);
-    let new_lines = build_anchored_lines(&batch.new_content);
+/// Generate a git-style diff preview (context/added/removed lines) for the edit batch.
+fn build_diff_preview(batch: &PreparedFileEdit) -> String {
+    let original_lines = build_content_lines(&batch.original_content);
+    let new_lines = build_content_lines(&batch.new_content);
     let preview_lines = build_preview_lines(batch, &original_lines, &new_lines);
     let preview_ranges = build_preview_ranges(&preview_lines);
 
@@ -300,7 +281,7 @@ pub(super) fn build_edit_file_success(prepared_batches: &[PreparedFileEdit]) -> 
                 batch.new_hash_sections.join("\n...\n")
             )
         };
-        let diff_section = build_diff_with_anchors(batch);
+        let diff_section = build_diff_preview(batch);
 
         file_sections.push(format!(
             "File: '{}'\nChanges:\n{}\nSummary: {}\n\nDiff:\n```diff\n{}\n```{}",

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -246,7 +246,7 @@ impl WorkspaceServer {
                 // Format response for clean markdown rendering
                 let text_message = if show_line_anchors {
                     format!(
-                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nLine format: `{{lineNumber}}:{{anchor}}|{{content}}`\n- `{{lineNumber}}`: 1-based line number\n- `{{anchor}}`: 6-character hex code (example: `792c6f`)\n- `{{content}}`: line content\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{{content}}`.",
+                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nLine format: `{{lineNumber}}:{{anchor}}|{{content}}`\n- `{{lineNumber}}`: 1-based line number\n- `{{anchor}}`: 6-character hex code (example: `792c6f`)\n- `{{content}}`: line content\n\n*(Note: The `{{lineNumber}}:{{anchor}}|` prefixes in the code block above are metadata added by the tool for edit reference, and are NOT part of the actual file content.)*\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{{content}}`.",
                         path_str, size_str, chunk_summary, summary_suffix, chunk.content
                     )
                 } else {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -213,6 +213,10 @@ pub(super) async fn search_content_in_file(
             display_path, query
         ));
 
+        if show_hashes {
+            s.push_str("*(Note: The `lineNumber:anchor|` prefixes in the code block below are metadata added by the tool for edit reference, and are NOT part of the actual file content.)*\n");
+        }
+
         s.push_str("```");
         s.push_str(language);
         s.push('\n');
@@ -476,6 +480,10 @@ pub(super) async fn search_content_in_dir(
         display_path,
         options_str
     );
+
+    if show_hashes {
+        text.push_str("*(Note: Matches in the files below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of actual file contents.)*\n\n");
+    }
 
     let total_files = file_matches.len();
     let mut paginated_results: Vec<FileMatch> = Vec::new();

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -311,7 +311,7 @@ impl WorkspaceServer {
                     let diff_output = format_file_diff(&old_content, content, path_str);
                     message.push_str(&diff_output);
                     message.push_str(&format!(
-                        "\nCurrent anchors:\n```\n{}\n```\n",
+                        "\nCurrent anchors:\n*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n```\n{}\n```\n",
                         format_as_hashlines(content)
                     ));
                 } else {
@@ -360,6 +360,7 @@ impl WorkspaceServer {
                         }
                     };
 
+                    message.push_str("*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n");
                     message.push_str(&format!("```\n{}\n```\n", display_hashlines));
                 }
 

--- a/src-tauri/tests/integration/workspace_guidance_tests.rs
+++ b/src-tauri/tests/integration/workspace_guidance_tests.rs
@@ -176,8 +176,20 @@ async fn persistent_shell_at_workspace_root_does_not_suggest_file_tools() {
     ensure_settings_repository().await;
 
     let temp_dir = tempdir().expect("temp dir");
+    // Canonicalize the base dir so the workspace path matches the shell's
+    // resolved `pwd`. On macOS, tempdir() returns a `/var/folders/...` path that
+    // the shell reports as `/private/var/folders/...`; without canonicalization
+    // the reported CWD never equals the workspace root and `display_cwd` would
+    // not collapse to ".".
+    //
+    // Skip this on Windows: `std::fs::canonicalize` there yields a `\\?\`
+    // verbatim path that the shell does NOT report, which would break the match.
+    #[cfg(not(target_os = "windows"))]
+    let base_dir = std::fs::canonicalize(temp_dir.path()).expect("canonicalize temp dir");
+    #[cfg(target_os = "windows")]
+    let base_dir = temp_dir.path().to_path_buf();
     let session_id = "persistent-shell-root-guidance";
-    let server = build_workspace_server(temp_dir.path(), session_id);
+    let server = build_workspace_server(&base_dir, session_id);
 
     let result = server
         .handle_execute_shell(

--- a/src-tauri/tests/integration/workspace_guidance_tests.rs
+++ b/src-tauri/tests/integration/workspace_guidance_tests.rs
@@ -157,6 +157,47 @@ async fn run_shell_success_hint_no_longer_mentions_stop_process() {
         !text.contains("stopProcess"),
         "completed runShell responses should not mention stopProcess: {text}"
     );
+    assert!(
+        !text.contains("💡 Next:"),
+        "completed runShell responses should not append generic next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("listDirectory"),
+        "completed runShell responses should not suggest listDirectory verification: {text}"
+    );
+    assert!(
+        !text.contains("readFile to verify"),
+        "completed runShell responses should not suggest readFile verification: {text}"
+    );
+}
+
+#[tokio::test]
+async fn persistent_shell_at_workspace_root_does_not_suggest_file_tools() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "persistent-shell-root-guidance";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_execute_shell(
+            json!({
+                "command": simple_shell_command()
+            }),
+            session_id,
+        )
+        .await
+        .expect("runInPersistentShell should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        !text.contains("💡 Next:"),
+        "persistent shell at workspace root should not append file-tool next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("listDirectory"),
+        "persistent shell at workspace root should not suggest listDirectory: {text}"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -294,7 +294,7 @@ async fn edit_file_directory_target_reports_directory_error_before_anchor_guidan
 }
 
 #[tokio::test]
-async fn edit_file_rejects_anchors_for_top_insert() {
+async fn edit_file_ignores_anchors_for_top_insert() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "edit-file-top-insert-anchor";
     let server = build_workspace_server(temp_dir.path(), session_id);
@@ -320,12 +320,9 @@ async fn edit_file_rejects_anchors_for_top_insert() {
         .await
         .expect("edit should return MCPResult");
 
-    let text = extract_text_content(&result);
-    assert_eq!(result.is_error, Some(true));
-    assert!(
-        text.contains("must omit 'startAnchor' and 'endAnchor'"),
-        "prepend edits should reject ignored anchors: {text}"
-    );
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "header\nalpha\nbeta\n");
 }
 
 #[tokio::test]
@@ -516,7 +513,7 @@ async fn edit_files_delete_only_response_does_not_claim_new_anchors_exist() {
 }
 
 #[tokio::test]
-async fn edit_files_success_response_includes_diff_block_with_anchor_annotations() {
+async fn edit_files_success_response_includes_diff_block() {
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "edit-files-success-diff-anchors";
     let server = build_workspace_server(temp_dir.path(), session_id);
@@ -526,9 +523,6 @@ async fn edit_files_success_response_includes_diff_block_with_anchor_annotations
 
     let original_hashlines = format_as_hashlines("alpha\nbeta\n");
     let first_anchor = extract_anchor(&original_hashlines, 0);
-    let new_hashlines = format_as_hashlines("ALPHA\nbeta\n");
-    let new_first_anchor = extract_anchor(&new_hashlines, 0);
-    let new_second_anchor = extract_anchor(&new_hashlines, 1);
 
     let result = server
         .handle_edit_file(
@@ -555,16 +549,16 @@ async fn edit_files_success_response_includes_diff_block_with_anchor_annotations
         "success response should include a diff block: {text}"
     );
     assert!(
-        text.contains(&format!("- 1:{first_anchor}|alpha")),
-        "diff should annotate removed lines with their original anchor: {text}"
+        text.contains("- alpha"),
+        "diff should show removed line content without hashline annotations: {text}"
     );
     assert!(
-        text.contains(&format!("+ 1:{new_first_anchor}|ALPHA")),
-        "diff should annotate added lines with their new anchor: {text}"
+        text.contains("+ ALPHA"),
+        "diff should show added line content without hashline annotations: {text}"
     );
     assert!(
-        text.contains(&format!("  2:{new_second_anchor}|beta")),
-        "diff should render context lines in readFile hashline format: {text}"
+        text.contains("  beta"),
+        "diff should render unchanged context lines as plain text: {text}"
     );
 }
 
@@ -580,9 +574,6 @@ async fn edit_files_delete_only_response_includes_diff_block() {
 
     let original_hashlines = format_as_hashlines("alpha\nbeta\ngamma\n");
     let second_anchor = extract_anchor(&original_hashlines, 1);
-    let new_hashlines = format_as_hashlines("alpha\ngamma\n");
-    let alpha_anchor = extract_anchor(&new_hashlines, 0);
-    let gamma_anchor = extract_anchor(&new_hashlines, 1);
 
     let result = server
         .handle_edit_file(
@@ -608,13 +599,12 @@ async fn edit_files_delete_only_response_includes_diff_block() {
         "delete-only success should still include a diff block: {text}"
     );
     assert!(
-        text.contains(&format!("- 2:{second_anchor}|beta")),
-        "delete-only diff should annotate the removed line with its original anchor: {text}"
+        text.contains("- beta"),
+        "delete-only diff should show removed line content without hashline annotations: {text}"
     );
     assert!(
-        text.contains(&format!("  1:{alpha_anchor}|alpha"))
-            && text.contains(&format!("  2:{gamma_anchor}|gamma")),
-        "delete-only diff should keep surrounding context lines: {text}"
+        text.contains("  alpha") && text.contains("  gamma"),
+        "delete-only diff should keep surrounding context lines as plain text: {text}"
     );
 }
 

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.24_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64-setup.exe) · [`LibrAgent_0.8.24_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.24_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.24_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.AppImage) · [`LibrAgent_0.8.24_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent_0.8.24_amd64.deb) · [`LibrAgent-0.8.24-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.24/LibrAgent-0.8.24-1.x86_64.rpm)


### PR DESCRIPTION
This PR adds clear metadata notes to readFile/writeFile/search outputs and renders a clean diff in editFile. It also relaxes the anchor validation rule for prepend edits.