### PR TITLE
feat(workspace): add strReplace as default edit tool

### DIFF
--- a/.agents/skills/libragent-quality/SKILL.md
+++ b/.agents/skills/libragent-quality/SKILL.md
@@ -77,8 +77,11 @@ pnpm rust:check
 # Check with all features
 pnpm rust:check:all
 
-# Run tests
+# Run tests (default strReplace build)
 pnpm rust:test
+
+# Run tests (edit-file-only build; anchor/editFile regression)
+pnpm rust:test:edit-file
 
 # Complete Rust validation
 pnpm rust:validate
@@ -95,9 +98,10 @@ The `refactor:validate` command executes:
 5. **Rust fmt** - Rust code formatting
 6. **Rust clippy** - Rust linting
 7. **Rust check** - Rust compilation check with all features
-8. **Rust test** - Rust test suite
-9. **Vite build** - Production build verification
-10. **Unimported** - Unused code detection
+8. **Rust test** - Rust test suite (default `workspace-str-replace` build)
+9. **Rust test (edit-file)** - Rust test suite with `--no-default-features --features workspace-edit-file`
+10. **Vite build** - Production build verification
+11. **Unimported** - Unused code detection
 
 ## Common Validation Scenarios
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: 🧪 Run Rust integration tests
         run: pnpm rust:test
 
+      - name: 🧪 Run Rust integration tests (edit-file build)
+        run: pnpm rust:test:edit-file
+
       # Code Quality Checks (PR only)
       - name: 🦀 Install Clippy
         run: rustup component add clippy

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "rust:check": "node scripts/run-rust-command.cjs check",
     "rust:check:all": "node scripts/run-rust-command.cjs check --all-features",
     "rust:test": "node scripts/run-rust-command.cjs test --tests --profile ci-test",
+    "rust:test:edit-file": "node scripts/run-rust-command.cjs test --tests --profile ci-test --no-default-features --features workspace-edit-file",
     "rust:clean": "cd src-tauri && cargo clean",
     "rust:validate": "pnpm rust:fmt && pnpm rust:clippy:all",
     "assistants:validate": "node scripts/validate-assistant-skills.cjs",

--- a/scripts/refactor-pipeline.js
+++ b/scripts/refactor-pipeline.js
@@ -68,6 +68,11 @@ const VALIDATE_STAGES = [
   { name: 'rust:clippy:all', command: pnpmCommand, args: ['rust:clippy:all'] },
   { name: 'rust:test', command: pnpmCommand, args: ['rust:test'] },
   {
+    name: 'rust:test:edit-file',
+    command: pnpmCommand,
+    args: ['rust:test:edit-file'],
+  },
+  {
     name: 'build:nosync',
     command: pnpmCommand,
     args: ['build:nosync'],

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -39,6 +39,11 @@ if ($LASTEXITCODE -ne 0) {
     Write-Host "Error: Backend tests failed"
     exit 1
 }
+pnpm rust:test:edit-file
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Backend edit-file tests failed"
+    exit 1
+}
 
 # 3. Verify Frontend Build (Type check + Build)
 Write-Host "Verifying frontend build..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,6 +20,7 @@ pnpm test:run
 # 2. Backend Tests
 echo "Running Backend Tests..."
 pnpm rust:test
+pnpm rust:test:edit-file
 
 # 3. Verify Frontend Build (Type check + Build)
 echo "Verifying Frontend Build..."

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,6 +99,11 @@ tauri-plugin-mcp-bridge = "0.11.2"
 sqlite-vec = "0.1.9"
 fastembed = "5.15.0"
 
+[features]
+default = ["workspace-str-replace"]
+workspace-edit-file = []
+workspace-str-replace = []
+
 [dev-dependencies]
 # test-util enables tokio::time::pause() / advance() for time-controlled async tests.
 tokio = { version = "1.52", features = ["test-util"] }

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -415,17 +415,26 @@ impl SuccessHint {
             ],
             ("readFile", ToolGroup::Workspace) => vec![
                 "Use writeFile to modify the content".to_string(),
-                "Use editFile to make targeted edits".to_string(),
+                format!(
+                    "Use {} to make targeted edits",
+                    crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
+                ),
             ],
             ("listDirectory", ToolGroup::Workspace) => vec![
                 "Use readFile to view file contents".to_string(),
                 "Use writeFile to create new files".to_string(),
                 "Use searchFiles with filePattern to narrow down names".to_string(),
             ],
+            #[cfg(feature = "workspace-edit-file")]
             (
                 "editFile" | "replaceLines" | "insertAfterLine" | "deleteLines",
                 ToolGroup::Workspace,
             ) => vec![
+                "Use readFile to verify your edits".to_string(),
+                "Use runShell to execute the updated code".to_string(),
+            ],
+            #[cfg(feature = "workspace-str-replace")]
+            ("strReplace", ToolGroup::Workspace) => vec![
                 "Use readFile to verify your edits".to_string(),
                 "Use runShell to execute the updated code".to_string(),
             ],

--- a/src-tauri/src/mcp/builtin/workspace/context.rs
+++ b/src-tauri/src/mcp/builtin/workspace/context.rs
@@ -1,3 +1,4 @@
+use super::edit_mode::workspace_file_tools_context_list;
 use super::persistent_shell;
 use super::terminal_manager;
 use crate::session::SessionManager;
@@ -86,11 +87,14 @@ pub async fn build_context_prompt(
         }
     };
 
+    let file_tools_list = workspace_file_tools_context_list();
     let isolation_lines = if state.is_docker {
-        "- Isolation: Docker (shell commands run in a Linux container; workspace root is /workspace)\n\
-         - File tools (readFile, writeFile, listDirectory, editFile) access the same /workspace files via the host bind mount; changes outside /workspace are visible to shell only, not to file tools\n"
+        format!(
+            "- Isolation: Docker (shell commands run in a Linux container; workspace root is /workspace)\n\
+             - File tools ({file_tools_list}) access the same /workspace files via the host bind mount; changes outside /workspace are visible to shell only, not to file tools\n"
+        )
     } else {
-        ""
+        String::new()
     };
 
     format!(

--- a/src-tauri/src/mcp/builtin/workspace/dispatch.rs
+++ b/src-tauri/src/mcp/builtin/workspace/dispatch.rs
@@ -38,11 +38,17 @@ impl WorkspaceServer {
             "listDirectory" => self.handle_list_directory(args, session_id).await,
             "importFiles" => self.handle_import_files(args, session_id).await,
             "searchFiles" => self.handle_search(args, session_id).await,
+            #[cfg(feature = "workspace-str-replace")]
+            "strReplace" => self.handle_str_replace(args, session_id).await,
+            #[cfg(feature = "workspace-edit-file")]
             // editFile is the model-facing mutation tool. Per-operation aliases remain
             // dispatchable for backward compatibility and internally normalize into editFile.
             "editFile" => self.handle_edit_file(args, session_id).await,
+            #[cfg(feature = "workspace-edit-file")]
             "replaceLines" => self.handle_replace_lines(args, session_id).await,
+            #[cfg(feature = "workspace-edit-file")]
             "insertAfterLine" => self.handle_insert_after_line(args, session_id).await,
+            #[cfg(feature = "workspace-edit-file")]
             "deleteLines" => self.handle_delete_lines(args, session_id).await,
 
             // ── Code execution tools ──────────────────────────────────────────

--- a/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
+++ b/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
@@ -1,142 +1,120 @@
 //! Compile-time selection between line+anchor edits and string replacement.
-
-#[cfg(all(feature = "workspace-edit-file", feature = "workspace-str-replace"))]
-compile_error!("Enable only one of `workspace-edit-file` or `workspace-str-replace`");
+//!
+//! Production builds enable exactly one of `workspace-edit-file` or
+//! `workspace-str-replace`. When both are enabled (e.g. `cargo clippy --all-features`),
+//! `workspace-str-replace` takes precedence.
 
 #[cfg(not(any(feature = "workspace-edit-file", feature = "workspace-str-replace")))]
 compile_error!("Enable either `workspace-edit-file` or `workspace-str-replace`");
 
-#[cfg(feature = "workspace-edit-file")]
-pub const PRIMARY_EDIT_TOOL: &str = "editFile";
+pub const PRIMARY_EDIT_TOOL: &str = if cfg!(feature = "workspace-str-replace") {
+    "strReplace"
+} else {
+    "editFile"
+};
 
-#[cfg(feature = "workspace-str-replace")]
-pub const PRIMARY_EDIT_TOOL: &str = "strReplace";
+/// Line+anchor metadata (`42:a31f2c|...`) is only active for edit-file-only builds.
+pub const LINE_ANCHORS_ENABLED: bool =
+    cfg!(feature = "workspace-edit-file") && !cfg!(feature = "workspace-str-replace");
 
 /// Workspace service-context bullet listing file mutation tools.
 pub fn workspace_file_tools_context_list() -> String {
     format!("readFile, writeFile, listDirectory, {PRIMARY_EDIT_TOOL}")
 }
 
-#[cfg(feature = "workspace-edit-file")]
 pub fn read_file_tool_hint() -> &'static str {
-    "Use showLineAnchors=true when you need anchors for editFile."
+    if LINE_ANCHORS_ENABLED {
+        "Use showLineAnchors=true when you need anchors for editFile."
+    } else {
+        "Read files before strReplace so old_string matches the on-disk content exactly."
+    }
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_tool_hint() -> &'static str {
-    "Read files before strReplace so old_string matches the on-disk content exactly."
-}
-
-#[cfg(feature = "workspace-edit-file")]
+#[cfg(all(
+    feature = "workspace-edit-file",
+    not(feature = "workspace-str-replace")
+))]
 pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
     "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. For editFile, pass only the 6-character anchor (for example 'a31f2c'), not '42:a31f2c' or the trailing '|...'."
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
-    "Optional: prefix each line with line number metadata (default: false). strReplace uses the raw line text after readFile — anchors are not required."
-}
-
-#[cfg(feature = "workspace-edit-file")]
+#[cfg(all(
+    feature = "workspace-edit-file",
+    not(feature = "workspace-str-replace")
+))]
 pub fn search_show_line_anchors_schema_hint() -> &'static str {
     "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c')."
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn search_show_line_anchors_schema_hint() -> &'static str {
-    "Optional: include line-number metadata in search hits (default: false). For strReplace, copy the matched line text from readFile instead of anchors."
-}
-
-#[cfg(feature = "workspace-edit-file")]
-pub fn read_file_anchor_output_suffix() -> &'static str {
-    "\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{content}`."
-}
-
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_anchor_output_suffix() -> &'static str {
-    "\n\n*(Line prefixes are metadata only. For strReplace, copy the content after `|` into old_string.)*"
-}
-
-#[cfg(feature = "workspace-edit-file")]
 pub fn read_file_primary_next_action(show_line_anchors: bool) -> String {
-    if show_line_anchors {
-        "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+    if LINE_ANCHORS_ENABLED {
+        if show_line_anchors {
+            "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+        } else {
+            "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors"
+                .to_string()
+        }
     } else {
-        "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors".to_string()
+        "Copy the exact text block you want to change into strReplace.old_string".to_string()
     }
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_primary_next_action(_show_line_anchors: bool) -> String {
-    "Copy the exact text block you want to change into strReplace.old_string".to_string()
-}
-
-#[cfg(feature = "workspace-edit-file")]
 pub fn read_file_secondary_next_action() -> &'static str {
-    "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line"
-}
-
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_secondary_next_action() -> &'static str {
-    "Use strReplace when you already know the exact old_string to replace"
-}
-
-#[cfg(feature = "workspace-edit-file")]
-pub fn search_inline_match_footer(show_hashes: bool) -> String {
-    if show_hashes {
-        "Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n".to_string()
+    if LINE_ANCHORS_ENABLED {
+        "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line"
     } else {
-        "If you plan to use editFile next, run again with `showLineAnchors: true` to get anchors.\n".to_string()
+        "Use strReplace when you already know the exact old_string to replace"
     }
 }
 
-#[cfg(feature = "workspace-str-replace")]
 pub fn search_inline_match_footer(show_hashes: bool) -> String {
-    let _ = show_hashes;
-    "Use readFile on a match, then strReplace with the exact old_string copied from that output.\n".to_string()
-}
-
-#[cfg(feature = "workspace-edit-file")]
-pub fn search_directory_next_step(show_hashes: bool) -> &'static str {
-    if show_hashes {
-        "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
+    if LINE_ANCHORS_ENABLED {
+        if show_hashes {
+            "Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n".to_string()
+        } else {
+            "If you plan to use editFile next, run again with `showLineAnchors: true` to get anchors.\n"
+                .to_string()
+        }
     } else {
-        "Run with `showLineAnchors: true` to get anchors for targeted editing tools"
+        let _ = show_hashes;
+        "Use readFile on a match, then strReplace with the exact old_string copied from that output.\n"
+            .to_string()
     }
 }
 
-#[cfg(feature = "workspace-str-replace")]
 pub fn search_directory_next_step(show_hashes: bool) -> &'static str {
-    let _ = show_hashes;
-    "Use readFile on a hit, then strReplace with old_string copied verbatim from the file"
+    if LINE_ANCHORS_ENABLED {
+        if show_hashes {
+            "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
+        } else {
+            "Run with `showLineAnchors: true` to get anchors for targeted editing tools"
+        }
+    } else {
+        let _ = show_hashes;
+        "Use readFile on a hit, then strReplace with old_string copied verbatim from the file"
+    }
 }
 
