### PR TITLE
feat(workspace): split searchFiles into globFiles and grepFiles

### DIFF
--- a/.agents/skills/extract-log-debug/references/log_patterns.md
+++ b/.agents/skills/extract-log-debug/references/log_patterns.md
@@ -63,7 +63,9 @@
 - `WorkspaceServer` - Workspace server logs
 - `readFile` / `writeFile` / `editFile` - File operations
 - `listFiles` - Directory listing
-- `searchFiles` - File search
+- `globFiles` - Find files by glob pattern
+- `grepFiles` - Search file contents with regex
+- `searchFiles` - Legacy combined search (dispatch only)
 
 #### Knowledge Base
 

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -423,7 +423,7 @@ impl SuccessHint {
             ("listDirectory", ToolGroup::Workspace) => vec![
                 "Use readFile to view file contents".to_string(),
                 "Use writeFile to create new files".to_string(),
-                "Use searchFiles with filePattern to narrow down names".to_string(),
+                "Use globFiles with filePattern to narrow down names".to_string(),
             ],
             #[cfg(feature = "workspace-edit-file")]
             (
@@ -438,9 +438,20 @@ impl SuccessHint {
                 "Use readFile to verify your edits".to_string(),
                 "Use runShell to execute the updated code".to_string(),
             ],
-            ("searchFiles", ToolGroup::Workspace) => vec![
+            ("globFiles", ToolGroup::Workspace) => vec![
+                "Use grepFiles to search inside matched files".to_string(),
+                "Use readFile to inspect a specific match".to_string(),
+            ],
+            ("grepFiles", ToolGroup::Workspace) => vec![
                 "Use readFile on interesting matches".to_string(),
-                "Use listDirectory to explore the surrounding module".to_string(),
+                format!(
+                    "Use {} to make targeted edits",
+                    crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
+                ),
+            ],
+            ("searchFiles", ToolGroup::Workspace) => vec![
+                "Use globFiles for filename search".to_string(),
+                "Use grepFiles for content search".to_string(),
             ],
 
             // Agent tools (Unified)

--- a/src-tauri/src/mcp/builtin/workspace/dispatch.rs
+++ b/src-tauri/src/mcp/builtin/workspace/dispatch.rs
@@ -37,6 +37,8 @@ impl WorkspaceServer {
             "writeFile" => self.handle_write_file(args, session_id).await,
             "listDirectory" => self.handle_list_directory(args, session_id).await,
             "importFiles" => self.handle_import_files(args, session_id).await,
+            "globFiles" => self.handle_glob_files(args, session_id).await,
+            "grepFiles" => self.handle_grep_files(args, session_id).await,
             "searchFiles" => self.handle_search(args, session_id).await,
             #[cfg(feature = "workspace-str-replace")]
             "strReplace" => self.handle_str_replace(args, session_id).await,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/helpers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/helpers.rs
@@ -1,4 +1,7 @@
+use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
 use crate::mcp::builtin::workspace::utils::is_internal_workspace_artifact_path;
+use crate::mcp::types::MCPResult;
+use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncReadExt;
@@ -196,4 +199,77 @@ pub(super) fn build_gitignore_matcher(
         search_root: search_root.to_path_buf(),
         matchers,
     })
+}
+
+pub(super) fn reject_empty_optional_str<'a>(
+    value: Option<&'a str>,
+    field: &str,
+    guidance: Vec<String>,
+) -> Result<Option<&'a str>, MCPResult> {
+    if matches!(value, Some("")) {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!("Invalid {field}: {field} must not be empty"),
+            ToolGroup::Workspace,
+        )
+        .guidance(guidance)
+        .to_mcp_result());
+    }
+    Ok(value)
+}
+
+pub(super) fn parse_pagination(args: &Value) -> Result<(usize, usize), MCPResult> {
+    let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
+    if !(1..=1000).contains(&limit_raw) {
+        return Err(guided_error(
+            ErrorCategory::InvalidInput,
+            format!(
+                "Invalid pagination parameter: limit must be between 1 and 1000, got {limit_raw}"
+            ),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Set limit to a value between 1 and 1000".to_string(),
+            "Use offset to paginate through additional results".to_string(),
+        ])
+        .to_mcp_result());
+    }
+    let limit = match usize::try_from(limit_raw) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Invalid pagination parameter: limit is too large for this platform ({limit_raw})"
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Set limit to a value between 1 and 1000".to_string(),
+                "Use smaller page sizes when paginating search results".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    let offset_raw = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
+    let offset = match usize::try_from(offset_raw) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(guided_error(
+                ErrorCategory::InvalidInput,
+                format!(
+                    "Invalid pagination parameter: offset is too large for this platform ({offset_raw})"
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Set offset to a smaller non-negative value".to_string(),
+                "Use limit and offset together to page through results".to_string(),
+            ])
+            .to_mcp_result());
+        }
+    };
+
+    Ok((limit, offset))
 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/mod.rs
