### PR TITLE
🎨 Palette: Replace native title with Tooltip for icon button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2025-02-09 - Add tooltip to unbookmark button
 **Learning:** Sighted mouse users lack context for icon-only buttons like "Remove bookmark" without visual tooltips, even when `aria-label` is present for screen readers.
 **Action:** Always wrap icon-only action buttons in `Tooltip` components to ensure parity between visual context and semantic accessibility labels.
+## 2024-07-08 - Replace native title attributes with Tooltip components for icon-only buttons
+**Learning:** Native `title` attributes on icon-only buttons provide poor UX as they have delayed rendering, lack visual consistency with the app's design system, and are not reliably accessible via keyboard navigation alone.
+**Action:** Always wrap icon-only buttons in the design system's `<Tooltip>` component to ensure immediate, visually consistent, and fully keyboard-accessible feedback instead of relying on the native HTML `title` attribute.

--- a/src/features/agent/components/AgentModelPicker.tsx
+++ b/src/features/agent/components/AgentModelPicker.tsx
@@ -10,6 +10,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { AIServiceProvider } from '@/lib/ai-service';
 import { llmConfigManager } from '@/lib/llm-config-manager';
 import { cn } from '@/lib/utils';
@@ -155,18 +160,32 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
       </Select>
 
       {showRefreshButton && (
-        <button
-          type="button"
-          onClick={() => refreshModels()}
-          disabled={disabled || isRefreshing || !canRefresh}
-          className="p-1 hover:bg-primary/10 rounded text-muted-foreground hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          title={refreshButtonLabel}
-          aria-label={refreshButtonLabel}
-        >
-          <RefreshCw
-            className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`}
-          />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              tabIndex={disabled || isRefreshing || !canRefresh ? 0 : -1}
+              className={cn(
+                'inline-flex',
+                disabled || isRefreshing || !canRefresh
+                  ? 'cursor-not-allowed'
+                  : '',
+              )}
+            >
+              <button
+                type="button"
+                onClick={() => refreshModels()}
+                disabled={disabled || isRefreshing || !canRefresh}
+                className="p-1 hover:bg-primary/10 rounded text-muted-foreground hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none"
+                aria-label={refreshButtonLabel}
+              >
+                <RefreshCw
+                  className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`}
+                />
+              </button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{refreshButtonLabel}</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
+++ b/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentModelPicker } from '../AgentModelPicker';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 const mockUseAgentModelsState = vi.hoisted(() => ({
   availableModels: {
@@ -58,7 +59,9 @@ describe('AgentModelPicker', () => {
 
   it('revalidates models when refresh is available', () => {
     render(
-      <AgentModelPicker currentModel="model-1" currentProvider="ollama" />,
+      <TooltipProvider>
+        <AgentModelPicker currentModel="model-1" currentProvider="ollama" />
+      </TooltipProvider>
     );
 
     const refreshButton = screen.getByRole('button', {
@@ -76,7 +79,9 @@ describe('AgentModelPicker', () => {
     mockUseAgentModelsState.refreshBlockedReason = 'missing-api-key';
 
     render(
-      <AgentModelPicker currentModel="model-1" currentProvider="anthropic" />,
+      <TooltipProvider>
+        <AgentModelPicker currentModel="model-1" currentProvider="anthropic" />
+      </TooltipProvider>
     );
 
     const refreshButton = screen.getByRole('button', {
@@ -84,10 +89,6 @@ describe('AgentModelPicker', () => {
     });
 
     expect(refreshButton).toBeDisabled();
-    expect(refreshButton).toHaveAttribute(
-      'title',
-      'Add an API key to enable model refresh',
-    );
   });
 
   it('hides refresh when custom openai model discovery is intentionally disabled', () => {
@@ -95,7 +96,9 @@ describe('AgentModelPicker', () => {
     mockUseAgentModelsState.refreshBlockedReason = 'custom-openai-model';
 
     render(
-      <AgentModelPicker currentModel="model-1" currentProvider="openai" />,
+      <TooltipProvider>
+        <AgentModelPicker currentModel="model-1" currentProvider="openai" />
+      </TooltipProvider>
     );
 
     expect(


### PR DESCRIPTION
💡 What
Replaced the native HTML `title` attribute with the design system's `<Tooltip>` component for the "Refresh Models" icon button in the `AgentModelPicker`.

🎯 Why
Native `title` attributes on icon-only buttons offer a poor user experience. They suffer from delayed rendering, look inconsistent with the application's overall design system, and are notoriously difficult or impossible to trigger consistently via keyboard navigation alone. Using the designated `Tooltip` component provides immediate, styled feedback.

📸 Before/After
Before: The refresh button relied on the browser's native, delayed tooltip.
After: Hovering or focusing the button immediately triggers the styled Shadcn UI tooltip.

♿ Accessibility
- Ensured sighted keyboard users can trigger the tooltip upon focus.
- Addressed a specific Radix UI edge case: when the inner button is `disabled` (e.g. missing API key), it stops emitting pointer events and breaks the tooltip. Wrapped the button in a `<span>` with conditional `tabIndex={0}` when disabled so the helpful message "Add an API key to enable model refresh" remains accessible to mouse and keyboard users.
- Maintained the `aria-label` directly on the button for screen reader context.

---
*PR created automatically by Jules for task [901342270150001066](https://jules.google.com/task/901342270150001066) started by @fritzprix*