-#[cfg(feature = "workspace-edit-file")]
 pub fn write_file_post_write_anchor_heading() -> &'static str {
-    "\nCurrent anchors:\n"
+    if LINE_ANCHORS_ENABLED {
+        "\nCurrent anchors:\n"
+    } else {
+        "\nCurrent content preview:\n"
+    }
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn write_file_post_write_anchor_heading() -> &'static str {
-    "\nCurrent content preview:\n"
-}
-
-#[cfg(feature = "workspace-edit-file")]
 pub fn write_file_anchor_preview_note() -> &'static str {
-    "*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n"
+    if LINE_ANCHORS_ENABLED {
+        "*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n"
+    } else {
+        ""
+    }
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn write_file_anchor_preview_note() -> &'static str {
-    "*(Note: Line prefixes are metadata only. For strReplace, copy exact text from readFile into old_string.)*\n"
-}
-
-#[cfg(feature = "workspace-edit-file")]
 pub fn read_file_anchor_prefix_note() -> &'static str {
     "*(Note: The `{lineNumber}:{anchor}|` prefixes in the code block above are metadata added by the tool for edit reference, and are NOT part of the actual file content.)*"
 }
 
-#[cfg(feature = "workspace-str-replace")]
-pub fn read_file_anchor_prefix_note() -> &'static str {
-    "*(Note: The `{lineNumber}:{anchor}|` prefixes in the code block above are metadata only and are NOT part of the actual file content.)*"
+pub fn read_file_anchor_output_suffix() -> &'static str {
+    "\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{content}`."
 }

--- a/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
+++ b/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
@@ -11,3 +11,132 @@ pub const PRIMARY_EDIT_TOOL: &str = "editFile";
 
 #[cfg(feature = "workspace-str-replace")]
 pub const PRIMARY_EDIT_TOOL: &str = "strReplace";