@@ -9,10 +9,31 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::builtin::workspace::utils::is_internal_workspace_artifact_path;
 use crate::mcp::types::MCPResult;
+use helpers::{parse_pagination, reject_empty_optional_str};
 use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+struct ResolvedSearchTarget {
+    workspace_root: PathBuf,
+    safe_path: PathBuf,
+    display_path: String,
+}
+
+struct GrepSearchParams<'a> {
+    workspace_root: &'a Path,
+    safe_path: &'a Path,
+    display_path: &'a str,
+    query_str: &'a str,
+    file_pattern: Option<&'a str>,
+    ignore_case: bool,
+    show_line_anchors: bool,
+    limit: usize,
+    offset: usize,
+}
 
 impl WorkspaceServer {
-    pub async fn handle_search(
+    pub async fn handle_glob_files(
         &self,
         args: Value,
         session_id: Option<String>,
@@ -22,32 +43,85 @@ impl WorkspaceServer {
             None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
         };
 
-        let query = args.get("query").and_then(|v| v.as_str());
-        let file_pattern = args.get("filePattern").and_then(|v| v.as_str());
-        if matches!(query, Some("")) {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                "Invalid query: query must not be empty".to_string(),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
-                "Provide a non-empty regex pattern for content search".to_string(),
-                "Omit query and use filePattern when you only want to find files".to_string(),
-            ])
-            .to_mcp_result());
-        }
-        if matches!(file_pattern, Some("")) {
-            return Ok(guided_error(
-                ErrorCategory::InvalidInput,
-                "Invalid filePattern: filePattern must not be empty".to_string(),
-                ToolGroup::Workspace,
-            )
-            .guidance(vec![
+        let file_pattern = match args.get("filePattern").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return Ok(missing_param_error("filePattern", ToolGroup::Workspace)),
+        };
+
+        let file_pattern = match reject_empty_optional_str(
+            Some(file_pattern),
+            "filePattern",
+            vec!["Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string()],
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return Ok(missing_param_error("filePattern", ToolGroup::Workspace));
+            }
+            Err(result) => return Ok(result),
+        };
+
+        let (limit, offset) = match parse_pagination(&args) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
+        let ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path,
+        } = match self.resolve_search_target(search_path, session_id).await {
+            Ok(target) => target,
+            Err(result) => return Ok(result),
+        };
+
+        files::search_files_only(
+            &workspace_root,
+            &safe_path,
+            &display_path,
+            file_pattern,
+            limit,
+            offset,
+        )
+        .await
+    }
+
+    pub async fn handle_grep_files(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        let search_path = match args.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return Ok(missing_param_error("path", ToolGroup::Workspace)),
+        };
+
+        let query = match args.get("query").and_then(|v| v.as_str()) {
+            Some(q) => q,
+            None => return Ok(missing_param_error("query", ToolGroup::Workspace)),
+        };
+
+        let query = match reject_empty_optional_str(
+            Some(query),
+            "query",
+            vec!["Provide a non-empty regex pattern for content search".to_string()],
+        ) {
+            Ok(Some(q)) => q,
+            Ok(None) => return Ok(missing_param_error("query", ToolGroup::Workspace)),
+            Err(result) => return Ok(result),
+        };
+
+        let file_pattern = match reject_empty_optional_str(
+            args.get("filePattern").and_then(|v| v.as_str()),
+            "filePattern",
+            vec![
                 "Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string(),
                 "Omit filePattern when you want content search across all files".to_string(),
-            ])
-            .to_mcp_result());
-        }
+            ],
+        ) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
         let ignore_case = args
             .get("ignoreCase")
             .and_then(|v| v.as_bool())
