### PR TITLE
fix: resolve absolute path write validation for teamwork root

### DIFF
--- a/src-tauri/src/agent/llm/circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/circuit_breaker.rs
@@ -132,6 +132,41 @@ fn build_tool_result_signature(message: &Message) -> String {
     }
 }
 
+fn is_loop_prevention_message(message: &Message) -> bool {
+    if message
+        .metadata
+        .as_ref()
+        .and_then(|metadata| {
+            metadata
+                .get("loopPrevention")
+                .or_else(|| {
+                    metadata
+                        .get("structuredContent")
+                        .and_then(|value| value.get("loopPrevention"))
+                })
+                .and_then(|value| value.as_bool())
+        })
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    message.content.iter().any(|content| {
+        matches!(
+            content,
+            crate::mcp::types::MCPContent::Text { text, .. }
+                if text.starts_with("Loop prevention:")
+        )
+    })
+}
+
+/// Count trailing tool results whose call signature matches `matcher`.
+///
+/// A different tool call (name/args) ends the streak and resets the counter.
+/// Outcome text differences do NOT reset the counter — once the agent is looping the
+/// same call, further repeats stay blocked until a different tool/args appears.
+/// Loop-prevention short-circuit results also keep the streak (they must not look like
+/// a “new outcome” that clears the counter).
 fn count_consecutive_identical_call_outcomes<F>(
     messages: &[Message],
     matcher: F,
@@ -151,25 +186,23 @@ where
                     break;
                 };
 
-                if matcher(tool_call_id) {
+                if !matcher(tool_call_id) {
+                    break;
+                }
+
+                consecutive_matches += 1;
+
+                if is_loop_prevention_message(message) {
+                    continue;
+                }
+
+                if repeated_outcome.is_none() {
                     let signature = build_tool_result_signature(message);
-                    let current_outcome = if is_tool_error_message(message) {
+                    repeated_outcome = Some(if is_tool_error_message(message) {
                         RepeatedOutcome::Error { signature }
                     } else {
                         RepeatedOutcome::Success { signature }
-                    };
-
-                    if let Some(expected_outcome) = &repeated_outcome {
-                        if expected_outcome != &current_outcome {
-                            break;
-                        }
-                    } else {
-                        repeated_outcome = Some(current_outcome);
-                    }
-
-                    consecutive_matches += 1;
-                } else {
-                    break;
+                    });
                 }
             }
             "assistant" => {}
@@ -181,7 +214,14 @@ where
         }
     }
 
