### PR TITLE
fix(agent): await database persistence of assistant messages to prevent race condition

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)

--- a/src-tauri/src/agent/llm/response.rs
+++ b/src-tauri/src/agent/llm/response.rs
@@ -86,21 +86,16 @@ fn assistant_message_has_only_internal_ui_callback_tool_calls(message: &Message)
         .unwrap_or(false)
 }
 
-async fn persist_assistant_message_to_db(message: &Message) {
+async fn persist_assistant_message_to_db(message: &Message) -> Result<(), String> {
     let repo = crate::state::get_message_repository();
-    if let Err(error) = repo.insert(message).await {
+    repo.insert(message).await.map_err(|error| {
         log::error!(
             "Failed to save assistant message to DB: msg_id={}, error={}",
             message.id,
             error
         );
-    }
-}
-
-fn spawn_persist_assistant_message_to_db(message: Message) {
-    tokio::spawn(async move {
-        persist_assistant_message_to_db(&message).await;
-    });
+        format!("Failed to save assistant message to DB: {}", error)
+    })
 }
 
 async fn cache_assistant_message(
@@ -419,7 +414,7 @@ pub async fn handle_llm_response(
         reset_streaming_recovery_retry_counts(active_sessions, &session_id).await;
 
         if crate::agent::workflow::session_has_pending_events(active_sessions, &session_id).await {
-            spawn_persist_assistant_message_to_db(msg_for_db);
+            persist_assistant_message_to_db(&msg_for_db).await?;
             crate::agent::workflow::continue_workflow_if_pending_events(
                 session_repo,
                 active_sessions,
@@ -446,7 +441,7 @@ pub async fn handle_llm_response(
             log::info!("Completed workflow for session: {}", session_id);
         }
     } else {
-        spawn_persist_assistant_message_to_db(msg_for_db);
+        persist_assistant_message_to_db(&msg_for_db).await?;
 
         // Tools found! Initiate execution
         log::info!(

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.29_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64-setup.exe) · [`LibrAgent_0.8.29_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.29_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.29_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.AppImage) · [`LibrAgent_0.8.29_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent_0.8.29_amd64.deb) · [`LibrAgent-0.8.29-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.29/LibrAgent-0.8.29-1.x86_64.rpm)


### PR DESCRIPTION
## Summary\nEnforces synchronous, awaited writing of assistant messages containing tool calls to the database. This prevents a race condition where fast tool calls (like readFile) insert their results into the database before the parent assistant message finishes writing. Corrects message ordering (rowid ASC) and resolves the UI spinner rendering issue.