@@ -59,76 +133,112 @@ impl WorkspaceServer {
         } else {
             false
         };
-        let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50);
-        if !(1..=1000).contains(&limit_raw) {
+
+        let (limit, offset) = match parse_pagination(&args) {
+            Ok(value) => value,
+            Err(result) => return Ok(result),
+        };
+
+        let ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path,
+        } = match self.resolve_search_target(search_path, session_id).await {
+            Ok(target) => target,
+            Err(result) => return Ok(result),
+        };
+
+        self.search_content(GrepSearchParams {
+            workspace_root: &workspace_root,
+            safe_path: &safe_path,
+            display_path: &display_path,
+            query_str: query,
+            file_pattern,
+            ignore_case,
+            show_line_anchors,
+            limit,
+            offset,
+        })
+        .await
+    }
+
+    /// Backward-compatible router for the hidden `searchFiles` dispatch alias.
+    pub async fn handle_search(
+        &self,
+        args: Value,
+        session_id: Option<String>,
+    ) -> Result<MCPResult, String> {
+        warn!(
+            "searchFiles is deprecated; use globFiles for filename search or grepFiles for content search"
+        );
+
+        let query = args.get("query").and_then(|v| v.as_str());
+        let file_pattern = args.get("filePattern").and_then(|v| v.as_str());
+
+        if matches!(query, Some("")) {
             return Ok(guided_error(
                 ErrorCategory::InvalidInput,
-                format!(
-                    "Invalid pagination parameter: limit must be between 1 and 1000, got {}",
-                    limit_raw
-                ),
+                "Invalid query: query must not be empty".to_string(),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Set limit to a value between 1 and 1000".to_string(),
-                "Use offset to paginate through additional results".to_string(),
+                "Provide a non-empty regex pattern for content search with grepFiles".to_string(),
+                "Use globFiles with filePattern when you only want to find files".to_string(),
             ])
             .to_mcp_result());
         }
-        let limit = match usize::try_from(limit_raw) {
-            Ok(value) => value,
-            Err(_) => {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Invalid pagination parameter: limit is too large for this platform ({})",
-                        limit_raw
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Set limit to a value between 1 and 1000".to_string(),
-                    "Use smaller page sizes when paginating search results".to_string(),
-                ])
-                .to_mcp_result());
-            }
-        };
 
-        let offset_raw = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
-        let offset = match usize::try_from(offset_raw) {
-            Ok(value) => value,
-            Err(_) => {
-                return Ok(guided_error(
-                    ErrorCategory::InvalidInput,
-                    format!(
-                        "Invalid pagination parameter: offset is too large for this platform ({})",
-                        offset_raw
-                    ),
-                    ToolGroup::Workspace,
-                )
-                .guidance(vec![
-                    "Set offset to a smaller non-negative value".to_string(),
-                    "Use limit and offset together to page through results".to_string(),
-                ])
-                .to_mcp_result());
-            }
-        };
+        if matches!(file_pattern, Some("")) {
+            return Ok(guided_error(
+                ErrorCategory::InvalidInput,
+                "Invalid filePattern: filePattern must not be empty".to_string(),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Provide a non-empty glob like `*.rs` or `src/**/*.ts`".to_string(),
+                "Omit filePattern when you want content search across all files with grepFiles"
+                    .to_string(),
+            ])
+            .to_mcp_result());
+        }
 