+
+/// Workspace service-context bullet listing file mutation tools.
+pub fn workspace_file_tools_context_list() -> String {
+    format!("readFile, writeFile, listDirectory, {PRIMARY_EDIT_TOOL}")
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_tool_hint() -> &'static str {
+    "Use showLineAnchors=true when you need anchors for editFile."
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_tool_hint() -> &'static str {
+    "Read files before strReplace so old_string matches the on-disk content exactly."
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
+    "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. For editFile, pass only the 6-character anchor (for example 'a31f2c'), not '42:a31f2c' or the trailing '|...'."
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
+    "Optional: prefix each line with line number metadata (default: false). strReplace uses the raw line text after readFile — anchors are not required."
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn search_show_line_anchors_schema_hint() -> &'static str {
+    "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c')."
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn search_show_line_anchors_schema_hint() -> &'static str {
+    "Optional: include line-number metadata in search hits (default: false). For strReplace, copy the matched line text from readFile instead of anchors."
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_anchor_output_suffix() -> &'static str {
+    "\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{content}`."
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_anchor_output_suffix() -> &'static str {
+    "\n\n*(Line prefixes are metadata only. For strReplace, copy the content after `|` into old_string.)*"
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_primary_next_action(show_line_anchors: bool) -> String {
+    if show_line_anchors {
+        "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+    } else {
+        "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors".to_string()
+    }
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_primary_next_action(_show_line_anchors: bool) -> String {
+    "Copy the exact text block you want to change into strReplace.old_string".to_string()
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_secondary_next_action() -> &'static str {
+    "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line"
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_secondary_next_action() -> &'static str {
+    "Use strReplace when you already know the exact old_string to replace"
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn search_inline_match_footer(show_hashes: bool) -> String {
+    if show_hashes {
+        "Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n".to_string()
+    } else {
+        "If you plan to use editFile next, run again with `showLineAnchors: true` to get anchors.\n".to_string()
+    }
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn search_inline_match_footer(show_hashes: bool) -> String {
+    let _ = show_hashes;
+    "Use readFile on a match, then strReplace with the exact old_string copied from that output.\n".to_string()
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn search_directory_next_step(show_hashes: bool) -> &'static str {
+    if show_hashes {
+        "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
+    } else {
+        "Run with `showLineAnchors: true` to get anchors for targeted editing tools"
+    }
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn search_directory_next_step(show_hashes: bool) -> &'static str {
+    let _ = show_hashes;
+    "Use readFile on a hit, then strReplace with old_string copied verbatim from the file"
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn write_file_post_write_anchor_heading() -> &'static str {
+    "\nCurrent anchors:\n"
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn write_file_post_write_anchor_heading() -> &'static str {
+    "\nCurrent content preview:\n"
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn write_file_anchor_preview_note() -> &'static str {
+    "*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n"
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn write_file_anchor_preview_note() -> &'static str {
+    "*(Note: Line prefixes are metadata only. For strReplace, copy exact text from readFile into old_string.)*\n"
+}
+
+#[cfg(feature = "workspace-edit-file")]
+pub fn read_file_anchor_prefix_note() -> &'static str {
+    "*(Note: The `{lineNumber}:{anchor}|` prefixes in the code block above are metadata added by the tool for edit reference, and are NOT part of the actual file content.)*"
+}
+
+#[cfg(feature = "workspace-str-replace")]
+pub fn read_file_anchor_prefix_note() -> &'static str {
+    "*(Note: The `{lineNumber}:{anchor}|` prefixes in the code block above are metadata only and are NOT part of the actual file content.)*"
+}

--- a/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
+++ b/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
@@ -1,0 +1,13 @@
+//! Compile-time selection between line+anchor edits and string replacement.
+
+#[cfg(all(feature = "workspace-edit-file", feature = "workspace-str-replace"))]
+compile_error!("Enable only one of `workspace-edit-file` or `workspace-str-replace`");
+
+#[cfg(not(any(feature = "workspace-edit-file", feature = "workspace-str-replace")))]
+compile_error!("Enable either `workspace-edit-file` or `workspace-str-replace`");
+
+#[cfg(feature = "workspace-edit-file")]
+pub const PRIMARY_EDIT_TOOL: &str = "editFile";
+
+#[cfg(feature = "workspace-str-replace")]
+pub const PRIMARY_EDIT_TOOL: &str = "strReplace";

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/mod.rs
@@ -1,7 +1,10 @@
 // File operations module - split for maintainability
 // Original file_operations.rs was 2022 lines - now split into focused modules
 
+#[cfg(feature = "workspace-edit-file")]
 pub mod edit_line;
+#[cfg(feature = "workspace-str-replace")]
+pub mod str_replace;
 pub mod import;
 pub mod list_dir;
 pub mod read;

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/mod.rs
@@ -3,11 +3,11 @@
 
 #[cfg(feature = "workspace-edit-file")]
 pub mod edit_line;
-#[cfg(feature = "workspace-str-replace")]
-pub mod str_replace;
 pub mod import;
 pub mod list_dir;
 pub mod read;
 pub mod search;
+#[cfg(feature = "workspace-str-replace")]
+pub mod str_replace;
 pub mod utils;
 pub mod write;

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -1,8 +1,8 @@
-use super::super::WorkspaceServer;
 use super::super::edit_mode::{
-    read_file_anchor_output_suffix, read_file_anchor_prefix_note,
-    read_file_primary_next_action, read_file_secondary_next_action,
+    read_file_anchor_output_suffix, read_file_anchor_prefix_note, read_file_primary_next_action,
+    read_file_secondary_next_action, LINE_ANCHORS_ENABLED,
 };
+use super::super::WorkspaceServer;
 use super::utils::{
     detect_language, format_file_size, format_hashline, initial_prefix_hash_state,
     update_prefix_hash_state, LARGE_FILE_THRESHOLD,
@@ -19,6 +19,16 @@ const READ_FILE_BASE_HEADROOM_BYTES: usize = 1024;
 const READ_FILE_ANCHOR_HEADROOM_BYTES: usize = 2 * 1024;
 const READ_FILE_MIN_VISIBLE_CONTENT_BYTES: usize = 1024;
 const EMPTY_FILE_OUT_OF_RANGE_PREFIX: &str = "File is empty (0 lines);";
+
+fn parse_show_line_anchors(args: &Value) -> bool {
+    if !LINE_ANCHORS_ENABLED {
+        return false;
+    }
+
+    args.get("showLineAnchors")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
 
 #[derive(Debug)]
 struct ReadFileChunk {
@@ -91,10 +101,7 @@ impl WorkspaceServer {
             Ok(size) => size,
             Err(result) => return Ok(result),
         };
-        let show_line_anchors = args
-            .get("showLineAnchors")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false); // Default OFF: reduce noise unless precise editing is needed
+        let show_line_anchors = parse_show_line_anchors(&args);
 
         if let Some(sz) = size_opt {
             if sz == 0 {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -257,16 +257,31 @@ impl WorkspaceServer {
                     )
                 };
 
-                let first_hint = if show_line_anchors {
-                    "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
-                } else {
-                    "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors".to_string()
+                let first_hint = {
+                    #[cfg(feature = "workspace-edit-file")]
+                    {
+                        if show_line_anchors {
+                            "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
+                        } else {
+                            "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors".to_string()
+                        }
+                    }
+                    #[cfg(feature = "workspace-str-replace")]
+                    {
+                        let _ = show_line_anchors;
+                        "Copy the exact text block you want to change into strReplace.old_string".to_string()
+                    }
                 };
-                let mut next_actions = vec![
-                    first_hint,
+                let mut next_actions = vec![first_hint];
+                #[cfg(feature = "workspace-edit-file")]
+                next_actions.push(
                     "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line".to_string(),
-                    "writeFile for full file replacement".to_string(),
-                ];
+                );
+                #[cfg(feature = "workspace-str-replace")]
+                next_actions.push(
+                    "Use strReplace when you already know the exact old_string to replace".to_string(),
+                );
+                next_actions.push("writeFile for full file replacement".to_string());
                 if let Some(next_start_line) = chunk.next_start_line {
                     next_actions.insert(
                         0,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -1,4 +1,8 @@
 use super::super::WorkspaceServer;
+use super::super::edit_mode::{
+    read_file_anchor_output_suffix, read_file_anchor_prefix_note,
+    read_file_primary_next_action, read_file_secondary_next_action,
+};
 use super::utils::{
     detect_language, format_file_size, format_hashline, initial_prefix_hash_state,
     update_prefix_hash_state, LARGE_FILE_THRESHOLD,
@@ -246,8 +250,8 @@ impl WorkspaceServer {
                 // Format response for clean markdown rendering
                 let text_message = if show_line_anchors {
                     format!(
-                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nLine format: `{{lineNumber}}:{{anchor}}|{{content}}`\n- `{{lineNumber}}`: 1-based line number\n- `{{anchor}}`: 6-character hex code (example: `792c6f`)\n- `{{content}}`: line content\n\n*(Note: The `{{lineNumber}}:{{anchor}}|` prefixes in the code block above are metadata added by the tool for edit reference, and are NOT part of the actual file content.)*\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{{content}}`.",
-                        path_str, size_str, chunk_summary, summary_suffix, chunk.content
+                        "📄 **`{}`** — {} — {}{}\n\n```\n{}\n```\n\nLine format: `{{lineNumber}}:{{anchor}}|{{content}}`\n- `{{lineNumber}}`: 1-based line number\n- `{{anchor}}`: 6-character hex code (example: `792c6f`)\n- `{{content}}`: line content\n\n{}{}",
+                        path_str, size_str, chunk_summary, summary_suffix, chunk.content, read_file_anchor_prefix_note(), read_file_anchor_output_suffix()
                     )
                 } else {
                     let language = detect_language(&safe_path);
@@ -257,30 +261,9 @@ impl WorkspaceServer {
                     )
                 };
 
-                let first_hint = {
-                    #[cfg(feature = "workspace-edit-file")]
-                    {
-                        if show_line_anchors {
-                            "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
-                        } else {
-                            "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors".to_string()
-                        }
-                    }
-                    #[cfg(feature = "workspace-str-replace")]
-                    {
-                        let _ = show_line_anchors;
-                        "Copy the exact text block you want to change into strReplace.old_string".to_string()
-                    }
-                };
+                let first_hint = read_file_primary_next_action(show_line_anchors);
                 let mut next_actions = vec![first_hint];
-                #[cfg(feature = "workspace-edit-file")]
-                next_actions.push(
-                    "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line".to_string(),
-                );
-                #[cfg(feature = "workspace-str-replace")]
-                next_actions.push(
-                    "Use strReplace when you already know the exact old_string to replace".to_string(),
-                );
+                next_actions.push(read_file_secondary_next_action().to_string());
                 next_actions.push("writeFile for full file replacement".to_string());
                 if let Some(next_start_line) = chunk.next_start_line {
                     next_actions.insert(

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -1,9 +1,9 @@
+use super::super::super::edit_mode::{search_directory_next_step, search_inline_match_footer};
 use super::super::utils::{
     compute_anchor, detect_language, format_file_size, initial_prefix_hash_state,
     update_prefix_hash_state,
 };
 use super::helpers::*;
-use super::super::super::edit_mode::{search_directory_next_step, search_inline_match_footer};
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -3,6 +3,7 @@ use super::super::utils::{
     update_prefix_hash_state,
 };
 use super::helpers::*;
+use super::super::super::edit_mode::{search_directory_next_step, search_inline_match_footer};
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::types::MCPResult;
 use serde_json::{json, Value};
@@ -250,11 +251,9 @@ pub(super) async fn search_content_in_file(
         }
 
         if show_hashes {
-            s.push_str("Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n");
+            s.push_str(&search_inline_match_footer(true));
         } else {
-            s.push_str(
-                "If you plan to use editFile next, run again with `showLineAnchors: true` to get anchors.\n",
-            );
+            s.push_str(&search_inline_match_footer(false));
         }
         s
     };
@@ -618,17 +617,7 @@ pub(super) async fn search_content_in_dir(
 
     let mut next_steps =
         vec!["Use search with a specific file path to see all matches in that file".to_string()];
-    if show_hashes {
-        next_steps.push(
-            "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
-                .to_string(),
-        );
-    } else {
-        next_steps.push(
-            "Run with `showLineAnchors: true` to get anchors for targeted editing tools."
-                .to_string(),
-        );
-    }
+    next_steps.push(search_directory_next_step(show_hashes).to_string());
 
     Ok(SuccessHint::new(text, next_steps).to_mcp_result_with_data(Some(structured)))
 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -2,6 +2,7 @@ mod content;
 mod files;
 mod helpers;
 
+use super::super::edit_mode::LINE_ANCHORS_ENABLED;
 use super::super::WorkspaceServer;
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, ErrorCategory, ToolGroup,
@@ -51,10 +52,13 @@ impl WorkspaceServer {
             .get("ignoreCase")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let show_line_anchors = args
-            .get("showLineAnchors")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        let show_line_anchors = if LINE_ANCHORS_ENABLED {
+            args.get("showLineAnchors")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        } else {
+            false
+        };
         let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
         if !(1..=1000).contains(&limit_raw) {
             return Ok(guided_error(

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
@@ -1,0 +1,254 @@
+use super::super::WorkspaceServer;
+use super::utils::format_file_diff;
+use crate::mcp::builtin::error_guidance::{
+    guided_error, missing_param_error, not_found_error, ErrorCategory, SuccessHint, ToolGroup,
+};
+use crate::mcp::types::MCPResult;
+use serde_json::Value;
+use std::path::Path;
+use tokio::fs;
+use tokio::io::AsyncReadExt;
+
+async fn read_validated_utf8_file(path: &Path) -> Result<String, String> {
+    let max_size = crate::config::max_file_size();
+    let metadata = fs::metadata(path)
+        .await
+        .map_err(|error| format!("Failed to read file metadata: {error}"))?;
+
+    if metadata.len() > max_size as u64 {
+        return Err(format!(
+            "File size error: File exceeds the maximum allowed size of {max_size} bytes"
+        ));
+    }
+
+    let file = fs::File::open(path)
+        .await
+        .map_err(|error| format!("Failed to open file: {error}"))?;
+
+    let mut buffer = Vec::new();
+    let read_limit = (max_size as u64).saturating_add(1);
+    let bytes_read = file
+        .take(read_limit)
+        .read_to_end(&mut buffer)
+        .await
+        .map_err(|error| format!("Failed to read file: {error}"))?;
+
+    if bytes_read > max_size {
+        return Err(format!(
+            "File size error: File exceeds the maximum allowed size of {max_size} bytes"
+        ));
+    }
+
+    String::from_utf8(buffer).map_err(|_| {
+        "Failed to read file: Content appears to be binary or contains invalid UTF-8 characters"
+            .to_string()
+    })
+}
+
+fn count_occurrences(content: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+
+    content.match_indices(needle).count()
+}
+
+impl WorkspaceServer {
+    pub async fn handle_str_replace(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        let path_str = match args.get("path").and_then(|value| value.as_str()) {
+            Some(path) if !path.trim().is_empty() => path.trim(),
+            Some(_) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    "Path parameter cannot be empty",
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Provide a file path (relative paths resolve from the workspace)".to_string(),
+                ])
+                .to_mcp_result());
+            }
+            None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
+        };
+
+        if path_str.contains("..") {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Path traversal patterns (..) are not allowed",
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Use a normal file path without '..' traversal segments".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
+        let old_string = match args.get("old_string").and_then(|value| value.as_str()) {
+            Some(value) if !value.is_empty() => value,
+            Some(_) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    "Parameter 'old_string' cannot be empty",
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Provide the exact text to replace, copied from readFile output".to_string(),
+                ])
+                .to_mcp_result());
+            }
+            None => return Ok(missing_param_error("old_string", ToolGroup::Workspace)),
+        };
+
+        let new_string = match args.get("new_string").and_then(|value| value.as_str()) {
+            Some(value) => value,
+            None => return Ok(missing_param_error("new_string", ToolGroup::Workspace)),
+        };
+
+        let replace_all = args
+            .get("replace_all")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+
+        let target_session_id = session_id
+            .clone()
+            .unwrap_or_else(|| self.session_id.clone());
+
+        let safe_path = match self
+            .validate_write_path_with_teamwork_access(path_str, Some(target_session_id))
+            .await
+        {
+            Ok(path) => path,
+            Err(error) => {
+                return Ok(guided_error(
+                    ErrorCategory::PermissionDenied,
+                    format!("Path validation failed: {error}"),
+                    ToolGroup::Workspace,
+                )
+                .to_mcp_result());
+            }
+        };
+
+        if !safe_path.exists() {
+            return Ok(not_found_error("file", path_str, ToolGroup::Workspace));
+        }
+
+        let original_content = match read_validated_utf8_file(&safe_path).await {
+            Ok(content) => content,
+            Err(error) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    error,
+                    ToolGroup::Workspace,
+                )
+                .to_mcp_result());
+            }
+        };
+
+        let occurrences = count_occurrences(&original_content, old_string);
+        if occurrences == 0 {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!("old_string was not found in '{path_str}'"),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Use readFile on the target path and copy the exact text block to replace"
+                    .to_string(),
+                "Check whitespace, indentation, and line endings — matching is exact".to_string(),
+                "For larger structural edits, split the change into smaller unique old_string values"
+                    .to_string(),
+            ])
+            .to_mcp_result());
+        }
+
+        if !replace_all && occurrences > 1 {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "old_string matched {occurrences} times in '{path_str}'. Set replace_all=true to replace every occurrence, or provide a more specific old_string."
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Include more surrounding context in old_string so only one match remains".to_string(),
+                "Or pass \"replace_all\": true when every occurrence should change".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
+        let new_content = if replace_all {
+            original_content.replace(old_string, new_string)
+        } else {
+            original_content.replacen(old_string, new_string, 1)
+        };
+
+        if new_content.len() > crate::config::max_file_size() {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Replacement would exceed the maximum allowed file size of {} bytes",
+                    crate::config::max_file_size()
+                ),
+                ToolGroup::Workspace,
+            )
+            .to_mcp_result());
+        }
+
+        if let Err(error) = fs::write(&safe_path, &new_content).await {
+            return Ok(guided_error(
+                ErrorCategory::InternalError,
+                format!("Failed to write file: {error}"),
+                ToolGroup::Workspace,
+            )
+            .to_mcp_result());
+        }
+
+        let replacements = if replace_all {
+            occurrences
+        } else {
+            1
+        };
+        let diff_output = format_file_diff(&original_content, &new_content, path_str);
+        let message = format!(
+            "Replaced {replacements} occurrence(s) in '{path_str}'.\n\n{diff_output}"
+        );
+
+        Ok(SuccessHint::new(
+            message,
+            vec!["Use readFile to verify the updated content".to_string()],
+        )
+        .to_mcp_result())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{count_occurrences, read_validated_utf8_file};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn count_occurrences_handles_empty_needle() {
+        assert_eq!(count_occurrences("abc", ""), 0);
+    }
+
+    #[test]
+    fn count_occurrences_counts_non_overlapping_matches() {
+        assert_eq!(count_occurrences("foo foo foo", "foo"), 3);
+        assert_eq!(count_occurrences("aaa", "aa"), 1);
+    }
+
+    #[tokio::test]
+    async fn read_validated_utf8_file_rejects_binary() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(&[0xff, 0xfe, 0xfd]).expect("write bytes");
+        let error = read_validated_utf8_file(file.path())
+            .await
+            .expect_err("binary should fail");
+        assert!(error.contains("UTF-8"), "{error}");
+    }
+}

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
@@ -139,12 +139,10 @@ impl WorkspaceServer {
         let original_content = match read_validated_utf8_file(&safe_path).await {
             Ok(content) => content,
             Err(error) => {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    error,
-                    ToolGroup::Workspace,
-                )
-                .to_mcp_result());
+                return Ok(
+                    guided_error(ErrorCategory::InvalidInput, error, ToolGroup::Workspace)
+                        .to_mcp_result(),
+                );
             }
         };
 
@@ -207,15 +205,10 @@ impl WorkspaceServer {
             .to_mcp_result());
         }
 
-        let replacements = if replace_all {
-            occurrences
-        } else {
-            1
-        };
+        let replacements = if replace_all { occurrences } else { 1 };
         let diff_output = format_file_diff(&original_content, &new_content, path_str);
-        let message = format!(
-            "Replaced {replacements} occurrence(s) in '{path_str}'.\n\n{diff_output}"
-        );
+        let message =
+            format!("Replaced {replacements} occurrence(s) in '{path_str}'.\n\n{diff_output}");
 
         Ok(SuccessHint::new(
             message,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/utils.rs
@@ -85,6 +85,25 @@ pub fn format_as_hashlines(content: &str) -> String {
         .join("\n")
 }
 
+/// Format a single line for writeFile/readFile previews (anchored or raw).
+pub fn format_preview_line(line_number: usize, content: &str, prefix_state: &mut u32) -> String {
+    if crate::mcp::builtin::workspace::edit_mode::LINE_ANCHORS_ENABLED {
+        format_hashline(line_number, content, prefix_state)
+    } else {
+        let _ = (line_number, prefix_state);
+        content.to_string()
+    }
+}
+
+/// Format multi-line file content for post-write previews.
+pub fn format_file_content_preview(content: &str) -> String {
+    if crate::mcp::builtin::workspace::edit_mode::LINE_ANCHORS_ENABLED {
+        format_as_hashlines(content)
+    } else {
+        content.to_string()
+    }
+}
+
 /// Format file size in bytes to human-readable format (B, KB, MB, GB)
 pub fn format_file_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -2,6 +2,9 @@ use super::super::WorkspaceServer;
 use super::utils::{
     format_as_hashlines, format_file_size, format_hashline, initial_prefix_hash_state,
 };
+use crate::mcp::builtin::workspace::edit_mode::{
+    write_file_anchor_preview_note, write_file_post_write_anchor_heading,
+};
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, permission_denied_error, ErrorCategory, SuccessHint,
     ToolGroup,
@@ -470,7 +473,9 @@ impl WorkspaceServer {
                     let diff_output = format_file_diff(&old_content, content, &write_display_path);
                     message.push_str(&diff_output);
                     message.push_str(&format!(
-                        "\nCurrent anchors:\n*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n```\n{}\n```\n",
+                        "{}{}```\n{}\n```\n",
+                        write_file_post_write_anchor_heading(),
+                        write_file_anchor_preview_note(),
                         format_as_hashlines(content)
                     ));
                 } else {
@@ -518,7 +523,7 @@ impl WorkspaceServer {
                         }
                     };
 
-                    message.push_str("*(Note: The lines in the code block below are prefixed with `lineNumber:anchor|` for subsequent editing. These prefixes are metadata and are NOT part of the actual file content.)*\n");
+                    message.push_str(write_file_anchor_preview_note());
                     message.push_str(&format!("```\n{}\n```\n", display_hashlines));
                 }
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -262,7 +262,8 @@ impl WorkspaceServer {
                             path_str
                         ),
                         format!(
-                            "Use editFile for targeted edits to \"{}\" instead of rewriting the whole file.",
+                            "Use {} for targeted edits to \"{}\" instead of rewriting the whole file.",
+                            crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL,
                             path_str
                         ),
                     ])
@@ -441,13 +442,14 @@ impl WorkspaceServer {
                          **Correct usage reminder:**\n\
                          - To **replace** an existing file: `writeFile` with `\"mode\": \"overwrite\"`\n\
                          - To **add to the end** of an existing file: `\"mode\": \"append\"`\n\
-                         - To **edit parts** of an existing file: use `editFile` (not another `writeFile` create)\n\
+                         - To **edit parts** of an existing file: use `{}` (not another `writeFile` create)\n\
                          - To **create a new file** when unsure the path is free: pick a unique name, or accept this auto-suffix behavior\n\n",
                         requested_path_str,
                         requested_path_str,
                         write_display_path,
                         total_size_str,
-                        total_lines
+                        total_lines,
+                        crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL,
                     ));
                 } else {
                     message.push_str(&format!(
@@ -531,8 +533,9 @@ impl WorkspaceServer {
                         requested_path_str, write_display_path
                     ));
                     next_steps.push(format!(
-                        "If you meant to modify \"{}\" in place, use editFile or writeFile mode=\"append\" / mode=\"overwrite\" — not another default create.",
-                        requested_path_str
+                        "If you meant to modify \"{}\" in place, use {} or writeFile mode=\"append\" / mode=\"overwrite\" — not another default create.",
+                        requested_path_str,
+                        crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL,
                     ));
                 }
 
@@ -559,7 +562,8 @@ impl WorkspaceServer {
                     || write_display_path.ends_with(".ts")
                 {
                     next_steps.push(format!(
-                        "Use editFile for targeted edits to \"{}\"",
+                        "Use {} for targeted edits to \"{}\"",
+                        crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL,
                         write_display_path
                     ));
                 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -1,13 +1,13 @@
 use super::super::WorkspaceServer;
 use super::utils::{
-    format_as_hashlines, format_file_size, format_hashline, initial_prefix_hash_state,
-};
-use crate::mcp::builtin::workspace::edit_mode::{
-    write_file_anchor_preview_note, write_file_post_write_anchor_heading,
+    format_file_content_preview, format_file_size, format_preview_line, initial_prefix_hash_state,
 };
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, permission_denied_error, ErrorCategory, SuccessHint,
     ToolGroup,
+};
+use crate::mcp::builtin::workspace::edit_mode::{
+    write_file_anchor_preview_note, write_file_post_write_anchor_heading,
 };
 use crate::mcp::types::MCPResult;
 use crate::services::SecureFileManager;
@@ -104,7 +104,7 @@ struct AppendPreview {
     total_size_bytes: u64,
     shown_lines: usize,
     preview_was_truncated: bool,
-    display_hashlines: String,
+    display_lines: String,
 }
 
 fn read_back_append_preview(
@@ -133,9 +133,9 @@ fn read_back_append_preview(
         })?;
 
         total_lines += 1;
-        let anchored_line = format_hashline(total_lines, &line, &mut prefix_state);
-        preview_bytes += anchored_line.len() + 1;
-        tail_lines.push_back(anchored_line);
+        let preview_line = format_preview_line(total_lines, &line, &mut prefix_state);
+        preview_bytes += preview_line.len() + 1;
+        tail_lines.push_back(preview_line);
 
         while tail_lines.len() > max_display_lines
             || (preview_bytes > max_display_bytes && tail_lines.len() > 1)
@@ -155,7 +155,7 @@ fn read_back_append_preview(
         total_size_bytes,
         shown_lines,
         preview_was_truncated,
-        display_hashlines: tail_lines.into_iter().collect::<Vec<_>>().join("\n"),
+        display_lines: tail_lines.into_iter().collect::<Vec<_>>().join("\n"),
     })
 }
 
@@ -476,19 +476,19 @@ impl WorkspaceServer {
                         "{}{}```\n{}\n```\n",
                         write_file_post_write_anchor_heading(),
                         write_file_anchor_preview_note(),
-                        format_as_hashlines(content)
+                        format_file_content_preview(content)
                     ));
                 } else {
-                    let display_hashlines = if let Some(preview) = append_preview.as_ref() {
+                    let display_lines = if let Some(preview) = append_preview.as_ref() {
                         if preview.preview_was_truncated {
                             format!(
                                 "{}\n\n... (truncated: showing last {} of {} lines, including the appended tail)",
-                                preview.display_hashlines,
+                                preview.display_lines,
                                 preview.shown_lines,
                                 preview.total_lines,
                             )
                         } else {
-                            preview.display_hashlines.clone()
+                            preview.display_lines.clone()
                         }
                     } else {
                         let current_content = current_content
@@ -514,17 +514,17 @@ impl WorkspaceServer {
                             let partial = truncated.join("\n");
                             format!(
                                 "{}\n\n... (truncated: showing first {} of {} lines)",
-                                format_as_hashlines(&partial),
+                                format_file_content_preview(&partial),
                                 truncated.len(),
                                 content_lines.len(),
                             )
                         } else {
-                            format_as_hashlines(current_content)
+                            format_file_content_preview(current_content)
                         }
                     };
 
                     message.push_str(write_file_anchor_preview_note());
-                    message.push_str(&format!("```\n{}\n```\n", display_hashlines));
+                    message.push_str(&format!("```\n{}\n```\n", display_lines));
                 }
 
                 let mut next_steps = Vec::new();

--- a/src-tauri/src/mcp/builtin/workspace/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/mod.rs
@@ -9,6 +9,7 @@ use crate::mcp::MCPTool;
 pub mod code_execution;
 pub mod context;
 pub mod dispatch;
+pub mod edit_mode;
 pub mod export_operations;
 pub mod file_operations;
 pub mod handlers;

--- a/src-tauri/src/mcp/builtin/workspace/sensitive_tools.json
+++ b/src-tauri/src/mcp/builtin/workspace/sensitive_tools.json
@@ -1,6 +1,7 @@
 {
     "requires_approval": [
         "workspace__writeFile",
+        "workspace__strReplace",
         "workspace__editFile",
         "workspace__runShell",
         "workspace__runInPersistentShell",

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -1,15 +1,16 @@
-use crate::mcp::{
-    schema::SchemaProperties,
-    utils::schema_builder::*,
-    MCPTool,
-};
+use crate::mcp::{schema::SchemaProperties, utils::schema_builder::*, MCPTool};
 
 #[cfg(feature = "workspace-edit-file")]
 use crate::mcp::schema::JSONSchema;
 
+use super::super::edit_mode::{read_file_tool_hint, PRIMARY_EDIT_TOOL};
+
+#[cfg(all(
+    feature = "workspace-edit-file",
+    not(feature = "workspace-str-replace")
+))]
 use super::super::edit_mode::{
-    read_file_show_line_anchors_schema_hint, read_file_tool_hint,
-    search_show_line_anchors_schema_hint, PRIMARY_EDIT_TOOL,
+    read_file_show_line_anchors_schema_hint, search_show_line_anchors_schema_hint,
 };
 
 // Note: maximum file size is enforced at runtime (LIBRAGENT_MAX_FILE_SIZE).
@@ -42,6 +43,10 @@ pub fn create_read_file_tool() -> MCPTool {
             Some("Number of lines to read. If negative, reads that many lines from the end of the file (tail mode)."),
         ),
     );
+    #[cfg(all(
+        feature = "workspace-edit-file",
+        not(feature = "workspace-str-replace")
+    ))]
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(read_file_show_line_anchors_schema_hint())),
@@ -238,6 +243,10 @@ pub fn create_search_tool() -> MCPTool {
         "ignoreCase".to_string(),
         boolean_prop(Some("Case-insensitive search (default: false)")),
     );
+    #[cfg(all(
+        feature = "workspace-edit-file",
+        not(feature = "workspace-str-replace")
+    ))]
     props.insert(
         "showLineAnchors".to_string(),
         boolean_prop(Some(search_show_line_anchors_schema_hint())),

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -1,8 +1,23 @@
 use crate::mcp::{
-    schema::{JSONSchema, SchemaProperties},
+    schema::SchemaProperties,
     utils::schema_builder::*,
     MCPTool,
 };
+
+#[cfg(feature = "workspace-edit-file")]
+use crate::mcp::schema::JSONSchema;
+
+use super::super::edit_mode::PRIMARY_EDIT_TOOL;
+
+#[cfg(feature = "workspace-edit-file")]
+fn read_file_edit_hint() -> &'static str {
+    "Use showLineAnchors=true when you need anchors for editFile."
+}
+
+#[cfg(feature = "workspace-str-replace")]
+fn read_file_edit_hint() -> &'static str {
+    "Read files before strReplace so old_string matches the on-disk content exactly."
+}
 
 // Note: maximum file size is enforced at runtime (LIBRAGENT_MAX_FILE_SIZE).
 // The input schema cannot call runtime functions; therefore `content` has no hard cap here.
