### PR TITLE
fix(app_setup): harden skills manifest atomic writes (#1552)

### DIFF
--- a/.agents/skills/extract-log-debug/references/log_patterns.md
+++ b/.agents/skills/extract-log-debug/references/log_patterns.md
@@ -63,7 +63,9 @@
 - `WorkspaceServer` - Workspace server logs
 - `readFile` / `writeFile` / `editFile` - File operations
 - `listFiles` - Directory listing
-- `searchFiles` - File search
+- `globFiles` - Find files by glob pattern
+- `grepFiles` - Search file contents with regex
+- `searchFiles` - Legacy combined search (dispatch only)
 
 #### Knowledge Base
 

--- a/.agents/skills/setup-wizard/SKILL.md
+++ b/.agents/skills/setup-wizard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-wizard
-description: Use when the user needs to diagnose and install runtime environment dependencies (Python, Node.js, etc.) for running LibrAgent. LibrAgent 실행에 필요한 Python, Node.js 등의 환경을 자동으로 진단하고 설치하도록 안내하는 마법사입니다.
+description: Use when the user needs to diagnose and install runtime environment dependencies (Python, Node.js, uv) for running LibrAgent or MCP servers. Use on new machines, MCP "command not found" errors, or missing Python/Node runtime failures. LibrAgent 실행에 필요한 Python, Node.js 등의 환경을 자동으로 진단하고 설치하도록 안내하는 마법사입니다.
 license: Complete terms in LICENSE.txt
 ---
 
@@ -8,18 +8,18 @@ license: Complete terms in LICENSE.txt
 
 Automated installation and verification of MCP runtime dependencies.
 
-## When to Use
+## Path conventions
 
-- User reports MCP server failures due to missing runtimes
-- Setting up LibrAgent on a new machine
-- Troubleshooting "command not found" or "python/node not installed" errors
-- Verifying system readiness for MCP operations
+Paths in this skill are relative to this skill's Base Directory. Replace `<skill-base-dir>` with its absolute path in commands.
 
-## Quick Start
+## Workflow
 
-### Check Current Installation
+1. **Detect OS** — identify platform via terminal
+2. **Check installations** — run verification commands below
+3. **Install missing components** — use platform scripts or [installation-guide.md](references/installation-guide.md)
+4. **Verify** — run `verify_setup` script or manual checks; confirm Python 3.11+, Node 18+, uv available
 
-Use platform detection and verification commands:
+## Quick Verification
 
 **Windows (PowerShell):**
 
@@ -29,7 +29,7 @@ Get-Command node -ErrorAction SilentlyContinue
 Get-Command uv -ErrorAction SilentlyContinue
 ```
 
-**Linux/macOS (Bash):**
+**Linux/macOS:**
 
 ```bash
 which python3 && python3 --version
@@ -37,174 +37,34 @@ which node && node --version
 which uv && uv --version
 ```
 
-### Installation Strategy
+Report what is missing, then load only the relevant section from the installation guide.
 
-1. **Detect OS** - Use `run_in_terminal` to identify platform
-2. **Check existing installations** - Verify versions and PATH configuration
-3. **Install missing components** - Follow OS-specific installation guides
-4. **Verify installation** - Confirm executables are accessible
+## Automated Scripts
 
-## Installation Guides
-
-### Python Installation
-
-**Windows:**
-
-- Use Microsoft Store: `winget install Python.Python.3.12`
-- Or download from python.org (ensure "Add to PATH" is checked)
-- Verify: `python --version`
-
-**Linux:**
-
-```bash
-# Ubuntu/Debian
-sudo apt update && sudo apt install python3 python3-pip python3-venv
-
-# Fedora/RHEL
-sudo dnf install python3 python3-pip
-
-# Arch Linux
-sudo pacman -S python python-pip
-```
-
-**macOS:**
-
-```bash
-# Using Homebrew (recommended)
-brew install python3
-
-# Or use system Python (macOS 12.3+)
-python3 --version
-```
-
-### Node.js Installation
-
-**Windows:**
+Prefer scripts when the user wants hands-off install:
 
 ```powershell
-# Using winget
-winget install OpenJS.NodeJS.LTS
-
-# Or download from nodejs.org
+# Windows examples
+& "<skill-base-dir>/scripts/verify_setup.ps1"
+& "<skill-base-dir>/scripts/install_python.ps1"
+& "<skill-base-dir>/scripts/install_node.ps1"
+& "<skill-base-dir>/scripts/install_uv.ps1"
 ```
-
-**Linux:**
 
 ```bash
-# Ubuntu/Debian (NodeSource)
-curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-sudo apt-get install -y nodejs
-
-# Fedora/RHEL
-sudo dnf install nodejs npm
-
-# Arch Linux
-sudo pacman -S nodejs npm
-```
-
-**macOS:**
-
-```bash
-# Using Homebrew
-brew install node
-```
-
-### uv Installation
-
-**All Platforms:**
-
-```bash
-# Using pip (after Python is installed)
-pip install uv
-
-# Or using pipx (recommended for isolated installation)
-pip install pipx
-pipx install uv
-```
-
-**Windows PowerShell (standalone):**
-
-```powershell
-irm https://astral.sh/uv/install.ps1 | iex
-```
-
-**Linux/macOS (standalone):**
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-## Verification
-
-After installation, verify all components:
-
-```bash
-# Python
-python --version  # or python3 --version
-pip --version
-
-# Node.js
-node --version
-npm --version
-
-# uv
-uv --version
-```
-
-Expected output format:
-
-- Python: `Python 3.11+`
-- Node: `v18.0.0+`
-- uv: `0.1.0+`
-
-## Common Issues
-
-### PATH Not Updated
-
-**Symptoms:** `command not found` after installation
-
-**Solutions:**
-
-- **Windows:** Restart terminal or reboot system
-- **Linux/macOS:** Run `source ~/.bashrc` or `source ~/.zshrc`
-- Manually add to PATH if needed (see [PATH_CONFIG.md](references/PATH_CONFIG.md))
-
-### Python vs Python3
-
-**Linux/macOS:** Use `python3` and `pip3` explicitly
-**Windows:** Usually aliased to `python` and `pip`
-
-### Permission Issues
-
-**Linux/macOS:** Use `sudo` for system-wide installation or pipx/venv for user-local
-**Windows:** Run terminal as Administrator if needed
-
-### Multiple Python Versions
-
-Use virtual environments to isolate dependencies:
-
-```bash
-python -m venv mcp_env
-source mcp_env/bin/activate  # Linux/macOS
-.\mcp_env\Scripts\activate   # Windows
+# Linux/macOS examples
+bash "<skill-base-dir>/scripts/verify_setup.sh"
+bash "<skill-base-dir>/scripts/install_python.sh"
+bash "<skill-base-dir>/scripts/install_node.sh"
+bash "<skill-base-dir>/scripts/install_uv.sh"
 ```
 
 ## Advanced Topics
 
-- **PATH Configuration:** [PATH_CONFIG.md](references/PATH_CONFIG.md)
-- **Virtual Environments:** [VENV_GUIDE.md](references/VENV_GUIDE.md)
-- **Offline Installation:** [OFFLINE_INSTALL.md](references/OFFLINE_INSTALL.md)
-
-## Scripts
-
-Automated installation scripts are available in `scripts/`:
-
-- `install_python.ps1` / `install_python.sh` - Python installation
-- `install_node.ps1` / `install_node.sh` - Node.js installation
-- `install_uv.ps1` / `install_uv.sh` - uv installation
-- `verify_setup.ps1` / `verify_setup.sh` - Comprehensive verification
-
-Execute scripts based on user's platform and permission level.
+- **PATH configuration:** [PATH_CONFIG.md](references/PATH_CONFIG.md)
+- **Virtual environments:** [VENV_GUIDE.md](references/VENV_GUIDE.md)
+- **Offline installation:** [OFFLINE_INSTALL.md](references/OFFLINE_INSTALL.md)
+- **OS-specific commands:** [installation-guide.md](references/installation-guide.md)
 
 ## Integration with LibrAgent
 
@@ -214,4 +74,4 @@ LibrAgent MCP servers require:
 - **Node.js 18+** for TypeScript-based MCP servers
 - **uv** for fast Python dependency management
 
-Check `src-tauri/src/mcp/server_manager.rs` for runtime detection logic.
+After setup, re-run the verification script before retrying failed MCP servers.

--- a/.agents/skills/setup-wizard/references/installation-guide.md
+++ b/.agents/skills/setup-wizard/references/installation-guide.md
@@ -1,0 +1,118 @@
+# Installation Guide
+
+## Python
+
+**Windows:**
+
+```powershell
+winget install Python.Python.3.12
+# Verify: python --version (ensure "Add to PATH" if installing from python.org)
+```
+
+**Linux:**
+
+```bash
+# Ubuntu/Debian
+sudo apt update && sudo apt install python3 python3-pip python3-venv
+# Fedora/RHEL: sudo dnf install python3 python3-pip
+# Arch: sudo pacman -S python python-pip
+```
+
+**macOS:**
+
+```bash
+brew install python3
+# Or use system Python (macOS 12.3+): python3 --version
+```
+
+## Node.js
+
+**Windows:**
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+**Linux:**
+
+```bash
+# Ubuntu/Debian (NodeSource)
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt-get install -y nodejs
+# Fedora/RHEL: sudo dnf install nodejs npm
+# Arch: sudo pacman -S nodejs npm
+```
+
+**macOS:**
+
+```bash
+brew install node
+```
+
+## uv
+
+**pip (after Python):**
+
+```bash
+pip install uv
+# Or isolated: pip install pipx && pipx install uv
+```
+
+**Windows PowerShell (standalone):**
+
+```powershell
+irm https://astral.sh/uv/install.ps1 | iex
+```
+
+**Linux/macOS (standalone):**
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## Verification
+
+```bash
+python --version   # or python3
+pip --version
+node --version
+npm --version
+uv --version
+```
+
+Expected: Python 3.11+, Node v18+, uv 0.1.0+
+
+## Common Issues
+
+### PATH not updated
+
+- **Windows**: restart terminal or reboot
+- **Linux/macOS**: `source ~/.bashrc` or `source ~/.zshrc`
+
+### Python vs python3
+
+Linux/macOS: prefer `python3` / `pip3`. Windows: usually `python` / `pip`.
+
+### Permission issues
+
+Linux/macOS: `sudo` for system-wide, or pipx/venv for user-local. Windows: Administrator if needed.
+
+### Multiple Python versions
+
+```bash
+python -m venv mcp_env
+source mcp_env/bin/activate   # Linux/macOS
+.\mcp_env\Scripts\activate    # Windows
+```
+
+## Advanced
+
+- PATH configuration: see PATH_CONFIG.md (if present in skill bundle)
+- Virtual environments: VENV_GUIDE.md
+- Offline installation: OFFLINE_INSTALL.md
+
+## LibrAgent Requirements
+
+- Python 3.11+ for Python-based MCP servers
+- Node.js 18+ for TypeScript-based MCP servers
+- uv for fast Python dependency management

--- a/.agents/skills/skill-creator/scripts/init_skill.py
+++ b/.agents/skills/skill-creator/scripts/init_skill.py
@@ -14,6 +14,8 @@ Examples:
 import sys
 from pathlib import Path
 
+from io_utils import configure_stdio, write_text
+
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
@@ -207,15 +209,15 @@ def init_skill(skill_name, path):
 
     # Check if directory already exists
     if skill_dir.exists():
-        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        print(f"[ERROR] Skill directory already exists: {skill_dir}")
         return None
 
     # Create skill directory
     try:
         skill_dir.mkdir(parents=True, exist_ok=False)
-        print(f"✅ Created skill directory: {skill_dir}")
+        print(f"[OK] Created skill directory: {skill_dir}")
     except Exception as e:
-        print(f"❌ Error creating directory: {e}")
+        print(f"[ERROR] Error creating directory: {e}")
         return None
 
     # Create SKILL.md from template
@@ -225,12 +227,12 @@ def init_skill(skill_name, path):
         skill_title=skill_title
     )
 
-    skill_md_path = skill_dir / 'SKILL.md'
+    skill_md_path = skill_dir / "SKILL.md"
     try:
-        skill_md_path.write_text(skill_content)
-        print("✅ Created SKILL.md")
+        write_text(skill_md_path, skill_content)
+        print("[OK] Created SKILL.md")
     except Exception as e:
-        print(f"❌ Error creating SKILL.md: {e}")
+        print(f"[ERROR] Error creating SKILL.md: {e}")
         return None
 
     # Create resource directories with example files
@@ -238,30 +240,30 @@ def init_skill(skill_name, path):
         # Create scripts/ directory with example script
         scripts_dir = skill_dir / 'scripts'
         scripts_dir.mkdir(exist_ok=True)
-        example_script = scripts_dir / 'example.py'
-        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script = scripts_dir / "example.py"
+        write_text(example_script, EXAMPLE_SCRIPT.format(skill_name=skill_name))
         example_script.chmod(0o755)
-        print("✅ Created scripts/example.py")
+        print("[OK] Created scripts/example.py")
 
         # Create references/ directory with example reference doc
-        references_dir = skill_dir / 'references'
+        references_dir = skill_dir / "references"
         references_dir.mkdir(exist_ok=True)
-        example_reference = references_dir / 'api_reference.md'
-        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
-        print("✅ Created references/api_reference.md")
+        example_reference = references_dir / "api_reference.md"
+        write_text(example_reference, EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("[OK] Created references/api_reference.md")
 
         # Create assets/ directory with example asset placeholder
-        assets_dir = skill_dir / 'assets'
+        assets_dir = skill_dir / "assets"
         assets_dir.mkdir(exist_ok=True)
-        example_asset = assets_dir / 'example_asset.txt'
-        example_asset.write_text(EXAMPLE_ASSET)
-        print("✅ Created assets/example_asset.txt")
+        example_asset = assets_dir / "example_asset.txt"
+        write_text(example_asset, EXAMPLE_ASSET)
+        print("[OK] Created assets/example_asset.txt")
     except Exception as e:
-        print(f"❌ Error creating resource directories: {e}")
+        print(f"[ERROR] Error creating resource directories: {e}")
         return None
 
     # Print next steps
-    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print(f"\n[OK] Skill '{skill_name}' initialized successfully at {skill_dir}")
     print("\nNext steps:")
     print("1. Edit SKILL.md to complete the TODO items and update the description")
     print("2. Customize or delete the example files in scripts/, references/, and assets/")
@@ -271,7 +273,8 @@ def init_skill(skill_name, path):
 
 
 def main():
-    if len(sys.argv) < 4 or sys.argv[2] != '--path':
+    configure_stdio()
+    if len(sys.argv) < 4 or sys.argv[2] != "--path":
         print("Usage: init_skill.py <skill-name> --path <path>")
         print("\nSkill name requirements:")
         print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
@@ -287,8 +290,8 @@ def main():
     skill_name = sys.argv[1]
     path = sys.argv[3]
 
-    print(f"🚀 Initializing skill: {skill_name}")
-    print(f"   Location: {path}")
+    print(f"Initializing skill: {skill_name}")
+    print(f"Location: {path}")
     print()
 
     result = init_skill(skill_name, path)

--- a/.agents/skills/skill-creator/scripts/io_utils.py
+++ b/.agents/skills/skill-creator/scripts/io_utils.py
@@ -1,0 +1,32 @@
+"""Cross-platform UTF-8 helpers for skill-creator scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+UTF8 = "utf-8"
+
+
+def configure_stdio() -> None:
+    """Prefer UTF-8 on stdout/stderr when the stream supports reconfiguration."""
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None:
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding=UTF8, errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
+def read_text(path: Path | str) -> str:
+    """Read a text file as UTF-8."""
+    return Path(path).read_text(encoding=UTF8)
+
+
+def write_text(path: Path | str, content: str) -> None:
+    """Write a text file as UTF-8 with LF newlines."""
+    Path(path).write_text(content, encoding=UTF8, newline="\n")

--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -13,6 +13,8 @@ Example:
 import sys
 import zipfile
 from pathlib import Path
+
+from io_utils import configure_stdio
 from validate_skill import validate_skill_full as validate_skill
 
 
@@ -31,27 +33,27 @@ def package_skill(skill_path, output_dir=None):
 
     # Validate skill folder exists
     if not skill_path.exists():
-        print(f"❌ Error: Skill folder not found: {skill_path}")
+        print(f"[ERROR] Skill folder not found: {skill_path}")
         return None
 
     if not skill_path.is_dir():
-        print(f"❌ Error: Path is not a directory: {skill_path}")
+        print(f"[ERROR] Path is not a directory: {skill_path}")
         return None
 
     # Validate SKILL.md exists
     skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
-        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        print(f"[ERROR] SKILL.md not found in {skill_path}")
         return None
 
     # Run validation before packaging
-    print("🔍 Validating skill...")
+    print("Validating skill...")
     valid, message = validate_skill(skill_path)
     if not valid:
-        print(f"❌ Validation failed: {message}")
-        print("   Please fix the validation errors before packaging.")
+        print(f"[ERROR] Validation failed: {message}")
+        print("Please fix the validation errors before packaging.")
         return None
-    print(f"✅ {message}\n")
+    print(f"[OK] {message}\n")
 
     # Determine output location
     skill_name = skill_path.name
@@ -65,24 +67,25 @@ def package_skill(skill_path, output_dir=None):
 
     # Create the .skill file (zip format)
     try:
-        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
             # Walk through the skill directory
-            for file_path in skill_path.rglob('*'):
+            for file_path in skill_path.rglob("*"):
                 if file_path.is_file():
                     # Calculate the relative path within the zip
                     arcname = file_path.relative_to(skill_path.parent)
                     zipf.write(file_path, arcname)
                     print(f"  Added: {arcname}")
 
-        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        print(f"\n[OK] Successfully packaged skill to: {skill_filename}")
         return skill_filename
 
     except Exception as e:
-        print(f"❌ Error creating .skill file: {e}")
+        print(f"[ERROR] Error creating .skill file: {e}")
         return None
 
 
 def main():
+    configure_stdio()
     if len(sys.argv) < 2:
         print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
         print("\nExample:")
@@ -93,9 +96,9 @@ def main():
     skill_path = sys.argv[1]
     output_dir = sys.argv[2] if len(sys.argv) > 2 else None
 
-    print(f"📦 Packaging skill: {skill_path}")
+    print(f"Packaging skill: {skill_path}")
     if output_dir:
-        print(f"   Output directory: {output_dir}")
+        print(f"Output directory: {output_dir}")
     print()
 
     result = package_skill(skill_path, output_dir)

--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -3,28 +3,31 @@
 Quick validation script for skills - minimal version
 """
 
-import sys
-import os
 import re
-import yaml
+import sys
 from pathlib import Path
+
+import yaml
+
+from io_utils import configure_stdio, read_text
+
 
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
 
     # Check SKILL.md exists
-    skill_md = skill_path / 'SKILL.md'
+    skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
-    if not content.startswith('---'):
+    content = read_text(skill_md)
+    if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 
     # Extract frontmatter
-    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
 
@@ -39,7 +42,7 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
@@ -50,46 +53,56 @@ def validate_skill(skill_path):
         )
 
     # Check required fields
-    if 'name' not in frontmatter:
+    if "name" not in frontmatter:
         return False, "Missing 'name' in frontmatter"
-    if 'description' not in frontmatter:
+    if "description" not in frontmatter:
         return False, "Missing 'description' in frontmatter"
 
     # Extract name for validation
-    name = frontmatter.get('name', '')
+    name = frontmatter.get("name", "")
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
     if name:
         # Check naming convention (hyphen-case: lowercase with hyphens)
-        if not re.match(r'^[a-z0-9-]+$', name):
-            return False, f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)"
-        if name.startswith('-') or name.endswith('-') or '--' in name:
-            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return False, (
+                f"Name '{name}' should be hyphen-case "
+                "(lowercase letters, digits, and hyphens only)"
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return False, (
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+            )
         # Check name length (max 64 characters per spec)
         if len(name) > 64:
             return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
 
     # Extract and validate description
-    description = frontmatter.get('description', '')
+    description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
     if description:
         # Check for angle brackets
-        if '<' in description or '>' in description:
+        if "<" in description or ">" in description:
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length (max 1024 characters per spec)
         if len(description) > 1024:
-            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+            return False, (
+                f"Description is too long ({len(description)} characters). "
+                "Maximum is 1024 characters."
+            )
 
     return True, "Skill is valid!"
 
+
 if __name__ == "__main__":
+    configure_stdio()
     if len(sys.argv) != 2:
         print("Usage: python quick_validate.py <skill_directory>")
         sys.exit(1)
-    
+
     valid, message = validate_skill(sys.argv[1])
     print(message)
     sys.exit(0 if valid else 1)

--- a/.agents/skills/skill-creator/scripts/validate_skill.py
+++ b/.agents/skills/skill-creator/scripts/validate_skill.py
@@ -4,64 +4,79 @@ Full mechanical validation for skills.
 Covers: frontmatter (via quick_validate) + body semantics.
 """
 
-import sys
 import os
+import re
+import sys
+import urllib.parse
+from pathlib import Path
+
+import yaml
 
 # Ensure the script's directory is in sys.path to resolve quick_validate.py
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import re
-import yaml
-from pathlib import Path
-import urllib.parse
+from io_utils import configure_stdio, read_text
 from quick_validate import validate_skill  # existing frontmatter validation
 
 # Constants
 MAX_BODY_LINES = 500
-FORBIDDEN_FILES = {'README.md', 'CHANGELOG.md', 'INSTALLATION_GUIDE.md',
-                   'QUICK_REFERENCE.md', 'TODO.md', 'CONTRIBUTING.md'}
-TRIGGER_KEYWORDS = ['use when', 'when the user', 'triggers on', 'trigger',
-                    'use this skill', 'should be used']
+FORBIDDEN_FILES = {
+    "README.md",
+    "CHANGELOG.md",
+    "INSTALLATION_GUIDE.md",
+    "QUICK_REFERENCE.md",
+    "TODO.md",
+    "CONTRIBUTING.md",
+}
+TRIGGER_KEYWORDS = [
+    "use when",
+    "when the user",
+    "triggers on",
+    "trigger",
+    "use this skill",
+    "should be used",
+]
+
 
 def validate_skill_full(skill_path):
     """Full mechanical validation: frontmatter + body semantics."""
     skill_path = Path(skill_path).resolve()
-    
+
     # 1. Frontmatter validation (delegates to existing)
     valid, msg = validate_skill(skill_path)
     if not valid:
         return False, msg
-    
+
     # Check SKILL.md exists
-    skill_md = skill_path / 'SKILL.md'
+    skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         return False, "SKILL.md not found"
-        
-    content = skill_md.read_text()
-    
+
+    content = read_text(skill_md)
+
     # 2. Body line count
-    body = content.split('---', 2)[2] if '---' in content else ''
+    body = content.split("---", 2)[2] if "---" in content else ""
     body_lines = len(body.strip().splitlines())
     if body_lines > MAX_BODY_LINES:
         return False, f"SKILL.md body is {body_lines} lines (max {MAX_BODY_LINES})"
-    
+
     # 3. Body not empty
     if not body.strip():
         return False, "SKILL.md body is empty"
-    
+
     # 4. Forbidden files
-    files = {f.name for f in skill_path.rglob('*') if f.is_file()}
+    files = {f.name for f in skill_path.rglob("*") if f.is_file()}
     found_forbidden = files & FORBIDDEN_FILES
     if found_forbidden:
         return False, f"Forbidden files found: {', '.join(sorted(found_forbidden))}"
-    
+
     # 5. References exist (check markdown links, ignoring code blocks)
-    body_no_code = re.sub(r'```[\s\S]*?```', '', body)
-    ref_patterns = re.findall(r'\[.*?\]\(([^)#]+)\)', body_no_code)
+    body_no_code = re.sub(r"```[\s\S]*?```", "", body)
+    ref_patterns = re.findall(r"\[.*?\]\(([^)#]+)\)", body_no_code)
     broken_refs = []
     for ref in ref_patterns:
         # Skip URLs and absolute path or mailto
-        if ref.startswith('http://') or ref.startswith('https://') or ref.startswith('mailto:'):
+        if ref.startswith(("http://", "https://", "mailto:")):
             continue
         # Decode URL-encoded paths
         decoded_ref = urllib.parse.unquote(ref)
@@ -70,61 +85,75 @@ def validate_skill_full(skill_path):
             broken_refs.append(decoded_ref)
     if broken_refs:
         return False, f"Missing referenced files: {', '.join(broken_refs)}"
-    
+
     # 6. Description has trigger keywords
     desc = None
-    fm_match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     if fm_match:
         try:
             fm = yaml.safe_load(fm_match.group(1))
             if isinstance(fm, dict):
-                desc = fm.get('description', '') or ''
+                desc = fm.get("description", "") or ""
         except Exception:
             pass
-    
+
     if desc:
         desc_lower = desc.lower()
         has_trigger = any(kw in desc_lower for kw in TRIGGER_KEYWORDS)
         if not has_trigger:
-            return False, "Description missing trigger keywords (use when, when the user, triggers on, etc.)"
-    
+            return False, (
+                "Description missing trigger keywords "
+                "(use when, when the user, triggers on, etc.)"
+            )
+
     # 7. References >100 lines have TOC
     warnings = []
-    for ref_file in skill_path.rglob('*'):
-        if ref_file.is_file() and ref_file.suffix == '.md' and ref_file.name != 'SKILL.md':
-            ref_content = ref_file.read_text()
+    for ref_file in skill_path.rglob("*"):
+        if ref_file.is_file() and ref_file.suffix == ".md" and ref_file.name != "SKILL.md":
+            ref_content = read_text(ref_file)
             ref_lines = len(ref_content.strip().splitlines())
             if ref_lines > 100:
                 first_50 = ref_content.splitlines()[:50]
-                has_heading_list = any(line.strip().startswith('## ') or line.strip().startswith('- ') for line in first_50)
+                has_heading_list = any(
+                    line.strip().startswith("## ") or line.strip().startswith("- ")
+                    for line in first_50
+                )
                 if not has_heading_list:
-                    warnings.append(f"Warning: Reference file {ref_file.name} is long ({ref_lines} lines) but missing a Table of Contents or summary.")
-    
+                    warnings.append(
+                        f"Warning: Reference file {ref_file.name} is long ({ref_lines} lines) "
+                        "but missing a Table of Contents or summary."
+                    )
+
     # 8. Scripts executable check
-    scripts_dir = skill_path / 'scripts'
+    scripts_dir = skill_path / "scripts"
     if scripts_dir.exists():
         for script in scripts_dir.iterdir():
             if script.is_file():
-                if os.name != 'nt' and not os.access(script, os.X_OK):
+                if os.name != "nt" and not os.access(script, os.X_OK):
                     try:
-                        script_text = script.read_text()
-                        first_line = script_text.splitlines()[0] if script_text else ''
-                        if first_line.startswith('#!'):
-                            warnings.append(f"Warning: Script {script.name} has a shebang but is not executable. Run chmod +x on it.")
+                        script_text = read_text(script)
+                        first_line = script_text.splitlines()[0] if script_text else ""
+                        if first_line.startswith("#!"):
+                            warnings.append(
+                                f"Warning: Script {script.name} has a shebang but is not "
+                                "executable. Run chmod +x on it."
+                            )
                     except Exception:
                         pass
 
     success_msg = "Skill passed full mechanical validation!"
     if warnings:
         success_msg += "\n" + "\n".join(warnings)
-        
+
     return True, success_msg
 
+
 if __name__ == "__main__":
+    configure_stdio()
     if len(sys.argv) < 2:
         print("Usage: python validate_skill.py <skill_directory>")
         sys.exit(1)
-    
+
     valid, message = validate_skill_full(sys.argv[1])
     print(message)
     sys.exit(0 if valid else 1)

--- a/.github/skills/skill-creator/scripts/init_skill.py
+++ b/.github/skills/skill-creator/scripts/init_skill.py
@@ -14,6 +14,8 @@ Examples:
 import sys
 from pathlib import Path
 
+from io_utils import configure_stdio, write_text
+
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
@@ -207,15 +209,15 @@ def init_skill(skill_name, path):
 
     # Check if directory already exists
     if skill_dir.exists():
-        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        print(f"[ERROR] Skill directory already exists: {skill_dir}")
         return None
 
     # Create skill directory
     try:
         skill_dir.mkdir(parents=True, exist_ok=False)
-        print(f"✅ Created skill directory: {skill_dir}")
+        print(f"[OK] Created skill directory: {skill_dir}")
     except Exception as e:
-        print(f"❌ Error creating directory: {e}")
+        print(f"[ERROR] Error creating directory: {e}")
         return None
 
     # Create SKILL.md from template
@@ -225,12 +227,12 @@ def init_skill(skill_name, path):
         skill_title=skill_title
     )
 
-    skill_md_path = skill_dir / 'SKILL.md'
+    skill_md_path = skill_dir / "SKILL.md"
     try:
-        skill_md_path.write_text(skill_content)
-        print("✅ Created SKILL.md")
+        write_text(skill_md_path, skill_content)
+        print("[OK] Created SKILL.md")
     except Exception as e:
-        print(f"❌ Error creating SKILL.md: {e}")
+        print(f"[ERROR] Error creating SKILL.md: {e}")
         return None
 
     # Create resource directories with example files
@@ -238,30 +240,30 @@ def init_skill(skill_name, path):
         # Create scripts/ directory with example script
         scripts_dir = skill_dir / 'scripts'
         scripts_dir.mkdir(exist_ok=True)
-        example_script = scripts_dir / 'example.py'
-        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script = scripts_dir / "example.py"
+        write_text(example_script, EXAMPLE_SCRIPT.format(skill_name=skill_name))
         example_script.chmod(0o755)
-        print("✅ Created scripts/example.py")
+        print("[OK] Created scripts/example.py")
 
         # Create references/ directory with example reference doc
-        references_dir = skill_dir / 'references'
+        references_dir = skill_dir / "references"
         references_dir.mkdir(exist_ok=True)
-        example_reference = references_dir / 'api_reference.md'
-        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
-        print("✅ Created references/api_reference.md")
+        example_reference = references_dir / "api_reference.md"
+        write_text(example_reference, EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("[OK] Created references/api_reference.md")
 
         # Create assets/ directory with example asset placeholder
-        assets_dir = skill_dir / 'assets'
+        assets_dir = skill_dir / "assets"
         assets_dir.mkdir(exist_ok=True)
-        example_asset = assets_dir / 'example_asset.txt'
-        example_asset.write_text(EXAMPLE_ASSET)
-        print("✅ Created assets/example_asset.txt")
+        example_asset = assets_dir / "example_asset.txt"
+        write_text(example_asset, EXAMPLE_ASSET)
+        print("[OK] Created assets/example_asset.txt")
     except Exception as e:
-        print(f"❌ Error creating resource directories: {e}")
+        print(f"[ERROR] Error creating resource directories: {e}")
         return None
 
     # Print next steps
-    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print(f"\n[OK] Skill '{skill_name}' initialized successfully at {skill_dir}")
     print("\nNext steps:")
     print("1. Edit SKILL.md to complete the TODO items and update the description")
     print("2. Customize or delete the example files in scripts/, references/, and assets/")
@@ -271,7 +273,8 @@ def init_skill(skill_name, path):
 
 
 def main():
-    if len(sys.argv) < 4 or sys.argv[2] != '--path':
+    configure_stdio()
+    if len(sys.argv) < 4 or sys.argv[2] != "--path":
         print("Usage: init_skill.py <skill-name> --path <path>")
         print("\nSkill name requirements:")
         print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
@@ -287,8 +290,8 @@ def main():
     skill_name = sys.argv[1]
     path = sys.argv[3]
 
-    print(f"🚀 Initializing skill: {skill_name}")
-    print(f"   Location: {path}")
+    print(f"Initializing skill: {skill_name}")
+    print(f"Location: {path}")
     print()
 
     result = init_skill(skill_name, path)

--- a/.github/skills/skill-creator/scripts/io_utils.py
+++ b/.github/skills/skill-creator/scripts/io_utils.py
@@ -1,0 +1,32 @@
+"""Cross-platform UTF-8 helpers for skill-creator scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+UTF8 = "utf-8"
+
+
+def configure_stdio() -> None:
+    """Prefer UTF-8 on stdout/stderr when the stream supports reconfiguration."""
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None:
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding=UTF8, errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
+def read_text(path: Path | str) -> str:
+    """Read a text file as UTF-8."""
+    return Path(path).read_text(encoding=UTF8)
+
+
+def write_text(path: Path | str, content: str) -> None:
+    """Write a text file as UTF-8 with LF newlines."""
+    Path(path).write_text(content, encoding=UTF8, newline="\n")

--- a/.github/skills/skill-creator/scripts/package_skill.py
+++ b/.github/skills/skill-creator/scripts/package_skill.py
@@ -13,7 +13,9 @@ Example:
 import sys
 import zipfile
 from pathlib import Path
-from quick_validate import validate_skill
+
+from io_utils import configure_stdio
+from validate_skill import validate_skill_full as validate_skill
 
 
 def package_skill(skill_path, output_dir=None):
@@ -31,27 +33,27 @@ def package_skill(skill_path, output_dir=None):
 
     # Validate skill folder exists
     if not skill_path.exists():
-        print(f"❌ Error: Skill folder not found: {skill_path}")
+        print(f"[ERROR] Skill folder not found: {skill_path}")
         return None
 
     if not skill_path.is_dir():
-        print(f"❌ Error: Path is not a directory: {skill_path}")
+        print(f"[ERROR] Path is not a directory: {skill_path}")
         return None
 
     # Validate SKILL.md exists
     skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
-        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        print(f"[ERROR] SKILL.md not found in {skill_path}")
         return None
 
     # Run validation before packaging
-    print("🔍 Validating skill...")
+    print("Validating skill...")
     valid, message = validate_skill(skill_path)
     if not valid:
-        print(f"❌ Validation failed: {message}")
-        print("   Please fix the validation errors before packaging.")
+        print(f"[ERROR] Validation failed: {message}")
+        print("Please fix the validation errors before packaging.")
         return None
-    print(f"✅ {message}\n")
+    print(f"[OK] {message}\n")
 
     # Determine output location
     skill_name = skill_path.name
@@ -65,24 +67,25 @@ def package_skill(skill_path, output_dir=None):
 
     # Create the .skill file (zip format)
     try:
-        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
             # Walk through the skill directory
-            for file_path in skill_path.rglob('*'):
+            for file_path in skill_path.rglob("*"):
                 if file_path.is_file():
                     # Calculate the relative path within the zip
                     arcname = file_path.relative_to(skill_path.parent)
                     zipf.write(file_path, arcname)
                     print(f"  Added: {arcname}")
 
-        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        print(f"\n[OK] Successfully packaged skill to: {skill_filename}")
         return skill_filename
 
     except Exception as e:
-        print(f"❌ Error creating .skill file: {e}")
+        print(f"[ERROR] Error creating .skill file: {e}")
         return None
 
 
 def main():
+    configure_stdio()
     if len(sys.argv) < 2:
         print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
         print("\nExample:")
@@ -93,9 +96,9 @@ def main():
     skill_path = sys.argv[1]
     output_dir = sys.argv[2] if len(sys.argv) > 2 else None
 
-    print(f"📦 Packaging skill: {skill_path}")
+    print(f"Packaging skill: {skill_path}")
     if output_dir:
-        print(f"   Output directory: {output_dir}")
+        print(f"Output directory: {output_dir}")
     print()
 
     result = package_skill(skill_path, output_dir)

--- a/.github/skills/skill-creator/scripts/quick_validate.py
+++ b/.github/skills/skill-creator/scripts/quick_validate.py
@@ -1,7 +1,108 @@
 #!/usr/bin/env python3
-"""Backward-compatible alias for validate_skill.py (used by package_skill.py)."""
+"""
+Quick validation script for skills - minimal version
+"""
 
-from validate_skill import main, validate_skill
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+from io_utils import configure_stdio, read_text
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = read_text(skill_md)
+    if not content.startswith("---"):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get("name", "")
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return False, (
+                f"Name '{name}' should be hyphen-case "
+                "(lowercase letters, digits, and hyphens only)"
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return False, (
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+            )
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if "<" in description or ">" in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, (
+                f"Description is too long ({len(description)} characters). "
+                "Maximum is 1024 characters."
+            )
+
+    return True, "Skill is valid!"
+
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    configure_stdio()
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.github/skills/skill-creator/scripts/validate_skill.py
+++ b/.github/skills/skill-creator/scripts/validate_skill.py
@@ -1,489 +1,159 @@
 #!/usr/bin/env python3
 """
-LibrAgent skill validator.
-
-Usage:
-    python validate_skill.py <skill-directory> [--strict]
-
-Validates SKILL.md frontmatter (same rules as the Rust scanner) and warns about
-common LibrAgent deployment mistakes (wrong directory, managed system_skills, etc.).
-
-Exit codes:
-    0 - valid (warnings only unless --strict)
-    1 - validation errors
-    2 - missing dependency or invalid arguments
+Full mechanical validation for skills.
+Covers: frontmatter (via quick_validate) + body semantics.
 """
 
-from __future__ import annotations
-
-import argparse
+import os
 import re
 import sys
-from dataclasses import dataclass, field
+import urllib.parse
 from pathlib import Path
-from typing import Literal
 
-try:
-    import yaml
-except ImportError:
-    print("ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
-    sys.exit(2)
+import yaml
 
-ALLOWED_PROPERTIES = frozenset({"name", "description", "license", "allowed-tools", "metadata"})
-FORBIDDEN_SKILL_FILES = frozenset(
-    {
-        ".bundled_manifest.json",
-        "README.md",
-        "CHANGELOG.md",
-        "INSTALLATION.md",
-        "INSTALLATION_GUIDE.md",
-    }
-)
-FRONTMATTER_PATTERN = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
-NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
-SINGLE_QUOTE_ESCAPE_PATTERN = re.compile(r"\\'")
+# Ensure the script's directory is in sys.path to resolve quick_validate.py
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
+from io_utils import configure_stdio, read_text
+from quick_validate import validate_skill  # existing frontmatter validation
 
-@dataclass
-class ValidationIssue:
-    code: str
-    message: str
-    fix: str
-    level: Literal["error", "warning"] = "error"
+# Constants
+MAX_BODY_LINES = 500
+FORBIDDEN_FILES = {
+    "README.md",
+    "CHANGELOG.md",
+    "INSTALLATION_GUIDE.md",
+    "QUICK_REFERENCE.md",
+    "TODO.md",
+    "CONTRIBUTING.md",
+}
+TRIGGER_KEYWORDS = [
+    "use when",
+    "when the user",
+    "triggers on",
+    "trigger",
+    "use this skill",
+    "should be used",
+]
 
 
-@dataclass
-class ValidationReport:
-    issues: list[ValidationIssue] = field(default_factory=list)
-    frontmatter: dict | None = None
+def validate_skill_full(skill_path):
+    """Full mechanical validation: frontmatter + body semantics."""
+    skill_path = Path(skill_path).resolve()
 
-    @property
-    def errors(self) -> list[str]:
-        return [issue.message for issue in self.issues if issue.level == "error"]
+    # 1. Frontmatter validation (delegates to existing)
+    valid, msg = validate_skill(skill_path)
+    if not valid:
+        return False, msg
 
-    @property
-    def warnings(self) -> list[str]:
-        return [issue.message for issue in self.issues if issue.level == "warning"]
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
 
-    @property
-    def ok(self) -> bool:
-        return not self.errors
+    content = read_text(skill_md)
 
-    def fail_on_warnings(self, strict: bool) -> bool:
-        return self.ok and (not strict or not self.warnings)
+    # 2. Body line count
+    body = content.split("---", 2)[2] if "---" in content else ""
+    body_lines = len(body.strip().splitlines())
+    if body_lines > MAX_BODY_LINES:
+        return False, f"SKILL.md body is {body_lines} lines (max {MAX_BODY_LINES})"
 
-    def add_error(self, code: str, message: str, fix: str) -> None:
-        self.issues.append(ValidationIssue(code, message, fix, "error"))
+    # 3. Body not empty
+    if not body.strip():
+        return False, "SKILL.md body is empty"
 
-    def add_warning(self, code: str, message: str, fix: str) -> None:
-        self.issues.append(ValidationIssue(code, message, fix, "warning"))
+    # 4. Forbidden files
+    files = {f.name for f in skill_path.rglob("*") if f.is_file()}
+    found_forbidden = files & FORBIDDEN_FILES
+    if found_forbidden:
+        return False, f"Forbidden files found: {', '.join(sorted(found_forbidden))}"
 
-    def promote_warnings_to_errors(self) -> None:
-        promoted: list[ValidationIssue] = []
-        remaining: list[ValidationIssue] = []
-        for issue in self.issues:
-            if issue.level == "warning":
-                promoted.append(
-                    ValidationIssue(
-                        code=issue.code,
-                        message=issue.message,
-                        fix=issue.fix,
-                        level="error",
-                    )
-                )
-            else:
-                remaining.append(issue)
-        self.issues = remaining + promoted
+    # 5. References exist (check markdown links, ignoring code blocks)
+    body_no_code = re.sub(r"```[\s\S]*?```", "", body)
+    ref_patterns = re.findall(r"\[.*?\]\(([^)#]+)\)", body_no_code)
+    broken_refs = []
+    for ref in ref_patterns:
+        # Skip URLs and absolute path or mailto
+        if ref.startswith(("http://", "https://", "mailto:")):
+            continue
+        # Decode URL-encoded paths
+        decoded_ref = urllib.parse.unquote(ref)
+        ref_path = skill_path / decoded_ref
+        if not ref_path.exists():
+            broken_refs.append(decoded_ref)
+    if broken_refs:
+        return False, f"Missing referenced files: {', '.join(broken_refs)}"
 
-
-def extract_frontmatter(content: str) -> tuple[str | None, str | None]:
-    """Return (frontmatter_text, error_message)."""
-    if not content.startswith("---"):
-        return None, "No YAML frontmatter found (SKILL.md must start with ---)"
-
-    match = FRONTMATTER_PATTERN.match(content)
-    if not match:
-        return None, "Invalid frontmatter format (expected ---\\n...\\n---)"
-
-    return match.group(1), None
-
-
-def check_frontmatter_text(report: ValidationReport, frontmatter_text: str) -> dict | None:
-    if SINGLE_QUOTE_ESCAPE_PATTERN.search(frontmatter_text):
-        report.add_warning(
-            "SKILL-YAML-APOSTROPHE",
-            "Frontmatter uses \\' inside a single-quoted YAML string.",
-            "Use double quotes for description (\"Telegram's\") or double the quote (Telegram''s). "
-            "The Rust scanner silently skips skills with invalid YAML.",
-        )
-
-    try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-    except yaml.YAMLError as exc:
-        report.add_error(
-            "SKILL-YAML-PARSE",
-            f"Invalid YAML in frontmatter: {exc}",
-            "Fix YAML syntax in SKILL.md between the first --- markers. "
-            "Run: python <skill-creator>/scripts/validate_skill.py <skill-folder> --strict",
-        )
-        return None
-
-    if not isinstance(frontmatter, dict):
-        report.add_error(
-            "SKILL-FRONTMATTER-TYPE",
-            "Frontmatter must be a YAML mapping (key: value pairs).",
-            "Ensure SKILL.md starts with ---, then lines like name: my-skill, then ---.",
-        )
-        return None
-
-    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
-    if unexpected_keys:
-        report.add_error(
-            "SKILL-FRONTMATTER-KEYS",
-            "Unexpected frontmatter key(s): "
-            f"{', '.join(sorted(unexpected_keys))}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_PROPERTIES))}.",
-            "Remove unsupported keys or move extra metadata into the SKILL.md body.",
-        )
-
-    name = frontmatter.get("name")
-    if name is None:
-        report.add_error(
-            "SKILL-FIELD-NAME-MISSING",
-            "Missing required frontmatter field: name",
-            "Add `name: <folder-name>` to SKILL.md frontmatter (hyphen-case, max 64 chars).",
-        )
-    elif not isinstance(name, str):
-        report.add_error(
-            "SKILL-FIELD-NAME-TYPE",
-            f"name must be a string, got {type(name).__name__}.",
-            "Quote the name value, e.g. name: my-skill",
-        )
-    else:
-        name = name.strip()
-        if not name:
-            report.add_error(
-                "SKILL-FIELD-NAME-EMPTY",
-                "name cannot be empty",
-                "Set name to the skill folder name in hyphen-case.",
-            )
-        elif not NAME_PATTERN.match(name):
-            report.add_error(
-                "SKILL-FIELD-NAME-FORMAT",
-                f"name '{name}' must be hyphen-case (lowercase letters, digits, hyphens only).",
-                "Rename to hyphen-case, e.g. ai-daily-search, and match the folder name.",
-            )
-        elif name.startswith("-") or name.endswith("-") or "--" in name:
-            report.add_error(
-                "SKILL-FIELD-NAME-FORMAT",
-                f"name '{name}' cannot start/end with hyphen or contain '--'.",
-                "Use a single hyphen between words, e.g. telegram-formatter.",
-            )
-        elif len(name) > 64:
-            report.add_error(
-                "SKILL-FIELD-NAME-LENGTH",
-                f"name is too long ({len(name)} chars). Maximum is 64.",
-                "Shorten the skill name and rename the folder to match.",
-            )
-
-    description = frontmatter.get("description")
-    if description is None:
-        report.add_error(
-            "SKILL-FIELD-DESC-MISSING",
-            "Missing required frontmatter field: description",
-            "Add description with trigger phrases in double quotes if it contains apostrophes.",
-        )
-    elif not isinstance(description, str):
-        report.add_error(
-            "SKILL-FIELD-DESC-TYPE",
-            f"description must be a string, got {type(description).__name__}.",
-            "Use a quoted single-line description in frontmatter.",
-        )
-    else:
-        description = description.strip()
-        if not description:
-            report.add_error(
-                "SKILL-FIELD-DESC-EMPTY",
-                "description cannot be empty",
-                "Add a non-empty description with when-to-use triggers.",
-            )
-        elif "<" in description or ">" in description:
-            report.add_error(
-                "SKILL-FIELD-DESC-CHARS",
-                "description cannot contain angle brackets (< or >).",
-                "Remove XML-like characters from description.",
-            )
-        elif len(description) > 1024:
-            report.add_error(
-                "SKILL-FIELD-DESC-LENGTH",
-                f"description is too long ({len(description)} chars). Maximum is 1024.",
-                "Shorten description; move detail into the SKILL.md body or references/.",
-            )
-
-    return frontmatter
-
-
-def check_directory_name(report: ValidationReport, skill_path: Path, frontmatter: dict | None) -> None:
-    if not frontmatter:
-        return
-
-    name = frontmatter.get("name")
-    if not isinstance(name, str):
-        return
-
-    folder_name = skill_path.name
-    skill_name = name.strip()
-    if skill_name != folder_name:
-        report.add_warning(
-            "SKILL-NAME-MISMATCH",
-            f"Frontmatter name '{skill_name}' does not match directory name '{folder_name}'.",
-            f"Rename the folder to '{skill_name}' or change frontmatter name to '{folder_name}'.",
-        )
-
-
-def check_deployment_path(report: ValidationReport, skill_path: Path) -> None:
-    resolved = skill_path.resolve()
-    parts = [part.lower() for part in resolved.parts]
-    parent = resolved.parent
-    skill_name = resolved.name
-
-    if "system_skills" in parts:
-        report.add_warning(
-            "SKILL-PATH-SYSTEM-SKILLS",
-            "Location: system_skills (managed bundled mirror).",
-            "Do not deploy custom skills here. Use user_skills/ (global), "
-            ".libragent/skills/ (workspace), or src-tauri/bundled_skills/ (ship with app).",
-        )
-
-    if "user_skills" in parts:
-        return
-
-    if "workspaces" in parts:
+    # 6. Description has trigger keywords
+    desc = None
+    fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if fm_match:
         try:
-            workspace_index = parts.index("workspaces")
-        except ValueError:
-            workspace_index = -1
+            fm = yaml.safe_load(fm_match.group(1))
+            if isinstance(fm, dict):
+                desc = fm.get("description", "") or ""
+        except Exception:
+            pass
 
-        if workspace_index >= 0:
-            segments_after_session = resolved.parts[workspace_index + 2 :]
-            if len(segments_after_session) == 1:
-                report.add_warning(
-                    "SKILL-PATH-WORKSPACE-ROOT",
-                    f"Location: workspace session root (.../workspaces/<id>/{skill_name}/).",
-                    "Move the skill to .../workspaces/<id>/.libragent/skills/<skill-name>/ "
-                    "or deploy with deploy_skill.py --scope workspace.",
-                )
-            elif (
-                len(segments_after_session) >= 2
-                and segments_after_session[0].lower() == ".libragent"
-                and segments_after_session[1].lower() == "skills"
-            ):
-                return
-            elif len(segments_after_session) >= 1 and segments_after_session[0].lower() == "skills":
-                report.add_warning(
-                    "SKILL-PATH-WORKSPACE-LEGACY",
-                    "Location: legacy workspace skills/ folder.",
-                    "Use .../.libragent/skills/ for new workspace skills.",
-                )
-
-    resolved_str = str(resolved)
-    if ("\\skills\\" in resolved_str or "/skills/" in resolved_str) and "user_skills" not in parts:
-        if "system_skills" not in parts and "assistants" not in parts:
-            if "libragent" in resolved_str.lower() or "com.fritzprix.libragent" in parts:
-                report.add_warning(
-                    "SKILL-PATH-LEGACY-GLOBAL",
-                    "Location: legacy AppData skills/ directory.",
-                    "Global user skills belong in user_skills/, not skills/. "
-                    "Deploy with: deploy_skill.py <skill> --scope global",
-                )
-
-    if parent.joinpath(".bundled_manifest.json").is_file() and "system_skills" not in parts:
-        report.add_warning(
-            "SKILL-PATH-MANIFEST-WRONG",
-            "Parent directory contains .bundled_manifest.json.",
-            "Remove the manifest from this location. It only applies under system_skills/ during bundled sync.",
-        )
-
-
-def check_skill_layout(report: ValidationReport, skill_path: Path) -> None:
-    for child in skill_path.iterdir():
-        if not child.is_file():
-            continue
-        if child.name in FORBIDDEN_SKILL_FILES:
-            report.add_error(
-                "SKILL-LAYOUT-FORBIDDEN-FILE",
-                f"Forbidden file in skill directory: {child.name}",
-                "Remove auxiliary docs and manifests from the skill folder. "
-                "Keep SKILL.md plus optional scripts/, references/, assets/ only.",
+    if desc:
+        desc_lower = desc.lower()
+        has_trigger = any(kw in desc_lower for kw in TRIGGER_KEYWORDS)
+        if not has_trigger:
+            return False, (
+                "Description missing trigger keywords "
+                "(use when, when the user, triggers on, etc.)"
             )
 
-    skill_md = skill_path / "SKILL.md"
-    if skill_md.is_file():
-        content = skill_md.read_text(encoding="utf-8")
-        if content.startswith("\ufeff"):
-            content = content.removeprefix("\ufeff")
-        _, body = extract_frontmatter_and_body(content)
-        if body is not None and not body.strip():
-            report.add_warning(
-                "SKILL-LAYOUT-EMPTY-BODY",
-                "SKILL.md body is empty after frontmatter.",
-                "Add procedural instructions in the body or references/ (frontmatter alone is valid but not useful).",
-            )
+    # 7. References >100 lines have TOC
+    warnings = []
+    for ref_file in skill_path.rglob("*"):
+        if ref_file.is_file() and ref_file.suffix == ".md" and ref_file.name != "SKILL.md":
+            ref_content = read_text(ref_file)
+            ref_lines = len(ref_content.strip().splitlines())
+            if ref_lines > 100:
+                first_50 = ref_content.splitlines()[:50]
+                has_heading_list = any(
+                    line.strip().startswith("## ") or line.strip().startswith("- ")
+                    for line in first_50
+                )
+                if not has_heading_list:
+                    warnings.append(
+                        f"Warning: Reference file {ref_file.name} is long ({ref_lines} lines) "
+                        "but missing a Table of Contents or summary."
+                    )
 
+    # 8. Scripts executable check
+    scripts_dir = skill_path / "scripts"
+    if scripts_dir.exists():
+        for script in scripts_dir.iterdir():
+            if script.is_file():
+                if os.name != "nt" and not os.access(script, os.X_OK):
+                    try:
+                        script_text = read_text(script)
+                        first_line = script_text.splitlines()[0] if script_text else ""
+                        if first_line.startswith("#!"):
+                            warnings.append(
+                                f"Warning: Script {script.name} has a shebang but is not "
+                                "executable. Run chmod +x on it."
+                            )
+                    except Exception:
+                        pass
 
-def extract_frontmatter_and_body(content: str) -> tuple[str | None, str | None]:
-    if not content.startswith("---"):
-        return None, None
-    match = FRONTMATTER_PATTERN.match(content)
-    if not match:
-        return None, None
-    body = content[match.end() :]
-    return match.group(1), body
+    success_msg = "Skill passed full mechanical validation!"
+    if warnings:
+        success_msg += "\n" + "\n".join(warnings)
 
-
-def validate_skill_path(skill_path: Path, strict: bool = False) -> ValidationReport:
-    report = ValidationReport()
-    skill_path = skill_path.resolve()
-
-    if not skill_path.exists():
-        report.add_error(
-            "SKILL-MISSING-DIR",
-            f"Skill directory not found: {skill_path}",
-            "Pass the folder that directly contains SKILL.md, not its parent.",
-        )
-        return report
-
-    if not skill_path.is_dir():
-        report.add_error(
-            "SKILL-NOT-DIRECTORY",
-            f"Path is not a directory: {skill_path}",
-            "Point validate_skill.py at the skill folder, not SKILL.md itself.",
-        )
-        return report
-
-    skill_md = skill_path / "SKILL.md"
-    if not skill_md.is_file():
-        report.add_error(
-            "SKILL-MISSING-FILE",
-            "SKILL.md not found in skill directory",
-            f"Create {skill_path / 'SKILL.md'} with name/description frontmatter.",
-        )
-        return report
-
-    content = skill_md.read_text(encoding="utf-8")
-    if content.startswith("\ufeff"):
-        content = content.removeprefix("\ufeff")
-
-    frontmatter_text, frontmatter_error = extract_frontmatter(content)
-    if frontmatter_error:
-        code = "SKILL-FRONTMATTER-MISSING"
-        fix = "Start SKILL.md with --- on line 1, frontmatter keys, then closing ---."
-        if "Invalid frontmatter format" in frontmatter_error:
-            code = "SKILL-FRONTMATTER-FORMAT"
-            fix = "Ensure frontmatter is wrapped exactly as ---\\nname: ...\\ndescription: ...\\n---."
-        report.add_error(code, frontmatter_error, fix)
-        return report
-
-    assert frontmatter_text is not None
-    frontmatter = check_frontmatter_text(report, frontmatter_text)
-    report.frontmatter = frontmatter
-    check_directory_name(report, skill_path, frontmatter)
-    check_deployment_path(report, skill_path)
-    check_skill_layout(report, skill_path)
-
-    if strict:
-        report.promote_warnings_to_errors()
-
-    return report
-
-
-def validate_skill(skill_path: str | Path) -> tuple[bool, str]:
-    """Compatibility API used by package_skill.py (errors only, no path warnings as failures)."""
-    report = validate_skill_path(Path(skill_path), strict=False)
-    if report.errors:
-        return False, report.errors[0]
-    if report.warnings:
-        return True, f"Skill is valid with {len(report.warnings)} deployment warning(s)"
-    return True, "Skill is valid!"
-
-
-def format_report(report: ValidationReport) -> str:
-    lines: list[str] = []
-    if report.errors:
-        lines.append("Errors:")
-        lines.extend(f"  - {error}" for error in report.errors)
-    if report.warnings:
-        lines.append("Warnings:")
-        lines.extend(f"  - {warning}" for warning in report.warnings)
-    if report.ok and not report.warnings:
-        lines.append("Skill is valid!")
-    elif report.ok:
-        lines.append("Frontmatter is valid (review warnings before deploying).")
-    return "\n".join(lines)
-
-
-def format_detailed_report(report: ValidationReport, title: str) -> str:
-    lines = [f"=== {title} ==="]
-    if not report.issues:
-        lines.append("No issues found.")
-        return "\n".join(lines)
-
-    for issue in report.issues:
-        if report.ok and issue.level == "warning" and not report.warnings:
-            continue
-        prefix = "ERROR" if issue.level == "error" else "WARNING"
-        lines.append(f"[{issue.code}] {prefix}: {issue.message}")
-        lines.append(f"  Fix: {issue.fix}")
-        lines.append("")
-
-    if report.ok and not report.warnings:
-        lines.append("Validation passed.")
-    elif report.ok:
-        lines.append("Frontmatter is valid; review warnings before deploying.")
-    else:
-        lines.append("Validation failed. Resolve every ERROR before deploying.")
-
-    return "\n".join(lines).rstrip()
-
-
-def get_skill_name(report: ValidationReport) -> str | None:
-    if not report.frontmatter:
-        return None
-    name = report.frontmatter.get("name")
-    if isinstance(name, str) and name.strip():
-        return name.strip()
-    return None
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate a LibrAgent skill directory")
-    parser.add_argument("skill_directory", help="Path to the skill folder containing SKILL.md")
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Treat deployment warnings as errors",
-    )
-    parser.add_argument(
-        "--detailed",
-        action="store_true",
-        help="Print error codes and fix instructions",
-    )
-    args = parser.parse_args()
-
-    report = validate_skill_path(Path(args.skill_directory), strict=args.strict)
-    if args.detailed:
-        output = format_detailed_report(report, "Skill validation")
-    else:
-        output = format_report(report)
-    try:
-        print(output)
-    except UnicodeEncodeError:
-        print(output.encode("ascii", errors="replace").decode("ascii"))
-
-    if report.fail_on_warnings(args.strict):
-        return 0
-    return 1
+    return True, success_msg
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    configure_stdio()
+    if len(sys.argv) < 2:
+        print("Usage: python validate_skill.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill_full(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 🚀 LibrAgent CI/CD
+name: LibrAgent CI/CD
 
 on:
   push:
@@ -8,47 +8,55 @@ on:
 
 jobs:
   test:
-    name: 🧪 Test
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
-      - name: 📥 Checkout
+      - name: Checkout
         uses: actions/checkout@v7
 
-      - name: 🦀 Setup Rust
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: 🦀 Ensure Cargo bin on PATH (Windows)
+      - name: Ensure Cargo bin on PATH (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
           echo "$USERPROFILE/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: 🦀 Rust cache
+      - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
           save-if: ${{ runner.os != 'Windows' }}
 
-      - name: 📦 Install pnpm
+      - name: Install pnpm
         uses: pnpm/action-setup@v5
 
-      - name: 📦 Setup Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: 📦 Install dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: � Lint check
+      - name: Lint check
         run: pnpm lint
 
-      - name: �🔧 Install Tauri dependencies (Ubuntu)
+      - name: Validate bundled skills
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm skills:audit
+
+      - name: Check skills mirror drift
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm skills:mirror:check
+
+      - name: Install Tauri dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
@@ -65,49 +73,49 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
-      - name: 🧪 Run tests (if available)
+      - name: Run tests (if available)
         run: pnpm test || echo "No tests defined"
 
-      - name: 🔍 Check TypeScript
+      - name: Check TypeScript
         run: pnpm tsc --noEmit
 
-      - name: 📊 Check bundle budget (Ubuntu)
+      - name: Check bundle budget (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: pnpm build && pnpm perf:bundle
 
-      - name: 🦀 Check Rust
+      - name: Check Rust
         run: cd src-tauri && cargo check
 
-      - name: 🍎 Fix macOS SDKROOT for Rust linker
+      - name: Fix macOS SDKROOT for Rust linker
         if: runner.os == 'macOS'
         run: echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
 
-      - name: 🧪 Run Rust integration tests
+      - name: Run Rust integration tests
         run: pnpm rust:test
 
-      - name: 🧪 Run Rust integration tests (edit-file build)
+      - name: Run Rust integration tests (edit-file build)
         run: pnpm rust:test:edit-file
 
       # Code Quality Checks (PR only)
-      - name: 🦀 Install Clippy
+      - name: Install Clippy
         run: rustup component add clippy
-      - name: 🔍 Rust Clippy (PR)
+      - name: Rust Clippy (PR)
         if: github.event_name == 'pull_request'
         run: cd src-tauri && cargo clippy -- -D warnings
 
-      - name: 🦀 Install rustfmt
+      - name: Install rustfmt
         run: rustup component add rustfmt
-      - name: 🎨 Rust Format Check (PR)
+      - name: Rust Format Check (PR)
         if: github.event_name == 'pull_request'
         run: cd src-tauri && cargo fmt --check
 
       # Security Checks (PR only)
-      - name: 🔒 npm audit (PR)
+      - name: npm audit (PR)
         if: github.event_name == 'pull_request'
         run: pnpm audit --audit-level high
         continue-on-error: true
 
-      - name: 🔒 Cargo audit (PR)
+      - name: Cargo audit (PR)
         if: github.event_name == 'pull_request'
         run: |
           cargo install cargo-audit
@@ -115,7 +123,7 @@ jobs:
         continue-on-error: true
 
   build:
-    name: 🔨 Build
+    name: Build
     needs: test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -123,31 +131,31 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
-      - name: 📥 Checkout
+      - name: Checkout
         uses: actions/checkout@v7
 
-      - name: 🦀 Setup Rust
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: 🦀 Ensure Cargo bin on PATH (Windows)
+      - name: Ensure Cargo bin on PATH (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
           echo "$USERPROFILE/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: 📦 Install pnpm
+      - name: Install pnpm
         uses: pnpm/action-setup@v5
 
-      - name: 📦 Setup Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: 📦 Install dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: 🔧 Install Tauri dependencies (Ubuntu)
+      - name: Install Tauri dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
@@ -164,7 +172,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
-      - name: 🏗️ Build Tauri app
+      - name: Build Tauri app
         run: >-
           pnpm tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
         shell: bash
@@ -173,7 +181,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-      - name: 📦 Upload build artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: libragent-build-${{ matrix.os }}

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,41 @@
+name: Close linked issues on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const text = [
+              context.payload.pull_request.title ?? '',
+              context.payload.pull_request.body ?? '',
+            ].join('\n');
+
+            const regex =
+              /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*:?\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+
+            for (const match of text.matchAll(regex)) {
+              issueNumbers.add(Number.parseInt(match[1], 10));
+            }
+
+            for (const issue_number of issueNumbers) {
+              core.info(`Closing issue #${issue_number}`);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "rust:validate": "pnpm rust:fmt && pnpm rust:clippy:all",
     "assistants:validate": "node scripts/validate-assistant-skills.cjs",
     "skills:audit": "node scripts/audit-bundled-skills.cjs",
+    "skills:mirror:check": "node scripts/check-skills-mirror-drift.cjs",
     "skill:validate": "python .agents/skills/skill-creator/scripts/validate_skill.py",
     "skill:package": "python .agents/skills/skill-creator/scripts/package_skill.py",
     "refactor:prepare": "node scripts/refactor-pipeline.js prepare",

--- a/scripts/check-skills-mirror-drift.cjs
+++ b/scripts/check-skills-mirror-drift.cjs
@@ -1,0 +1,105 @@
+/**
+ * Ensures bundled skills stay in sync with .agents/skills source-of-truth copies.
+ *
+ * For each skill in MIRROR_MANIFEST, every file under .agents/skills/<name> must
+ * exist in src-tauri/bundled_skills/<name> with identical content.
+ * Extra files in bundled only are allowed.
+ */
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const AGENTS_SKILLS_DIR = path.join(repoRoot, '.agents', 'skills');
+const BUNDLED_SKILLS_DIR = path.join(repoRoot, 'src-tauri', 'bundled_skills');
+
+/** Skills maintained in .agents and mirrored into bundled_skills */
+const MIRROR_MANIFEST = ['setup-wizard'];
+
+function sha256(filePath) {
+  const data = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function listFilesRecursive(rootDir) {
+  const files = [];
+  if (!fs.existsSync(rootDir)) {
+    return files;
+  }
+
+  function walk(currentDir) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        files.push(path.relative(rootDir, fullPath).split(path.sep).join('/'));
+      }
+    }
+  }
+
+  walk(rootDir);
+  return files.sort();
+}
+
+function checkMirroredSkill(skillName) {
+  const sourceDir = path.join(AGENTS_SKILLS_DIR, skillName);
+  const bundledDir = path.join(BUNDLED_SKILLS_DIR, skillName);
+  const errors = [];
+
+  if (!fs.existsSync(sourceDir)) {
+    errors.push(`Source skill missing: .agents/skills/${skillName}`);
+    return errors;
+  }
+
+  if (!fs.existsSync(bundledDir)) {
+    errors.push(`Bundled skill missing: src-tauri/bundled_skills/${skillName}`);
+    return errors;
+  }
+
+  const sourceFiles = listFilesRecursive(sourceDir);
+  for (const relPath of sourceFiles) {
+    const sourceFile = path.join(sourceDir, relPath);
+    const bundledFile = path.join(bundledDir, ...relPath.split('/'));
+
+    if (!fs.existsSync(bundledFile)) {
+      errors.push(`Missing in bundled: ${skillName}/${relPath}`);
+      continue;
+    }
+
+    const sourceHash = sha256(sourceFile);
+    const bundledHash = sha256(bundledFile);
+    if (sourceHash !== bundledHash) {
+      errors.push(`Content drift: ${skillName}/${relPath}`);
+    }
+  }
+
+  return errors;
+}
+
+function main() {
+  const allErrors = [];
+
+  for (const skillName of MIRROR_MANIFEST) {
+    const errors = checkMirroredSkill(skillName);
+    allErrors.push(...errors);
+  }
+
+  if (allErrors.length === 0) {
+    console.log(
+      `[OK] Skills mirror check passed for: ${MIRROR_MANIFEST.join(', ')}`,
+    );
+    process.exit(0);
+  }
+
+  console.error('[ERROR] Skills mirror drift detected:\n');
+  for (const err of allErrors) {
+    console.error(`  - ${err}`);
+  }
+  console.error(
+    '\nFix: sync .agents/skills -> src-tauri/bundled_skills for mirrored skills.',
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/refactor-pipeline.js
+++ b/scripts/refactor-pipeline.js
@@ -96,6 +96,11 @@ const VALIDATE_STAGES = [
     args: ['skills:audit'],
   },
   {
+    name: 'skills:mirror:check',
+    command: pnpmCommand,
+    args: ['skills:mirror:check'],
+  },
+  {
     name: 'assistants:validate',
     command: pnpmCommand,
     args: ['assistants:validate'],

--- a/scripts/setup-git-hooks.cjs
+++ b/scripts/setup-git-hooks.cjs
@@ -22,11 +22,20 @@ const hookContent = `#!/bin/sh
 # Git pre-commit hook to validate all bundled skills before commit
 echo "🔍 Running bundled skills quality audit..."
 pnpm skills:audit
-RESULT=$?
+AUDIT_RESULT=$?
 
-if [ $RESULT -ne 0 ]; then
+if [ $AUDIT_RESULT -ne 0 ]; then
   echo "❌ Git commit aborted! Some bundled skills did not pass validation."
   echo "   Please resolve the skill warnings and score issues before committing."
+  exit 1
+fi
+
+echo "🔍 Running skills mirror drift check..."
+pnpm skills:mirror:check
+MIRROR_RESULT=$?
+
+if [ $MIRROR_RESULT -ne 0 ]; then
+  echo "❌ Git commit aborted! Mirrored skills are out of sync with .agents/skills."
   exit 1
 fi
 

--- a/src-tauri/bundled_skills/fine-tune/SKILL.md
+++ b/src-tauri/bundled_skills/fine-tune/SKILL.md
@@ -53,3 +53,8 @@ Once training completes, update the Assistant configuration to load the model pa
 
 - **Hardware Safety** — Always run pre-flight checks. If VRAM is less than 12GB, default to LoRA parameter-efficient training with low batch size.
 - **Privacy** — Ensure no credentials or API keys exist in the exported dataset before launching training.
+
+## References
+
+- [Hardware guide](references/hardware-guide.md)
+- [Llama-Factory setup](references/llama-factory-setup.md)

--- a/src-tauri/bundled_skills/fine-tune/references/hardware-guide.md
+++ b/src-tauri/bundled_skills/fine-tune/references/hardware-guide.md
@@ -1,0 +1,41 @@
+# Hardware Guide (Fine-Tune)
+
+`scripts/train.py` runs pre-flight checks automatically. Use this guide to interpret results and set expectations.
+
+## VRAM tiers
+
+| VRAM | train.py behavior | Expectation |
+| --- | --- | --- |
+| < 12 GB | QLoRA, batch=1, grad accum=8 | Slow but feasible on consumer GPU |
+| 12–16 GB | LoRA, batch=2 | Moderate throughput |
+| ≥ 16 GB | LoRA, batch=4 | Preferred for 7B-class models |
+
+## CPU-only fallback
+
+If CUDA unavailable, training may still run but is **impractical** for 7B models. Recommend:
+
+- Smaller base model
+- Cloud GPU
+- Export dataset only and train elsewhere
+
+## Dependencies
+
+- Python 3.10+
+- `torch` with CUDA matching driver (when using GPU)
+- Llama-Factory installed per [llama-factory-setup.md](llama-factory-setup.md)
+
+## Privacy pre-check
+
+Before export/training:
+
+- Scan dataset JSON for API keys, tokens, emails
+- Use `excludeErrors` and `excludeShort` filters on export
+- Redact or drop contaminated sessions
+
+## Disk space
+
+Reserve space for:
+
+- Dataset JSON
+- Base model cache (multi-GB)
+- Checkpoints under `--output_dir`

--- a/src-tauri/bundled_skills/fine-tune/references/llama-factory-setup.md
+++ b/src-tauri/bundled_skills/fine-tune/references/llama-factory-setup.md
@@ -1,0 +1,47 @@
+# Llama-Factory Setup
+
+`train.py` generates config and invokes Llama-Factory CLI. Prepare the environment once per machine.
+
+## Install (user environment)
+
+```bash
+pip install llamafactory
+# or follow upstream: https://github.com/hiyouga/LLaMA-Factory
+```
+
+Ensure `llamafactory-cli` or the entrypoint used by `train.py` is on PATH.
+
+## Dataset layout
+
+Export via `history__exportDataset` with `format: "llamaFactory"`.
+
+`train.py` expects:
+
+- `--data_path` pointing to exported JSON
+- `--output_dir` for checkpoints and logs
+
+Dataset directory is registered in generated config as `libragent_dataset`.
+
+## Training invocation
+
+```bash
+python "<skill-base-dir>/scripts/train.py" \
+  --data_path workspace/datasets/finetune_data.json \
+  --output_dir workspace/models/finetuned_model
+```
+
+## After training
+
+1. Locate adapter/full weights under `--output_dir`.
+2. Register model with Ollama, llama.cpp, or local HF inference stack.
+3. Update assistant model path in LibrAgent settings.
+
+## Troubleshooting
+
+| Error | Check |
+| --- | --- |
+| CUDA OOM | Re-run; train.py lowers batch for low VRAM |
+| Dataset not found | Export path matches `--data_path` |
+| CLI not found | Llama-Factory install and PATH |
+
+See [hardware-guide.md](hardware-guide.md) for GPU expectations.

--- a/src-tauri/bundled_skills/gatekeeper/SKILL.md
+++ b/src-tauri/bundled_skills/gatekeeper/SKILL.md
@@ -35,4 +35,10 @@ The Gatekeeper pattern sets up a loop between a Creator session and a Reviewer/G
 ## 🛠️ MCP Tools Guide
 
 - **Feedback Delivery**: Inject the reviewer's audit report using `agent__messageToSession` to wake and direct the Creator to rework.
-- **Infinite Loop Avoidance**: The parent session must track and enforce a **maximum rework limit (default: 3)** to prevent endless loops over minor stylistic differences.
+- **Infinite Loop Avoidance**: The parent session must track and enforce a **maximum rework limit (default: 3)** to prevent endless loops over minor stylistic differences. See [rework-limit-examples.md](references/rework-limit-examples.md).
+
+## References
+
+- [Quality criteria](references/criteria.md)
+- [Rework limit examples](references/rework-limit-examples.md)
+- [Troubleshooting](references/troubleshooting.md)

--- a/src-tauri/bundled_skills/gatekeeper/references/rework-limit-examples.md
+++ b/src-tauri/bundled_skills/gatekeeper/references/rework-limit-examples.md
@@ -1,0 +1,52 @@
+# Rework Limit Examples
+
+Parent session owns the counter. Default **max reworks: 3**.
+
+## Counter pattern (parent responsibility)
+
+Track per artifact or per creator session:
+
+```text
+reworkCount = 0
+MAX_REWORKS = 3
+```
+
+On **reject** from reviewer:
+
+1. If `reworkCount >= MAX_REWORKS` → escalate to user (do not message creator again).
+2. Else → `reworkCount += 1`, forward reject via `agent__messageToSession`.
+
+On **approve** → reset `reworkCount` for next artifact.
+
+## Reject message shape
+
+Send creator actionable, bounded feedback:
+
+```markdown
+## Gatekeeper Reject (attempt 2/3)
+
+Failed criteria:
+1. [C2] Unit tests missing for auth module
+2. [C4] No error handling on network timeout
+
+Files to fix:
+- src/auth/login.ts
+- src/auth/login.test.ts
+
+Required before resubmit:
+- Add tests covering invalid token + timeout
+- Run: pnpm test:run -- src/auth/login.test.ts
+```
+
+## Approve message shape
+
+```markdown
+## Gatekeeper Approve
+
+All criteria passed. Ship artifact.
+Summary: ...
+```
+
+## When to raise MAX_REWORKS
+
+Only when user explicitly allows extended polish (e.g. security-critical review). Document in `coordination/DECISIONS.md` for org work.

--- a/src-tauri/bundled_skills/gatekeeper/references/troubleshooting.md
+++ b/src-tauri/bundled_skills/gatekeeper/references/troubleshooting.md
@@ -1,0 +1,49 @@
+# Gatekeeper Troubleshooting
+
+## Symptom: endless rework loops
+
+**Cause:** Criteria too vague, or parent did not enforce rework limit.
+
+**Fix:**
+
+1. Tighten [criteria.md](criteria.md) with pass/fail checks, not style opinions.
+2. Parent tracks `reworkCount`; stop at limit (default 3) and escalate to user.
+3. On reject, require **numbered failed criteria** — not open-ended "improve quality."
+
+## Symptom: reviewer approves low-quality work
+
+**Cause:** Reviewer lacks concrete checklist or cannot see changed files.
+
+**Fix:**
+
+- Give reviewer explicit file paths and diff commands.
+- Require evidence per criterion (test output, lint result, screenshot path).
+
+## Symptom: creator ignores feedback
+
+**Cause:** Feedback not delivered via `agent__messageToSession`, or creator session ended.
+
+**Fix:**
+
+- Parent forwards structured reject payload to creator session ID.
+- Include: failed criteria, file paths, required next action.
+
+## Symptom: context bloat between loops
+
+**Cause:** Full chat history passed each rework.
+
+**Fix:**
+
+- Pass only: criteria snapshot, latest diff summary, failed items, target files.
+- See [rework-limit-examples.md](rework-limit-examples.md).
+
+## Escalation template
+
+When rework limit is hit, parent messages user:
+
+```markdown
+Gatekeeper loop stopped after N reworks.
+- Last reject reason: ...
+- Remaining failed criteria: ...
+- Options: relax criteria / manual review / ship with known gaps
+```

--- a/src-tauri/bundled_skills/hub-spoke/SKILL.md
+++ b/src-tauri/bundled_skills/hub-spoke/SKILL.md
@@ -35,3 +35,9 @@ The Hub-and-Spoke pattern designates a central Coordinator session (Hub) to mana
 
 - **Context Management**: Do not let the Hub read all conversation logs from all Spokes to prevent context overflow. Instruct the Hub to only request **summarized status reports and file list results**.
 - **Message Bridging**: If Worker B depends on Worker A's output, the Hub collects the artifact details from A and injects them to B via `agent__messageToSession`.
+
+## References
+
+- [Routing patterns](references/routing.md)
+- [Status polling](references/status-polling.md)
+- [Context budget](references/context-budget.md)

--- a/src-tauri/bundled_skills/hub-spoke/references/context-budget.md
+++ b/src-tauri/bundled_skills/hub-spoke/references/context-budget.md
@@ -1,0 +1,34 @@
+# Hub Context Budget
+
+The Hub coordinates many spokes; its context window is the bottleneck.
+
+## What the Hub should keep
+
+- Task queue and dependencies
+- Spoke session IDs and statuses
+- **Summaries** and artifact paths — not full spoke transcripts
+
+## What spokes should return
+
+End each spoke task with a fixed block:
+
+```markdown
+## Spoke Result
+- Status: completed | blocked | failed
+- Artifacts: path/to/file1, path/to/file2
+- Summary: (3-5 sentences)
+- Blockers: (if any)
+```
+
+## Message bridging (A → B)
+
+When spoke B needs A's output:
+
+1. Hub reads A's **Result block** only.
+2. Hub sends B a task containing: relevant file paths, summary, explicit acceptance criteria.
+3. Do not forward A's entire tool trace.
+
+## Hub prompt hygiene
+
+- Cap sibling list in org layer context (backend already truncates).
+- Archive completed spoke IDs from active working set once artifacts are captured.

--- a/src-tauri/bundled_skills/hub-spoke/references/status-polling.md
+++ b/src-tauri/bundled_skills/hub-spoke/references/status-polling.md
@@ -1,0 +1,33 @@
+# Hub Status Polling
+
+Hub monitors spokes without loading full conversation logs.
+
+## Polling workflow
+
+1. After `agent__startSession(..., waitForResult=false)`, store `sessionId`.
+2. Poll with `agent__checkSession(sessionId)` on an interval or before next dispatch.
+3. Request **summary fields only**: status, last message snippet, output file paths.
+
+## Status decisions
+
+| Status | Hub action |
+| --- | --- |
+| running | wait or work on other spokes |
+| completed | collect artifacts, merge or route to dependent spoke |
+| failed | retry once, reassign, or escalate to user |
+| stuck (no progress N checks) | `agent__messageToSession` nudge or stop |
+
+## Anti-patterns
+
+- Do not `history__readSession` on every spoke each poll — context explosion.
+- Do not spawn duplicate spokes for the same task without stopping the first.
+
+## Completion handoff to synthesis
+
+When all spokes complete, Hub collects:
+
+- Primary artifact paths (files)
+- One-paragraph outcome per spoke
+- Open risks or blockers
+
+Then runs integration step (tests, merge doc, user summary).

--- a/src-tauri/bundled_skills/knowledge-distiller/SKILL.md
+++ b/src-tauri/bundled_skills/knowledge-distiller/SKILL.md
@@ -56,3 +56,8 @@ Use the `knowledge__record_knowledge` tool to persist the findings:
 ## Safety & Efficiency
 - **De-duplication**: Before recording, use `knowledge__search_knowledge` to check if similar knowledge already exists to avoid redundant entries.
 - **Relevance**: Skip sessions that are purely social or don't contain reusable technical/project context.
+
+## References
+
+- [Extraction patterns](references/extraction-patterns.md)
+- [Knowledge schema](references/knowledge-schema.md)

--- a/src-tauri/bundled_skills/knowledge-distiller/references/extraction-patterns.md
+++ b/src-tauri/bundled_skills/knowledge-distiller/references/extraction-patterns.md
@@ -1,0 +1,45 @@
+# Knowledge Extraction Patterns
+
+Use when distilling sessions into the knowledge base.
+
+## High-value patterns
+
+| Pattern | Example signal | Record as |
+| --- | --- | --- |
+| Architecture decision | "We chose X because Y" | content + entities + `DECISION` relationship |
+| Bug + fix | root cause and confirmed fix | content with repro + resolution tags |
+| Config key / version | API URL, package pin | entity with version property |
+| User preference | naming, style, workflow | content tagged `preference` |
+| Project convention | "always run X before Y" | content tagged `convention` |
+
+## Low-value (skip)
+
+- Greetings, thanks, filler
+- Speculation without decision
+- Duplicates of existing knowledge (search first)
+
+## Extraction block template
+
+Before `knowledge__record_knowledge`:
+
+```markdown
+- **content**: Stand-alone paragraph (no "as discussed")
+- **entities**: [{ name, type }]
+- **relationships**: [{ from, to, type }]
+- **source**: sessionId + date
+- **tags**: distilled, <domain>
+```
+
+## Session scope shortcuts
+
+| User ask | Scope |
+| --- | --- |
+| "today" | `history__list` filter by date |
+| "recent N" | first N session IDs |
+| "this chat" | current session only |
+
+## De-duplication
+
+1. `knowledge__search_knowledge` with key terms from draft content.
+2. If match >80% overlap → update or skip, do not create duplicate.
+3. Prefer merging into one stronger entry over many fragments.

--- a/src-tauri/bundled_skills/knowledge-distiller/references/knowledge-schema.md
+++ b/src-tauri/bundled_skills/knowledge-distiller/references/knowledge-schema.md
@@ -1,0 +1,54 @@
+# Knowledge Schema
+
+Fields for `knowledge__record_knowledge` distillation workflow.
+
+## Required concepts
+
+| Field | Purpose |
+| --- | --- |
+| `content` | Human-readable summary; must stand alone without chat context |
+| `source` | Traceability: `sessionId`, date, or message ref |
+| `tags` | Always include `distilled`; add domain tags |
+
+## Optional structured fields
+
+| Field | When to use |
+| --- | --- |
+| `entities` | Technologies, projects, people, tools mentioned |
+| `relationships` | `USES`, `DEPENDS_ON`, `REPLACES`, `CONFIGURED_WITH` |
+
+## Entity example
+
+```json
+{
+  "name": "LibrAgent",
+  "type": "project"
+}
+```
+
+## Relationship example
+
+```json
+{
+  "from": "LibrAgent",
+  "to": "SeaORM",
+  "type": "USES"
+}
+```
+
+## Tag conventions
+
+- `distilled` — auto-extraction run
+- `auto-knowledge` — machine-assisted capture
+- `context-sync` — project state sync
+- `decision` — architectural choice
+- `preference` — user workflow preference
+- `runbook` — operational procedure
+
+## Quality bar
+
+Before recording, ask:
+
+1. Would a new agent understand this without reading the original chat?
+2. Is it actionable or referenceable later?
+3. Is it already in the knowledge base?

--- a/src-tauri/bundled_skills/org-restructure/SKILL.md
+++ b/src-tauri/bundled_skills/org-restructure/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: org-restructure
+description: Restructure a living explicit org in LibrAgent without dissolving it. Use when an org already exists and you need to add/remove/merge roles in ROLES.md, update the org constitution (agents.md, MISSION.md), remove or retire org child sessions, reassign KANBAN owners, or record structural changes in coordination files. Not for initial org creation (use org), initial scaffolding (use teamwork), org dissolution, or archive.
+---
+
+# Org Restructure
+
+Tune an existing explicit org. This is evolution, not creation and not teardown.
+
+Use `org` when the org does not exist yet or you need runtime coordination (spawn, resume, getOrg).
+Use `teamwork` when the teamwork artifact directory or constitution files do not exist yet.
+
+## Path conventions
+
+Teamwork files live in the app-local artifact directory (Teamwork SSOT). Access them via:
+
+- `@teamwork/...` aliases in agent tools
+- `./.libragent/teamwork/...` from shell in the org root workspace
+
+Do not edit repo-root copies unless the user explicitly wants repo pollution.
+
+## Workflow
+
+1. **Confirm this is restructure, not bootstrap.**
+   - `.libragent/teamwork.json` must exist with `executionSubstrate.mode: "org"` and `orgLineage.intended: true`.
+   - An `orgId` must already be set (from `agent__createOrg` or manifest).
+   - If not, stop and use `teamwork` then `org`.
+2. **Run pre-flight audit** — see [impact-analysis.md](references/impact-analysis.md).
+3. **Pick one primary operation** (add, layoff, merge, constitution update, child removal). Load the matching reference checklist.
+4. **Apply constitution + coordination changes** in dependency order (decision record → ROLES/MISSION/agents → KANBAN/HANDOFF → sessions).
+5. **Propagate refresh** — constitution edits apply on a later execution step, not the current turn.
+6. **Verify** with `agent__getOrg` and a quick coordination-file scan.
+
+## Operation routing
+
+| User intent | Read first | Primary edits |
+| --- | --- | --- |
+| Add a role | [constitution-update.md](references/constitution-update.md) | ROLES.md, MISSION.md, optional `skills/tf-*`, spawn child |
+| Remove a role (layoff) | [layoff-checklist.md](references/layoff-checklist.md) | ROLES.md, KANBAN owners, HANDOFF, child sessions |
+| Merge duplicate roles | [merge-checklist.md](references/merge-checklist.md) | ROLES.md, MISSION.md, skills, session mapping |
+| Change operating rules | [constitution-update.md](references/constitution-update.md) | agents.md, DECISIONS.md |
+| Remove child from org view | [layoff-checklist.md](references/layoff-checklist.md) § Child sessions | stop/delete session; no detach API yet |
+
+## Core rules
+
+1. **ROLES.md is the role contract; MISSION.md must stay in sync** when roles change. Update both in the same change set.
+2. **Record every structural change** in `@teamwork/coordination/DECISIONS.md` before or alongside file edits.
+3. **Reassign before you delete.** Move KANBAN owners and HANDOFF targets off a removed role before layoff or merge.
+4. **Prefer org root for coordination.** Resume or message the root (`orgLineage.rootSessionId`) to broadcast constitution refresh.
+5. **Do not call `agent__createOrg` again.** Restructure edits files and sessions; it does not recreate org identity.
+6. **Refresh semantics:** after `agents.md` / `ROLES.md` edits, tell active members the new rules apply on their next execution step.
+
+## Child session removal (current platform limits)
+
+There is no `agent__detachFromOrg` tool today. To remove a session from org view:
+
+- **Retire work:** `agent__stopSession(sessionId)` then `agent__deleteSession(sessionId)` if permanent removal is OK.
+- **Keep work, hide from org:** not supported — document the limitation and ask the user to choose stop/delete or leave the session idle.
+
+Passing `None` to `update_org_identity` exists in the backend but is not exposed as an agent tool.
+
+## Guardrails
+
+- Do not dissolve the org, delete the org root, or archive the entire teamwork artifact directory — out of scope.
+- Do not remove the org root session from the org; the root is the canonical entry point.
+- Do not edit only ROLES.md while leaving stale role sections in MISSION.md.
+- Do not lay off a role while its tasks remain assigned to that role in KANBAN.md.
+- Do not merge roles without picking one canonical agent ID and one primary artifact owner per merged responsibility.
+
+## References
+
+- [Impact analysis (pre-flight)](references/impact-analysis.md)
+- [Layoff checklist](references/layoff-checklist.md)
+- [Merge checklist](references/merge-checklist.md)
+- [Constitution update](references/constitution-update.md)

--- a/src-tauri/bundled_skills/org-restructure/references/constitution-update.md
+++ b/src-tauri/bundled_skills/org-restructure/references/constitution-update.md
@@ -1,0 +1,58 @@
+# Constitution Update
+
+Change org operating rules or add a role without dissolving the org.
+
+## agents.md updates
+
+Use when changing read/write rules, handoff discipline, execution substrate notes, or anti-conflict rules.
+
+1. Read current `@teamwork/agents.md` and `.libragent/teamwork.json` refresh semantics.
+2. Append decision to `@teamwork/coordination/DECISIONS.md` with reason and impact.
+3. Edit `agents.md` surgically — preserve unrelated sections.
+4. Message org root: summarize what changed; rules apply **next execution step**, not current turn.
+5. If children use `workspaceOverride`, check whether their local `agents.md` needs the same edit.
+
+Do not use repo-root `agents.md` unless that is the actual teamwork artifact path.
+
+## Add a role
+
+1. Complete impact analysis — confirm the role does not already exist.
+2. Record decision in DECISIONS.md.
+3. Add section to `ROLES.md` (ID, tools, I/O, handoff).
+4. Add matching subsection to `MISSION.md` under `## Roles`.
+5. Create `skills/tf-<slug>/SKILL.md` if the role needs durable guidance (see teamwork expert-skill template).
+6. Add backlog tasks in `KANBAN.md` with the new role as owner where appropriate.
+7. Spawn member from org root: `agent__startSession(agentId, task)` with task citing ROLES.md and first KANBAN item.
+8. Verify with `agent__getOrg()`.
+
+## MISSION.md updates
+
+Update when objective, deliverables, constraints, or role roster changes:
+
+- Layoff/merge: always sync with ROLES.md in the same commit/edit batch
+- Objective shift: record in DECISIONS.md; check KANBAN still aligns with definition of done
+
+## ROLES.md ↔ MISSION.md sync rule
+
+**ROLES.md** = detailed contract (tools, IDs, handoffs).
+**MISSION.md** = mission-level role summary.
+
+Every role in one file must appear in the other. On any restructure, diff both files before finishing.
+
+## DECISIONS.md template (structure changes)
+
+```markdown
+## Decision: <short title>
+- Date:
+- Change type: add role | layoff | merge | constitution
+- Files changed: agents.md, ROLES.md, ...
+- Sessions affected:
+- Effective: next execution step (constitution refresh)
+- Revisit when:
+```
+
+## After edits
+
+- Root resume or `agent__messageToSession` to active members
+- `agent__getOrg()` for membership sanity
+- Grep coordination files for stale role names

--- a/src-tauri/bundled_skills/org-restructure/references/impact-analysis.md
+++ b/src-tauri/bundled_skills/org-restructure/references/impact-analysis.md
@@ -1,0 +1,68 @@
+# Impact Analysis (Pre-flight)
+
+Run this audit before any org restructure. Do not skip when the change looks "small."
+
+## 1. Org identity
+
+```
+agent__getOrg()                    # or agent__getOrg(orgId="...")
+```
+
+Capture:
+
+- `orgId`, `orgName`, `rootSessionId`
+- All member sessions (id, status, assistant/agent label)
+- Which sessions are root vs children
+
+Map each active child to a **role name** by cross-checking:
+
+- `@teamwork/ROLES.md` agent IDs
+- Session `assistantId` / task text / recent HANDOFF entries
+
+There is no automatic role↔session API. Infer from ROLES.md IDs and session metadata.
+
+## 2. Constitution files
+
+Read in the teamwork artifact root:
+
+| File | Check for |
+| --- | --- |
+| `agents.md` | Operating rules, file paths, anti-conflict rules |
+| `MISSION.md` | Role list, deliverables, constraints |
+| `ROLES.md` | Per-role ID, tools, inputs/outputs, handoffs |
+| `.libragent/teamwork.json` | `orgLineage`, refresh semantics |
+
+Flag **drift**: role in ROLES.md but missing/different in MISSION.md.
+
+## 3. Coordination references
+
+| File | Search for removed/merged role names |
+| --- | --- |
+| `coordination/KANBAN.md` | `owner:` lines |
+| `coordination/HANDOFF.md` | role names in headings and body |
+| `coordination/DECISIONS.md` | prior structure decisions |
+| `coordination/RISKS.md` | `Owner:` fields |
+
+## 4. Role skills
+
+List `skills/tf-*/SKILL.md` (or custom role skill dirs referenced in ROLES.md).
+
+Note which skill directory maps to which role — layoff/merge must update or retire these.
+
+## 5. Session workspace overrides
+
+For each org child from `getOrg`:
+
+- If spawned with `workspaceOverride`, it may have a **different** `agents.md` / `SOUL.md`.
+- Constitution changes in the shared artifact root do not automatically change override workspaces.
+- Plan separate edits or respawn if override dirs need updating.
+
+## 6. Output: change plan
+
+Before editing, write a short plan (in chat or DISCUSSION.md):
+
+1. Operation type (add / layoff / merge / constitution / child removal)
+2. Files to touch (ordered)
+3. Sessions to stop, delete, respawn, or message
+4. KANBAN/HANDOFF reassignments
+5. Who needs a refresh notice (usually all active org members via root)

--- a/src-tauri/bundled_skills/org-restructure/references/layoff-checklist.md
+++ b/src-tauri/bundled_skills/org-restructure/references/layoff-checklist.md
@@ -1,0 +1,81 @@
+# Layoff Checklist
+
+Remove a role from a living org without dissolving the org.
+
+## When to use
+
+- User wants to drop a specialist role (e.g. "we don't need a separate researcher anymore")
+- Role scope was absorbed by the coordinator
+- Duplicate role is being removed in favor of a merge (see [merge-checklist.md](merge-checklist.md) instead if combining)
+
+## Steps
+
+### 1. Record the decision
+
+Append to `@teamwork/coordination/DECISIONS.md`:
+
+```markdown
+## Decision: Role layoff — <Role Name>
+- Date:
+- Removed role: <Role Name>
+- Reason:
+- Tasks reassigned to: <Role Name or coordinator>
+- Sessions affected: <session ids or "none active">
+- Skills retired: skills/tf-<slug>/ (or "kept for reference")
+```
+
+### 2. Reassign open work
+
+In `@teamwork/coordination/KANBAN.md`:
+
+- Find all tasks owned by the laid-off role
+- Reassign `owner:` to coordinator or surviving role
+- Move blocked items to **Blocked** with updated owner if needed
+
+In `@teamwork/coordination/HANDOFF.md`:
+
+- Add an entry routing in-flight work to the new owner
+- Do not delete historical handoffs
+
+### 3. Update constitution (both files)
+
+**`ROLES.md`:** Remove the role section (or mark `## <Role> (retired)` only if user wants audit trail — prefer full removal + DECISIONS record).
+
+**`MISSION.md`:** Remove the matching role subsection under `## Roles`.
+
+Keep `agents.md` in sync only if it lists roles by name or points to removed skills.
+
+### 4. Role skill
+
+- **Delete** `skills/tf-<slug>/` if the role is gone permanently, or
+- Add a one-line deprecated notice in the skill frontmatter if the user wants to keep history
+
+### 5. Child sessions
+
+For each active session mapped to this role:
+
+| Goal | Action |
+| --- | --- |
+| Work complete, remove from org view | `agent__stopSession` → `agent__deleteSession` |
+| Work incomplete, reassign | `agent__messageToSession` with new owner instructions; stop old session if redundant |
+| Detach but keep session | **Not supported** — inform user |
+
+Never delete the **org root** session.
+
+### 6. Broadcast refresh
+
+Message the org root (or `agent__messageToSession` to active children):
+
+- Which role was removed
+- New owner for former tasks
+- Constitution files changed; rules apply on next execution step
+
+### 7. Verify
+
+- `agent__getOrg()` — laid-off sessions gone or stopped
+- Grep KANBAN/HANDOFF for old role name
+- ROLES.md and MISSION.md agree on remaining roles
+
+## Child sessions (org view only)
+
+Same session rules as step 5. There is no detach-from-org API; deletion is the only way to remove a session from org listing today.

--- a/src-tauri/bundled_skills/org-restructure/references/merge-checklist.md
+++ b/src-tauri/bundled_skills/org-restructure/references/merge-checklist.md
@@ -1,0 +1,83 @@
+# Merge Checklist
+
+Combine two or more overlapping roles into one canonical role.
+
+## When to use
+
+- Duplicate specialists with fuzzy boundaries
+- User says "merge marketing and product into one strategist"
+- Two ROLES.md sections own the same artifacts
+
+## Steps
+
+### 1. Record the decision
+
+```markdown
+## Decision: Role merge
+- Date:
+- Merged: <Role A> + <Role B> → <Canonical Role>
+- Canonical agent ID: <uuid from ROLES.md>
+- Retired agent IDs: <list>
+- Primary artifact owner: <paths>
+- Session kept: <session id or "respawn from root">
+```
+
+### 2. Pick the canonical role
+
+Decide upfront:
+
+| Field | Rule |
+| --- | --- |
+| **Role name** | User preference, or the more general name |
+| **Agent ID** | Keep the session you will retain; or the ID tied to the better assistant config |
+| **Artifacts** | Union of deliverables; one primary writer per file |
+| **Tools** | Union of allowed tool families; trim duplicates in prose |
+| **Handoff targets** | Rewire to surviving role names only |
+
+### 3. Merge ROLES.md sections
+
+One merged section:
+
+```markdown
+## <Canonical Role>
+- **ID**: <assistant name> (`<canonical-uuid>`)
+- **책임**: <combined responsibilities, no duplication>
+- **허용 도구**: <union, deduplicated>
+- **필수 입력**: <combined>
+- **필수 출력**: <combined, note primary files>
+- **Handoff**: <updated targets>
+```
+
+Delete the retired role sections.
+
+### 4. Sync MISSION.md
+
+Replace the separate role subsections with one subsection matching the merged role.
+
+### 5. Skills
+
+| Situation | Action |
+| --- | --- |
+| Both had `skills/tf-*` | Merge content into one skill; delete or deprecate the other |
+| Only one had a skill | Rename slug if role name changed |
+| Neither had skills | Optional: create one if merged role is durable |
+
+### 6. Coordination files
+
+- **KANBAN:** Rewrite `owner:` from retired names → canonical role name
+- **HANDOFF:** Add merge notice; future entries use canonical name only
+- **RISKS:** Update `Owner:` fields
+
+### 7. Sessions
+
+| Situation | Action |
+| --- | --- |
+| One active session per merged role | Keep one; stop/delete the other after handoff |
+| Both active with in-flight work | Message both; consolidate to one; stop redundant |
+| Neither active | Next spawn uses canonical agent ID from root |
+
+Do not leave two org children doing the same merged role without explicit parallel split in ROLES.md.
+
+### 8. Broadcast and verify
+
+Same as layoff: root message, refresh semantics, `getOrg` check, grep for retired role names.

--- a/src-tauri/bundled_skills/org/SKILL.md
+++ b/src-tauri/bundled_skills/org/SKILL.md
@@ -8,6 +8,7 @@ description: Run explicit org-based teamwork in LibrAgent. Use when collaboratio
 Org is explicit lineage teamwork. It is not generic delegation and it is not scheduled automation.
 
 Use `teamwork` first when the workspace constitution is not ready.
+Use `org-restructure` when the org already exists and roles or constitution files need to change (add, layoff, merge, agents.md updates).
 
 ## Workflow
 
@@ -47,3 +48,4 @@ Use `teamwork` first when the workspace constitution is not ready.
 ## References
 
 - [Org patterns and tool call examples](references/org-patterns.md)
+- Living org changes (roles, constitution): use bundled skill `org-restructure`

--- a/src-tauri/bundled_skills/pair-programming/SKILL.md
+++ b/src-tauri/bundled_skills/pair-programming/SKILL.md
@@ -40,3 +40,9 @@ The Pair Programming pattern binds two sessions to a shared workspace (`workspac
 ## 🛠️ MCP Tools Guide
 
 - **Turn Coordination**: The parent session collects the Driver's changes summary and forwards them to the Navigator via `agent__messageToSession` to invoke the next turn, maintaining a lock-step loop.
+
+## References
+
+- [Role rotation](references/role-rotation.md)
+- [Turn protocol](references/turn-protocol.md)
+- [Diff review checklist](references/diff-review-checklist.md)

--- a/src-tauri/bundled_skills/pair-programming/references/diff-review-checklist.md
+++ b/src-tauri/bundled_skills/pair-programming/references/diff-review-checklist.md
@@ -1,0 +1,37 @@
+# Diff Review Checklist (Navigator)
+
+Both sessions share `workspaceOverride`. Navigator reviews before approving the next turn.
+
+## Quick review steps
+
+1. Identify changed files (git status, workspace search, or Driver's Change Summary).
+2. Read diff for scope creep — changes should match the micro-task only.
+3. Check tests/lint if the project defines them.
+4. Verify no secrets, debug prints, or commented-out blocks left behind.
+
+## Checklist
+
+- [ ] Change matches the stated micro-task
+- [ ] No unrelated file edits
+- [ ] Naming matches project conventions
+- [ ] Error paths handled for new logic
+- [ ] Tests added or updated when behavior changed
+- [ ] No credentials in code or logs
+
+## Revise vs approve
+
+**Approve** when checklist passes or issues are trivial (typos).
+
+**Revise** when:
+
+- Missing tests for new behavior
+- Architectural mismatch with agreed design
+- Incomplete micro-task
+
+Keep revise feedback numbered and file-specific.
+
+## Role rotation
+
+Before rotation, Navigator posts **handoff note** summarizing open items. New Driver reads shared workspace + handoff only — not full prior chat.
+
+See [role-rotation.md](role-rotation.md).

--- a/src-tauri/bundled_skills/pair-programming/references/turn-protocol.md
+++ b/src-tauri/bundled_skills/pair-programming/references/turn-protocol.md
@@ -1,0 +1,41 @@
+# Pair Programming Turn Protocol
+
+Driver and Navigator alternate via parent-mediated messages.
+
+## Roles
+
+| Role | Does | Does not |
+| --- | --- | --- |
+| **Driver** | Edit files, run commands, implement | Redesign architecture without Navigator sign-off |
+| **Navigator** | Review diff, guide structure, set next micro-task | Large unsolicited rewrites |
+
+## Turn cycle
+
+1. Navigator sends **micro-task** (one logical unit).
+2. Driver implements and posts **Change Summary**.
+3. Navigator reviews (diff/view) and replies **Approve next** or **Revise**.
+4. Repeat until milestone; optionally rotate roles.
+
+## Change Summary (Driver → Navigator)
+
+```markdown
+## Driver Turn Complete
+- Task: <micro-task>
+- Files changed: <paths>
+- Approach: <2-3 sentences>
+- Tests run: <command + result or "not run">
+- Ready for: review | next task
+```
+
+## Navigator feedback
+
+```markdown
+## Navigator Review
+- Verdict: approve | revise
+- Issues: <numbered list>
+- Next micro-task: <single clear instruction>
+```
+
+## Parent coordination
+
+Use `agent__messageToSession` to pass Change Summary and Review between sessions. Parent enforces turn order — spokes do not message each other directly unless Hub pattern explicitly allows.

--- a/src-tauri/bundled_skills/pipeline/SKILL.md
+++ b/src-tauri/bundled_skills/pipeline/SKILL.md
@@ -33,3 +33,9 @@ Input ──► [ Stage A ] ──► (Artifacts) ──► [ Stage B ] ──�
 - **Context Filtering**: Avoid passing the entire conversation logs of previous stages to prevent context bloat. Only pass the **summarized markdown text and file paths**.
 
 See [pipeline-specs.md](references/pipeline-specs.md) for details.
+
+## References
+
+- [Pipeline specs](references/pipeline-specs.md)
+- [Handover templates](references/handover-templates.md)
+- [Failure recovery](references/failure-recovery.md)

--- a/src-tauri/bundled_skills/pipeline/references/failure-recovery.md
+++ b/src-tauri/bundled_skills/pipeline/references/failure-recovery.md
@@ -1,0 +1,36 @@
+# Pipeline Failure Recovery
+
+## Stage failed mid-pipeline
+
+1. **Stop downstream** — do not spawn next stage on bad input.
+2. **Capture error** — exit reason from `agent__checkSession` or child message.
+3. **Choose recovery:**
+
+| Situation | Action |
+| --- | --- |
+| Transient (timeout, rate limit) | Retry same stage once with narrowed task |
+| Bad handover | Fix handover template, re-run **same** stage |
+| Wrong upstream artifact | Re-run **previous** stage only |
+| Unrecoverable | Report to user with stage name + files touched |
+
+## Partial artifact safety
+
+- Shared `workspaceOverride` means later stages may read half-done files.
+- On failure, mark WIP in a `PIPELINE_STATUS.md` or coordination note.
+- Next retry should state which files are authoritative.
+
+## Idempotent stages
+
+Design stages so re-run does not duplicate work:
+
+- Research → overwrite `docs/RESEARCH.md`
+- Implement → branch or explicit "continue from line X"
+
+## User escalation template
+
+```markdown
+Pipeline stopped at stage: <name>
+Reason: <error>
+Artifacts so far: <paths>
+Suggested fix: <retry stage N | fix handover | user decision>
+```

--- a/src-tauri/bundled_skills/pipeline/references/handover-templates.md
+++ b/src-tauri/bundled_skills/pipeline/references/handover-templates.md
@@ -1,0 +1,45 @@
+# Pipeline Handover Templates
+
+Bind only what the next stage needs.
+
+## Stage completion block (every worker)
+
+```markdown
+## Stage Complete: <Stage Name>
+- Input used: <paths or prior stage id>
+- Output artifacts:
+  - <path> — <one line description>
+- Decisions made: <bullets>
+- Open questions: <bullets or "none">
+- Recommended next stage focus: <one paragraph>
+```
+
+## Handover to next stage (parent binds into task)
+
+```markdown
+You are stage "<Next Stage>" in a pipeline.
+
+Prior stage output:
+<paste Stage Complete block>
+
+Read these files first:
+- <path1>
+- <path2>
+
+Your deliverable:
+- <explicit output>
+
+Do not restart prior work; extend or refine only.
+```
+
+## Sequential spawn pattern
+
+```text
+sessionA = startSession(..., waitForResult=true)
+handover = extract Stage Complete from A
+sessionB = startSession(task=handover + criteria, waitForResult=true)
+```
+
+## Context filtering rule
+
+Never attach full prior-stage message history. File paths + Stage Complete block are sufficient.

--- a/src-tauri/bundled_skills/setup-wizard/LICENSE.txt
+++ b/src-tauri/bundled_skills/setup-wizard/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LibrAgent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src-tauri/bundled_skills/setup-wizard/SKILL.md
+++ b/src-tauri/bundled_skills/setup-wizard/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: setup-wizard
-description: Use when the user needs to diagnose and install runtime environment dependencies (Python, Node.js, etc.) for running LibrAgent. LibrAgent 실행에 필요한 Python, Node.js 등의 환경을 자동으로 진단하고 설치하도록 안내하는 마법사입니다.
+description: Use when the user needs to diagnose and install runtime environment dependencies (Python, Node.js, uv) for running LibrAgent or MCP servers. Use on new machines, MCP "command not found" errors, or missing Python/Node runtime failures. LibrAgent 실행에 필요한 Python, Node.js 등의 환경을 자동으로 진단하고 설치하도록 안내하는 마법사입니다.
+license: Complete terms in LICENSE.txt
 ---
 
 # System Setup for MCP Servers
 
-Diagnose missing runtimes and guide installation—do not dump full OS install guides into the conversation.
+Automated installation and verification of MCP runtime dependencies.
+
+## Path conventions
+
+Paths in this skill are relative to this skill's Base Directory. Replace `<skill-base-dir>` with its absolute path in commands.
 
 ## Workflow
 
 1. **Detect OS** — identify platform via terminal
 2. **Check installations** — run verification commands below
-3. **Install missing components** — follow [references/installation-guide.md](references/installation-guide.md) for the detected OS only
-4. **Verify** — re-run checks; confirm Python 3.11+, Node 18+, uv available
+3. **Install missing components** — use platform scripts or [installation-guide.md](references/installation-guide.md)
+4. **Verify** — run `verify_setup` script or manual checks; confirm Python 3.11+, Node 18+, uv available
 
 ## Quick Verification
 
@@ -34,6 +39,39 @@ which uv && uv --version
 
 Report what is missing, then load only the relevant section from the installation guide.
 
-## Scripts
+## Automated Scripts
 
-Platform scripts in `scripts/` (if bundled): `install_python`, `install_node`, `install_uv`, `verify_setup` — use when the user prefers automated install over manual commands.
+Prefer scripts when the user wants hands-off install:
+
+```powershell
+# Windows examples
+& "<skill-base-dir>/scripts/verify_setup.ps1"
+& "<skill-base-dir>/scripts/install_python.ps1"
+& "<skill-base-dir>/scripts/install_node.ps1"
+& "<skill-base-dir>/scripts/install_uv.ps1"
+```
+
+```bash
+# Linux/macOS examples
+bash "<skill-base-dir>/scripts/verify_setup.sh"
+bash "<skill-base-dir>/scripts/install_python.sh"
+bash "<skill-base-dir>/scripts/install_node.sh"
+bash "<skill-base-dir>/scripts/install_uv.sh"
+```
+
+## Advanced Topics
+
+- **PATH configuration:** [PATH_CONFIG.md](references/PATH_CONFIG.md)
+- **Virtual environments:** [VENV_GUIDE.md](references/VENV_GUIDE.md)
+- **Offline installation:** [OFFLINE_INSTALL.md](references/OFFLINE_INSTALL.md)
+- **OS-specific commands:** [installation-guide.md](references/installation-guide.md)
+
+## Integration with LibrAgent
+
+LibrAgent MCP servers require:
+
+- **Python 3.11+** for Python-based MCP servers
+- **Node.js 18+** for TypeScript-based MCP servers
+- **uv** for fast Python dependency management
+
+After setup, re-run the verification script before retrying failed MCP servers.

--- a/src-tauri/bundled_skills/setup-wizard/references/OFFLINE_INSTALL.md
+++ b/src-tauri/bundled_skills/setup-wizard/references/OFFLINE_INSTALL.md
@@ -1,0 +1,316 @@
+# Offline Installation Guide
+
+## Overview
+
+Install Python, Node.js, and uv without internet connectivity.
+
+## Preparation (Online Machine)
+
+### Download Python
+
+**Windows:**
+
+1. Visit python.org/downloads
+2. Download "Windows installer (64-bit)"
+3. Save file: `python-3.11.x-amd64.exe`
+
+**Linux:**
+
+```bash
+# Download source tarball
+wget https://www.python.org/ftp/python/3.11.x/Python-3.11.x.tgz
+
+# Or use your distro's package cache
+apt-get download python3 python3-pip
+dnf download python3 python3-pip
+```
+
+**macOS:**
+
+```bash
+# Download official installer
+curl -O https://www.python.org/ftp/python/3.11.x/python-3.11.x-macos11.pkg
+```
+
+### Download Node.js
+
+**Windows:**
+
+1. Visit nodejs.org/download
+2. Download "Windows Installer (.msi)" - 64-bit
+3. Save file: `node-v20.x.x-x64.msi`
+
+**Linux:**
+
+```bash
+# Download binary tarball
+wget https://nodejs.org/dist/v20.x.x/node-v20.x.x-linux-x64.tar.xz
+```
+
+**macOS:**
+
+```bash
+# Download PKG installer
+curl -O https://nodejs.org/dist/v20.x.x/node-v20.x.x.pkg
+```
+
+### Download uv
+
+**All Platforms:**
+
+```bash
+# Download prebuilt binary
+# Windows
+curl -LO https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-pc-windows-msvc.zip
+
+# Linux
+curl -LO https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz
+
+# macOS (Intel)
+curl -LO https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-apple-darwin.tar.gz
+
+# macOS (Apple Silicon)
+curl -LO https://github.com/astral-sh/uv/releases/latest/download/uv-aarch64-apple-darwin.tar.gz
+```
+
+### Download Python Packages
+
+```bash
+# Create requirements.txt with needed packages
+cat > requirements.txt <<EOF
+fastmcp
+anthropic
+openai
+requests
+EOF
+
+# Download packages and dependencies
+pip download -r requirements.txt -d ./packages/
+```
+
+## Installation (Offline Machine)
+
+### Python Installation
+
+**Windows:**
+
+```powershell
+# Run installer
+.\python-3.11.x-amd64.exe /quiet InstallAllUsers=1 PrependPath=1
+```
+
+**Linux (from binary):**
+
+```bash
+# Extract and install
+tar xzf Python-3.11.x.tgz
+cd Python-3.11.x
+./configure --prefix=/usr/local
+make
+sudo make install
+```
+
+**Linux (from .deb packages):**
+
+```bash
+sudo dpkg -i python3_*.deb python3-pip_*.deb
+sudo apt-get install -f  # Fix dependencies if needed
+```
+
+**macOS:**
+
+```bash
+# Install PKG
+sudo installer -pkg python-3.11.x-macos11.pkg -target /
+```
+
+### Node.js Installation
+
+**Windows:**
+
+```powershell
+# Run MSI installer
+msiexec /i node-v20.x.x-x64.msi /quiet
+```
+
+**Linux:**
+
+```bash
+# Extract binary
+tar xJf node-v20.x.x-linux-x64.tar.xz
+sudo mv node-v20.x.x-linux-x64 /opt/nodejs
+
+# Add to PATH
+echo 'export PATH="/opt/nodejs/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+**macOS:**
+
+```bash
+# Install PKG
+sudo installer -pkg node-v20.x.x.pkg -target /
+```
+
+### uv Installation
+
+**Windows:**
+
+```powershell
+# Extract and move to PATH
+Expand-Archive uv-x86_64-pc-windows-msvc.zip
+Move-Item uv-x86_64-pc-windows-msvc\uv.exe $env:USERPROFILE\.cargo\bin\
+```
+
+**Linux/macOS:**
+
+```bash
+# Extract and install
+tar xzf uv-*.tar.gz
+sudo mv uv /usr/local/bin/
+chmod +x /usr/local/bin/uv
+```
+
+### Python Packages Installation
+
+```bash
+# Install from downloaded packages
+pip install --no-index --find-links=./packages/ -r requirements.txt
+```
+
+## Verification
+
+```bash
+# Check installations
+python --version
+pip --version
+node --version
+npm --version
+uv --version
+
+# Test package import
+python -c "import fastmcp; print('fastmcp OK')"
+```
+
+## Creating Offline Package Cache
+
+### For Python Projects
+
+```bash
+# Create wheel cache
+pip wheel -r requirements.txt -w ./wheelhouse/
+
+# Install from wheelhouse
+pip install --no-index --find-links=./wheelhouse/ -r requirements.txt
+```
+
+### For Node.js Projects
+
+```bash
+# Create offline npm cache
+npm install --cache ./npm-cache/ --prefer-offline
+
+# Or use npm pack
+npm pack package-name
+```
+
+### For uv
+
+```bash
+# uv caches packages automatically in ~/.cache/uv/
+# Copy cache to offline machine:
+tar czf uv-cache.tar.gz ~/.cache/uv/
+
+# On offline machine:
+tar xzf uv-cache.tar.gz -C ~/
+```
+
+## Portable Installation
+
+### Python Portable (Windows)
+
+1. Download "embeddable package" from python.org
+2. Extract to `C:\Python311Portable\`
+3. Add `python311._pth` file:
+   ```
+   python311.zip
+   .
+   ./Lib/site-packages
+   ```
+4. Install pip manually:
+   ```powershell
+   python get-pip.py --no-index
+   ```
+
+### Node.js Portable (Windows)
+
+1. Download ZIP archive from nodejs.org
+2. Extract to desired location
+3. Add to PATH or use full path: `C:\node\node.exe`
+
+## Corporate Environment
+
+### Using Internal Mirrors
+
+```bash
+# Python (pip)
+pip install --index-url http://internal-pypi/simple/ package-name
+
+# Node.js (npm)
+npm config set registry http://internal-npm/
+
+# uv
+export UV_INDEX_URL=http://internal-pypi/simple/
+```
+
+### Proxy Configuration
+
+```bash
+# System-wide proxy
+export HTTP_PROXY=http://proxy:8080
+export HTTPS_PROXY=http://proxy:8080
+
+# pip proxy
+pip install --proxy http://proxy:8080 package-name
+
+# npm proxy
+npm config set proxy http://proxy:8080
+npm config set https-proxy http://proxy:8080
+```
+
+## Troubleshooting
+
+### Missing System Libraries (Linux)
+
+Python compilation may need:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install build-essential libssl-dev libffi-dev python3-dev
+
+# Fedora/RHEL
+sudo dnf groupinstall "Development Tools"
+sudo dnf install openssl-devel libffi-devel python3-devel
+```
+
+### Certificate Issues
+
+```bash
+# Disable SSL verification (testing only)
+pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org package-name
+
+# Or add custom CA certificate
+export REQUESTS_CA_BUNDLE=/path/to/ca-bundle.crt
+```
+
+### Permission Errors
+
+```bash
+# Install to user directory (no sudo needed)
+pip install --user package-name
+
+# Or use virtual environment
+python -m venv venv
+source venv/bin/activate
+pip install package-name
+```

--- a/src-tauri/bundled_skills/setup-wizard/references/PATH_CONFIG.md
+++ b/src-tauri/bundled_skills/setup-wizard/references/PATH_CONFIG.md
@@ -1,0 +1,196 @@
+# PATH Configuration Guide
+
+## Understanding PATH
+
+The PATH environment variable tells the operating system where to find executable files. When you type a command like `python` or `node`, the system searches directories listed in PATH.
+
+## Viewing Current PATH
+
+**Windows PowerShell:**
+
+```powershell
+$env:PATH -split ';'
+```
+
+**Linux/macOS:**
+
+```bash
+echo $PATH | tr ':' '\n'
+```
+
+## Adding to PATH
+
+### Windows
+
+**Method 1: System Settings (Permanent)**
+
+1. Search "Environment Variables" in Start menu
+2. Click "Environment Variables"
+3. Under "User variables" or "System variables", select "Path"
+4. Click "Edit" → "New"
+5. Add directory path (e.g., `C:\Python311\Scripts`)
+6. Click OK and restart terminal
+
+**Method 2: PowerShell (Current Session)**
+
+```powershell
+$env:PATH += ";C:\path\to\directory"
+```
+
+**Method 3: PowerShell Profile (Permanent)**
+
+```powershell
+# Edit profile
+notepad $PROFILE
+
+# Add this line:
+$env:PATH += ";C:\path\to\directory"
+```
+
+### Linux/macOS
+
+**Method 1: Shell RC File (Permanent)**
+
+For Bash (`~/.bashrc` or `~/.bash_profile`):
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For Zsh (`~/.zshrc`):
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Apply changes:
+
+```bash
+source ~/.bashrc  # or ~/.zshrc
+```
+
+**Method 2: Current Session Only**
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Common PATH Locations
+
+### Python
+
+**Windows:**
+
+- `C:\Python311\`
+- `C:\Python311\Scripts\`
+- `%APPDATA%\Python\Python311\Scripts\`
+
+**Linux:**
+
+- `/usr/bin/`
+- `/usr/local/bin/`
+- `~/.local/bin/`
+
+**macOS:**
+
+- `/usr/local/bin/`
+- `/opt/homebrew/bin/` (Apple Silicon)
+- `~/Library/Python/3.11/bin/`
+
+### Node.js
+
+**Windows:**
+
+- `C:\Program Files\nodejs\`
+- `%APPDATA%\npm\`
+
+**Linux:**
+
+- `/usr/bin/`
+- `/usr/local/bin/`
+- `~/.npm-global/bin/`
+
+**macOS:**
+
+- `/usr/local/bin/`
+- `/opt/homebrew/bin/`
+
+### uv
+
+**Windows:**
+
+- `%USERPROFILE%\.cargo\bin\`
+
+**Linux/macOS:**
+
+- `~/.cargo/bin/`
+
+## Troubleshooting
+
+### PATH Not Updating
+
+**Windows:**
+
+- Close all terminal windows and reopen
+- Log out and log back in
+- Restart computer (system-wide changes)
+
+**Linux/macOS:**
+
+- Run `source ~/.bashrc` or `source ~/.zshrc`
+- Close terminal and open new one
+- Check shell type: `echo $SHELL`
+
+### Duplicate Entries
+
+**Windows:**
+
+```powershell
+# Remove duplicates
+$paths = $env:PATH -split ';' | Select-Object -Unique
+$env:PATH = $paths -join ';'
+```
+
+**Linux/macOS:**
+
+```bash
+# View duplicates
+echo $PATH | tr ':' '\n' | sort | uniq -d
+```
+
+### Permission Denied
+
+**Linux/macOS:**
+
+- Ensure directories have execute permissions: `chmod +x /path/to/executable`
+- Check file ownership: `ls -la /path/to/executable`
+
+### Wrong Version Executed
+
+Multiple versions installed? Check which one is found first:
+
+```bash
+# Windows
+Get-Command python -All
+
+# Linux/macOS
+which -a python3
+```
+
+Order matters: The first match in PATH is executed.
+
+## Security Considerations
+
+- **Avoid adding current directory (`.`) to PATH** - Security risk
+- **Use absolute paths** - Avoid relative paths in PATH
+- **Limit write permissions** - Ensure PATH directories aren't world-writable
+- **Order matters** - Place trusted directories first
+
+## PATH Priority
+
+Directories are searched in order:
+
+1. **Windows:** Left to right (separated by `;`)
+2. **Linux/macOS:** Left to right (separated by `:`)
+
+To prioritize a specific installation, place it earlier in PATH.

--- a/src-tauri/bundled_skills/setup-wizard/references/VENV_GUIDE.md
+++ b/src-tauri/bundled_skills/setup-wizard/references/VENV_GUIDE.md
@@ -1,0 +1,252 @@
+# Virtual Environment Guide
+
+## Why Virtual Environments?
+
+Virtual environments isolate Python dependencies per project, preventing:
+
+- Version conflicts between projects
+- Global package pollution
+- Permission issues with system Python
+- "It works on my machine" problems
+
+## Creating Virtual Environments
+
+### Python venv (Built-in)
+
+**All Platforms:**
+
+```bash
+# Create venv
+python -m venv myenv
+
+# Activate
+source myenv/bin/activate  # Linux/macOS
+.\myenv\Scripts\activate   # Windows PowerShell
+myenv\Scripts\activate.bat # Windows CMD
+
+# Deactivate
+deactivate
+```
+
+### uv (Recommended for Speed)
+
+**All Platforms:**
+
+```bash
+# Create venv with uv (much faster)
+uv venv
+
+# Activate
+source .venv/bin/activate  # Linux/macOS
+.\.venv\Scripts\activate   # Windows
+
+# Install packages
+uv pip install package-name
+
+# Generate requirements
+uv pip freeze > requirements.txt
+```
+
+## Virtual Environment Locations
+
+**Standard locations:**
+
+- Project root: `./venv` or `./.venv`
+- Centralized: `~/.virtualenvs/project-name/`
+
+**LibrAgent MCP servers:**
+
+- Each MCP server may have its own venv
+- Check `mcp-server-directory/.venv/`
+
+## Managing Dependencies
+
+### Installing Packages
+
+```bash
+# Activate venv first!
+source .venv/bin/activate
+
+# Using pip
+pip install package-name
+
+# Using uv (faster)
+uv pip install package-name
+
+# From requirements.txt
+pip install -r requirements.txt
+uv pip install -r requirements.txt
+```
+
+### Exporting Dependencies
+
+```bash
+# Generate requirements.txt
+pip freeze > requirements.txt
+uv pip freeze > requirements.txt
+
+# With version hashes (more secure)
+pip freeze --all > requirements.txt
+```
+
+## IDE Integration
+
+### VS Code
+
+Add to `.vscode/settings.json`:
+
+```json
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.terminal.activateEnvironment": true
+}
+```
+
+### PyCharm
+
+1. File → Settings → Project → Python Interpreter
+2. Click gear icon → Add
+3. Select "Virtualenv Environment" → "Existing environment"
+4. Choose `.venv/bin/python`
+
+## Common Issues
+
+### Activation Not Working
+
+**Symptoms:** `(venv)` prefix doesn't appear
+
+**Solutions:**
+
+- Ensure correct activation script path
+- Check script execution policy (Windows): `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`
+- Try absolute path: `C:\path\to\venv\Scripts\activate`
+
+### Wrong Python Version
+
+**Symptoms:** Venv uses different Python than expected
+
+**Solutions:**
+
+```bash
+# Specify Python version explicitly
+python3.11 -m venv myenv
+/usr/bin/python3.11 -m venv myenv
+C:\Python311\python.exe -m venv myenv
+```
+
+### Packages Not Found After Activation
+
+**Symptoms:** `ModuleNotFoundError` despite installing package
+
+**Solutions:**
+
+- Verify venv is activated: `which python` or `Get-Command python`
+- Check pip installation: `pip list`
+- Reinstall package in activated venv
+
+### Venv Too Large
+
+**Symptoms:** Venv directory consumes excessive disk space
+
+**Solutions:**
+
+- Don't commit venv to git (add to `.gitignore`)
+- Use `--without-pip` and install pip later if needed
+- Clean up unused packages: `pip uninstall package-name`
+
+## Best Practices
+
+### Project Structure
+
+```
+project/
+├── .venv/           # Virtual environment (gitignored)
+├── src/             # Source code
+├── requirements.txt # Dependencies
+└── README.md
+```
+
+### Gitignore
+
+Add to `.gitignore`:
+
+```
+# Virtual environments
+venv/
+.venv/
+env/
+ENV/
+```
+
+### Requirements.txt Management
+
+**Split requirements:**
+
+- `requirements.txt` - Production dependencies
+- `requirements-dev.txt` - Development tools (pytest, black, etc.)
+
+Install both:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+### Reproducible Environments
+
+```bash
+# Pin versions
+pip freeze > requirements.txt
+
+# Or use pip-tools for deterministic builds
+pip install pip-tools
+pip-compile requirements.in
+pip-sync requirements.txt
+```
+
+## MCP Server Contexts
+
+LibrAgent MCP servers may use venvs:
+
+**Check MCP server venv:**
+
+```bash
+# Look for .venv or venv directory
+ls -la /path/to/mcp-server/
+
+# Check which Python is used
+cat /path/to/mcp-server/start.sh
+```
+
+**Activate MCP server venv manually:**
+
+```bash
+cd /path/to/mcp-server
+source .venv/bin/activate
+python server.py
+```
+
+## uv Virtual Environments
+
+uv provides faster venv operations:
+
+```bash
+# Create venv
+uv venv
+
+# Install packages (parallel, cached)
+uv pip install -r requirements.txt
+
+# Sync exact dependencies
+uv pip sync requirements.txt
+
+# Compile requirements with hashes
+uv pip compile requirements.in -o requirements.txt
+```
+
+**Benefits:**
+
+- 10-100x faster than pip
+- Parallel downloads
+- Disk cache for offline installs
+- Drop-in pip replacement

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_node.ps1
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_node.ps1
@@ -1,0 +1,80 @@
+# Node.js Installation Script for Windows
+# Run as Administrator for system-wide installation
+
+param(
+    [switch]$UserInstall = $false,
+    [string]$Version = "LTS"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Node.js Installation Script ===" -ForegroundColor Cyan
+Write-Host "Target Version: $Version" -ForegroundColor Green
+Write-Host ""
+
+# Check if Node.js is already installed
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+if ($nodeCmd) {
+    $currentVersion = node --version 2>&1
+    Write-Host "Node.js already installed: $currentVersion" -ForegroundColor Yellow
+    $continue = Read-Host "Do you want to continue with installation? (y/n)"
+    if ($continue -ne 'y') {
+        Write-Host "Installation cancelled." -ForegroundColor Red
+        exit 0
+    }
+}
+
+# Install using winget (recommended)
+Write-Host "Installing Node.js using winget..." -ForegroundColor Cyan
+try {
+    if ($UserInstall) {
+        winget install --id OpenJS.NodeJS.LTS --scope user --silent
+    } else {
+        winget install --id OpenJS.NodeJS.LTS --scope machine --silent
+    }
+    Write-Host "Node.js installed successfully!" -ForegroundColor Green
+} catch {
+    Write-Host "winget installation failed. Please install manually from nodejs.org" -ForegroundColor Red
+    Write-Host "Download: https://nodejs.org/en/download/" -ForegroundColor Yellow
+    exit 1
+}
+
+# Refresh environment variables
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+# Verify installation
+Write-Host ""
+Write-Host "Verifying installation..." -ForegroundColor Cyan
+Start-Sleep -Seconds 2
+
+try {
+    $nodeVersion = node --version 2>&1
+    $npmVersion = npm --version 2>&1
+    
+    Write-Host "✓ Node.js: $nodeVersion" -ForegroundColor Green
+    Write-Host "✓ npm: $npmVersion" -ForegroundColor Green
+    
+    Write-Host ""
+    Write-Host "Node.js installation completed successfully!" -ForegroundColor Green
+    Write-Host "Please restart your terminal to ensure PATH is updated." -ForegroundColor Yellow
+} catch {
+    Write-Host "✗ Verification failed. Please restart your terminal and try again." -ForegroundColor Red
+    exit 1
+}
+
+# Configure npm global directory (user scope)
+if ($UserInstall) {
+    Write-Host ""
+    Write-Host "Configuring npm global directory..." -ForegroundColor Cyan
+    $npmPrefix = "$env:APPDATA\npm"
+    npm config set prefix $npmPrefix
+    Write-Host "✓ npm global directory: $npmPrefix" -ForegroundColor Green
+    Write-Host "Ensure $npmPrefix is in your PATH" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "=== Installation Complete ===" -ForegroundColor Cyan
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "1. Restart your terminal"
+Write-Host "2. Run: node --version"
+Write-Host "3. Run: npm --version"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_node.sh
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_node.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Node.js Installation Script for Linux
+
+set -e
+
+echo "=== Node.js Installation Script ==="
+echo ""
+
+# Detect distribution
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$ID
+    OS_VERSION=$VERSION_ID
+else
+    echo "Cannot detect OS distribution."
+    exit 1
+fi
+
+echo "Detected OS: $OS $OS_VERSION"
+echo ""
+
+# Check if Node.js is already installed
+if command -v node &> /dev/null; then
+    CURRENT_VERSION=$(node --version)
+    echo "Node.js already installed: $CURRENT_VERSION"
+    read -p "Do you want to continue with installation? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+fi
+
+# Install Node.js based on distribution
+case $OS in
+    ubuntu|debian)
+        echo "Installing Node.js on Ubuntu/Debian..."
+        curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        ;;
+    
+    fedora|rhel|centos)
+        echo "Installing Node.js on Fedora/RHEL/CentOS..."
+        curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -
+        sudo dnf install -y nodejs
+        ;;
+    
+    arch|manjaro)
+        echo "Installing Node.js on Arch Linux..."
+        sudo pacman -S --noconfirm nodejs npm
+        ;;
+    
+    opensuse*)
+        echo "Installing Node.js on openSUSE..."
+        sudo zypper install -y nodejs npm
+        ;;
+    
+    *)
+        echo "Unsupported distribution: $OS"
+        echo "Please install Node.js manually using one of these methods:"
+        echo "1. NodeSource: https://github.com/nodesource/distributions"
+        echo "2. nvm: https://github.com/nvm-sh/nvm"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Node.js installed successfully!"
+echo ""
+
+# Verify installation
+echo "Verifying installation..."
+sleep 1
+
+if command -v node &> /dev/null; then
+    NODE_VERSION=$(node --version)
+    NPM_VERSION=$(npm --version)
+    
+    echo "✓ Node.js: $NODE_VERSION"
+    echo "✓ npm: $NPM_VERSION"
+else
+    echo "✗ Verification failed. Please check installation logs."
+    exit 1
+fi
+
+echo ""
+echo "=== Installation Complete ==="
+echo "Next steps:"
+echo "1. Run: node --version"
+echo "2. Run: npm --version"
+echo "3. Configure npm global directory (optional):"
+echo "   npm config set prefix ~/.npm-global"
+echo "   export PATH=~/.npm-global/bin:\$PATH"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_python.ps1
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_python.ps1
@@ -1,0 +1,96 @@
+# Python Installation Script for Windows
+# Run as Administrator for system-wide installation
+
+param(
+    [switch]$UserInstall = $false,
+    [string]$Version = "3.12"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Python Installation Script ===" -ForegroundColor Cyan
+Write-Host "Target Version: Python $Version" -ForegroundColor Green
+Write-Host ""
+
+# Check if Python is already installed
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if ($pythonCmd) {
+    $currentVersion = python --version 2>&1
+    Write-Host "Python already installed: $currentVersion" -ForegroundColor Yellow
+    $continue = Read-Host "Do you want to continue with installation? (y/n)"
+    if ($continue -ne 'y') {
+        Write-Host "Installation cancelled." -ForegroundColor Red
+        exit 0
+    }
+}
+
+# Install using winget (recommended)
+Write-Host "Installing Python using winget..." -ForegroundColor Cyan
+try {
+    if ($UserInstall) {
+        winget install --id Python.Python.3.12 --scope user --silent
+    } else {
+        winget install --id Python.Python.3.12 --scope machine --silent
+    }
+    Write-Host "Python installed successfully!" -ForegroundColor Green
+} catch {
+    Write-Host "winget installation failed. Trying alternative method..." -ForegroundColor Yellow
+    
+    # Fallback: Download and install manually
+    $downloadUrl = "https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe"
+    $installerPath = "$env:TEMP\python-installer.exe"
+    
+    Write-Host "Downloading Python installer..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath
+    
+    Write-Host "Running installer..." -ForegroundColor Cyan
+    if ($UserInstall) {
+        Start-Process -FilePath $installerPath -ArgumentList "/quiet", "InstallAllUsers=0", "PrependPath=1" -Wait
+    } else {
+        Start-Process -FilePath $installerPath -ArgumentList "/quiet", "InstallAllUsers=1", "PrependPath=1" -Wait
+    }
+    
+    Remove-Item $installerPath -Force
+    Write-Host "Python installed successfully!" -ForegroundColor Green
+}
+
+# Refresh environment variables
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+# Verify installation
+Write-Host ""
+Write-Host "Verifying installation..." -ForegroundColor Cyan
+Start-Sleep -Seconds 2
+
+try {
+    $pythonVersion = python --version 2>&1
+    $pipVersion = pip --version 2>&1
+    
+    Write-Host "✓ Python: $pythonVersion" -ForegroundColor Green
+    Write-Host "✓ pip: $pipVersion" -ForegroundColor Green
+    
+    Write-Host ""
+    Write-Host "Python installation completed successfully!" -ForegroundColor Green
+    Write-Host "Please restart your terminal to ensure PATH is updated." -ForegroundColor Yellow
+} catch {
+    Write-Host "✗ Verification failed. Please restart your terminal and try again." -ForegroundColor Red
+    Write-Host "If the problem persists, check PATH configuration." -ForegroundColor Yellow
+    exit 1
+}
+
+# Upgrade pip
+Write-Host ""
+Write-Host "Upgrading pip to latest version..." -ForegroundColor Cyan
+try {
+    python -m pip install --upgrade pip
+    Write-Host "✓ pip upgraded successfully!" -ForegroundColor Green
+} catch {
+    Write-Host "⚠ Failed to upgrade pip. You may need to upgrade manually later." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "=== Installation Complete ===" -ForegroundColor Cyan
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "1. Restart your terminal (or reboot if needed)"
+Write-Host "2. Run: python --version"
+Write-Host "3. Install uv: pip install uv"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_python.sh
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_python.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Python Installation Script for Linux
+
+set -e
+
+echo "=== Python Installation Script ==="
+echo ""
+
+# Detect distribution
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$ID
+    OS_VERSION=$VERSION_ID
+else
+    echo "Cannot detect OS distribution."
+    exit 1
+fi
+
+echo "Detected OS: $OS $OS_VERSION"
+echo ""
+
+# Check if Python is already installed
+if command -v python3 &> /dev/null; then
+    CURRENT_VERSION=$(python3 --version)
+    echo "Python already installed: $CURRENT_VERSION"
+    read -p "Do you want to continue with installation? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+fi
+
+# Install Python based on distribution
+case $OS in
+    ubuntu|debian)
+        echo "Installing Python on Ubuntu/Debian..."
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-pip python3-venv python3-dev
+        ;;
+    
+    fedora|rhel|centos)
+        echo "Installing Python on Fedora/RHEL/CentOS..."
+        sudo dnf install -y python3 python3-pip python3-devel
+        ;;
+    
+    arch|manjaro)
+        echo "Installing Python on Arch Linux..."
+        sudo pacman -S --noconfirm python python-pip
+        ;;
+    
+    opensuse*)
+        echo "Installing Python on openSUSE..."
+        sudo zypper install -y python3 python3-pip python3-devel
+        ;;
+    
+    *)
+        echo "Unsupported distribution: $OS"
+        echo "Please install Python manually from python.org"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Python installed successfully!"
+echo ""
+
+# Verify installation
+echo "Verifying installation..."
+sleep 1
+
+if command -v python3 &> /dev/null; then
+    PYTHON_VERSION=$(python3 --version)
+    PIP_VERSION=$(pip3 --version)
+    
+    echo "✓ Python: $PYTHON_VERSION"
+    echo "✓ pip: $PIP_VERSION"
+else
+    echo "✗ Verification failed. Please check installation logs."
+    exit 1
+fi
+
+# Upgrade pip
+echo ""
+echo "Upgrading pip to latest version..."
+python3 -m pip install --upgrade pip --user
+
+echo ""
+echo "=== Installation Complete ==="
+echo "Next steps:"
+echo "1. Run: python3 --version"
+echo "2. Install uv: pip3 install uv --user"
+echo "3. Add ~/.local/bin to PATH if not already present"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_uv.ps1
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_uv.ps1
@@ -1,0 +1,102 @@
+# uv Installation Script for Windows
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== uv Installation Script ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if uv is already installed
+$uvCmd = Get-Command uv -ErrorAction SilentlyContinue
+if ($uvCmd) {
+    $currentVersion = uv --version 2>&1
+    Write-Host "uv already installed: $currentVersion" -ForegroundColor Yellow
+    $continue = Read-Host "Do you want to continue with installation? (y/n)"
+    if ($continue -ne 'y') {
+        Write-Host "Installation cancelled." -ForegroundColor Red
+        exit 0
+    }
+}
+
+# Method 1: Using standalone installer (recommended)
+Write-Host "Installing uv using standalone installer..." -ForegroundColor Cyan
+try {
+    irm https://astral.sh/uv/install.ps1 | iex
+    Write-Host "✓ uv installed via standalone installer!" -ForegroundColor Green
+} catch {
+    Write-Host "Standalone installation failed. Trying pip method..." -ForegroundColor Yellow
+    
+    # Method 2: Using pip
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCmd) {
+        Write-Host "✗ Python not found. Please install Python first." -ForegroundColor Red
+        Write-Host "Run: .\install_python.ps1" -ForegroundColor Yellow
+        exit 1
+    }
+    
+    Write-Host "Installing uv using pip..." -ForegroundColor Cyan
+    python -m pip install uv --user
+    Write-Host "✓ uv installed via pip!" -ForegroundColor Green
+}
+
+# Refresh environment variables
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+# Add cargo bin to PATH if not present
+$cargoBinPath = "$env:USERPROFILE\.cargo\bin"
+if ($env:Path -notlike "*$cargoBinPath*") {
+    Write-Host ""
+    Write-Host "Adding $cargoBinPath to PATH..." -ForegroundColor Cyan
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        $env:Path + ";$cargoBinPath",
+        [EnvironmentVariableTarget]::User
+    )
+    $env:Path += ";$cargoBinPath"
+    Write-Host "✓ PATH updated!" -ForegroundColor Green
+}
+
+# Verify installation
+Write-Host ""
+Write-Host "Verifying installation..." -ForegroundColor Cyan
+Start-Sleep -Seconds 2
+
+try {
+    # Try to find uv in common locations
+    $uvPaths = @(
+        "$env:USERPROFILE\.cargo\bin\uv.exe",
+        "$env:LOCALAPPDATA\Programs\uv\uv.exe"
+    )
+    
+    $uvFound = $false
+    foreach ($path in $uvPaths) {
+        if (Test-Path $path) {
+            $uvVersion = & $path --version 2>&1
+            Write-Host "✓ uv: $uvVersion" -ForegroundColor Green
+            Write-Host "  Location: $path" -ForegroundColor Gray
+            $uvFound = $true
+            break
+        }
+    }
+    
+    if (-not $uvFound) {
+        # Try direct command
+        $uvVersion = uv --version 2>&1
+        Write-Host "✓ uv: $uvVersion" -ForegroundColor Green
+    }
+    
+    Write-Host ""
+    Write-Host "uv installation completed successfully!" -ForegroundColor Green
+    Write-Host "Please restart your terminal to ensure PATH is updated." -ForegroundColor Yellow
+} catch {
+    Write-Host "✗ Verification failed. Please restart your terminal and try again." -ForegroundColor Red
+    Write-Host "uv should be in: $cargoBinPath" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host ""
+Write-Host "=== Installation Complete ===" -ForegroundColor Cyan
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "1. Restart your terminal"
+Write-Host "2. Run: uv --version"
+Write-Host "3. Create venv: uv venv"
+Write-Host "4. Install packages: uv pip install package-name"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/install_uv.sh
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/install_uv.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# uv Installation Script for Linux/macOS
+
+set -e
+
+echo "=== uv Installation Script ==="
+echo ""
+
+# Check if uv is already installed
+if command -v uv &> /dev/null; then
+    CURRENT_VERSION=$(uv --version)
+    echo "uv already installed: $CURRENT_VERSION"
+    read -p "Do you want to continue with installation? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+fi
+
+# Method 1: Using standalone installer (recommended)
+echo "Installing uv using standalone installer..."
+if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+    echo "✓ uv installed via standalone installer!"
+else
+    echo "Standalone installation failed. Trying pip method..."
+    
+    # Method 2: Using pip
+    if ! command -v python3 &> /dev/null; then
+        echo "✗ Python not found. Please install Python first."
+        echo "Run: ./install_python.sh"
+        exit 1
+    fi
+    
+    echo "Installing uv using pip..."
+    python3 -m pip install uv --user
+    echo "✓ uv installed via pip!"
+fi
+
+# Add cargo bin to PATH if not present
+CARGO_BIN="$HOME/.cargo/bin"
+if [[ ":$PATH:" != *":$CARGO_BIN:"* ]]; then
+    echo ""
+    echo "Adding $CARGO_BIN to PATH..."
+    
+    # Detect shell
+    if [ -n "$ZSH_VERSION" ]; then
+        SHELL_RC="$HOME/.zshrc"
+    elif [ -n "$BASH_VERSION" ]; then
+        SHELL_RC="$HOME/.bashrc"
+    else
+        SHELL_RC="$HOME/.profile"
+    fi
+    
+    echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> "$SHELL_RC"
+    export PATH="$HOME/.cargo/bin:$PATH"
+    echo "✓ PATH updated in $SHELL_RC!"
+fi
+
+# Verify installation
+echo ""
+echo "Verifying installation..."
+sleep 1
+
+# Source the updated PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+
+if command -v uv &> /dev/null; then
+    UV_VERSION=$(uv --version)
+    UV_PATH=$(which uv)
+    
+    echo "✓ uv: $UV_VERSION"
+    echo "  Location: $UV_PATH"
+    
+    echo ""
+    echo "uv installation completed successfully!"
+else
+    echo "✗ Verification failed. Please run: source $SHELL_RC"
+    echo "Then try: uv --version"
+    exit 1
+fi
+
+echo ""
+echo "=== Installation Complete ==="
+echo "Next steps:"
+echo "1. Run: source $SHELL_RC  (or restart terminal)"
+echo "2. Run: uv --version"
+echo "3. Create venv: uv venv"
+echo "4. Install packages: uv pip install package-name"

--- a/src-tauri/bundled_skills/setup-wizard/scripts/verify_setup.ps1
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/verify_setup.ps1
@@ -1,0 +1,144 @@
+# System Setup Verification Script for Windows
+# Checks Python, Node.js, and uv installations
+
+$ErrorActionPreference = "Continue"
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  System Setup Verification for MCP" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+$allGood = $true
+
+# Check Python
+Write-Host "[1/3] Checking Python..." -ForegroundColor Yellow
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if ($pythonCmd) {
+    try {
+        $pythonVersion = python --version 2>&1
+        $pipVersion = pip --version 2>&1
+        
+        Write-Host "  ✓ Python: $pythonVersion" -ForegroundColor Green
+        Write-Host "  ✓ pip: $pipVersion" -ForegroundColor Green
+        
+        # Check Python version (3.11+)
+        if ($pythonVersion -match "Python (\d+)\.(\d+)") {
+            $major = [int]$matches[1]
+            $minor = [int]$matches[2]
+            if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 11)) {
+                Write-Host "  ⚠ Warning: Python 3.11+ recommended (found $major.$minor)" -ForegroundColor Yellow
+            }
+        }
+    } catch {
+        Write-Host "  ✗ Python found but not working properly" -ForegroundColor Red
+        $allGood = $false
+    }
+} else {
+    Write-Host "  ✗ Python not found" -ForegroundColor Red
+    Write-Host "    Install with: .\scripts\install_python.ps1" -ForegroundColor Gray
+    $allGood = $false
+}
+
+Write-Host ""
+
+# Check Node.js
+Write-Host "[2/3] Checking Node.js..." -ForegroundColor Yellow
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+if ($nodeCmd) {
+    try {
+        $nodeVersion = node --version 2>&1
+        $npmVersion = npm --version 2>&1
+        
+        Write-Host "  ✓ Node.js: $nodeVersion" -ForegroundColor Green
+        Write-Host "  ✓ npm: $npmVersion" -ForegroundColor Green
+        
+        # Check Node version (18+)
+        if ($nodeVersion -match "v(\d+)\.") {
+            $major = [int]$matches[1]
+            if ($major -lt 18) {
+                Write-Host "  ⚠ Warning: Node.js 18+ recommended (found v$major)" -ForegroundColor Yellow
+            }
+        }
+    } catch {
+        Write-Host "  ✗ Node.js found but not working properly" -ForegroundColor Red
+        $allGood = $false
+    }
+} else {
+    Write-Host "  ✗ Node.js not found" -ForegroundColor Red
+    Write-Host "    Install with: .\scripts\install_node.ps1" -ForegroundColor Gray
+    $allGood = $false
+}
+
+Write-Host ""
+
+# Check uv
+Write-Host "[3/3] Checking uv..." -ForegroundColor Yellow
+$uvCmd = Get-Command uv -ErrorAction SilentlyContinue
+if ($uvCmd) {
+    try {
+        $uvVersion = uv --version 2>&1
+        Write-Host "  ✓ uv: $uvVersion" -ForegroundColor Green
+    } catch {
+        Write-Host "  ✗ uv found but not working properly" -ForegroundColor Red
+        $allGood = $false
+    }
+} else {
+    Write-Host "  ✗ uv not found" -ForegroundColor Red
+    Write-Host "    Install with: .\scripts\install_uv.ps1" -ForegroundColor Gray
+    $allGood = $false
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+
+# Summary
+if ($allGood) {
+    Write-Host "✓ All systems ready for MCP!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "You can now:" -ForegroundColor Cyan
+    Write-Host "  • Run Python-based MCP servers"
+    Write-Host "  • Run Node.js-based MCP servers"
+    Write-Host "  • Use uv for fast Python package management"
+    Write-Host ""
+} else {
+    Write-Host "✗ Some components are missing" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Please install missing components:" -ForegroundColor Yellow
+    Write-Host "  • Python:  .\scripts\install_python.ps1"
+    Write-Host "  • Node.js: .\scripts\install_node.ps1"
+    Write-Host "  • uv:      .\scripts\install_uv.ps1"
+    Write-Host ""
+    Write-Host "Or install all at once:" -ForegroundColor Yellow
+    Write-Host "  .\scripts\install_python.ps1; .\scripts\install_node.ps1; .\scripts\install_uv.ps1"
+    Write-Host ""
+}
+
+# PATH check
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "PATH Configuration:" -ForegroundColor Cyan
+Write-Host ""
+
+$pathEntries = $env:PATH -split ';'
+$relevantPaths = $pathEntries | Where-Object {
+    $_ -match 'Python|node|npm|cargo|\.local'
+}
+
+if ($relevantPaths) {
+    Write-Host "Relevant PATH entries:" -ForegroundColor Green
+    foreach ($path in $relevantPaths) {
+        Write-Host "  • $path" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "⚠ No Python/Node paths found in PATH" -ForegroundColor Yellow
+    Write-Host "You may need to restart your terminal or reboot." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+
+# Exit with appropriate code
+if ($allGood) {
+    exit 0
+} else {
+    exit 1
+}

--- a/src-tauri/bundled_skills/setup-wizard/scripts/verify_setup.sh
+++ b/src-tauri/bundled_skills/setup-wizard/scripts/verify_setup.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# System Setup Verification Script for Linux/macOS
+# Checks Python, Node.js, and uv installations
+
+set +e  # Don't exit on errors
+
+echo "========================================"
+echo "  System Setup Verification for MCP"
+echo "========================================"
+echo ""
+
+all_good=true
+
+# Check Python
+echo "[1/3] Checking Python..."
+if command -v python3 &> /dev/null; then
+    PYTHON_VERSION=$(python3 --version 2>&1)
+    PIP_VERSION=$(pip3 --version 2>&1)
+    
+    echo "  ✓ Python: $PYTHON_VERSION"
+    echo "  ✓ pip: $PIP_VERSION"
+    
+    # Check Python version (3.11+)
+    if python3 --version 2>&1 | grep -qE "Python 3\.([0-9]|10)\."; then
+        echo "  ⚠ Warning: Python 3.11+ recommended"
+    fi
+else
+    echo "  ✗ Python not found"
+    echo "    Install with: ./scripts/install_python.sh"
+    all_good=false
+fi
+
+echo ""
+
+# Check Node.js
+echo "[2/3] Checking Node.js..."
+if command -v node &> /dev/null; then
+    NODE_VERSION=$(node --version 2>&1)
+    NPM_VERSION=$(npm --version 2>&1)
+    
+    echo "  ✓ Node.js: $NODE_VERSION"
+    echo "  ✓ npm: $NPM_VERSION"
+    
+    # Check Node version (18+)
+    NODE_MAJOR=$(echo $NODE_VERSION | sed 's/v\([0-9]*\).*/\1/')
+    if [ "$NODE_MAJOR" -lt 18 ]; then
+        echo "  ⚠ Warning: Node.js 18+ recommended (found v$NODE_MAJOR)"
+    fi
+else
+    echo "  ✗ Node.js not found"
+    echo "    Install with: ./scripts/install_node.sh"
+    all_good=false
+fi
+
+echo ""
+
+# Check uv
+echo "[3/3] Checking uv..."
+if command -v uv &> /dev/null; then
+    UV_VERSION=$(uv --version 2>&1)
+    echo "  ✓ uv: $UV_VERSION"
+else
+    echo "  ✗ uv not found"
+    echo "    Install with: ./scripts/install_uv.sh"
+    all_good=false
+fi
+
+echo ""
+echo "========================================"
+
+# Summary
+if [ "$all_good" = true ]; then
+    echo "✓ All systems ready for MCP!"
+    echo ""
+    echo "You can now:"
+    echo "  • Run Python-based MCP servers"
+    echo "  • Run Node.js-based MCP servers"
+    echo "  • Use uv for fast Python package management"
+    echo ""
+else
+    echo "✗ Some components are missing"
+    echo ""
+    echo "Please install missing components:"
+    echo "  • Python:  ./scripts/install_python.sh"
+    echo "  • Node.js: ./scripts/install_node.sh"
+    echo "  • uv:      ./scripts/install_uv.sh"
+    echo ""
+    echo "Or install all at once:"
+    echo "  ./scripts/install_python.sh && ./scripts/install_node.sh && ./scripts/install_uv.sh"
+    echo ""
+fi
+
+# PATH check
+echo "========================================"
+echo "PATH Configuration:"
+echo ""
+
+# Show relevant PATH entries
+echo "$PATH" | tr ':' '\n' | grep -E 'python|node|npm|cargo|\.local' > /tmp/relevant_paths.txt
+
+if [ -s /tmp/relevant_paths.txt ]; then
+    echo "Relevant PATH entries:"
+    while IFS= read -r path; do
+        echo "  • $path"
+    done < /tmp/relevant_paths.txt
+    rm /tmp/relevant_paths.txt
+else
+    echo "⚠ No Python/Node paths found in PATH"
+    echo "You may need to restart your terminal or source your shell RC file."
+fi
+
+echo ""
+echo "========================================"
+
+# Exit with appropriate code
+if [ "$all_good" = true ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/src-tauri/bundled_skills/skill-creator/scripts/io_utils.py
+++ b/src-tauri/bundled_skills/skill-creator/scripts/io_utils.py
@@ -1,0 +1,32 @@
+"""Cross-platform UTF-8 helpers for skill-creator scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+UTF8 = "utf-8"
+
+
+def configure_stdio() -> None:
+    """Prefer UTF-8 on stdout/stderr when the stream supports reconfiguration."""
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None:
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding=UTF8, errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
+def read_text(path: Path | str) -> str:
+    """Read a text file as UTF-8."""
+    return Path(path).read_text(encoding=UTF8)
+
+
+def write_text(path: Path | str, content: str) -> None:
+    """Write a text file as UTF-8 with LF newlines."""
+    Path(path).write_text(content, encoding=UTF8, newline="\n")

--- a/src-tauri/bundled_skills/skill-creator/scripts/quick_validate.py
+++ b/src-tauri/bundled_skills/skill-creator/scripts/quick_validate.py
@@ -1,7 +1,108 @@
 #!/usr/bin/env python3
-"""Backward-compatible alias for validate_skill.py (used by package_skill.py)."""
+"""
+Quick validation script for skills - minimal version
+"""
 
-from validate_skill import main, validate_skill
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+from io_utils import configure_stdio, read_text
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = read_text(skill_md)
+    if not content.startswith("---"):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get("name", "")
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return False, (
+                f"Name '{name}' should be hyphen-case "
+                "(lowercase letters, digits, and hyphens only)"
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return False, (
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+            )
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if "<" in description or ">" in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, (
+                f"Description is too long ({len(description)} characters). "
+                "Maximum is 1024 characters."
+            )
+
+    return True, "Skill is valid!"
+
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    configure_stdio()
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/src-tauri/bundled_skills/skill-creator/scripts/validate_skill.py
+++ b/src-tauri/bundled_skills/skill-creator/scripts/validate_skill.py
@@ -1,489 +1,159 @@
 #!/usr/bin/env python3
 """
-LibrAgent skill validator.
-
-Usage:
-    python validate_skill.py <skill-directory> [--strict]
-
-Validates SKILL.md frontmatter (same rules as the Rust scanner) and warns about
-common LibrAgent deployment mistakes (wrong directory, managed system_skills, etc.).
-
-Exit codes:
-    0 - valid (warnings only unless --strict)
-    1 - validation errors
-    2 - missing dependency or invalid arguments
+Full mechanical validation for skills.
+Covers: frontmatter (via quick_validate) + body semantics.
 """
 
-from __future__ import annotations
-
-import argparse
+import os
 import re
 import sys
-from dataclasses import dataclass, field
+import urllib.parse
 from pathlib import Path
-from typing import Literal
 
-try:
-    import yaml
-except ImportError:
-    print("ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
-    sys.exit(2)
+import yaml
 
-ALLOWED_PROPERTIES = frozenset({"name", "description", "license", "allowed-tools", "metadata"})
-FORBIDDEN_SKILL_FILES = frozenset(
-    {
-        ".bundled_manifest.json",
-        "README.md",
-        "CHANGELOG.md",
-        "INSTALLATION.md",
-        "INSTALLATION_GUIDE.md",
-    }
-)
-FRONTMATTER_PATTERN = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
-NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
-SINGLE_QUOTE_ESCAPE_PATTERN = re.compile(r"\\'")
+# Ensure the script's directory is in sys.path to resolve quick_validate.py
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
+from io_utils import configure_stdio, read_text
+from quick_validate import validate_skill  # existing frontmatter validation
 
-@dataclass
-class ValidationIssue:
-    code: str
-    message: str
-    fix: str
-    level: Literal["error", "warning"] = "error"
+# Constants
+MAX_BODY_LINES = 500
+FORBIDDEN_FILES = {
+    "README.md",
+    "CHANGELOG.md",
+    "INSTALLATION_GUIDE.md",
+    "QUICK_REFERENCE.md",
+    "TODO.md",
+    "CONTRIBUTING.md",
+}
+TRIGGER_KEYWORDS = [
+    "use when",
+    "when the user",
+    "triggers on",
+    "trigger",
+    "use this skill",
+    "should be used",
+]
 
 
-@dataclass
-class ValidationReport:
-    issues: list[ValidationIssue] = field(default_factory=list)
-    frontmatter: dict | None = None
+def validate_skill_full(skill_path):
+    """Full mechanical validation: frontmatter + body semantics."""
+    skill_path = Path(skill_path).resolve()
 
-    @property
-    def errors(self) -> list[str]:
-        return [issue.message for issue in self.issues if issue.level == "error"]
+    # 1. Frontmatter validation (delegates to existing)
+    valid, msg = validate_skill(skill_path)
+    if not valid:
+        return False, msg
 
-    @property
-    def warnings(self) -> list[str]:
-        return [issue.message for issue in self.issues if issue.level == "warning"]
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
 
-    @property
-    def ok(self) -> bool:
-        return not self.errors
+    content = read_text(skill_md)
 
-    def fail_on_warnings(self, strict: bool) -> bool:
-        return self.ok and (not strict or not self.warnings)
+    # 2. Body line count
+    body = content.split("---", 2)[2] if "---" in content else ""
+    body_lines = len(body.strip().splitlines())
+    if body_lines > MAX_BODY_LINES:
+        return False, f"SKILL.md body is {body_lines} lines (max {MAX_BODY_LINES})"
 
-    def add_error(self, code: str, message: str, fix: str) -> None:
-        self.issues.append(ValidationIssue(code, message, fix, "error"))
+    # 3. Body not empty
+    if not body.strip():
+        return False, "SKILL.md body is empty"
 
-    def add_warning(self, code: str, message: str, fix: str) -> None:
-        self.issues.append(ValidationIssue(code, message, fix, "warning"))
+    # 4. Forbidden files
+    files = {f.name for f in skill_path.rglob("*") if f.is_file()}
+    found_forbidden = files & FORBIDDEN_FILES
+    if found_forbidden:
+        return False, f"Forbidden files found: {', '.join(sorted(found_forbidden))}"
 
-    def promote_warnings_to_errors(self) -> None:
-        promoted: list[ValidationIssue] = []
-        remaining: list[ValidationIssue] = []
-        for issue in self.issues:
-            if issue.level == "warning":
-                promoted.append(
-                    ValidationIssue(
-                        code=issue.code,
-                        message=issue.message,
-                        fix=issue.fix,
-                        level="error",
-                    )
-                )
-            else:
-                remaining.append(issue)
-        self.issues = remaining + promoted
+    # 5. References exist (check markdown links, ignoring code blocks)
+    body_no_code = re.sub(r"```[\s\S]*?```", "", body)
+    ref_patterns = re.findall(r"\[.*?\]\(([^)#]+)\)", body_no_code)
+    broken_refs = []
+    for ref in ref_patterns:
+        # Skip URLs and absolute path or mailto
+        if ref.startswith(("http://", "https://", "mailto:")):
+            continue
+        # Decode URL-encoded paths
+        decoded_ref = urllib.parse.unquote(ref)
+        ref_path = skill_path / decoded_ref
+        if not ref_path.exists():
+            broken_refs.append(decoded_ref)
+    if broken_refs:
+        return False, f"Missing referenced files: {', '.join(broken_refs)}"
 
-
-def extract_frontmatter(content: str) -> tuple[str | None, str | None]:
-    """Return (frontmatter_text, error_message)."""
-    if not content.startswith("---"):
-        return None, "No YAML frontmatter found (SKILL.md must start with ---)"
-
-    match = FRONTMATTER_PATTERN.match(content)
-    if not match:
-        return None, "Invalid frontmatter format (expected ---\\n...\\n---)"
-
-    return match.group(1), None
-
-
-def check_frontmatter_text(report: ValidationReport, frontmatter_text: str) -> dict | None:
-    if SINGLE_QUOTE_ESCAPE_PATTERN.search(frontmatter_text):
-        report.add_warning(
-            "SKILL-YAML-APOSTROPHE",
-            "Frontmatter uses \\' inside a single-quoted YAML string.",
-            "Use double quotes for description (\"Telegram's\") or double the quote (Telegram''s). "
-            "The Rust scanner silently skips skills with invalid YAML.",
-        )
-
-    try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-    except yaml.YAMLError as exc:
-        report.add_error(
-            "SKILL-YAML-PARSE",
-            f"Invalid YAML in frontmatter: {exc}",
-            "Fix YAML syntax in SKILL.md between the first --- markers. "
-            "Run: python <skill-creator>/scripts/validate_skill.py <skill-folder> --strict",
-        )
-        return None
-
-    if not isinstance(frontmatter, dict):
-        report.add_error(
-            "SKILL-FRONTMATTER-TYPE",
-            "Frontmatter must be a YAML mapping (key: value pairs).",
-            "Ensure SKILL.md starts with ---, then lines like name: my-skill, then ---.",
-        )
-        return None
-
-    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
-    if unexpected_keys:
-        report.add_error(
-            "SKILL-FRONTMATTER-KEYS",
-            "Unexpected frontmatter key(s): "
-            f"{', '.join(sorted(unexpected_keys))}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_PROPERTIES))}.",
-            "Remove unsupported keys or move extra metadata into the SKILL.md body.",
-        )
-
-    name = frontmatter.get("name")
-    if name is None:
-        report.add_error(
-            "SKILL-FIELD-NAME-MISSING",
-            "Missing required frontmatter field: name",
-            "Add `name: <folder-name>` to SKILL.md frontmatter (hyphen-case, max 64 chars).",
-        )
-    elif not isinstance(name, str):
-        report.add_error(
-            "SKILL-FIELD-NAME-TYPE",
-            f"name must be a string, got {type(name).__name__}.",
-            "Quote the name value, e.g. name: my-skill",
-        )
-    else:
-        name = name.strip()
-        if not name:
-            report.add_error(
-                "SKILL-FIELD-NAME-EMPTY",
-                "name cannot be empty",
-                "Set name to the skill folder name in hyphen-case.",
-            )
-        elif not NAME_PATTERN.match(name):
-            report.add_error(
-                "SKILL-FIELD-NAME-FORMAT",
-                f"name '{name}' must be hyphen-case (lowercase letters, digits, hyphens only).",
-                "Rename to hyphen-case, e.g. ai-daily-search, and match the folder name.",
-            )
-        elif name.startswith("-") or name.endswith("-") or "--" in name:
-            report.add_error(
-                "SKILL-FIELD-NAME-FORMAT",
-                f"name '{name}' cannot start/end with hyphen or contain '--'.",
-                "Use a single hyphen between words, e.g. telegram-formatter.",
-            )
-        elif len(name) > 64:
-            report.add_error(
-                "SKILL-FIELD-NAME-LENGTH",
-                f"name is too long ({len(name)} chars). Maximum is 64.",
-                "Shorten the skill name and rename the folder to match.",
-            )
-
-    description = frontmatter.get("description")
-    if description is None:
-        report.add_error(
-            "SKILL-FIELD-DESC-MISSING",
-            "Missing required frontmatter field: description",
-            "Add description with trigger phrases in double quotes if it contains apostrophes.",
-        )
-    elif not isinstance(description, str):
-        report.add_error(
-            "SKILL-FIELD-DESC-TYPE",
-            f"description must be a string, got {type(description).__name__}.",
-            "Use a quoted single-line description in frontmatter.",
-        )
-    else:
-        description = description.strip()
-        if not description:
-            report.add_error(
-                "SKILL-FIELD-DESC-EMPTY",
-                "description cannot be empty",
-                "Add a non-empty description with when-to-use triggers.",
-            )
-        elif "<" in description or ">" in description:
-            report.add_error(
-                "SKILL-FIELD-DESC-CHARS",
-                "description cannot contain angle brackets (< or >).",
-                "Remove XML-like characters from description.",
-            )
-        elif len(description) > 1024:
-            report.add_error(
-                "SKILL-FIELD-DESC-LENGTH",
-                f"description is too long ({len(description)} chars). Maximum is 1024.",
-                "Shorten description; move detail into the SKILL.md body or references/.",
-            )
-
-    return frontmatter
-
-
-def check_directory_name(report: ValidationReport, skill_path: Path, frontmatter: dict | None) -> None:
-    if not frontmatter:
-        return
-
-    name = frontmatter.get("name")
-    if not isinstance(name, str):
-        return
-
-    folder_name = skill_path.name
-    skill_name = name.strip()
-    if skill_name != folder_name:
-        report.add_warning(
-            "SKILL-NAME-MISMATCH",
-            f"Frontmatter name '{skill_name}' does not match directory name '{folder_name}'.",
-            f"Rename the folder to '{skill_name}' or change frontmatter name to '{folder_name}'.",
-        )
-
-
-def check_deployment_path(report: ValidationReport, skill_path: Path) -> None:
-    resolved = skill_path.resolve()
-    parts = [part.lower() for part in resolved.parts]
-    parent = resolved.parent
-    skill_name = resolved.name
-
-    if "system_skills" in parts:
-        report.add_warning(
-            "SKILL-PATH-SYSTEM-SKILLS",
-            "Location: system_skills (managed bundled mirror).",
-            "Do not deploy custom skills here. Use user_skills/ (global), "
-            ".libragent/skills/ (workspace), or src-tauri/bundled_skills/ (ship with app).",
-        )
-
-    if "user_skills" in parts:
-        return
-
-    if "workspaces" in parts:
+    # 6. Description has trigger keywords
+    desc = None
+    fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if fm_match:
         try:
-            workspace_index = parts.index("workspaces")
-        except ValueError:
-            workspace_index = -1
+            fm = yaml.safe_load(fm_match.group(1))
+            if isinstance(fm, dict):
+                desc = fm.get("description", "") or ""
+        except Exception:
+            pass
 
-        if workspace_index >= 0:
-            segments_after_session = resolved.parts[workspace_index + 2 :]
-            if len(segments_after_session) == 1:
-                report.add_warning(
-                    "SKILL-PATH-WORKSPACE-ROOT",
-                    f"Location: workspace session root (.../workspaces/<id>/{skill_name}/).",
-                    "Move the skill to .../workspaces/<id>/.libragent/skills/<skill-name>/ "
-                    "or deploy with deploy_skill.py --scope workspace.",
-                )
-            elif (
-                len(segments_after_session) >= 2
-                and segments_after_session[0].lower() == ".libragent"
-                and segments_after_session[1].lower() == "skills"
-            ):
-                return
-            elif len(segments_after_session) >= 1 and segments_after_session[0].lower() == "skills":
-                report.add_warning(
-                    "SKILL-PATH-WORKSPACE-LEGACY",
-                    "Location: legacy workspace skills/ folder.",
-                    "Use .../.libragent/skills/ for new workspace skills.",
-                )
-
-    resolved_str = str(resolved)
-    if ("\\skills\\" in resolved_str or "/skills/" in resolved_str) and "user_skills" not in parts:
-        if "system_skills" not in parts and "assistants" not in parts:
-            if "libragent" in resolved_str.lower() or "com.fritzprix.libragent" in parts:
-                report.add_warning(
-                    "SKILL-PATH-LEGACY-GLOBAL",
-                    "Location: legacy AppData skills/ directory.",
-                    "Global user skills belong in user_skills/, not skills/. "
-                    "Deploy with: deploy_skill.py <skill> --scope global",
-                )
-
-    if parent.joinpath(".bundled_manifest.json").is_file() and "system_skills" not in parts:
-        report.add_warning(
-            "SKILL-PATH-MANIFEST-WRONG",
-            "Parent directory contains .bundled_manifest.json.",
-            "Remove the manifest from this location. It only applies under system_skills/ during bundled sync.",
-        )
-
-
-def check_skill_layout(report: ValidationReport, skill_path: Path) -> None:
-    for child in skill_path.iterdir():
-        if not child.is_file():
-            continue
-        if child.name in FORBIDDEN_SKILL_FILES:
-            report.add_error(
-                "SKILL-LAYOUT-FORBIDDEN-FILE",
-                f"Forbidden file in skill directory: {child.name}",
-                "Remove auxiliary docs and manifests from the skill folder. "
-                "Keep SKILL.md plus optional scripts/, references/, assets/ only.",
+    if desc:
+        desc_lower = desc.lower()
+        has_trigger = any(kw in desc_lower for kw in TRIGGER_KEYWORDS)
+        if not has_trigger:
+            return False, (
+                "Description missing trigger keywords "
+                "(use when, when the user, triggers on, etc.)"
             )
 
-    skill_md = skill_path / "SKILL.md"
-    if skill_md.is_file():
-        content = skill_md.read_text(encoding="utf-8")
-        if content.startswith("\ufeff"):
-            content = content.removeprefix("\ufeff")
-        _, body = extract_frontmatter_and_body(content)
-        if body is not None and not body.strip():
-            report.add_warning(
-                "SKILL-LAYOUT-EMPTY-BODY",
-                "SKILL.md body is empty after frontmatter.",
-                "Add procedural instructions in the body or references/ (frontmatter alone is valid but not useful).",
-            )
+    # 7. References >100 lines have TOC
+    warnings = []
+    for ref_file in skill_path.rglob("*"):
+        if ref_file.is_file() and ref_file.suffix == ".md" and ref_file.name != "SKILL.md":
+            ref_content = read_text(ref_file)
+            ref_lines = len(ref_content.strip().splitlines())
+            if ref_lines > 100:
+                first_50 = ref_content.splitlines()[:50]
+                has_heading_list = any(
+                    line.strip().startswith("## ") or line.strip().startswith("- ")
+                    for line in first_50
+                )
+                if not has_heading_list:
+                    warnings.append(
+                        f"Warning: Reference file {ref_file.name} is long ({ref_lines} lines) "
+                        "but missing a Table of Contents or summary."
+                    )
 
+    # 8. Scripts executable check
+    scripts_dir = skill_path / "scripts"
+    if scripts_dir.exists():
+        for script in scripts_dir.iterdir():
+            if script.is_file():
+                if os.name != "nt" and not os.access(script, os.X_OK):
+                    try:
+                        script_text = read_text(script)
+                        first_line = script_text.splitlines()[0] if script_text else ""
+                        if first_line.startswith("#!"):
+                            warnings.append(
+                                f"Warning: Script {script.name} has a shebang but is not "
+                                "executable. Run chmod +x on it."
+                            )
+                    except Exception:
+                        pass
 
-def extract_frontmatter_and_body(content: str) -> tuple[str | None, str | None]:
-    if not content.startswith("---"):
-        return None, None
-    match = FRONTMATTER_PATTERN.match(content)
-    if not match:
-        return None, None
-    body = content[match.end() :]
-    return match.group(1), body
+    success_msg = "Skill passed full mechanical validation!"
+    if warnings:
+        success_msg += "\n" + "\n".join(warnings)
 
-
-def validate_skill_path(skill_path: Path, strict: bool = False) -> ValidationReport:
-    report = ValidationReport()
-    skill_path = skill_path.resolve()
-
-    if not skill_path.exists():
-        report.add_error(
-            "SKILL-MISSING-DIR",
-            f"Skill directory not found: {skill_path}",
-            "Pass the folder that directly contains SKILL.md, not its parent.",
-        )
-        return report
-
-    if not skill_path.is_dir():
-        report.add_error(
-            "SKILL-NOT-DIRECTORY",
-            f"Path is not a directory: {skill_path}",
-            "Point validate_skill.py at the skill folder, not SKILL.md itself.",
-        )
-        return report
-
-    skill_md = skill_path / "SKILL.md"
-    if not skill_md.is_file():
-        report.add_error(
-            "SKILL-MISSING-FILE",
-            "SKILL.md not found in skill directory",
-            f"Create {skill_path / 'SKILL.md'} with name/description frontmatter.",
-        )
-        return report
-
-    content = skill_md.read_text(encoding="utf-8")
-    if content.startswith("\ufeff"):
-        content = content.removeprefix("\ufeff")
-
-    frontmatter_text, frontmatter_error = extract_frontmatter(content)
-    if frontmatter_error:
-        code = "SKILL-FRONTMATTER-MISSING"
-        fix = "Start SKILL.md with --- on line 1, frontmatter keys, then closing ---."
-        if "Invalid frontmatter format" in frontmatter_error:
-            code = "SKILL-FRONTMATTER-FORMAT"
-            fix = "Ensure frontmatter is wrapped exactly as ---\\nname: ...\\ndescription: ...\\n---."
-        report.add_error(code, frontmatter_error, fix)
-        return report
-
-    assert frontmatter_text is not None
-    frontmatter = check_frontmatter_text(report, frontmatter_text)
-    report.frontmatter = frontmatter
-    check_directory_name(report, skill_path, frontmatter)
-    check_deployment_path(report, skill_path)
-    check_skill_layout(report, skill_path)
-
-    if strict:
-        report.promote_warnings_to_errors()
-
-    return report
-
-
-def validate_skill(skill_path: str | Path) -> tuple[bool, str]:
-    """Compatibility API used by package_skill.py (errors only, no path warnings as failures)."""
-    report = validate_skill_path(Path(skill_path), strict=False)
-    if report.errors:
-        return False, report.errors[0]
-    if report.warnings:
-        return True, f"Skill is valid with {len(report.warnings)} deployment warning(s)"
-    return True, "Skill is valid!"
-
-
-def format_report(report: ValidationReport) -> str:
-    lines: list[str] = []
-    if report.errors:
-        lines.append("Errors:")
-        lines.extend(f"  - {error}" for error in report.errors)
-    if report.warnings:
-        lines.append("Warnings:")
-        lines.extend(f"  - {warning}" for warning in report.warnings)
-    if report.ok and not report.warnings:
-        lines.append("Skill is valid!")
-    elif report.ok:
-        lines.append("Frontmatter is valid (review warnings before deploying).")
-    return "\n".join(lines)
-
-
-def format_detailed_report(report: ValidationReport, title: str) -> str:
-    lines = [f"=== {title} ==="]
-    if not report.issues:
-        lines.append("No issues found.")
-        return "\n".join(lines)
-
-    for issue in report.issues:
-        if report.ok and issue.level == "warning" and not report.warnings:
-            continue
-        prefix = "ERROR" if issue.level == "error" else "WARNING"
-        lines.append(f"[{issue.code}] {prefix}: {issue.message}")
-        lines.append(f"  Fix: {issue.fix}")
-        lines.append("")
-
-    if report.ok and not report.warnings:
-        lines.append("Validation passed.")
-    elif report.ok:
-        lines.append("Frontmatter is valid; review warnings before deploying.")
-    else:
-        lines.append("Validation failed. Resolve every ERROR before deploying.")
-
-    return "\n".join(lines).rstrip()
-
-
-def get_skill_name(report: ValidationReport) -> str | None:
-    if not report.frontmatter:
-        return None
-    name = report.frontmatter.get("name")
-    if isinstance(name, str) and name.strip():
-        return name.strip()
-    return None
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate a LibrAgent skill directory")
-    parser.add_argument("skill_directory", help="Path to the skill folder containing SKILL.md")
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Treat deployment warnings as errors",
-    )
-    parser.add_argument(
-        "--detailed",
-        action="store_true",
-        help="Print error codes and fix instructions",
-    )
-    args = parser.parse_args()
-
-    report = validate_skill_path(Path(args.skill_directory), strict=args.strict)
-    if args.detailed:
-        output = format_detailed_report(report, "Skill validation")
-    else:
-        output = format_report(report)
-    try:
-        print(output)
-    except UnicodeEncodeError:
-        print(output.encode("ascii", errors="replace").decode("ascii"))
-
-    if report.fail_on_warnings(args.strict):
-        return 0
-    return 1
+    return True, success_msg
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    configure_stdio()
+    if len(sys.argv) < 2:
+        print("Usage: python validate_skill.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill_full(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/src-tauri/bundled_skills/teamwork/SKILL.md
+++ b/src-tauri/bundled_skills/teamwork/SKILL.md
@@ -84,6 +84,7 @@ After choosing the execution substrate, route to the matching specialist skill:
 
 - **Plain child sessions** - stay here and use `delegate` when child-session mechanics matter.
 - **Explicit org lineage** - switch to `org`.
+- **Living org restructure** (add/layoff/merge roles, constitution edits) - switch to `org-restructure` after the org exists.
 - **Global scheduled tasks or groups** - switch to `schedule`.
 - **In-session delays or session-bound recurrence** - switch to `session-schedule`.
 

--- a/src-tauri/src/lifecycle/app_setup/mod.rs
+++ b/src-tauri/src/lifecycle/app_setup/mod.rs
@@ -8,8 +8,8 @@ pub use managed_skills::{
     sync_managed_system_skills_snapshot, LegacySkillMigrationAction,
 };
 pub use skills_manifest::{
-    hash_skill_directory, replace_skill_directory_atomically, write_manifest_atomically,
-    BundledSkillsManifest,
+    hash_skill_directory, load_persisted_bundled_skills_manifest,
+    replace_skill_directory_atomically, write_manifest_atomically, BundledSkillsManifest,
 };
 
 use crate::agent;

--- a/src-tauri/src/lifecycle/app_setup/skills_manifest.rs
+++ b/src-tauri/src/lifecycle/app_setup/skills_manifest.rs
@@ -2,7 +2,7 @@ use crate::services::skill_service::SKILL_FILE_NAME;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Marker file written into every bundled skill directory in AppData.
 /// Used to distinguish bundled skills from user-created ones so that skills
@@ -195,7 +195,7 @@ pub(crate) fn build_marked_bundled_skills_manifest(
     Ok(manifest)
 }
 
-pub(crate) fn load_persisted_bundled_skills_manifest(
+pub fn load_persisted_bundled_skills_manifest(
     manifest_path: &Path,
 ) -> Result<Option<BundledSkillsManifest>, String> {
     if !manifest_path.exists() {
@@ -222,6 +222,133 @@ pub(crate) fn load_persisted_bundled_skills_manifest(
     Ok(Some(manifest))
 }
 
+fn remove_path_if_exists(path: &Path) -> std::io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if path.is_file() {
+        std::fs::remove_file(path)
+    } else {
+        std::fs::remove_dir_all(path)
+    }
+}
+
+fn best_effort_remove_path(path: &Path, context: &str) {
+    if let Err(error) = remove_path_if_exists(path) {
+        log::warn!(
+            "Failed to remove {} at {}: {}",
+            context,
+            path.display(),
+            error
+        );
+    }
+}
+
+fn best_effort_rename(from: &Path, to: &Path, context: &str) {
+    if let Err(error) = std::fs::rename(from, to) {
+        log::warn!(
+            "Failed to {} from {} to {}: {}",
+            context,
+            from.display(),
+            to.display(),
+            error
+        );
+    }
+}
+
+/// Rolls back staged file replacement unless `commit()` is called after the target is updated.
+struct StagedFileReplaceGuard {
+    staging_path: PathBuf,
+    target_path: PathBuf,
+    backup_path: PathBuf,
+    moved_target_to_backup: bool,
+    committed: bool,
+}
+
+impl StagedFileReplaceGuard {
+    fn new(staging_path: PathBuf, target_path: PathBuf, backup_path: PathBuf) -> Self {
+        Self {
+            staging_path,
+            target_path,
+            backup_path,
+            moved_target_to_backup: false,
+            committed: false,
+        }
+    }
+
+    fn mark_target_moved_to_backup(&mut self) {
+        self.moved_target_to_backup = true;
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for StagedFileReplaceGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        best_effort_remove_path(&self.staging_path, "staging manifest file");
+        if self.moved_target_to_backup && !self.target_path.exists() {
+            best_effort_rename(
+                &self.backup_path,
+                &self.target_path,
+                "restore manifest from backup",
+            );
+        }
+    }
+}
+
+/// Rolls back staged directory replacement unless `commit()` is called after the target is updated.
+struct StagedDirReplaceGuard {
+    staging_path: PathBuf,
+    target_path: PathBuf,
+    backup_path: PathBuf,
+    moved_target_to_backup: bool,
+    committed: bool,
+}
+
+impl StagedDirReplaceGuard {
+    fn new(staging_path: PathBuf, target_path: PathBuf, backup_path: PathBuf) -> Self {
+        Self {
+            staging_path,
+            target_path,
+            backup_path,
+            moved_target_to_backup: false,
+            committed: false,
+        }
+    }
+
+    fn mark_target_moved_to_backup(&mut self) {
+        self.moved_target_to_backup = true;
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for StagedDirReplaceGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        best_effort_remove_path(&self.staging_path, "staging skill directory");
+        if self.moved_target_to_backup && !self.target_path.exists() {
+            best_effort_rename(
+                &self.backup_path,
+                &self.target_path,
+                "restore skill directory from backup",
+            );
+        }
+    }
+}
+
 pub fn write_manifest_atomically(
     manifest_path: &Path,
     manifest: &BundledSkillsManifest,
@@ -231,6 +358,15 @@ pub fn write_manifest_atomically(
     let temp_path = manifest_path.with_extension("json.tmp");
     let backup_path = manifest_path.with_extension("json.bak");
 
+    remove_path_if_exists(&temp_path).map_err(|error| {
+        log::warn!(
+            "Failed to clear stale temp manifest {}: {}",
+            temp_path.display(),
+            error
+        );
+        "Failed to clear stale temporary manifest file".to_string()
+    })?;
+
     std::fs::write(&temp_path, payload).map_err(|error| {
         log::warn!(
             "Failed to write temp manifest {}: {}",
@@ -239,6 +375,13 @@ pub fn write_manifest_atomically(
         );
         "Failed to write temporary manifest file".to_string()
     })?;
+
+    let mut guard = StagedFileReplaceGuard::new(
+        temp_path.clone(),
+        manifest_path.to_path_buf(),
+        backup_path.clone(),
+    );
+    let mut moved_existing_to_backup = false;
 
     if backup_path.exists() {
         std::fs::remove_file(&backup_path).map_err(|error| {
@@ -251,7 +394,7 @@ pub fn write_manifest_atomically(
         })?;
     }
 
-    let moved_existing_to_backup = if manifest_path.exists() {
+    if manifest_path.exists() {
         std::fs::rename(manifest_path, &backup_path).map_err(|error| {
             log::warn!(
                 "Failed to move existing manifest aside from {} to {}: {}",
@@ -261,39 +404,28 @@ pub fn write_manifest_atomically(
             );
             "Failed to move existing manifest aside".to_string()
         })?;
-        true
-    } else {
-        false
-    };
-
-    match std::fs::rename(&temp_path, manifest_path) {
-        Ok(()) => {
-            if moved_existing_to_backup {
-                std::fs::remove_file(&backup_path).map_err(|error| {
-                    log::warn!(
-                        "Failed to remove backup manifest {}: {}",
-                        backup_path.display(),
-                        error
-                    );
-                    "Failed to remove backup manifest".to_string()
-                })?;
-            }
-            Ok(())
-        }
-        Err(error) => {
-            let _ = std::fs::remove_file(&temp_path);
-            if moved_existing_to_backup && !manifest_path.exists() {
-                let _ = std::fs::rename(&backup_path, manifest_path);
-            }
-            log::warn!(
-                "Failed to finalize manifest from {} to {}: {}",
-                temp_path.display(),
-                manifest_path.display(),
-                error
-            );
-            Err("Failed to finalize manifest file".to_string())
-        }
+        moved_existing_to_backup = true;
+        guard.mark_target_moved_to_backup();
     }
+
+    std::fs::rename(&temp_path, manifest_path).map_err(|error| {
+        log::warn!(
+            "Failed to finalize manifest from {} to {}: {}",
+            temp_path.display(),
+            manifest_path.display(),
+            error
+        );
+        "Failed to finalize manifest file".to_string()
+    })?;
+
+    guard.commit();
+
+    // Manifest is committed; leftover backup files are non-fatal.
+    if moved_existing_to_backup {
+        best_effort_remove_path(&backup_path, "backup manifest file");
+    }
+
+    Ok(())
 }
 
 pub fn replace_skill_directory_atomically(
@@ -311,22 +443,18 @@ pub fn replace_skill_directory_atomically(
     let temp_dir = parent.join(format!(".sync-tmp-{}", skill_name));
     let backup_dir = parent.join(format!(".sync-backup-{}", skill_name));
 
-    if temp_dir.exists() {
-        std::fs::remove_dir_all(&temp_dir).map_err(|error| {
-            log::warn!("Failed to clear temp dir {}: {}", temp_dir.display(), error);
-            "Failed to clear temporary sync directory".to_string()
-        })?;
-    }
-    if backup_dir.exists() {
-        std::fs::remove_dir_all(&backup_dir).map_err(|error| {
-            log::warn!(
-                "Failed to clear backup dir {}: {}",
-                backup_dir.display(),
-                error
-            );
-            "Failed to clear existing backup directory".to_string()
-        })?;
-    }
+    remove_path_if_exists(&temp_dir).map_err(|error| {
+        log::warn!("Failed to clear temp dir {}: {}", temp_dir.display(), error);
+        "Failed to clear temporary sync directory".to_string()
+    })?;
+    remove_path_if_exists(&backup_dir).map_err(|error| {
+        log::warn!(
+            "Failed to clear backup dir {}: {}",
+            backup_dir.display(),
+            error
+        );
+        "Failed to clear existing backup directory".to_string()
+    })?;
 
     copy_dir_recursive_path(source_dir, &temp_dir).map_err(|e| {
         log::warn!(
@@ -338,7 +466,14 @@ pub fn replace_skill_directory_atomically(
         "Failed to copy skill directory".to_string()
     })?;
 
-    let moved_existing_to_backup = if target_dir.exists() {
+    let mut guard = StagedDirReplaceGuard::new(
+        temp_dir.clone(),
+        target_dir.to_path_buf(),
+        backup_dir.clone(),
+    );
+    let mut moved_existing_to_backup = false;
+
+    if target_dir.exists() {
         std::fs::rename(target_dir, &backup_dir).map_err(|error| {
             log::warn!(
                 "Failed to move existing managed skill aside from {} to {}: {}",
@@ -348,48 +483,38 @@ pub fn replace_skill_directory_atomically(
             );
             "Failed to move existing managed skill aside".to_string()
         })?;
-        true
-    } else {
-        false
-    };
-
-    match std::fs::rename(&temp_dir, target_dir) {
-        Ok(()) => {
-            let marker_path = target_dir.join(BUNDLED_SKILL_MARKER);
-            std::fs::write(&marker_path, b"bundled\n").map_err(|error| {
-                log::warn!(
-                    "Failed to write bundled marker at {}: {}",
-                    marker_path.display(),
-                    error
-                );
-                "Failed to write bundled skill marker".to_string()
-            })?;
-            if moved_existing_to_backup {
-                std::fs::remove_dir_all(&backup_dir).map_err(|error| {
-                    log::warn!(
-                        "Failed to remove backup dir {}: {}",
-                        backup_dir.display(),
-                        error
-                    );
-                    "Failed to remove backup directory".to_string()
-                })?;
-            }
-            Ok(())
-        }
-        Err(error) => {
-            let _ = std::fs::remove_dir_all(&temp_dir);
-            if moved_existing_to_backup && !target_dir.exists() {
-                let _ = std::fs::rename(&backup_dir, target_dir);
-            }
-            log::warn!(
-                "Failed to activate managed skill from {} to {}: {}",
-                temp_dir.display(),
-                target_dir.display(),
-                error
-            );
-            Err("Failed to activate managed skill".to_string())
-        }
+        moved_existing_to_backup = true;
+        guard.mark_target_moved_to_backup();
     }
+
+    std::fs::rename(&temp_dir, target_dir).map_err(|error| {
+        log::warn!(
+            "Failed to activate managed skill from {} to {}: {}",
+            temp_dir.display(),
+            target_dir.display(),
+            error
+        );
+        "Failed to activate managed skill".to_string()
+    })?;
+
+    guard.commit();
+
+    let marker_path = target_dir.join(BUNDLED_SKILL_MARKER);
+    std::fs::write(&marker_path, b"bundled\n").map_err(|error| {
+        log::warn!(
+            "Failed to write bundled marker at {}: {}",
+            marker_path.display(),
+            error
+        );
+        "Failed to write bundled skill marker".to_string()
+    })?;
+
+    // Skill directory is committed; leftover backup directories are non-fatal.
+    if moved_existing_to_backup {
+        best_effort_remove_path(&backup_dir, "backup skill directory");
+    }
+
+    Ok(())
 }
 
 pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -423,7 +423,7 @@ impl SuccessHint {
             ("listDirectory", ToolGroup::Workspace) => vec![
                 "Use readFile to view file contents".to_string(),
                 "Use writeFile to create new files".to_string(),
-                "Use searchFiles with filePattern to narrow down names".to_string(),
+                "Use globFiles with filePattern to narrow down names".to_string(),
             ],
             #[cfg(feature = "workspace-edit-file")]
             (
@@ -438,9 +438,20 @@ impl SuccessHint {
                 "Use readFile to verify your edits".to_string(),
                 "Use runShell to execute the updated code".to_string(),
             ],
-            ("searchFiles", ToolGroup::Workspace) => vec![
+            ("globFiles", ToolGroup::Workspace) => vec![
+                "Use grepFiles to search inside matched files".to_string(),
+                "Use readFile to inspect a specific match".to_string(),
+            ],
+            ("grepFiles", ToolGroup::Workspace) => vec![
                 "Use readFile on interesting matches".to_string(),
-                "Use listDirectory to explore the surrounding module".to_string(),
+                format!(
+                    "Use {} to make targeted edits",
+                    crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
+                ),
+            ],
+            ("searchFiles", ToolGroup::Workspace) => vec![
+                "Use globFiles for filename search".to_string(),
+                "Use grepFiles for content search".to_string(),
             ],
 
             // Agent tools (Unified)

--- a/src-tauri/src/mcp/builtin/workspace/dispatch.rs
+++ b/src-tauri/src/mcp/builtin/workspace/dispatch.rs
@@ -37,6 +37,8 @@ impl WorkspaceServer {
             "writeFile" => self.handle_write_file(args, session_id).await,
             "listDirectory" => self.handle_list_directory(args, session_id).await,
             "importFiles" => self.handle_import_files(args, session_id).await,
+            "globFiles" => self.handle_glob_files(args, session_id).await,
+            "grepFiles" => self.handle_grep_files(args, session_id).await,
             "searchFiles" => self.handle_search(args, session_id).await,
             #[cfg(feature = "workspace-str-replace")]
             "strReplace" => self.handle_str_replace(args, session_id).await,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/helpers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/helpers.rs
@@ -1,4 +1,7 @@
+use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
 use crate::mcp::builtin::workspace::utils::is_internal_workspace_artifact_path;
+use crate::mcp::types::MCPResult;
+use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncReadExt;
@@ -196,4 +199,77 @@ pub(super) fn build_gitignore_matcher(
         search_root: search_root.to_path_buf(),
         matchers,
     })
+}
+
+pub(super) fn reject_empty_optional_str<'a>(
+    value: Option<&'a str>,
+    field: &str,
+    guidance: Vec<String>,
+) -> Result<Option<&'a str>, MCPResult> {
+    if matches!(value, Some("")) {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!("Invalid {field}: {field} must not be empty"),
+            ToolGroup::Workspace,
+        )
+        .guidance(guidance)
+        .to_mcp_result());
+    }
+    Ok(value)
+}
+
+pub(super) fn parse_pagination(args: &Value) -> Result<(usize, usize), MCPResult> {
+    let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
+    if !(1..=1000).contains(&limit_raw) {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Invalid pagination parameter: limit must be between 1 and 1000, got {limit_raw}"
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Set limit to a value between 1 and 1000".to_string(),
+            "Use offset to paginate through additional results".to_string(),
+        ])
+        .to_mcp_result());
+    }
+    let limit = match usize::try_from(limit_raw) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Invalid pagination parameter: limit is too large for this platform ({limit_raw})"
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Set limit to a value between 1 and 1000".to_string(),
+                "Use smaller page sizes when paginating search results".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    let offset_raw = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
+    let offset = match usize::try_from(offset_raw) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Invalid pagination parameter: offset is too large for this platform ({offset_raw})"
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Set offset to a smaller non-negative value".to_string(),
+                "Use limit and offset together to page through results".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    Ok((limit, offset))
 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -9,10 +9,31 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::builtin::workspace::utils::is_internal_workspace_artifact_path;
 use crate::mcp::types::MCPResult;
+use helpers::{parse_pagination, reject_empty_optional_str};
 use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+struct ResolvedSearchTarget {
+    workspace_root: PathBuf,
+    safe_path: PathBuf,
+    display_path: String,
+}
+
+struct GrepSearchParams<'a> {
+    workspace_root: &'a Path,
+    safe_path: &'a Path,
+    display_path: &'a str,
+    query_str: &'a str,
+    file_pattern: Option<&'a str>,
+    ignore_case: bool,
+    show_line_anchors: bool,
+    limit: usize,
+    offset: usize,
+}
 
 impl WorkspaceServer {
-    pub async fn handle_search(
+    pub async fn handle_glob_files(
         &self,
         args: Value,
         session_id: Option<String>,
@@ -22,32 +43,85 @@ impl WorkspaceServer {
             None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
         };
 
-        let query = args.get("query").and_then(|v| v.as_str());
-        let file_pattern = args.get("filePattern").and_then(|v| v.as_str());
-        if matches!(query, Some("")) {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                "Invalid query: query must not be empty".to_string(),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
-                "Provide a non-empty regex pattern for content search".to_string(),
-                "Omit query and use filePattern when you only want to find files".to_string(),
-            ])
-            .to_mcp_result());
-        }
-        if matches!(file_pattern, Some("")) {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                "Invalid filePattern: filePattern must not be empty".to_string(),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
+        let file_pattern = match args.get("filePattern").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return Ok(missing_param_error("filePattern", ToolGroup::Workspace)),
+        };
+
+        let file_pattern = match reject_empty_optional_str(
+            Some(file_pattern),
+            "filePattern",
+            vec!["Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string()],
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return Ok(missing_param_error("filePattern", ToolGroup::Workspace));
+            }
+            Err(result) => return Ok(result),
+        };
+
+        let (limit, offset) = match parse_pagination(&args) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
+        let ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path,
+        } = match self.resolve_search_target(search_path, session_id).await {
+            Ok(target) => target,
+            Err(result) => return Ok(result),
+        };
+
+        files::search_files_only(
+            &workspace_root,
+            &safe_path,
+            &display_path,
+            file_pattern,
+            limit,
+            offset,
+        )
+        .await
+    }
+
+    pub async fn handle_grep_files(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        let search_path = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
+        };
+
+        let query = match args.get("query").and_then(|v| v.as_str()) {
+            Some(q) => q,
+            None => return Ok(missing_param_error("query", ToolGroup::Workspace)),
+        };
+
+        let query = match reject_empty_optional_str(
+            Some(query),
+            "query",
+            vec!["Provide a non-empty regex pattern for content search".to_string()],
+        ) {
+            Ok(Some(q)) => q,
+            Ok(None) => return Ok(missing_param_error("query", ToolGroup::Workspace)),
+            Err(result) => return Ok(result),
+        };
+
+        let file_pattern = match reject_empty_optional_str(
+            args.get("filePattern").and_then(|v| v.as_str()),
+            "filePattern",
+            vec![
                 "Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string(),
                 "Omit filePattern when you want content search across all files".to_string(),
-            ])
-            .to_mcp_result());
-        }
+            ],
+        ) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
         let ignore_case = args
             .get("ignoreCase")
             .and_then(|v| v.as_bool())
@@ -59,76 +133,112 @@ impl WorkspaceServer {
         } else {
             false
         };
-        let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
-        if !(1..=1000).contains(&limit_raw) {
+
+        let (limit, offset) = match parse_pagination(&args) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
+        let ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path,
+        } = match self.resolve_search_target(search_path, session_id).await {
+            Ok(target) => target,
+            Err(result) => return Ok(result),
+        };
+
+        self.search_content(GrepSearchParams {
+            workspace_root: &workspace_root,
+            safe_path: &safe_path,
+            display_path: &display_path,
+            query_str: query,
+            file_pattern,
+            ignore_case,
+            show_line_anchors,
+            limit,
+            offset,
+        })
+        .await
+    }
+
+    /// Backward-compatible router for the hidden `searchFiles` dispatch alias.
+    pub async fn handle_search(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        warn!(
+            "searchFiles is deprecated; use globFiles for filename search or grepFiles for content search"
+        );
+
+        let query = args.get("query").and_then(|v| v.as_str());
+        let file_pattern = args.get("filePattern").and_then(|v| v.as_str());
+
+        if matches!(query, Some("")) {
             return Ok(guided_error(
                 ErrorCategory::InvalidInput,
-                format!(
-                    "Invalid pagination parameter: limit must be between 1 and 1000, got {}",
-                    limit_raw
-                ),
+                "Invalid query: query must not be empty".to_string(),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Set limit to a value between 1 and 1000".to_string(),
-                "Use offset to paginate through additional results".to_string(),
+                "Provide a non-empty regex pattern for content search with grepFiles".to_string(),
+                "Use globFiles with filePattern when you only want to find files".to_string(),
             ])
             .to_mcp_result());
         }
-        let limit = match usize::try_from(limit_raw) {
-            Ok(value) => value,
-            Err(_) => {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Invalid pagination parameter: limit is too large for this platform ({})",
-                        limit_raw
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Set limit to a value between 1 and 1000".to_string(),
-                    "Use smaller page sizes when paginating search results".to_string(),
-                ])
-                .to_mcp_result());
-            }
-        };
 
-        let offset_raw = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
-        let offset = match usize::try_from(offset_raw) {
-            Ok(value) => value,
-            Err(_) => {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Invalid pagination parameter: offset is too large for this platform ({})",
-                        offset_raw
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Set offset to a smaller non-negative value".to_string(),
-                    "Use limit and offset together to page through results".to_string(),
-                ])
-                .to_mcp_result());
-            }
-        };
+        if matches!(file_pattern, Some("")) {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Invalid filePattern: filePattern must not be empty".to_string(),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string(),
+                "Omit filePattern when you want content search across all files with grepFiles"
+                    .to_string(),
+            ])
+            .to_mcp_result());
+        }
 
-        let target_session_id = session_id
-            .clone()
-            .unwrap_or_else(|| self.session_id.clone());
+        if query.is_some() {
+            return self.handle_grep_files(args, session_id).await;
+        }
+
+        if file_pattern.is_some() {
+            return self.handle_glob_files(args, session_id).await;
+        }
+
+        Ok(guided_error(
+            ErrorCategory::MissingRequiredParam,
+            "Provide either 'query' (to search text) or 'filePattern' (to find files)".to_string(),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Use grepFiles with query for content search".to_string(),
+            "Use globFiles with filePattern for filename search".to_string(),
+        ])
+        .to_mcp_result())
+    }
+
+    async fn resolve_search_target(
+        &self,
+        search_path: &str,
+        session_id: Option<String>,
+    ) -> Result<ResolvedSearchTarget, MCPResult> {
+        let target_session_id = session_id.unwrap_or_else(|| self.session_id.clone());
         let workspace_root = self.get_workspace_dir(&target_session_id);
 
-        // Security validation
         let safe_path = match self
             .validate_read_path_with_skill_access(search_path, Some(target_session_id))
             .await
         {
             Ok(path) => path,
             Err(e) => {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::PermissionDenied,
-                    format!("Path validation failed: {}", e),
+                    format!("Path validation failed: {e}"),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
@@ -140,7 +250,7 @@ impl WorkspaceServer {
         };
 
         if safe_path.is_file() && is_internal_workspace_artifact_path(&workspace_root, &safe_path) {
-            return Ok(guided_error(
+            return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 "Internal LibrAgent temp/export artifacts are excluded from search".to_string(),
                 ToolGroup::Workspace,
@@ -148,39 +258,32 @@ impl WorkspaceServer {
             .guidance(vec![
                 "Search workspace files outside .libragent/tmp and .libragent/exports".to_string(),
                 "Use readProcessOutput or listProcesses to inspect temp process output".to_string(),
-                "Use export on real workspace files instead of searching generated export artifacts".to_string(),
+                "Use export on real workspace files instead of searching generated export artifacts"
+                    .to_string(),
             ])
             .to_mcp_result());
         }
 
-        // Determine if we are doing file name search only or content search
-        if query.is_none() {
-            // File Name Search Only
-            let pattern = match file_pattern {
-                Some(p) => p,
-                None => {
-                    return Ok(guided_error(
-                        ErrorCategory::MissingRequiredParam,
-                        "Provide either 'query' (to search text) or 'filePattern' (to find files)"
-                            .to_string(),
-                        ToolGroup::Workspace,
-                    )
-                    .to_mcp_result());
-                }
-            };
-            return files::search_files_only(
-                &workspace_root,
-                &safe_path,
-                search_path,
-                pattern,
-                limit,
-                offset,
-            )
-            .await;
-        }
+        Ok(ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path: search_path.to_string(),
+        })
+    }
 
-        // Text Content Search
-        let query_str = query.unwrap();
+    async fn search_content(&self, params: GrepSearchParams<'_>) -> Result<MCPResult, String> {
+        let GrepSearchParams {
+            workspace_root,
+            safe_path,
+            display_path,
+            query_str,
+            file_pattern,
+            ignore_case,
+            show_line_anchors,
+            limit,
+            offset,
+        } = params;
+
         let regex = match regex::RegexBuilder::new(query_str)
             .case_insensitive(ignore_case)
             .multi_line(true)
@@ -191,7 +294,7 @@ impl WorkspaceServer {
             Err(e) => {
                 return Ok(guided_error(
                     ErrorCategory::InvalidInput,
-                    format!("Invalid regex pattern: {}", e),
+                    format!("Invalid regex pattern: {e}"),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
@@ -208,7 +311,7 @@ impl WorkspaceServer {
                 Err(e) => {
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
-                        format!("Invalid filePattern: {}", e),
+                        format!("Invalid filePattern: {e}"),
                         ToolGroup::Workspace,
                     )
                     .to_mcp_result());
@@ -219,11 +322,11 @@ impl WorkspaceServer {
 
         if safe_path.is_dir() {
             content::search_content_in_dir(content::SearchDirectoryRequest {
-                workspace_root: &workspace_root,
-                dir: &safe_path,
+                workspace_root,
+                dir: safe_path,
                 file_pattern: glob_pat.as_ref(),
                 search: content::SearchContentRequest {
-                    display_path: search_path,
+                    display_path,
                     regex: &regex,
                     query: query_str,
                     show_hashes: show_line_anchors,
@@ -235,9 +338,9 @@ impl WorkspaceServer {
             .await
         } else {
             content::search_content_in_file(
-                &safe_path,
+                safe_path,
                 content::SearchContentRequest {
-                    display_path: search_path,
+                    display_path,
                     regex: &regex,
                     query: query_str,
                     show_hashes: show_line_anchors,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -146,7 +146,7 @@ pub fn create_list_directory_tool() -> MCPTool {
 - listDirectory('src/components') — subdirectory
 - listDirectory('/tmp') — absolute directory
 
-Returns names and types (file/directory). Use search with filePattern when you need glob-style filtering."
+Returns names and types (file/directory). Use globFiles when you need glob-style filtering."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -197,6 +197,116 @@ pub fn create_import_files_tool() -> MCPTool {
     }
 }
 
+fn search_path_prop() -> crate::mcp::schema::JSONSchema {
+    string_prop(
+        Some(1),
+        Some(1000),
+        Some("Path to the file or directory to search. Relative paths resolve from the workspace; absolute paths are also allowed unless protected. Use @teamwork or @teamwork/... (or relative .libragent/teamwork/...) for the canonical teamwork scaffold root. Read-only skill aliases such as @system-skills/... and @user-skills/... may also be searched when available."),
+    )
+}
+
+pub fn create_glob_files_tool() -> MCPTool {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), search_path_prop());
+    props.insert(
+        "filePattern".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Glob pattern to match file or directory names (e.g. '*.rs', 'src/**/*.ts')."),
+        ),
+    );
+    props.insert(
+        "limit".to_string(),
+        integer_prop(
+            Some(1),
+            Some(1000),
+            Some("Maximum number of matched files/directories to return (default: 50)."),
+        ),
+    );
+    props.insert(
+        "offset".to_string(),
+        integer_prop(
+            Some(0),
+            None,
+            Some("Number of results to skip for pagination (default: 0)."),
+        ),
+    );
+
+    MCPTool {
+        name: "globFiles".to_string(),
+        title: Some("Glob Workspace Files".to_string()),
+        description: "Find files and directories by glob pattern. Use grepFiles to search inside matches, or readFile to inspect a specific path.".to_string(),
+        input_schema: object_schema(
+            props,
+            vec!["path".to_string(), "filePattern".to_string()],
+        ),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+pub fn create_grep_files_tool() -> MCPTool {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), search_path_prop());
+    props.insert(
+        "query".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Regular expression pattern to search for text inside files. Matched against full file content with multiline mode enabled, so ^ and $ match line boundaries. '.' does not match newlines unless you opt into that in the regex itself (for example with (?s))."),
+        ),
+    );
+    props.insert(
+        "filePattern".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Optional glob pattern to limit which files are searched (e.g. '*.rs', 'src/**/*.ts')."),
+        ),
+    );
+    props.insert(
+        "limit".to_string(),
+        integer_prop(
+            Some(1),
+            Some(1000),
+            Some("Maximum number of matching lines to return (default: 50)."),
+        ),
+    );
+    props.insert(
+        "offset".to_string(),
+        integer_prop(
+            Some(0),
+            None,
+            Some("Number of matching lines to skip for pagination (default: 0)."),
+        ),
+    );
+    props.insert(
+        "ignoreCase".to_string(),
+        boolean_prop(Some("Case-insensitive search (default: false).")),
+    );
+    #[cfg(all(
+        feature = "workspace-edit-file",
+        not(feature = "workspace-str-replace")
+    ))]
+    props.insert(
+        "showLineAnchors".to_string(),
+        boolean_prop(Some(search_show_line_anchors_schema_hint())),
+    );
+
+    MCPTool {
+        name: "grepFiles".to_string(),
+        title: Some("Grep Workspace Files".to_string()),
+        description: format!(
+            "Search file contents with a regex pattern. Results are line-based and paginated by matching lines. Use readFile on a hit, then {PRIMARY_EDIT_TOOL} to apply targeted edits."
+        ),
+        input_schema: object_schema(props, vec!["path".to_string(), "query".to_string()]),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+/// Legacy combined search tool kept for backward-compatible dispatch only.
 pub fn create_search_tool() -> MCPTool {
     let mut props = SchemaProperties::new();
     props.insert(

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -364,8 +364,10 @@ pub fn create_search_tool() -> MCPTool {
 
     MCPTool {
         name: "searchFiles".to_string(),
-        title: Some("Search Workspace".to_string()),
-        description: "Search files by name or content. Content search uses regex against full file text with multiline mode enabled, reports line-based hits, and paginates by matching lines rather than files. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
+        title: Some("Search Workspace (Deprecated)".to_string()),
+        description: "DEPRECATED: Use globFiles for filename search or grepFiles for content search. \
+                     This tool is kept for backward compatibility and will be removed in a future version. \
+                     Note: Requires either 'query' (content search) or 'filePattern' (filename search).".to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
@@ -12,7 +12,8 @@ pub fn file_tools() -> Vec<MCPTool> {
         file_tools::create_write_file_tool(),
         file_tools::create_list_directory_tool(),
         file_tools::create_import_files_tool(),
-        file_tools::create_search_tool(),
+        file_tools::create_glob_files_tool(),
+        file_tools::create_grep_files_tool(),
     ];
 
     #[cfg(feature = "workspace-str-replace")]

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -100,6 +100,7 @@ pub mod skill_scan_cache_tests;
 pub mod skill_service_content_access_tests;
 pub mod skill_service_helpers_tests;
 pub mod skill_service_import_conflict_tests;
+pub mod skills_manifest_tests;
 pub mod sqlite_url_format_tests;
 pub mod subsession_llm_inheritance_tests;
 pub mod teamwork_scaffold_script_tests;

--- a/src-tauri/tests/integration/skills_manifest_tests.rs
+++ b/src-tauri/tests/integration/skills_manifest_tests.rs
@@ -1,0 +1,145 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use tauri_mcp_agent_lib::lifecycle::app_setup::{
+    hash_skill_directory, load_persisted_bundled_skills_manifest,
+    replace_skill_directory_atomically, write_manifest_atomically, BundledSkillsManifest,
+};
+use tempfile::TempDir;
+
+const EMPTY_DIR_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+fn write_skill(dir: &Path, name: &str, description: &str, body: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {}\ndescription: {}\n---\n{}\n",
+            name, description, body
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn hash_skill_directory_empty_directory() {
+    let root = TempDir::new().unwrap();
+    let skill_dir = root.path().join("empty-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+
+    let hash = hash_skill_directory(&skill_dir).unwrap();
+    assert_eq!(hash, EMPTY_DIR_SHA256);
+}
+
+#[test]
+fn load_persisted_bundled_skills_manifest_returns_none_for_missing_file() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join("missing-manifest.json");
+
+    assert_eq!(
+        load_persisted_bundled_skills_manifest(&manifest_path).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn load_persisted_bundled_skills_manifest_returns_none_for_corrupt_json() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join(".bundled_skills_manifest.json");
+    fs::write(&manifest_path, b"not-json").unwrap();
+
+    assert_eq!(
+        load_persisted_bundled_skills_manifest(&manifest_path).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn load_persisted_bundled_skills_manifest_returns_none_for_unsupported_schema() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join(".bundled_skills_manifest.json");
+    fs::write(&manifest_path, br#"{"schemaVersion":999,"skills":{}}"#).unwrap();
+
+    assert_eq!(
+        load_persisted_bundled_skills_manifest(&manifest_path).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn load_persisted_bundled_skills_manifest_reads_valid_manifest() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join(".bundled_skills_manifest.json");
+    fs::write(
+        &manifest_path,
+        br#"{"schemaVersion":1,"skills":{"alpha":"abc123"}}"#,
+    )
+    .unwrap();
+
+    let manifest = load_persisted_bundled_skills_manifest(&manifest_path)
+        .unwrap()
+        .expect("valid manifest should load");
+    assert_eq!(manifest.schema_version, 1);
+    assert_eq!(manifest.skills.get("alpha"), Some(&"abc123".to_string()));
+}
+
+#[test]
+fn write_manifest_atomically_leaves_no_staging_artifacts_on_success() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join(".bundled_skills_manifest.json");
+    let temp_path = manifest_path.with_extension("json.tmp");
+    let backup_path = manifest_path.with_extension("json.bak");
+
+    let mut skills = BTreeMap::new();
+    skills.insert("skill1".to_string(), "hash1".to_string());
+    let manifest = BundledSkillsManifest {
+        schema_version: 1,
+        skills,
+    };
+
+    write_manifest_atomically(&manifest_path, &manifest).unwrap();
+
+    assert!(manifest_path.exists());
+    assert!(!temp_path.exists());
+    assert!(!backup_path.exists());
+}
+
+#[test]
+fn write_manifest_atomically_clears_stale_temp_directory() {
+    let root = TempDir::new().unwrap();
+    let manifest_path = root.path().join(".bundled_skills_manifest.json");
+    let temp_path = manifest_path.with_extension("json.tmp");
+    fs::create_dir_all(&temp_path).unwrap();
+
+    let manifest = BundledSkillsManifest {
+        schema_version: 1,
+        skills: BTreeMap::new(),
+    };
+
+    write_manifest_atomically(&manifest_path, &manifest).unwrap();
+
+    assert!(manifest_path.exists());
+    assert!(!temp_path.exists());
+}
+
+#[test]
+fn replace_skill_directory_atomically_leaves_no_staging_artifacts_on_success() {
+    let root = TempDir::new().unwrap();
+    let source_dir = root.path().join("source-skill");
+    let target_dir = root.path().join("target-skill");
+    let parent = target_dir.parent().unwrap();
+    let temp_dir = parent.join(".sync-tmp-target-skill");
+    let backup_dir = parent.join(".sync-backup-target-skill");
+
+    write_skill(&source_dir, "target-skill", "Source", "source body");
+    fs::create_dir_all(&temp_dir).unwrap();
+    fs::create_dir_all(&backup_dir).unwrap();
+
+    replace_skill_directory_atomically(&source_dir, &target_dir).unwrap();
+
+    assert!(target_dir.exists());
+    assert!(target_dir.join("SKILL.md").exists());
+    assert!(target_dir.join(".bundled_skill").exists());
+    assert!(!temp_dir.exists());
+    assert!(!backup_dir.exists());
+}

--- a/src-tauri/tests/integration/workspace_new_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_new_search_tests.rs
@@ -1,0 +1,172 @@
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tempfile::tempdir;
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+#[tokio::test]
+async fn glob_files_works_correctly() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create test files
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::create_dir_all(workspace_dir.join("tests")).expect("tests dir");
+    std::fs::write(workspace_dir.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+    std::fs::write(workspace_dir.join("src/lib.rs"), "pub fn lib() {}").expect("write lib.rs");
+    std::fs::write(workspace_dir.join("tests/integration.rs"), "mod tests;").expect("write integration.rs");
+    std::fs::write(workspace_dir.join("README.md"), "# Project").expect("write README");
+
+    // Call handle_glob_files directly (the new tool)
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("glob_files should succeed");
+
+    let text = extract_text_content(&result);
+    println!("GlobFiles output:\n{}", text);
+
+    // Should find all .rs files
+    assert!(text.contains("src/main.rs"), "Expected src/main.rs in output: {}", text);
+    assert!(text.contains("src/lib.rs"), "Expected src/lib.rs in output: {}", text);
+    assert!(text.contains("tests/integration.rs"), "Expected tests/integration.rs in output: {}", text);
+    assert!(!text.contains("README.md"), "Should not include README.md: {}", text);
+
+    // Check structured content
+    let structured = result.structured_content.as_ref().expect("structured content expected");
+    assert_eq!(structured["files_found"], json!(3));
+}
+
+#[tokio::test]
+async fn grep_files_works_correctly() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create test files
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(
+        workspace_dir.join("src/main.rs"),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}",
+    )
+    .expect("write main.rs");
+    std::fs::write(
+        workspace_dir.join("src/lib.rs"),
+        "pub fn helper() -> i32 {\n    42\n}",
+    )
+    .expect("write lib.rs");
+
+    // Call handle_grep_files directly (the new tool)
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "let\\s+x\\s*=\\s*1",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grep_files should succeed");
+
+    let text = extract_text_content(&result);
+    println!("GrepFiles output:\n{}", text);
+
+    // Should find the match in main.rs
+    assert!(text.contains("src/main.rs"), "Expected src/main.rs in output: {}", text);
+    assert!(text.contains("let x = 1;"), "Expected 'let x = 1;' in output: {}", text);
+    assert!(!text.contains("src/lib.rs"), "Should not include lib.rs: {}", text);
+
+    // Check structured content
+    let structured = result.structured_content.as_ref().expect("structured content expected");
+    assert_eq!(structured["total_matches"], json!(1));
+}
+
+#[tokio::test]
+async fn glob_files_with_limit_and_offset() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-pagination-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create multiple test files
+    for i in 0..10 {
+        std::fs::write(workspace_dir.join(format!("file_{}.txt", i)), "content").expect("write file");
+    }
+
+    // Test limit
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.txt",
+                "limit": 5,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("glob_files should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("Showing 1 to 5 of 10 total"), "Expected pagination info: {}", text);
+    assert_eq!(result.structured_content.as_ref().unwrap()["files_found"], json!(10));
+}
+
+#[tokio::test]
+async fn grep_files_pagination_works() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-pagination-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create file with many matches
+    let content = (0..20).map(|i| format!("line {} with needle", i)).collect::<Vec<_>>().join("\n");
+    std::fs::write(workspace_dir.join("matches.txt"), content).expect("write file");
+
+    // Test limit
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "limit": 5,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grep_files should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("Showing 1 to 5 of 20 total matches"), "Expected pagination: {}", text);
+    assert_eq!(result.structured_content.as_ref().unwrap()["total_matches"], json!(20));
+}

--- a/src-tauri/tests/integration/workspace_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_search_tests.rs
@@ -1053,3 +1053,211 @@ async fn search_skips_binary_looking_files_even_without_binary_extension() {
     assert_eq!(structured["files_with_matches"], json!(1));
     assert_eq!(structured["skipped_binary_files"], json!(1));
 }
+
+#[tokio::test]
+async fn glob_files_finds_by_pattern() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-pattern";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(workspace_dir.join("src/main.ts"), "export {}\n").expect("write ts");
+    std::fs::write(workspace_dir.join("README.md"), "# docs\n").expect("write md");
+
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.ts",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("src/main.ts"), "expected ts match: {text}");
+    assert!(
+        !text.contains("README.md"),
+        "md file should not match: {text}"
+    );
+}
+
+#[tokio::test]
+async fn grep_files_finds_content() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-content";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(workspace_dir.join("src/main.ts"), "const needle = true;\n")
+        .expect("write source file");
+    std::fs::write(workspace_dir.join("src/other.ts"), "const hay = true;\n")
+        .expect("write other file");
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("src/main.ts"),
+        "expected match in main.ts: {text}"
+    );
+    assert!(
+        !text.contains("other.ts"),
+        "other.ts should not match: {text}"
+    );
+}
+
+#[tokio::test]
+async fn glob_files_rejects_empty_file_pattern() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-empty-pattern";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "empty filePattern should error: {result:?}"
+    );
+    let text = extract_text_content(&result);
+    assert!(text.contains("filePattern"), "{text}");
+}
+
+#[tokio::test]
+async fn grep_files_rejects_empty_query() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-empty-query";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "empty query should error: {result:?}"
+    );
+    let text = extract_text_content(&result);
+    assert!(text.contains("query"), "{text}");
+}
+
+#[tokio::test]
+async fn grep_files_optional_file_pattern_scopes_results() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-pattern-scope";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("match.rs"), "needle\n").expect("write rs");
+    std::fs::write(workspace_dir.join("match.ts"), "needle\n").expect("write ts");
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("match.rs"), "expected rs match: {text}");
+    assert!(
+        !text.contains("match.ts"),
+        "ts file should be filtered out: {text}"
+    );
+}
+
+#[tokio::test]
+async fn search_files_compat_still_works() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-files-compat";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("legacy.ts"), "legacy-token\n").expect("write file");
+
+    let glob_result = server
+        .call_tool(
+            "globFiles",
+            json!({
+                "path": ".",
+                "filePattern": "*.ts",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles dispatch should succeed");
+    let glob_text = extract_text_content(&glob_result);
+    assert!(glob_text.contains("legacy.ts"), "{glob_text}");
+
+    let grep_result = server
+        .call_tool(
+            "grepFiles",
+            json!({
+                "path": ".",
+                "query": "legacy-token",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles dispatch should succeed");
+    let grep_text = extract_text_content(&grep_result);
+    assert!(grep_text.contains("legacy.ts"), "{grep_text}");
+
+    let compat_result = server
+        .call_tool(
+            "searchFiles",
+            json!({
+                "path": ".",
+                "query": "legacy-token",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("searchFiles compat dispatch should succeed");
+    let compat_text = extract_text_content(&compat_result);
+    assert!(compat_text.contains("legacy.ts"), "{compat_text}");
+}
+
+#[tokio::test]
+async fn workspace_file_tools_expose_glob_and_grep_not_search_files() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools;
+
+    let names: Vec<String> = file_tools().into_iter().map(|tool| tool.name).collect();
+
+    assert!(names.contains(&"globFiles".to_string()), "{names:?}");
+    assert!(names.contains(&"grepFiles".to_string()), "{names:?}");
+    assert!(!names.contains(&"searchFiles".to_string()), "{names:?}");
+}

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -196,16 +196,26 @@ async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
 #[tokio::test]
 async fn read_file_and_search_schemas_omit_show_line_anchors() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::{
-        create_read_file_tool, create_search_tool,
+        create_glob_files_tool, create_grep_files_tool, create_read_file_tool, create_search_tool,
     };
 
     let read_schema = serde_json::to_value(create_read_file_tool().input_schema)
         .expect("serialize readFile schema");
+    let grep_schema = serde_json::to_value(create_grep_files_tool().input_schema)
+        .expect("serialize grepFiles schema");
+    let glob_schema = serde_json::to_value(create_glob_files_tool().input_schema)
+        .expect("serialize globFiles schema");
     let search_schema = serde_json::to_value(create_search_tool().input_schema)
         .expect("serialize searchFiles schema");
     let read_props = read_schema["properties"]
         .as_object()
         .expect("readFile properties");
+    let grep_props = grep_schema["properties"]
+        .as_object()
+        .expect("grepFiles properties");
+    let glob_props = glob_schema["properties"]
+        .as_object()
+        .expect("globFiles properties");
     let search_props = search_schema["properties"]
         .as_object()
         .expect("searchFiles properties");
@@ -215,9 +225,29 @@ async fn read_file_and_search_schemas_omit_show_line_anchors() {
         "readFile schema should not expose showLineAnchors on strReplace builds"
     );
     assert!(
+        !grep_props.contains_key("showLineAnchors"),
+        "grepFiles schema should not expose showLineAnchors on strReplace builds"
+    );
+    assert!(
+        !glob_props.contains_key("query"),
+        "globFiles schema should not expose query"
+    );
+    assert!(
         !search_props.contains_key("showLineAnchors"),
         "searchFiles schema should not expose showLineAnchors on strReplace builds"
     );
+
+    let glob_required = glob_schema["required"]
+        .as_array()
+        .expect("globFiles required");
+    assert!(glob_required.contains(&json!("path")));
+    assert!(glob_required.contains(&json!("filePattern")));
+
+    let grep_required = grep_schema["required"]
+        .as_array()
+        .expect("grepFiles required");
+    assert!(grep_required.contains(&json!("path")));
+    assert!(grep_required.contains(&json!("query")));
 }
 
 #[tokio::test]

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
## Summary

- Add RAII staging guards (`StagedFileReplaceGuard`, `StagedDirReplaceGuard`) for `write_manifest_atomically` and `replace_skill_directory_atomically` to roll back temp/backup state on failure
- Clear stale temp artifacts (file or directory) before atomic writes
- Use best-effort post-commit backup cleanup so committed manifest/skill data is not rolled back when backup removal fails
- Export `load_persisted_bundled_skills_manifest` and add integration tests for manifest loading, hashing, and staging artifact cleanup

## Test plan

- [x] `pnpm refactor:validate`
- [x] Integration tests in `skills_manifest_tests.rs` (runs on Linux/macOS CI)
- [x] Verify managed skills sync on app startup leaves no orphaned `.json.tmp` / `.sync-backup-*` artifacts after simulated failures

Fixes #1552