-        let target_session_id = session_id
-            .clone()
-            .unwrap_or_else(|| self.session_id.clone());
+        if query.is_some() {
+            return self.handle_grep_files(args, session_id).await;
+        }
+
+        if file_pattern.is_some() {
+            return self.handle_glob_files(args, session_id).await;
+        }
+
+        Ok(guided_error(
+            ErrorCategory::MissingRequiredParam,
+            "Provide either 'query' (to search text) or 'filePattern' (to find files)".to_string(),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Use grepFiles with query for content search".to_string(),
+            "Use globFiles with filePattern for filename search".to_string(),
+        ])
+        .to_mcp_result())
+    }
+
+    async fn resolve_search_target(
+        &self,
+        search_path: &str,
+        session_id: Option<String>,
+    ) -> Result<ResolvedSearchTarget, MCPResult> {
+        let target_session_id = session_id.unwrap_or_else(|| self.session_id.clone());
         let workspace_root = self.get_workspace_dir(&target_session_id);
 
-        // Security validation
         let safe_path = match self
             .validate_read_path_with_skill_access(search_path, Some(target_session_id))
             .await
         {
             Ok(path) => path,
             Err(e) => {
-                return Ok(guided_error(
+                return Err(guided_error(
                     ErrorCategory::PermissionDenied,
-                    format!("Path validation failed: {}", e),
+                    format!("Path validation failed: {e}"),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
@@ -140,7 +250,7 @@ impl WorkspaceServer {
         };
 
         if safe_path.is_file() && is_internal_workspace_artifact_path(&workspace_root, &safe_path) {
-            return Ok(guided_error(
+            return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 "Internal LibrAgent temp/export artifacts are excluded from search".to_string(),
                 ToolGroup::Workspace,
@@ -148,39 +258,32 @@ impl WorkspaceServer {
             .guidance(vec![
                 "Search workspace files outside .libragent/tmp and .libragent/exports".to_string(),
                 "Use readProcessOutput or listProcesses to inspect temp process output".to_string(),
-                "Use export on real workspace files instead of searching generated export artifacts".to_string(),
+                "Use export on real workspace files instead of searching generated export artifacts"
+                    .to_string(),
             ])
             .to_mcp_result());
         }
 
-        // Determine if we are doing file name search only or content search
-        if query.is_none() {
-            // File Name Search Only
-            let pattern = match file_pattern {
-                Some(p) => p,
-                None => {
-                    return Ok(guided_error(
-                        ErrorCategory::MissingRequiredParam,
-                        "Provide either 'query' (to search text) or 'filePattern' (to find files)"
-                            .to_string(),
-                        ToolGroup::Workspace,
-                    )
-                    .to_mcp_result());
-                }
-            };
-            return files::search_files_only(
-                &workspace_root,
-                &safe_path,
-                search_path,
-                pattern,
-                limit,
-                offset,
-            )
-            .await;
-        }
+        Ok(ResolvedSearchTarget {
+            workspace_root,
+            safe_path,
+            display_path: search_path.to_string(),
+        })
+    }
 
-        // Text Content Search
-        let query_str = query.unwrap();
+    async fn search_content(&self, params: GrepSearchParams<'_>) -> Result<MCPResult, String> {
+        let GrepSearchParams {
+            workspace_root,
+            safe_path,
+            display_path,
+            query_str,
+            file_pattern,
+            ignore_case,
+            show_line_anchors,
+            limit,
+            offset,
+        } = params;
+
         let regex = match regex::RegexBuilder::new(query_str)
             .case_insensitive(ignore_case)
             .multi_line(true)
@@ -191,7 +294,7 @@ impl WorkspaceServer {
             Err(e) => {
                 return Ok(guided_error(
                     ErrorCategory::InvalidInput,
-                    format!("Invalid regex pattern: {}", e),
+                    format!("Invalid regex pattern: {e}"),
                     ToolGroup::Workspace,
                 )
                 .guidance(vec![
@@ -208,7 +311,7 @@ impl WorkspaceServer {
                 Err(e) => {
                     return Ok(guided_error(
                         ErrorCategory::InvalidInput,
-                        format!("Invalid filePattern: {}", e),
+                        format!("Invalid filePattern: {e}"),
                         ToolGroup::Workspace,
                     )
                     .to_mcp_result());
@@ -219,11 +322,11 @@ impl WorkspaceServer {
 
         if safe_path.is_dir() {
             content::search_content_in_dir(content::SearchDirectoryRequest {
-                workspace_root: &workspace_root,
-                dir: &safe_path,
+                workspace_root,
+                dir: safe_path,
                 file_pattern: glob_pat.as_ref(),
                 search: content::SearchContentRequest {
-                    display_path: search_path,
+                    display_path,
                     regex: &regex,
                     query: query_str,
                     show_hashes: show_line_anchors,
@@ -235,9 +338,9 @@ impl WorkspaceServer {
             .await
         } else {
             content::search_content_in_file(
-                &safe_path,
+                safe_path,
                 content::SearchContentRequest {
-                    display_path: search_path,
+                    display_path,
                     regex: &regex,
                     query: query_str,
                     show_hashes: show_line_anchors,

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -146,7 +146,7 @@ pub fn create_list_directory_tool() -> MCPTool {
 - listDirectory('src/components') — subdirectory
 - listDirectory('/tmp') — absolute directory
 
-Returns names and types (file/directory). Use search with filePattern when you need glob-style filtering."
+Returns names and types (file/directory). Use globFiles when you need glob-style filtering."
             .to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
@@ -197,6 +197,116 @@ pub fn create_import_files_tool() -> MCPTool {
     }
 }
 
+fn search_path_prop() -> crate::mcp::schema::JSONSchema {
+    string_prop(
+        Some(1),
+        Some(1000),
+        Some("Path to the file or directory to search. Relative paths resolve from the workspace; absolute paths are also allowed unless protected. Use @teamwork or @teamwork/... (or relative .libragent/teamwork/...) for the canonical teamwork scaffold root. Read-only skill aliases such as @system-skills/... and @user-skills/... may also be searched when available."),
+    )
+}
+
+pub fn create_glob_files_tool() -> MCPTool {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), search_path_prop());
+    props.insert(
+        "filePattern".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Glob pattern to match file or directory names (e.g. '*.rs', 'src/**/*.ts')."),
+        ),
+    );
+    props.insert(
+        "limit".to_string(),
+        integer_prop(
+            Some(1),
+            Some(1000),
+            Some("Maximum number of matched files/directories to return (default: 50)."),
+        ),
+    );
+    props.insert(
+        "offset".to_string(),
+        integer_prop(
+            Some(0),
+            None,
+            Some("Number of results to skip for pagination (default: 0)."),
+        ),
+    );
+
+    MCPTool {
+        name: "globFiles".to_string(),
+        title: Some("Glob Workspace Files".to_string()),
+        description: "Find files and directories by glob pattern. Use grepFiles to search inside matches, or readFile to inspect a specific path.".to_string(),
+        input_schema: object_schema(
+            props,
+            vec!["path".to_string(), "filePattern".to_string()],
+        ),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+pub fn create_grep_files_tool() -> MCPTool {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), search_path_prop());
+    props.insert(
+        "query".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Regular expression pattern to search for text inside files. Matched against full file content with multiline mode enabled, so ^ and $ match line boundaries. '.' does not match newlines unless you opt into that in the regex itself (for example with (?s))."),
+        ),
+    );
+    props.insert(
+        "filePattern".to_string(),
+        string_prop(
+            Some(1),
+            Some(1000),
+            Some("Optional glob pattern to limit which files are searched (e.g. '*.rs', 'src/**/*.ts')."),
+        ),
+    );
+    props.insert(
+        "limit".to_string(),
+        integer_prop(
+            Some(1),
+            Some(1000),
+            Some("Maximum number of matching lines to return (default: 50)."),
+        ),
+    );
+    props.insert(
+        "offset".to_string(),
+        integer_prop(
+            Some(0),
+            None,
+            Some("Number of matching lines to skip for pagination (default: 0)."),
+        ),
+    );
+    props.insert(
+        "ignoreCase".to_string(),
+        boolean_prop(Some("Case-insensitive search (default: false).")),
+    );
+    #[cfg(all(
+        feature = "workspace-edit-file",
+        not(feature = "workspace-str-replace")
+    ))]
+    props.insert(
+        "showLineAnchors".to_string(),
+        boolean_prop(Some(search_show_line_anchors_schema_hint())),
+    );
+
+    MCPTool {
+        name: "grepFiles".to_string(),
+        title: Some("Grep Workspace Files".to_string()),
+        description: format!(
+            "Search file contents with a regex pattern. Results are line-based and paginated by matching lines. Use readFile on a hit, then {PRIMARY_EDIT_TOOL} to apply targeted edits."
+        ),
+        input_schema: object_schema(props, vec!["path".to_string(), "query".to_string()]),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+/// Legacy combined search tool kept for backward-compatible dispatch only.
 pub fn create_search_tool() -> MCPTool {
     let mut props = SchemaProperties::new();
     props.insert(

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -364,8 +364,10 @@ pub fn create_search_tool() -> MCPTool {
 
     MCPTool {
         name: "searchFiles".to_string(),
-        title: Some("Search Workspace".to_string()),
-        description: "Search files by name or content. Content search uses regex against full file text with multiline mode enabled, reports line-based hits, and paginates by matching lines rather than files. Relative paths resolve from the workspace; absolute paths are also allowed unless protected.".to_string(),
+        title: Some("Search Workspace (Deprecated)".to_string()),
+        description: "DEPRECATED: Use globFiles for filename search or grepFiles for content search. \
+                     This tool is kept for backward compatibility and will be removed in a future version. \
+                     Note: Requires either 'query' (content search) or 'filePattern' (filename search).".to_string(),
         input_schema: object_schema(props, vec!["path".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/mod.rs
@@ -12,7 +12,8 @@ pub fn file_tools() -> Vec<MCPTool> {
         file_tools::create_write_file_tool(),
         file_tools::create_list_directory_tool(),
         file_tools::create_import_files_tool(),
-        file_tools::create_search_tool(),
+        file_tools::create_glob_files_tool(),
+        file_tools::create_grep_files_tool(),
     ];
 
     #[cfg(feature = "workspace-str-replace")]

--- a/src-tauri/tests/integration/workspace_new_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_new_search_tests.rs
@@ -1,0 +1,172 @@
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tempfile::tempdir;
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+#[tokio::test]
+async fn glob_files_works_correctly() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create test files
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::create_dir_all(workspace_dir.join("tests")).expect("tests dir");
+    std::fs::write(workspace_dir.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+    std::fs::write(workspace_dir.join("src/lib.rs"), "pub fn lib() {}").expect("write lib.rs");
+    std::fs::write(workspace_dir.join("tests/integration.rs"), "mod tests;").expect("write integration.rs");
+    std::fs::write(workspace_dir.join("README.md"), "# Project").expect("write README");
+
+    // Call handle_glob_files directly (the new tool)
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("glob_files should succeed");
+
+    let text = extract_text_content(&result);
+    println!("GlobFiles output:\n{}", text);
+
+    // Should find all .rs files
+    assert!(text.contains("src/main.rs"), "Expected src/main.rs in output: {}", text);
+    assert!(text.contains("src/lib.rs"), "Expected src/lib.rs in output: {}", text);
+    assert!(text.contains("tests/integration.rs"), "Expected tests/integration.rs in output: {}", text);
+    assert!(!text.contains("README.md"), "Should not include README.md: {}", text);
+
+    // Check structured content
+    let structured = result.structured_content.as_ref().expect("structured content expected");
+    assert_eq!(structured["files_found"], json!(3));
+}
+
+#[tokio::test]
+async fn grep_files_works_correctly() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create test files
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(
+        workspace_dir.join("src/main.rs"),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}",
+    )
+    .expect("write main.rs");
+    std::fs::write(
+        workspace_dir.join("src/lib.rs"),
+        "pub fn helper() -> i32 {\n    42\n}",
+    )
+    .expect("write lib.rs");
+
+    // Call handle_grep_files directly (the new tool)
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "let\\s+x\\s*=\\s*1",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grep_files should succeed");
+
+    let text = extract_text_content(&result);
+    println!("GrepFiles output:\n{}", text);
+
+    // Should find the match in main.rs
+    assert!(text.contains("src/main.rs"), "Expected src/main.rs in output: {}", text);
+    assert!(text.contains("let x = 1;"), "Expected 'let x = 1;' in output: {}", text);
+    assert!(!text.contains("src/lib.rs"), "Should not include lib.rs: {}", text);
+
+    // Check structured content
+    let structured = result.structured_content.as_ref().expect("structured content expected");
+    assert_eq!(structured["total_matches"], json!(1));
+}
+
+#[tokio::test]
+async fn glob_files_with_limit_and_offset() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-pagination-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create multiple test files
+    for i in 0..10 {
+        std::fs::write(workspace_dir.join(format!("file_{}.txt", i)), "content").expect("write file");
+    }
+
+    // Test limit
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.txt",
+                "limit": 5,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("glob_files should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("Showing 1 to 5 of 10 total"), "Expected pagination info: {}", text);
+    assert_eq!(result.structured_content.as_ref().unwrap()["files_found"], json!(10));
+}
+
+#[tokio::test]
+async fn grep_files_pagination_works() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-pagination-test";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    // Create file with many matches
+    let content = (0..20).map(|i| format!("line {} with needle", i)).collect::<Vec<_>>().join("\n");
+    std::fs::write(workspace_dir.join("matches.txt"), content).expect("write file");
+
+    // Test limit
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "limit": 5,
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grep_files should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("Showing 1 to 5 of 20 total matches"), "Expected pagination: {}", text);
+    assert_eq!(result.structured_content.as_ref().unwrap()["total_matches"], json!(20));
+}

--- a/src-tauri/tests/integration/workspace_search_tests.rs
+++ b/src-tauri/tests/integration/workspace_search_tests.rs
@@ -1053,3 +1053,211 @@ async fn search_skips_binary_looking_files_even_without_binary_extension() {
     assert_eq!(structured["files_with_matches"], json!(1));
     assert_eq!(structured["skipped_binary_files"], json!(1));
 }
+
+#[tokio::test]
+async fn glob_files_finds_by_pattern() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-pattern";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(workspace_dir.join("src/main.ts"), "export {}\n").expect("write ts");
+    std::fs::write(workspace_dir.join("README.md"), "# docs\n").expect("write md");
+
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "*.ts",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("src/main.ts"), "expected ts match: {text}");
+    assert!(
+        !text.contains("README.md"),
+        "md file should not match: {text}"
+    );
+}
+
+#[tokio::test]
+async fn grep_files_finds_content() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-content";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::create_dir_all(workspace_dir.join("src")).expect("src dir");
+    std::fs::write(workspace_dir.join("src/main.ts"), "const needle = true;\n")
+        .expect("write source file");
+    std::fs::write(workspace_dir.join("src/other.ts"), "const hay = true;\n")
+        .expect("write other file");
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("src/main.ts"),
+        "expected match in main.ts: {text}"
+    );
+    assert!(
+        !text.contains("other.ts"),
+        "other.ts should not match: {text}"
+    );
+}
+
+#[tokio::test]
+async fn glob_files_rejects_empty_file_pattern() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "glob-files-empty-pattern";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_glob_files(
+            json!({
+                "path": ".",
+                "filePattern": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "empty filePattern should error: {result:?}"
+    );
+    let text = extract_text_content(&result);
+    assert!(text.contains("filePattern"), "{text}");
+}
+
+#[tokio::test]
+async fn grep_files_rejects_empty_query() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-empty-query";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should return");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "empty query should error: {result:?}"
+    );
+    let text = extract_text_content(&result);
+    assert!(text.contains("query"), "{text}");
+}
+
+#[tokio::test]
+async fn grep_files_optional_file_pattern_scopes_results() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "grep-files-pattern-scope";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("match.rs"), "needle\n").expect("write rs");
+    std::fs::write(workspace_dir.join("match.ts"), "needle\n").expect("write ts");
+
+    let result = server
+        .handle_grep_files(
+            json!({
+                "path": ".",
+                "query": "needle",
+                "filePattern": "*.rs",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(text.contains("match.rs"), "expected rs match: {text}");
+    assert!(
+        !text.contains("match.ts"),
+        "ts file should be filtered out: {text}"
+    );
+}
+
+#[tokio::test]
+async fn search_files_compat_still_works() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "search-files-compat";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("legacy.ts"), "legacy-token\n").expect("write file");
+
+    let glob_result = server
+        .call_tool(
+            "globFiles",
+            json!({
+                "path": ".",
+                "filePattern": "*.ts",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("globFiles dispatch should succeed");
+    let glob_text = extract_text_content(&glob_result);
+    assert!(glob_text.contains("legacy.ts"), "{glob_text}");
+
+    let grep_result = server
+        .call_tool(
+            "grepFiles",
+            json!({
+                "path": ".",
+                "query": "legacy-token",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("grepFiles dispatch should succeed");
+    let grep_text = extract_text_content(&grep_result);
+    assert!(grep_text.contains("legacy.ts"), "{grep_text}");
+
+    let compat_result = server
+        .call_tool(
+            "searchFiles",
+            json!({
+                "path": ".",
+                "query": "legacy-token",
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("searchFiles compat dispatch should succeed");
+    let compat_text = extract_text_content(&compat_result);
+    assert!(compat_text.contains("legacy.ts"), "{compat_text}");
+}
+
+#[tokio::test]
+async fn workspace_file_tools_expose_glob_and_grep_not_search_files() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools;
+
+    let names: Vec<String> = file_tools().into_iter().map(|tool| tool.name).collect();
+
+    assert!(names.contains(&"globFiles".to_string()), "{names:?}");
+    assert!(names.contains(&"grepFiles".to_string()), "{names:?}");
+    assert!(!names.contains(&"searchFiles".to_string()), "{names:?}");
+}

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -196,16 +196,26 @@ async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
 #[tokio::test]
 async fn read_file_and_search_schemas_omit_show_line_anchors() {
     use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::{
-        create_read_file_tool, create_search_tool,
+        create_glob_files_tool, create_grep_files_tool, create_read_file_tool, create_search_tool,
     };
 
     let read_schema = serde_json::to_value(create_read_file_tool().input_schema)
         .expect("serialize readFile schema");
+    let grep_schema = serde_json::to_value(create_grep_files_tool().input_schema)
+        .expect("serialize grepFiles schema");
+    let glob_schema = serde_json::to_value(create_glob_files_tool().input_schema)
+        .expect("serialize globFiles schema");
     let search_schema = serde_json::to_value(create_search_tool().input_schema)
         .expect("serialize searchFiles schema");
     let read_props = read_schema["properties"]
         .as_object()
         .expect("readFile properties");
+    let grep_props = grep_schema["properties"]
+        .as_object()
+        .expect("grepFiles properties");
+    let glob_props = glob_schema["properties"]
+        .as_object()
+        .expect("globFiles properties");
     let search_props = search_schema["properties"]
         .as_object()
         .expect("searchFiles properties");
@@ -215,9 +225,29 @@ async fn read_file_and_search_schemas_omit_show_line_anchors() {
         "readFile schema should not expose showLineAnchors on strReplace builds"
     );
     assert!(
+        !grep_props.contains_key("showLineAnchors"),
+        "grepFiles schema should not expose showLineAnchors on strReplace builds"
+    );
+    assert!(
+        !glob_props.contains_key("query"),
+        "globFiles schema should not expose query"
+    );
+    assert!(
         !search_props.contains_key("showLineAnchors"),
         "searchFiles schema should not expose showLineAnchors on strReplace builds"
     );
+
+    let glob_required = glob_schema["required"]
+        .as_array()
+        .expect("globFiles required");
+    assert!(glob_required.contains(&json!("path")));
+    assert!(glob_required.contains(&json!("filePattern")));
+
+    let grep_required = grep_schema["required"]
+        .as_array()
+        .expect("grepFiles required");
+    assert!(grep_required.contains(&json!("path")));
+    assert!(grep_required.contains(&json!("query")));
 }
 
 #[tokio::test]

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 


### PR DESCRIPTION
## Summary

- Split the implicit searchFiles tool into explicit globFiles (filename glob) and grepFiles (regex content search) to reduce agent parameter confusion and align with Cursor-style ergonomics.
- Keep searchFiles as a hidden dispatch-only backward-compat alias that routes to the new handlers and logs a deprecation warning.
- Add integration tests, schema checks, and updated success hints for the globFiles -> grepFiles -> 
eadFile -> strReplace workflow.

## Test plan

- [x] pnpm refactor:validate
- [x] Integration tests for globFiles, grepFiles, and searchFiles compat dispatch
- [x] Schema tests confirming required fields and strReplace build anchor gating
- [x] Manual agent smoke test: glob a file pattern, grep content, read, then strReplace

Closes #1554