@@ -44,8 +59,10 @@ pub fn create_read_file_tool() -> MCPTool {
     MCPTool {
         name: "readFile".to_string(),
         title: Some("Read File".to_string()),
-        description: "Read the contents of a file. Supports reading from a specific offset and line count (size), including negative size for tailing the end of the file. Large responses are chunked automatically to stay inline. Use showLineAnchors=true when you need anchors for editFile."
-            .to_string(),
+        description: format!(
+            "Read the contents of a file. Supports reading from a specific offset and line count (size), including negative size for tailing the end of the file. Large responses are chunked automatically to stay inline. {}",
+            read_file_edit_hint()
+        ),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
         annotations: None,
@@ -65,12 +82,15 @@ pub fn create_write_file_tool() -> MCPTool {
             Some("Path to write. Relative paths resolve from the workspace; absolute paths are also allowed unless protected. Use @teamwork/... or .libragent/teamwork/... to write into the canonical teamwork scaffold root without changing workspaceOverride."),
         ),
     );
+    let mode_description = format!(
+        "Write mode. 'create' (default) writes a new file; if the path already exists it keeps that file and writes to a sibling path with a numeric suffix (e.g. report-1.md) instead of failing. 'overwrite' replaces the entire existing file. 'append' adds content verbatim to the end (no automatic newline). Use overwrite/append/{PRIMARY_EDIT_TOOL} when you intend to change an existing file."
+    );
     props.insert(
         "mode".to_string(),
         enum_prop(
             vec!["create", "overwrite", "append"],
             "create",
-            Some("Write mode. 'create' (default) writes a new file; if the path already exists it keeps that file and writes to a sibling path with a numeric suffix (e.g. report-1.md) instead of failing. 'overwrite' replaces the entire existing file. 'append' adds content verbatim to the end (no automatic newline). Use overwrite/append/editFile when you intend to change an existing file."),
+            Some(mode_description.as_str()),
         ),
     );
     props.insert(
@@ -85,8 +105,9 @@ pub fn create_write_file_tool() -> MCPTool {
     MCPTool {
         name: "writeFile".to_string(),
         title: Some("Write File".to_string()),
-        description: "Create, overwrite, or append content to a file. Missing parent directories are created automatically. Default mode='create': if the target already exists, content is saved to a new sibling path (stem-N.ext) and the response clearly reports the alternate path—existing files are never overwritten unless mode='overwrite'. Append writes content verbatim—include \\n in content when starting a new line. Responses include current line anchors so follow-up editFile calls can usually reuse them directly. mode='overwrite' returns a diff of the changes."
-            .to_string(),
+        description: format!(
+            "Create, overwrite, or append content to a file. Missing parent directories are created automatically. Default mode='create': if the target already exists, content is saved to a new sibling path (stem-N.ext) and the response clearly reports the alternate path—existing files are never overwritten unless mode='overwrite'. Append writes content verbatim—include \\n in content when starting a new line. Use {PRIMARY_EDIT_TOOL} for targeted in-place edits. mode='overwrite' returns a diff of the changes."
+        ),
         input_schema: object_schema(props, vec!["path".to_string(), "content".to_string()]),
         output_schema: None,
         annotations: None,
@@ -556,9 +577,71 @@ Use flat params (line/anchor) for a single deletion, or the `edits` array for mu
 // Note: maximum file size is enforced at runtime (LIBRAGENT_MAX_FILE_SIZE).
 // The input schema cannot call runtime functions; therefore `content` has no hard cap here.
 
+#[cfg(feature = "workspace-str-replace")]
+pub fn create_str_replace_tool() -> MCPTool {
+    let mut props = SchemaProperties::new();
+    props.insert(
+        "path".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Path to the file to edit. Relative paths resolve from the workspace; absolute paths are also allowed unless protected."),
+        ),
+    );
+    props.insert(
+        "replace_all".to_string(),
+        boolean_prop(Some(
+            "Replace every occurrence of old_string. Default false replaces only the first unique match.",
+        )),
+    );
+    props.insert(
+        "old_string".to_string(),
+        string_prop(
+            Some(1),
+            None,
+            Some("Exact text to find in the file. Copy verbatim from readFile output, including whitespace and newlines."),
+        ),
+    );
+    props.insert(
+        "new_string".to_string(),
+        string_prop(
+            Some(0),
+            None,
+            Some("Replacement text. Use an empty string to delete the matched block."),
+        ),
+    );
+
+    MCPTool {
+        name: "strReplace".to_string(),
+        title: Some("Replace Text in File".to_string()),
+        description: "Perform exact string replacement in an existing file.
+
+PREREQUISITE: Use readFile first and copy the exact text block into old_string. Matching is literal — whitespace, indentation, and line endings must match.
+
+- Single replacement (default): old_string must match exactly once unless replace_all=true.
+- replace_all=true: every occurrence of old_string is replaced.
+- new_string may be empty to delete the matched text.
+
+Use writeFile mode='create' for new files and mode='overwrite' only when replacing the entire file."
+            .to_string(),
+        input_schema: object_schema(
+            props,
+            vec![
+                "path".to_string(),
+                "old_string".to_string(),
+                "new_string".to_string(),
+            ],
+        ),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+#[cfg(feature = "workspace-edit-file")]
 /// Maximum number of edit operations allowed in a single editFile call.
 pub const EDIT_FILE_MAX_EDITS: u32 = 50;
 
+#[cfg(feature = "workspace-edit-file")]
 fn edit_anchor_props() -> SchemaProperties {
     let start_anchor_desc =
         "6-character opaque anchor for the start line from readFile(showLineAnchors=true). Required for edits that touch an existing line. Do not include the line number or '|content'.";
@@ -585,6 +668,7 @@ fn edit_anchor_props() -> SchemaProperties {
     props
 }
 
+#[cfg(feature = "workspace-edit-file")]
 fn create_prepend_edit_variant() -> JSONSchema {
     let content_desc =
         "Content to insert at the beginning of the file. startLine defaults to 0 when omitted.";
@@ -610,6 +694,7 @@ fn create_prepend_edit_variant() -> JSONSchema {
     schema
 }
 
+#[cfg(feature = "workspace-edit-file")]
 fn create_line_edit_variant() -> JSONSchema {
     let start_line_desc = "Target start line number (1-based). Use endLine only for multi-line replace/delete ranges.";
     let end_line_desc =
@@ -649,6 +734,7 @@ fn create_line_edit_variant() -> JSONSchema {
     schema
 }
 
+#[cfg(feature = "workspace-edit-file")]
 fn create_insert_after_edit_variant() -> JSONSchema {
     let start_line_desc =
         "Line number to insert after (1-based). Use 0 only to prepend at the file top.";
@@ -689,6 +775,7 @@ fn create_insert_after_edit_variant() -> JSONSchema {
     schema
 }
 
+#[cfg(feature = "workspace-edit-file")]
 pub fn create_edit_item_schema() -> JSONSchema {
     one_of_object_schema(
         vec![
@@ -702,6 +789,7 @@ pub fn create_edit_item_schema() -> JSONSchema {
     )
 }
 
+#[cfg(feature = "workspace-edit-file")]
 pub fn create_edit_file_input_schema() -> JSONSchema {
     let mut props = SchemaProperties::new();
     props.insert(
@@ -724,6 +812,7 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
     object_schema(props, vec!["path".to_string(), "edits".to_string()])
 }
 
+#[cfg(feature = "workspace-edit-file")]
 pub fn create_edit_file_tool() -> MCPTool {
     MCPTool {
         name: "editFile".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -7,17 +7,10 @@ use crate::mcp::{
 #[cfg(feature = "workspace-edit-file")]
 use crate::mcp::schema::JSONSchema;
 
-use super::super::edit_mode::PRIMARY_EDIT_TOOL;
-
-#[cfg(feature = "workspace-edit-file")]
-fn read_file_edit_hint() -> &'static str {
-    "Use showLineAnchors=true when you need anchors for editFile."
-}
-
-#[cfg(feature = "workspace-str-replace")]
-fn read_file_edit_hint() -> &'static str {
-    "Read files before strReplace so old_string matches the on-disk content exactly."
-}
+use super::super::edit_mode::{
+    read_file_show_line_anchors_schema_hint, read_file_tool_hint,
+    search_show_line_anchors_schema_hint, PRIMARY_EDIT_TOOL,
+};
 
 // Note: maximum file size is enforced at runtime (LIBRAGENT_MAX_FILE_SIZE).
 // The input schema cannot call runtime functions; therefore `content` has no hard cap here.
@@ -51,9 +44,7 @@ pub fn create_read_file_tool() -> MCPTool {
     );
     props.insert(
         "showLineAnchors".to_string(),
-        boolean_prop(Some(
-            "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. Here '42' is the line number and 'a31f2c' is the anchor. For edit tools, pass only the 6-character anchor (for example 'a31f2c'), not '42:a31f2c' or the trailing '|...'.",
-        )),
+        boolean_prop(Some(read_file_show_line_anchors_schema_hint())),
     );
 
     MCPTool {
@@ -61,7 +52,7 @@ pub fn create_read_file_tool() -> MCPTool {
         title: Some("Read File".to_string()),
         description: format!(
             "Read the contents of a file. Supports reading from a specific offset and line count (size), including negative size for tailing the end of the file. Large responses are chunked automatically to stay inline. {}",
-            read_file_edit_hint()
+            read_file_tool_hint()
         ),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -249,9 +240,7 @@ pub fn create_search_tool() -> MCPTool {
     );
     props.insert(
         "showLineAnchors".to_string(),
-        boolean_prop(Some(
-            "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c').",
-        )),
+        boolean_prop(Some(search_show_line_anchors_schema_hint())),
     );
 
     MCPTool {

--- a/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
@@ -7,17 +7,26 @@ pub mod terminal_tools;
 use crate::mcp::MCPTool;
 
 pub fn file_tools() -> Vec<MCPTool> {
-    vec![
+    let mut tools = vec![
         file_tools::create_read_file_tool(),
         file_tools::create_write_file_tool(),
         file_tools::create_list_directory_tool(),
         file_tools::create_import_files_tool(),
         file_tools::create_search_tool(),
-        // editFile is the single model-facing mutation tool.
+    ];
+
+    #[cfg(feature = "workspace-str-replace")]
+    tools.push(file_tools::create_str_replace_tool());
+
+    #[cfg(feature = "workspace-edit-file")]
+    {
+        // editFile is the single model-facing mutation tool when line+anchor edits are enabled.
         // Per-operation aliases remain dispatchable for older clients, but are hidden from
         // discovery so the agent only plans against one contract.
-        file_tools::create_edit_file_tool(),
-    ]
+        tools.push(file_tools::create_edit_file_tool());
+    }
+
+    tools
 }
 
 #[allow(clippy::vec_init_then_push)]

--- a/src-tauri/src/session/workspace_override.rs
+++ b/src-tauri/src/session/workspace_override.rs
@@ -186,8 +186,7 @@ fn create_symlink_or_junction(target: &Path, link: &Path) -> std::io::Result<()>
         if output.status.success() {
             Ok(())
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 String::from_utf8_lossy(&output.stderr).into_owned(),
             ))
         }

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -127,7 +127,7 @@ pub mod workspace_list_directory_regression_tests;
 pub mod workspace_local_file_scope_tests;
 pub mod workspace_override_hydration_tests;
 pub mod workspace_override_validation_tests;
-pub mod workspace_str_replace_tests;
 pub mod workspace_search_tests;
 pub mod workspace_skill_access_regression_tests;
+pub mod workspace_str_replace_tests;
 pub mod zip_extraction_security_test;

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -127,6 +127,7 @@ pub mod workspace_list_directory_regression_tests;
 pub mod workspace_local_file_scope_tests;
 pub mod workspace_override_hydration_tests;
 pub mod workspace_override_validation_tests;
+pub mod workspace_str_replace_tests;
 pub mod workspace_search_tests;
 pub mod workspace_skill_access_regression_tests;
 pub mod zip_extraction_security_test;

--- a/src-tauri/tests/integration/read_file_chunking_tests.rs
+++ b/src-tauri/tests/integration/read_file_chunking_tests.rs
@@ -206,6 +206,7 @@ async fn read_file_empty_file_preserves_standard_success_shape() {
     assert_eq!(structured["nextLineTooLarge"], json!(false));
 }
 
+#[cfg(feature = "workspace-edit-file")]
 #[tokio::test]
 async fn read_file_with_anchors_uses_more_conservative_line_budget() {
     let temp_dir = tempdir().expect("temp dir");
@@ -235,7 +236,8 @@ async fn read_file_with_anchors_uses_more_conservative_line_budget() {
     );
     assert!(
         text.contains(
-            tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::read_file_anchor_output_suffix()
+            tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::read_file_anchor_output_suffix(
+            )
         ),
         "anchored response should include mode-specific anchor guidance: {text}"
     );
@@ -288,6 +290,7 @@ async fn read_file_guides_single_line_retry_when_next_line_is_too_large() {
         text.contains("Do not rerun readFile on a broader range"),
         "response should warn against repeating a too-broad read: {text}"
     );
+    #[cfg(feature = "workspace-edit-file")]
     assert!(
         text.contains("rerun the same 1-line range without showLineAnchors"),
         "anchored retry guidance should mention dropping anchors if needed: {text}"

--- a/src-tauri/tests/integration/read_file_chunking_tests.rs
+++ b/src-tauri/tests/integration/read_file_chunking_tests.rs
@@ -74,9 +74,12 @@ async fn read_file_truncates_large_output_and_guides_next_chunk() {
     );
     assert!(
         text.contains(
-            "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors"
+            tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::read_file_primary_next_action(
+                false
+            )
+            .as_str()
         ),
-        "plain readFile should keep anchor guidance optional instead of sounding mandatory: {text}"
+        "plain readFile should keep edit planning guidance optional instead of sounding mandatory: {text}"
     );
     assert!(
         !text.contains("line truncated to fit inline limit"),
@@ -231,8 +234,10 @@ async fn read_file_with_anchors_uses_more_conservative_line_budget() {
         "anchored response should keep anchor guidance: {text}"
     );
     assert!(
-        text.contains("Do not pass `1:792c6f`"),
-        "anchored response should clarify that only the 6-character anchor is valid: {text}"
+        text.contains(
+            tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::read_file_anchor_output_suffix()
+        ),
+        "anchored response should include mode-specific anchor guidance: {text}"
     );
     assert!(
         !text.contains("line truncated to fit inline limit"),

--- a/src-tauri/tests/integration/tool_schema_property_order_tests.rs
+++ b/src-tauri/tests/integration/tool_schema_property_order_tests.rs
@@ -152,6 +152,7 @@ fn start_session_schema_property_order_puts_task_last() {
     );
 }
 
+#[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_line_variant_property_order_puts_content_last() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
@@ -175,6 +176,7 @@ fn edit_file_line_variant_property_order_puts_content_last() {
     );
 }
 
+#[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_prepend_variant_property_order_puts_content_last() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
@@ -187,6 +189,7 @@ fn edit_file_prepend_variant_property_order_puts_content_last() {
     assert_eq!(keys, vec!["startLine".to_string(), "content".to_string()]);
 }
 
+#[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_insert_after_variant_property_order_puts_content_last() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
@@ -206,5 +209,17 @@ fn edit_file_insert_after_variant_property_order_puts_content_last() {
             "endAnchor".to_string(),
             "content".to_string(),
         ]
+    );
+}
+
+#[cfg(feature = "workspace-str-replace")]
+#[test]
+fn str_replace_schema_property_order_puts_text_fields_last() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_str_replace_tool;
+
+    let tool = create_str_replace_tool();
+    assert_property_order(
+        &tool,
+        &["path", "replace_all", "old_string", "new_string"],
     );
 }

--- a/src-tauri/tests/integration/tool_schema_property_order_tests.rs
+++ b/src-tauri/tests/integration/tool_schema_property_order_tests.rs
@@ -218,8 +218,5 @@ fn str_replace_schema_property_order_puts_text_fields_last() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_str_replace_tool;
 
     let tool = create_str_replace_tool();
-    assert_property_order(
-        &tool,
-        &["path", "replace_all", "old_string", "new_string"],
-    );
+    assert_property_order(&tool, &["path", "replace_all", "old_string", "new_string"]);
 }

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "workspace-edit-file")]
+
 use serde_json::json;
 use std::sync::Arc;
 use tauri_mcp_agent_lib::mcp::builtin::workspace::file_operations::utils::format_as_hashlines;

--- a/src-tauri/tests/integration/workspace_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_search_tests.rs
@@ -848,8 +848,9 @@ async fn write_file_create_redirects_to_suffixed_path_when_target_exists() {
         "response must teach overwrite for intentional replace: {text}"
     );
     assert!(
-        text.contains("editFile"),
-        "response must mention editFile for in-place edits: {text}"
+        text.contains(tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL),
+        "response must mention {} for in-place edits: {text}",
+        tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
     );
     assert!(
         text.contains("IMPORTANT:") || text.contains("Continue with"),

--- a/src-tauri/tests/integration/workspace_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_search_tests.rs
@@ -940,10 +940,22 @@ async fn write_file_append_returns_updated_anchors_without_forcing_followup_read
         text.contains("Append is verbatim"),
         "append response should explain newline behavior: {text}"
     );
+    #[cfg(feature = "workspace-edit-file")]
     assert!(
         text.contains("1:") && text.contains("2:"),
         "append response should include current anchored lines for immediate follow-up edits: {text}"
     );
+    #[cfg(feature = "workspace-str-replace")]
+    {
+        assert!(
+            text.contains("alpha") && text.contains("beta"),
+            "append response should include raw file preview for strReplace builds: {text}"
+        );
+        assert!(
+            !text.contains("Current anchors"),
+            "strReplace builds should not label preview as anchors: {text}"
+        );
+    }
     assert!(
         !text.contains("Use `readFile` to see the full content including the appended part."),
         "append response should not force a follow-up read just to inspect the result: {text}"
@@ -985,9 +997,15 @@ async fn write_file_append_truncation_keeps_appended_tail_visible() {
         text.contains("fresh-tail-line"),
         "truncated append response should include the appended line in the preview: {text}"
     );
+    #[cfg(feature = "workspace-edit-file")]
     assert!(
         text.contains("\n42:") && !text.contains("\n1:"),
         "truncated append response should keep the tail window instead of restarting from line 1: {text}"
+    );
+    #[cfg(feature = "workspace-str-replace")]
+    assert!(
+        text.contains("line-42") && text.contains("```\nline-42"),
+        "truncated append preview should start at the tail window, not line 1: {text}"
     );
 }
 

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -50,7 +50,10 @@ async fn str_replace_replaces_single_unique_match() {
         .await
         .expect("strReplace should return");
 
-    assert!(!result.is_error.unwrap_or(true), "expected success: {result:?}");
+    assert!(
+        !result.is_error.unwrap_or(true),
+        "expected success: {result:?}"
+    );
     let text = extract_text_content(&result);
     assert!(text.contains("Replaced 1 occurrence"), "{text}");
 
@@ -81,7 +84,10 @@ async fn str_replace_rejects_ambiguous_match_without_replace_all() {
         .await
         .expect("strReplace should return");
 
-    assert!(result.is_error.unwrap_or(false), "expected error: {result:?}");
+    assert!(
+        result.is_error.unwrap_or(false),
+        "expected error: {result:?}"
+    );
     let text = extract_text_content(&result);
     assert!(text.contains("matched 3 times"), "{text}");
     assert_eq!(std::fs::read_to_string(file_path).unwrap(), "foo foo foo\n");
@@ -111,7 +117,10 @@ async fn str_replace_replace_all_updates_every_match() {
         .await
         .expect("strReplace should return");
 
-    assert!(!result.is_error.unwrap_or(true), "expected success: {result:?}");
+    assert!(
+        !result.is_error.unwrap_or(true),
+        "expected success: {result:?}"
+    );
     assert_eq!(std::fs::read_to_string(file_path).unwrap(), "bar bar bar\n");
 }
 
@@ -138,7 +147,10 @@ async fn str_replace_rejects_missing_old_string() {
         .await
         .expect("strReplace should return");
 
-    assert!(result.is_error.unwrap_or(false), "expected error: {result:?}");
+    assert!(
+        result.is_error.unwrap_or(false),
+        "expected error: {result:?}"
+    );
     let text = extract_text_content(&result);
     assert!(text.contains("old_string was not found"), "{text}");
 }
@@ -147,10 +159,7 @@ async fn str_replace_rejects_missing_old_string() {
 async fn workspace_file_tools_expose_str_replace_not_edit_file() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools;
 
-    let names: Vec<String> = file_tools()
-        .into_iter()
-        .map(|tool| tool.name)
-        .collect();
+    let names: Vec<String> = file_tools().into_iter().map(|tool| tool.name).collect();
 
     assert!(names.contains(&"strReplace".to_string()), "{names:?}");
     assert!(!names.contains(&"editFile".to_string()), "{names:?}");
@@ -181,5 +190,83 @@ async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
     assert!(
         !text.contains("editFile"),
         "readFile hint should not mention editFile on strReplace builds: {text}"
+    );
+}
+
+#[tokio::test]
+async fn read_file_and_search_schemas_omit_show_line_anchors() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::{
+        create_read_file_tool, create_search_tool,
+    };
+
+    let read_schema = serde_json::to_value(create_read_file_tool().input_schema)
+        .expect("serialize readFile schema");
+    let search_schema = serde_json::to_value(create_search_tool().input_schema)
+        .expect("serialize searchFiles schema");
+    let read_props = read_schema["properties"]
+        .as_object()
+        .expect("readFile properties");
+    let search_props = search_schema["properties"]
+        .as_object()
+        .expect("searchFiles properties");
+
+    assert!(
+        !read_props.contains_key("showLineAnchors"),
+        "readFile schema should not expose showLineAnchors on strReplace builds"
+    );
+    assert!(
+        !search_props.contains_key("showLineAnchors"),
+        "searchFiles schema should not expose showLineAnchors on strReplace builds"
+    );
+}
+
+#[tokio::test]
+async fn write_file_append_preview_uses_raw_content_without_anchors() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "write-append-raw-preview";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    server
+        .call_tool(
+            "writeFile",
+            json!({
+                "path": "notes.txt",
+                "content": "alpha\n",
+                "mode": "create",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("create should succeed");
+
+    let result = server
+        .call_tool(
+            "writeFile",
+            json!({
+                "path": "notes.txt",
+                "content": "beta\n",
+                "mode": "append",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("append should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("alpha"),
+        "preview should show file content: {text}"
+    );
+    assert!(
+        text.contains("beta"),
+        "preview should show appended line: {text}"
+    );
+    assert!(
+        !text.contains("Current anchors"),
+        "strReplace builds must not mention anchors in writeFile preview: {text}"
+    );
+    assert!(
+        !text.contains('|'),
+        "preview should be raw lines without anchor pipe separators: {text}"
     );
 }

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -155,3 +155,31 @@ async fn workspace_file_tools_expose_str_replace_not_edit_file() {
     assert!(names.contains(&"strReplace".to_string()), "{names:?}");
     assert!(!names.contains(&"editFile".to_string()), "{names:?}");
 }
+
+#[tokio::test]
+async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-hint-str-replace";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+    std::fs::write(workspace_dir.join("hint.txt"), "hello\n").expect("seed");
+
+    let result = server
+        .call_tool(
+            "readFile",
+            json!({ "path": "hint.txt" }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("readFile should return");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("strReplace"),
+        "readFile hint should mention strReplace: {text}"
+    );
+    assert!(
+        !text.contains("editFile"),
+        "readFile hint should not mention editFile on strReplace builds: {text}"
+    );
+}

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -1,0 +1,157 @@
+#![cfg(feature = "workspace-str-replace")]
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tempfile::tempdir;
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+#[tokio::test]
+async fn str_replace_replaces_single_unique_match() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "str-replace-single";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let workspace_dir = server.get_workspace_dir(session_id);
+    let file_path = workspace_dir.join("demo.txt");
+    std::fs::write(&file_path, "alpha\nbeta\ngamma\n").expect("seed file");
+
+    let result = server
+        .call_tool(
+            "strReplace",
+            json!({
+                "path": "demo.txt",
+                "old_string": "beta",
+                "new_string": "BETA"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("strReplace should return");
+
+    assert!(!result.is_error.unwrap_or(true), "expected success: {result:?}");
+    let text = extract_text_content(&result);
+    assert!(text.contains("Replaced 1 occurrence"), "{text}");
+
+    let updated = std::fs::read_to_string(file_path).expect("read updated file");
+    assert_eq!(updated, "alpha\nBETA\ngamma\n");
+}
+
+#[tokio::test]
+async fn str_replace_rejects_ambiguous_match_without_replace_all() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "str-replace-ambiguous";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let workspace_dir = server.get_workspace_dir(session_id);
+    let file_path = workspace_dir.join("dup.txt");
+    std::fs::write(&file_path, "foo foo foo\n").expect("seed file");
+
+    let result = server
+        .call_tool(
+            "strReplace",
+            json!({
+                "path": "dup.txt",
+                "old_string": "foo",
+                "new_string": "bar"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("strReplace should return");
+
+    assert!(result.is_error.unwrap_or(false), "expected error: {result:?}");
+    let text = extract_text_content(&result);
+    assert!(text.contains("matched 3 times"), "{text}");
+    assert_eq!(std::fs::read_to_string(file_path).unwrap(), "foo foo foo\n");
+}
+
+#[tokio::test]
+async fn str_replace_replace_all_updates_every_match() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "str-replace-all";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let workspace_dir = server.get_workspace_dir(session_id);
+    let file_path = workspace_dir.join("all.txt");
+    std::fs::write(&file_path, "foo foo foo\n").expect("seed file");
+
+    let result = server
+        .call_tool(
+            "strReplace",
+            json!({
+                "path": "all.txt",
+                "old_string": "foo",
+                "new_string": "bar",
+                "replace_all": true
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("strReplace should return");
+
+    assert!(!result.is_error.unwrap_or(true), "expected success: {result:?}");
+    assert_eq!(std::fs::read_to_string(file_path).unwrap(), "bar bar bar\n");
+}
+
+#[tokio::test]
+async fn str_replace_rejects_missing_old_string() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "str-replace-missing";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let workspace_dir = server.get_workspace_dir(session_id);
+    let file_path = workspace_dir.join("missing.txt");
+    std::fs::write(&file_path, "hello world\n").expect("seed file");
+
+    let result = server
+        .call_tool(
+            "strReplace",
+            json!({
+                "path": "missing.txt",
+                "old_string": "goodbye",
+                "new_string": "hi"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("strReplace should return");
+
+    assert!(result.is_error.unwrap_or(false), "expected error: {result:?}");
+    let text = extract_text_content(&result);
+    assert!(text.contains("old_string was not found"), "{text}");
+}
+
+#[tokio::test]
+async fn workspace_file_tools_expose_str_replace_not_edit_file() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools;
+
+    let names: Vec<String> = file_tools()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
+
+    assert!(names.contains(&"strReplace".to_string()), "{names:?}");
+    assert!(!names.contains(&"editFile".to_string()), "{names:?}");
+}

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,8 +23,7 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName =
-  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
+export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -49,7 +48,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
+export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,7 +5,11 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
+export const EXECUTION_MODE_VALUES = [
+  'normal',
+  'yolo',
+  'unsafe',
+] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
## Summary

- Add `strReplace` as the default workspace file mutation tool (`workspace-str-replace` Cargo feature) and gate `editFile` behind `workspace-edit-file` for compile-time selection.
- Introduce `edit_mode.rs` to centralize mode-specific hints and tool copy for `readFile`, `searchFiles`, `writeFile`, workspace context, and error guidance so strReplace builds no longer mention `editFile`.
- Add integration tests for `strReplace` behavior (unique match, ambiguous match, `replace_all`) and hint consistency; keep existing `editFile` tests feature-gated.

## Test plan

- [x] `cargo test --test integration_tests workspace_str_replace` (6 tests)
- [x] `cargo test --test integration_tests read_file_chunking` (8 tests)
- [ ] `cargo test --test integration_tests --features workspace-edit-file workspace_hash_anchor` (edit-file regression)
- [ ] Manual agent session: readFile → strReplace on a real file edit task


Made with [Cursor](https://cursor.com)