-    repeated_outcome.map(|outcome| (consecutive_matches, outcome))
+    if consecutive_matches == 0 {
+        return None;
+    }
+
+    let outcome = repeated_outcome.unwrap_or_else(|| RepeatedOutcome::Error {
+        signature: "__loop_prevention__".to_string(),
+    });
+    Some((consecutive_matches, outcome))
 }
 
 pub fn evaluate_circuit_breaker_action(

--- a/src-tauri/src/agent/llm/natural_recovery.rs
+++ b/src-tauri/src/agent/llm/natural_recovery.rs
@@ -38,7 +38,9 @@ pub fn loop_prevention_tool_result(guidance: &str) -> ToolExecutionResult {
     ToolExecutionResult {
         success: false,
         content: String::new(),
-        structured_content: None,
+        structured_content: Some(serde_json::json!({
+            "loopPrevention": true,
+        })),
         error: Some(guidance.to_string()),
         is_error: true,
         mcp_content: Some(vec![MCPContent::Text {

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -293,10 +293,7 @@ pub async fn prepare_teamwork_workspace(
     let hint = SuccessHint::new(
         message.clone(),
         vec![
-            "Scaffold teamwork coordination artifacts in this app-local directory, not in the repo root."
-                .to_string(),
-            "The current session workspace does not change; parent/child workspace inheritance stays intact."
-                .to_string(),
+            "You must write all team-coordination files (like KANBAN.md, ROLES.md, MISSION.md) using the '@teamwork/' prefix (e.g., '@teamwork/coordination/KANBAN.md'). Do not write them in the project workspace root.".to_string(),
         ],
     );
 

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -287,13 +287,16 @@ pub async fn prepare_teamwork_workspace(
     let artifact_path =
         crate::services::WorkspaceService::provision_teamwork_workspace(caller_session_id).await?;
     let message = format!(
-        "Teamwork artifact directory is ready for session {}: {}",
-        caller_session_id, artifact_path
+        "Teamwork artifact directory is ready for session {}. Do not call prepareTeamworkWorkspace again — the empty @teamwork/ root already exists.",
+        caller_session_id
     );
     let hint = SuccessHint::new(
         message.clone(),
         vec![
-            "You must write all team-coordination files (like KANBAN.md, ROLES.md, MISSION.md) using the '@teamwork/' prefix (e.g., '@teamwork/coordination/KANBAN.md'). Do not write them in the project workspace root.".to_string(),
+            "Required next: scaffold the full org teamwork set. Prefer the teamwork skill + scripts/init_task_force.py with --output set to this response's artifactPath field. Or write under @teamwork/ (agents.md, MISSION.md, ROLES.md, coordination/*, and @teamwork/.libragent/teamwork.json with executionSubstrate.mode=\"org\" and orgLineage.intended=true)."
+                .to_string(),
+            "After that scaffold is complete, call createOrg(name=\"...\") from this root session, then startSession for org members so they inherit the shared workspace. Spawning children before createOrg leaves each spoke in an isolated workspace."
+                .to_string(),
         ],
     );
 
@@ -303,7 +306,17 @@ pub async fn prepare_teamwork_workspace(
         Some(caller_session_id),
         &message,
         "success",
-        vec![],
+        vec![
+            json!({
+                "actionType": "skill",
+                "toolName": "teamwork",
+                "reason": "Scaffold the full @teamwork/ artifact set (prefer init_task_force.py) before createOrg."
+            }),
+            json!({
+                "toolName": "createOrg",
+                "reason": "Create explicit org identity only after @teamwork/ scaffold + teamwork.json are ready."
+            }),
+        ],
     );
     response_data.insert(
         "sessionId".to_string(),

--- a/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
@@ -171,15 +171,15 @@ pub fn create_org_scaffold_preflight(scaffold: &TeamworkScaffoldStatus) -> Resul
 
     let mut guidance = scaffold.guidance_lines();
     guidance.push(
-        "If the app-local artifact directory has not been prepared yet, call prepareTeamworkWorkspace() from the root session first."
+        "If @teamwork/ has not been prepared yet, call prepareTeamworkWorkspace() from the root session first."
             .to_string(),
     );
     guidance.push(
-        "Use the teamwork skill or init_task_force.py to create or repair the required scaffold artifacts in that artifact directory."
+        "Use the teamwork skill or init_task_force.py to create or repair the required scaffold artifacts under @teamwork/."
             .to_string(),
     );
     guidance.push(
-        "After the scaffold exists and .libragent/teamwork.json declares executionSubstrate.mode=\"org\" plus executionSubstrate.orgLineage.intended=true, call createOrg(name=\"...\") again."
+        "After the scaffold exists and @teamwork/.libragent/teamwork.json declares executionSubstrate.mode=\"org\" plus executionSubstrate.orgLineage.intended=true, call createOrg(name=\"...\") again."
             .to_string(),
     );
 

--- a/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/orgs.rs
@@ -35,12 +35,7 @@ impl TeamworkScaffoldStatus {
     fn missing_paths(&self) -> Vec<String> {
         self.missing_files
             .iter()
-            .map(|relative| {
-                Path::new(&self.artifact_path)
-                    .join(relative)
-                    .display()
-                    .to_string()
-            })
+            .map(|relative| format!("@teamwork/{}", relative.replace('\\', "/")))
             .collect()
     }
 
@@ -49,29 +44,21 @@ impl TeamworkScaffoldStatus {
 
         if !self.missing_files.is_empty() {
             guidance.push(format!(
-                "Missing teamwork scaffold files under {}: {}.",
-                self.artifact_path,
+                "Missing teamwork scaffold files: {}.",
                 self.missing_paths().join(", ")
             ));
         }
 
         if let Some(error) = self.manifest_parse_error.as_deref() {
             guidance.push(format!(
-                "{} exists but could not be parsed: {}.",
-                Path::new(&self.artifact_path)
-                    .join(".libragent")
-                    .join("teamwork.json")
-                    .display(),
+                "@teamwork/.libragent/teamwork.json exists but could not be parsed: {}.",
                 error
             ));
         } else if !self.manifest_present {
-            guidance.push(format!(
-                "Missing machine-readable teamwork manifest: {}.",
-                Path::new(&self.artifact_path)
-                    .join(".libragent")
-                    .join("teamwork.json")
-                    .display()
-            ));
+            guidance.push(
+                "Missing machine-readable teamwork manifest: @teamwork/.libragent/teamwork.json."
+                    .to_string(),
+            );
         } else {
             if self.execution_substrate_mode.as_deref() != Some("org") {
                 let mode = self
@@ -79,7 +66,7 @@ impl TeamworkScaffoldStatus {
                     .as_deref()
                     .unwrap_or("missing");
                 guidance.push(format!(
-                    ".libragent/teamwork.json should declare executionSubstrate.mode=\"org\" (current: {}).",
+                    "@teamwork/.libragent/teamwork.json should declare executionSubstrate.mode=\"org\" (current: {}).",
                     mode
                 ));
             }
@@ -90,7 +77,7 @@ impl TeamworkScaffoldStatus {
                     .map(|value| value.to_string())
                     .unwrap_or_else(|| "missing".to_string());
                 guidance.push(format!(
-                    ".libragent/teamwork.json should declare executionSubstrate.orgLineage.intended=true (current: {}).",
+                    "@teamwork/.libragent/teamwork.json should declare executionSubstrate.orgLineage.intended=true (current: {}).",
                     intended
                 ));
             }
@@ -198,10 +185,7 @@ pub fn create_org_scaffold_preflight(scaffold: &TeamworkScaffoldStatus) -> Resul
 
     Err(guided_error(
         ErrorCategory::InvalidState,
-        format!(
-            "createOrg requires a complete org teamwork scaffold in the app-local artifact directory before explicit org identity can be created.\n\nChecked artifact directory: {}",
-            scaffold.artifact_path
-        ),
+        "createOrg requires a complete org teamwork scaffold in the teamwork directory before explicit org identity can be created.\n\nChecked directory: @teamwork/".to_string(),
         ToolGroup::Agent,
     )
     .with_guidance(guidance)

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -171,12 +171,13 @@ fn prepare_teamwork_workspace_tool() -> MCPTool {
             "Create or reuse an app-local teamwork artifact directory for the current governing/root session.",
             &["Caller should be a root or governing session."],
             &[
-                "Call when coordination metadata must live outside the repo workspace.",
-                "This path is for scaffolding artifacts only — it does not change the session workspace.",
+                "Call once when coordination metadata must live outside the repo workspace.",
+                "This only prepares an empty @teamwork/ directory — it does not scaffold files and does not change the session workspace.",
             ],
             &[
-                "Create an explicit org with agent__createOrg if team coordination is needed.",
-                "Spawn org members with agent__startSession.",
+                "Do not call prepareTeamworkWorkspace again after success.",
+                "Scaffold next via the teamwork skill (prefer scripts/init_task_force.py with --output = response artifactPath) or write the full set under @teamwork/ including coordination/* and @teamwork/.libragent/teamwork.json.",
+                "Only after the org scaffold is complete, call agent__createOrg, then agent__startSession for org members.",
             ],
         ),
         input_schema: object_prop(vec![], vec![], None),

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -402,8 +402,9 @@ impl SuccessHint {
                 "Use readProcessOutput to see the final results".to_string(),
             ],
             ("readProcessOutput", ToolGroup::Workspace) => vec![
-                "Analyze the output to verify command success".to_string(),
-                "Use stopProcess if the output indicates it's stuck".to_string(),
+                "Works while the process is still running; finishing is not required".to_string(),
+                "Use waitForProcess(processId, 0) only to check status, not to unlock reading".to_string(),
+                "If processId is missing from the registry, use listProcesses() — do not assume it is still starting".to_string(),
             ],
             ("listProcesses", ToolGroup::Workspace) => vec![
                 "Use waitForProcess(processId) to block until completion".to_string(),

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -292,10 +292,19 @@ impl SecurityValidator {
 
 /// Helper to check if a path starts with a base path, safely handling Windows UNC prefixes and case-insensitivity.
 pub fn path_starts_with(path: &Path, base: &Path) -> bool {
+    relative_path_under_base(path, base).is_some()
+}
+
+/// Return the relative suffix of `path` under `base`, or `None` if `path` is not under `base`.
+///
+/// Handles Windows verbatim vs normal drive prefixes and case-insensitive component matching.
+/// An exact match returns an empty `PathBuf` (callers may treat that as `"."`).
+///
+/// Returns `None` if the relative suffix contains `..` (parent-dir) components — a lexical
+/// prefix match alone is not enough to consider the path "under" the base.
+pub fn relative_path_under_base(path: &Path, base: &Path) -> Option<PathBuf> {
     #[cfg(target_os = "windows")]
     {
-        // On Windows, paths may have different prefixes (e.g., `\\?\C:\` vs `C:\`)
-        // and are case-insensitive. We compare path components individually.
         let mut path_comps = path.components();
         let mut base_comps = base.components();
 
@@ -303,21 +312,40 @@ pub fn path_starts_with(path: &Path, base: &Path) -> bool {
             match (path_comps.next(), base_comps.next()) {
                 (Some(p), Some(b)) => {
                     if !components_equal_ignore_case(&p, &b) {
-                        return false;
+                        return None;
                     }
                 }
-                // If base is fully matched, then path indeed starts with base.
-                (_, None) => return true,
-                // If path is shorter than base, it cannot start with it.
-                (None, Some(_)) => return false,
+                (_, None) => {
+                    return clean_relative_components(path_comps);
+                }
+                (None, Some(_)) => return None,
             }
         }
     }
 
     #[cfg(not(target_os = "windows"))]
     {
-        path.starts_with(base)
+        let relative = path.strip_prefix(base).ok()?;
+        clean_relative_components(relative.components())
     }
+}
+
+/// Build a relative path from components, skipping `.` and rejecting `..`.
+fn clean_relative_components<'a, I>(components: I) -> Option<PathBuf>
+where
+    I: Iterator<Item = Component<'a>>,
+{
+    let mut relative = PathBuf::new();
+    for component in components {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(name) => relative.push(name),
+            Component::ParentDir => return None,
+            // Prefix/RootDir must not appear in a relative suffix.
+            Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+    Some(relative)
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/mod.rs
@@ -1,4 +1,5 @@
 pub mod list;
+pub mod not_found;
 pub mod read_output;
 pub mod stop;
 pub mod wait;

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/not_found.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/not_found.rs
@@ -1,0 +1,11 @@
+/// Guidance when a processId is missing from the session registry.
+///
+/// "Not found" ≠ still running. `readProcessOutput` works while Running.
+pub fn process_not_found_guidance(available_summary: String) -> Vec<String> {
+    vec![
+        available_summary,
+        "Use listProcesses() to find a valid processId.".to_string(),
+        "readProcessOutput works while the process is still running — 'not found' means this ID is not in the registry."
+            .to_string(),
+    ]
+}

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
@@ -214,15 +214,13 @@ impl WorkspaceServer {
 
                 return Ok(guided_error(
                     ErrorCategory::ResourceNotFound,
-                    format!("Process '{}' not found", process_id),
+                    format!(
+                        "Process '{}' is not registered in this session",
+                        process_id
+                    ),
                     ToolGroup::Workspace,
                 )
-                .guidance(vec![
-                    available_text,
-                    "Use listProcesses() to see all processes with IDs".to_string(),
-                    "Check if process has finished - finished processes are kept for 24 hours"
-                        .to_string(),
-                ])
+                .guidance(super::not_found::process_not_found_guidance(available_text))
                 .to_mcp_result());
             }
         };

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/stop.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/stop.rs
@@ -55,13 +55,16 @@ impl WorkspaceServer {
 
             return Ok(guided_error(
                 ErrorCategory::ResourceNotFound,
-                format!("Process '{}' not found", process_id),
+                format!(
+                    "Process '{}' is not registered in this session",
+                    process_id
+                ),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
                 running_text,
-                "Use listProcesses() to see all processes".to_string(),
-                "Only running processes can be stopped".to_string(),
+                "Use listProcesses() to find a valid processId.".to_string(),
+                "Only starting/running processes can be stopped.".to_string(),
             ])
             .to_mcp_result());
         }

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
@@ -92,13 +92,13 @@ impl WorkspaceServer {
 
                     return Ok(guided_error(
                         ErrorCategory::ResourceNotFound,
-                        format!("Process '{}' not found in session", process_id),
+                        format!(
+                            "Process '{}' is not registered in this session",
+                            process_id
+                        ),
                         ToolGroup::Workspace,
                     )
-                    .guidance(vec![
-                        available_text,
-                        "Use listProcesses() to see all active processes".to_string(),
-                    ])
+                    .guidance(super::not_found::process_not_found_guidance(available_text))
                     .to_mcp_result());
                 }
             };

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -35,7 +35,7 @@ pub fn create_read_process_output_tool() -> MCPTool {
         name: "readProcessOutput".to_string(),
         title: Some("Read Process Output".to_string()),
         description:
-            "Read captured stdout, stderr, or both streams from a background process using head/tail line windows. Returns output_paths so file tools can inspect the full captured files."
+            "Read captured stdout, stderr, or both from a background process ID (spawnProcess or sync-timeout handoff). Works while the process is still running and after it finishes. Not for synchronous isolated/shell commands that already returned stdout/stderr inline — those registry entries are removed immediately. Returns output_paths for diagnostics (absolute internal paths; do not pass them to readFile/listDirectory)."
                 .to_string(),
         input_schema: object_schema(props, vec!["processId".to_string(), "stream".to_string()]),
         output_schema: None,

--- a/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
+++ b/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
@@ -469,6 +469,38 @@ impl WorkspaceServer {
             .await?;
         let effective_path = mapped_path.as_deref().unwrap_or(path_str);
 
+        // Fallback for absolute paths: if the path is absolute and within the teamwork root,
+        // map it to a teamwork write dynamically, matching the read validation logic.
+        let candidate_path = PathBuf::from(effective_path);
+        if candidate_path.is_absolute() {
+            if let Ok(teamwork_root) = self.get_teamwork_artifact_root(&target_session_id).await {
+                let normalized_candidate = candidate_path.canonicalize().unwrap_or_else(|e| {
+                    tracing::debug!(
+                        "Failed to canonicalize candidate path {:?}: {}",
+                        candidate_path,
+                        e
+                    );
+                    candidate_path.clone()
+                });
+                let normalized_teamwork_root = teamwork_root.canonicalize().unwrap_or_else(|e| {
+                    tracing::debug!(
+                        "Failed to canonicalize teamwork root {:?}: {}",
+                        teamwork_root,
+                        e
+                    );
+                    teamwork_root.clone()
+                });
+                if path_starts_with(&normalized_candidate, &normalized_teamwork_root) {
+                    let teamwork_manager =
+                        SecureFileManager::new_scoped_with_base_dir(teamwork_root);
+                    return teamwork_manager
+                        .get_security_validator()
+                        .validate_path_for_write(effective_path)
+                        .map_err(|e| format!("Security error: {e}"));
+                }
+            }
+        }
+
         self.validate_path_with_error_for_write(effective_path, Some(target_session_id))
     }
 

--- a/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
+++ b/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
@@ -3,7 +3,7 @@ use super::terminal_manager;
 use super::tools;
 use super::types::{PendingExecutions, PendingShellInputResolution};
 use super::utils;
-use crate::mcp::builtin::utils::path_starts_with;
+use crate::mcp::builtin::utils::{path_starts_with, relative_path_under_base};
 use crate::mcp::MCPTool;
 use crate::models::workspace_isolation::WorkspaceIsolationMode;
 use crate::repositories::SessionRepository;
@@ -378,6 +378,71 @@ impl WorkspaceServer {
         })
     }
 
+    /// Map an absolute path under the teamwork artifact root to a scoped relative path.
+    ///
+    /// Handles new-file writes (path may not exist yet) and Windows/Unix canonicalize
+    /// asymmetry by trying the raw root, the canonical root, and an existing-ancestor walk.
+    fn extract_absolute_teamwork_relative_path(
+        candidate: &Path,
+        teamwork_root: &Path,
+    ) -> Option<String> {
+        let canonical_root = teamwork_root.canonicalize().ok();
+
+        if let Some(relative) = relative_path_under_base(candidate, teamwork_root) {
+            return Some(Self::normalize_teamwork_relative_path(&relative));
+        }
+
+        if let Some(ref canonical_root) = canonical_root {
+            if teamwork_root != canonical_root.as_path() {
+                if let Some(relative) = relative_path_under_base(candidate, canonical_root) {
+                    return Some(Self::normalize_teamwork_relative_path(&relative));
+                }
+            }
+        }
+
+        // New files often fail canonicalize(); walk up to an existing ancestor first.
+        let canonical_root = canonical_root?;
+        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+        let mut current = candidate.to_path_buf();
+
+        loop {
+            match current.canonicalize() {
+                Ok(canonical_current) => {
+                    let relative = relative_path_under_base(&canonical_current, &canonical_root)?;
+                    let mut full = relative;
+                    for part in suffix.iter().rev() {
+                        // Reject parent-dir names collected during the walk (e.g. "..").
+                        if part == ".." {
+                            return None;
+                        }
+                        if part == "." {
+                            continue;
+                        }
+                        full.push(part);
+                    }
+                    return Some(Self::normalize_teamwork_relative_path(&full));
+                }
+                Err(_) => {
+                    let file_name = current.file_name()?.to_os_string();
+                    suffix.push(file_name);
+                    if !current.pop() {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+
+    fn normalize_teamwork_relative_path(relative: &Path) -> String {
+        if relative.as_os_str().is_empty() {
+            ".".to_string()
+        } else {
+            // Normalize Windows separators so scoped validators and agent-facing paths
+            // stay consistent across platforms (keep explicit '\\', not MAIN_SEPARATOR).
+            relative.to_string_lossy().replace('\\', "/")
+        }
+    }
+
     pub async fn validate_read_path_with_skill_access(
         &self,
         path_str: &str,
@@ -469,33 +534,19 @@ impl WorkspaceServer {
             .await?;
         let effective_path = mapped_path.as_deref().unwrap_or(path_str);
 
-        // Fallback for absolute paths: if the path is absolute and within the teamwork root,
-        // map it to a teamwork write dynamically, matching the read validation logic.
+        // Absolute path under the teamwork root: strip to a relative path and reuse the
+        // same scoped write validator as @teamwork/... (handles new-file create paths).
         let candidate_path = PathBuf::from(effective_path);
         if candidate_path.is_absolute() {
             if let Ok(teamwork_root) = self.get_teamwork_artifact_root(&target_session_id).await {
-                let normalized_candidate = candidate_path.canonicalize().unwrap_or_else(|e| {
-                    tracing::debug!(
-                        "Failed to canonicalize candidate path {:?}: {}",
-                        candidate_path,
-                        e
-                    );
-                    candidate_path.clone()
-                });
-                let normalized_teamwork_root = teamwork_root.canonicalize().unwrap_or_else(|e| {
-                    tracing::debug!(
-                        "Failed to canonicalize teamwork root {:?}: {}",
-                        teamwork_root,
-                        e
-                    );
-                    teamwork_root.clone()
-                });
-                if path_starts_with(&normalized_candidate, &normalized_teamwork_root) {
+                if let Some(relative_path) =
+                    Self::extract_absolute_teamwork_relative_path(&candidate_path, &teamwork_root)
+                {
                     let teamwork_manager =
                         SecureFileManager::new_scoped_with_base_dir(teamwork_root);
                     return teamwork_manager
                         .get_security_validator()
-                        .validate_path_for_write(effective_path)
+                        .validate_path_for_write(&relative_path)
                         .map_err(|e| format!("Security error: {e}"));
                 }
             }
@@ -790,6 +841,33 @@ mod tests {
         assert_eq!(
             WorkspaceServer::extract_teamwork_alias_relative_path("docs/README.md"),
             None
+        );
+    }
+
+    #[test]
+    fn test_extract_absolute_teamwork_relative_path_for_new_files() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let teamwork_root = temp_dir.path().join("teamwork-artifacts").join("session-1");
+        std::fs::create_dir_all(&teamwork_root).expect("create teamwork root");
+
+        let new_file = teamwork_root.join("coordination").join("KANBAN.md");
+        let relative =
+            WorkspaceServer::extract_absolute_teamwork_relative_path(&new_file, &teamwork_root)
+                .expect("new absolute path under teamwork root must map to relative");
+        assert_eq!(relative, "coordination/KANBAN.md");
+
+        let outside = temp_dir.path().join("outside.md");
+        assert!(
+            WorkspaceServer::extract_absolute_teamwork_relative_path(&outside, &teamwork_root)
+                .is_none()
+        );
+
+        // Lexical escape via ".." after the root prefix must not map to a relative path.
+        let traversal = teamwork_root.join("..").join("outside.md");
+        assert!(
+            WorkspaceServer::extract_absolute_teamwork_relative_path(&traversal, &teamwork_root)
+                .is_none(),
+            "parent-dir components after the teamwork root must be rejected"
         );
     }
 }

--- a/src-tauri/tests/integration/circuit_breaker_recovery_tests.rs
+++ b/src-tauri/tests/integration/circuit_breaker_recovery_tests.rs
@@ -322,7 +322,9 @@ fn natural_recovery_prefers_repeated_identical_success_before_hard_break() {
 }
 
 #[test]
-fn different_success_results_do_not_trigger_natural_recovery() {
+fn same_call_signature_counts_even_when_success_text_differs() {
+    // Same tool + args is a loop even if the successful payload text changes
+    // (e.g. polling). Counter resets only when a different tool/args appears.
     let repeated_args = r#"{"path":"src/main.ts"}"#;
     let current_call = test_tool_call("tc-3", "workspace__readFile", repeated_args);
     let messages = vec![
@@ -372,5 +374,111 @@ fn different_success_results_do_not_trigger_natural_recovery() {
         ),
     ];
 
-    assert_eq!(evaluate(&messages, &current_call, 3), None);
+    assert_eq!(
+        evaluate(&messages, &current_call, 3),
+        Some(CircuitBreakerAction::NaturalRecoverySuccess {
+            count: 3,
+            tool_name: "workspace__readFile".to_string(),
+            args: repeated_args.to_string(),
+        })
+    );
+}
+
+#[test]
+fn loop_prevention_blocks_do_not_reset_repeat_counter() {
+    // After natural recovery short-circuits the 3rd identical call, further
+    // identical calls must keep failing — the loop-prevention tool result must
+    // not look like a “new outcome” that clears the streak.
+    let repeated_success = "Teamwork artifact directory is ready";
+    let loop_prevention = "Loop prevention: 'agent__prepareTeamworkWorkspace' was called 3 times with identical parameters and the same successful result.\n\nThis call was blocked.";
+    let current_call = test_tool_call("tc-4", "agent__prepareTeamworkWorkspace", "{}");
+    let messages = vec![
+        test_message(
+            "assistant-1",
+            "assistant",
+            Some(vec![test_tool_call(
+                "tc-1",
+                "agent__prepareTeamworkWorkspace",
+                "{}",
+            )]),
+            None,
+            None,
+            "",
+            None,
+        ),
+        test_message(
+            "tool-1",
+            "tool",
+            None,
+            Some("tc-1"),
+            None,
+            repeated_success,
+            Some(false),
+        ),
+        test_message(
+            "assistant-2",
+            "assistant",
+            Some(vec![test_tool_call(
+                "tc-2",
+                "agent__prepareTeamworkWorkspace",
+                "{}",
+            )]),
+            None,
+            None,
+            "",
+            None,
+        ),
+        test_message(
+            "tool-2",
+            "tool",
+            None,
+            Some("tc-2"),
+            None,
+            repeated_success,
+            Some(false),
+        ),
+        test_message(
+            "assistant-3",
+            "assistant",
+            Some(vec![test_tool_call(
+                "tc-3",
+                "agent__prepareTeamworkWorkspace",
+                "{}",
+            )]),
+            None,
+            None,
+            "",
+            None,
+        ),
+        test_message(
+            "tool-3-loop-prevention",
+            "tool",
+            None,
+            Some("tc-3"),
+            Some(serde_json::json!({
+                "toolError": true,
+                "structuredContent": { "loopPrevention": true },
+                "loopPrevention": true
+            })),
+            loop_prevention,
+            Some(true),
+        ),
+    ];
+
+    assert_eq!(
+        evaluate(&messages, &current_call, 3),
+        Some(CircuitBreakerAction::HardBreak {
+            count: 4,
+            tool_name: "agent__prepareTeamworkWorkspace".to_string(),
+            args: "{}".to_string(),
+        })
+    );
+
+    // A different tool/args after the streak resets counting.
+    let different_call = test_tool_call(
+        "tc-5",
+        "workspace__writeFile",
+        r#"{"path":"@teamwork/agents.md","content":"x"}"#,
+    );
+    assert_eq!(evaluate(&messages, &different_call, 3), None);
 }

--- a/src-tauri/tests/integration/org_create_teamwork_workspace_guard_tests.rs
+++ b/src-tauri/tests/integration/org_create_teamwork_workspace_guard_tests.rs
@@ -126,7 +126,7 @@ fn create_org_preflight_rejects_missing_scaffold_with_precise_paths() {
 
     assert_eq!(result.is_error, Some(true));
     assert!(text.contains("createOrg requires a complete org teamwork scaffold"));
-    assert!(text.contains(&temp_dir.path().display().to_string()));
+    assert!(text.contains("@teamwork/"));
     assert!(text.contains("agents.md"));
     assert!(text.contains("coordination/KANBAN.md"));
     assert!(text.contains(".libragent/teamwork.json"));

--- a/src-tauri/tests/integration/read_process_output_tests.rs
+++ b/src-tauri/tests/integration/read_process_output_tests.rs
@@ -413,3 +413,49 @@ async fn read_process_output_avoids_stop_hint_after_process_has_finished() {
         "finished processes should not suggest waiting again: {text}"
     );
 }
+
+/// readProcessOutput not-found means missing from registry — not "still running".
+#[tokio::test]
+async fn test_read_process_output_not_found_guidance_is_accurate() {
+    ensure_settings_repository().await;
+
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-process-output-not-found";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+
+    let result = server
+        .call_tool(
+            "readProcessOutput",
+            json!({
+                "processId": "missing-id",
+                "stream": "both"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("call_tool should return MCP result");
+
+    assert_eq!(result.is_error, Some(true));
+    let text = extract_text_content(&result);
+
+    assert!(
+        text.contains("Process 'missing-id' is not registered in this session"),
+        "should surface registry miss: {text}"
+    );
+    assert!(
+        text.contains("not in the registry"),
+        "should diagnose registry miss, not unfinished process: {text}"
+    );
+    assert!(
+        text.contains("works while the process is still running"),
+        "must clarify finishing is not required: {text}"
+    );
+    assert!(
+        !text.contains("24 hours") && !text.contains("kept for"),
+        "must not include retention/TTL TMI: {text}"
+    );
+    assert!(
+        text.contains("listProcesses"),
+        "should point to listProcesses: {text}"
+    );
+}

--- a/src-tauri/tests/integration/teamwork_symlink_tests.rs
+++ b/src-tauri/tests/integration/teamwork_symlink_tests.rs
@@ -239,3 +239,80 @@ async fn test_workspace_server_path_resolution_and_security() {
         "Path traversal outside teamwork root must fail security check"
     );
 }
+
+#[tokio::test]
+async fn test_absolute_path_write_under_teamwork_root() {
+    common::register_sqlite_vec();
+    let db = common::setup_test_db_with_migrations().await;
+    let repo = SqliteSessionRepository::new(db);
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+
+    let base_dir = temp_dir.path().join("session-root");
+    let session_manager = SessionManager::new_with_base_dir(base_dir.clone()).unwrap();
+    let session_id = "absolute-write-session";
+    let org_root_id = "absolute-write-session";
+
+    let session = make_session(session_id, None, Some(org_root_id));
+    repo.upsert_session(&session).await.unwrap();
+
+    let artifact_dir = prepare_teamwork_artifact_dir_for_session(&session_manager, session_id)
+        .await
+        .unwrap();
+
+    let _workspace_dir = ensure_session_workspace_dir(&repo, &session_manager, session_id)
+        .await
+        .unwrap();
+
+    use std::sync::Arc;
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+    let server = WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager));
+
+    // New file: absolute path under teamwork root must validate for write (create path).
+    let absolute_new_file = artifact_dir.join("coordination").join("KANBAN.md");
+    let absolute_new_file_str = absolute_new_file.to_string_lossy().to_string();
+    let validated = server
+        .validate_write_path_with_teamwork_access(&absolute_new_file_str, None)
+        .await
+        .expect("absolute path under teamwork root must be writable");
+    let expected = artifact_dir
+        .canonicalize()
+        .expect("teamwork root should canonicalize")
+        .join("coordination")
+        .join("KANBAN.md");
+    assert_eq!(
+        validated, expected,
+        "validated write path should resolve inside the teamwork artifact directory"
+    );
+
+    // Alias path remains the preferred write form and must agree on the same target.
+    let alias_validated = server
+        .validate_write_path_with_teamwork_access("@teamwork/coordination/KANBAN.md", None)
+        .await
+        .expect("@teamwork alias write must succeed");
+    assert_eq!(
+        alias_validated, expected,
+        "absolute and @teamwork writes must target the same path"
+    );
+
+    // Absolute path outside teamwork root must not be accepted by the teamwork write path.
+    let outside = temp_dir.path().join("outside.md");
+    let outside_str = outside.to_string_lossy().to_string();
+    let outside_result = server
+        .validate_write_path_with_teamwork_access(&outside_str, None)
+        .await;
+    assert!(
+        outside_result.is_err(),
+        "absolute paths outside teamwork root must still fail scoped write validation"
+    );
+
+    // Absolute path with ".." after the teamwork root must not be treated as a valid teamwork write.
+    let traversal = artifact_dir.join("..").join("escape.md");
+    let traversal_str = traversal.to_string_lossy().to_string();
+    let traversal_result = server
+        .validate_write_path_with_teamwork_access(&traversal_str, None)
+        .await;
+    assert!(
+        traversal_result.is_err(),
+        "absolute paths that lexically escape the teamwork root via .. must fail"
+    );
+}


### PR DESCRIPTION
This PR resolves absolute path write validation for teamwork root, cleans up confusing success hints, hides physical absolute paths from preflight checks, and addresses issues raised in code reviews.