### PR TITLE
fix(workspace): align agent-facing tool guidance with actual behavior

### DIFF
--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -406,20 +406,17 @@ impl SuccessHint {
                 "Use waitForProcess(processId, 0) only to check status, not to unlock reading".to_string(),
                 "If processId is missing from the registry, use listProcesses() — do not assume it is still starting".to_string(),
             ],
-            ("listProcesses", ToolGroup::Workspace) => vec![
-                "Use waitForProcess(processId) to block until completion".to_string(),
-                "Use stopProcess(processId) to kill a stuck task".to_string(),
-            ],
+            ("listProcesses", ToolGroup::Workspace) => vec![],
             ("writeFile", ToolGroup::Workspace) => vec![
                 "Use readFile to verify the content".to_string(),
                 "Use listDirectory to see the file in context".to_string(),
             ],
             ("readFile", ToolGroup::Workspace) => vec![
-                "Use writeFile to modify the content".to_string(),
                 format!(
-                    "Use {} to make targeted edits",
+                    "Use {} for targeted in-place edits",
                     crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
                 ),
+                "Use writeFile only to create, overwrite, or append whole files".to_string(),
             ],
             ("listDirectory", ToolGroup::Workspace) => vec![
                 "Use readFile to view file contents".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
@@ -495,7 +495,7 @@ impl WorkspaceServer {
 
                 let might_be_interactive = validation::is_likely_interactive_command(command);
                 let mut message = format!(
-                    "Command exceeded the synchronous wait window after {} seconds and is still running in background.\n\nProcess ID: {}\nStatus: {}\nExit code: pending",
+                    "Sync timeout handoff: command was still running after {} seconds, so it continues in background.\n\nProcess ID: {}\nStatus: {}\nExit code: pending\n\nUse waitForProcess/readProcessOutput only with this processId — completed sync runs (success or failure) never get a processId.",
                     timeout_secs, process_id, status
                 );
 

--- a/src-tauri/src/mcp/builtin/workspace/context.rs
+++ b/src-tauri/src/mcp/builtin/workspace/context.rs
@@ -41,8 +41,8 @@ pub async fn build_context_prompt(
 ) -> String {
     let state = build_workspace_live_state(session_id, session_manager, shell_manager).await;
 
-    // ✅ ENHANCED: Get running processes with IDs and commands for AI visibility
-    let (total_count, running_processes_text) = {
+    // Running processes with IDs for AI visibility (finished-only totals omitted — no actionable IDs).
+    let running_processes_text = {
         match process_registry.try_read() {
             Ok(reg) => {
                 let mut running_processes: Vec<(String, String)> = reg
@@ -57,32 +57,23 @@ pub async fn build_context_prompt(
                 let running_count = running_processes.len();
                 let displayed_processes = running_processes.into_iter().take(5).collect::<Vec<_>>();
 
-                let total_count = reg
-                    .entries
-                    .values()
-                    .filter(|e| e.session_id == session_id)
-                    .count();
-
-                let running_text = if running_count == 0 {
+                if running_count == 0 {
                     "None".to_string()
                 } else {
                     let process_list = displayed_processes
                         .iter()
                         .map(|(id, cmd)| {
-                            // Truncate command if too long (safe string slicing)
                             let display_cmd = crate::utils::truncate_chars(cmd, 77);
                             format!("  • {} - {}", id, display_cmd)
                         })
                         .collect::<Vec<_>>()
                         .join("\n");
                     format!("{}\n{}", running_count, process_list)
-                };
-
-                (total_count, running_text)
+                }
             }
             Err(_) => {
                 // Lock is held by another task, return defaults to avoid blocking
-                (0, "None".to_string())
+                "None".to_string()
             }
         }
     };
@@ -104,8 +95,7 @@ pub async fn build_context_prompt(
 {isolation_lines}- Workspace Root: {workspace_dir}
 - Persistent Shell CWD: {shell_cwd}
 - Running Processes: {running_processes_text}
-- Internal Paths: `.libragent/tmp/` (process I/O), `.libragent/exports/` (exported files) are hidden from listing to keep workspace clean.
-- Total Processes: {total_count}",
+- Internal Paths: `.libragent/tmp/` (process I/O), `.libragent/exports/` (exported files) are hidden from listing to keep workspace clean.",
         workspace_dir = state.workspace_dir,
         shell_cwd = state.shell_cwd,
     )

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
@@ -155,7 +155,7 @@ impl WorkspaceServer {
 
                 return Ok(SuccessHint::new(
                     format!("Process {} is currently {:?}", process_id, status),
-                    SuccessHint::for_tool("pollProcess", ToolGroup::Workspace),
+                    SuccessHint::for_tool("waitForProcess", ToolGroup::Workspace),
                 )
                 .to_mcp_result_with_data(Some(response)));
             }

--- a/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/code_tools.rs
@@ -24,7 +24,9 @@ pub fn create_run_shell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution."),
+            Some(
+                "Max seconds to wait for this call to finish. If the command ends (success or failure) within this window, stdout/stderr are returned here with no processId. Only if it is still running after this timeout does the call hand off a processId.",
+            ),
         ),
     );
 
@@ -32,8 +34,10 @@ pub fn create_run_shell_tool() -> MCPTool {
         name: "runShell".to_string(),
         title: Some("Run Shell Command (Isolated)".to_string()),
         description: "Run a synchronous shell command (bash/sh). Stateless — each call starts fresh at workspace root.\n\
-                        Use 'cd dir && command' for subdirectories.\n\
-                       If the command exceeds the sync timeout, it stays alive in background and returns a processId for waitForProcess/readProcessOutput/stopProcess.\n\
+                       Use 'cd dir && command' for subdirectories.\n\
+                       Two outcomes:\n\
+                       1) Finished within timeout (exit success or failure): this response already has stdout/stderr and exit code. No processId — do not call waitForProcess/readProcessOutput for this run.\n\
+                       2) Still running after the sync timeout: response includes processId; only then use waitForProcess/readProcessOutput/stopProcess.\n\
                        For persistent cd/env vars: runInPersistentShell. For explicitly non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
@@ -151,9 +155,9 @@ pub fn create_spawn_process_tool() -> MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
         description: "Start a command as a non-blocking background process. Returns the background process ID immediately.\n\
-                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
+                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require processId.\n\
                        Stateless — starts from workspace root each call. No interactive input.\n\
-                       Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
+                       Use waitForProcess(processId) to wait for completion, readProcessOutput(processId) to get output."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -184,20 +188,24 @@ pub fn create_run_powershell_tool() -> MCPTool {
             Some(1),
             Some(crate::mcp::builtin::workspace::utils::max_sync_execution_timeout() as i64),
             crate::mcp::builtin::workspace::utils::default_sync_execution_timeout() as i64,
-            Some("Timeout in seconds for synchronous execution."),
+            Some(
+                "Max seconds to wait for this call to finish. If the command ends (success or failure) within this window, stdout/stderr are returned here with no processId. Only if it is still running after this timeout does the call hand off a processId.",
+            ),
         ),
     );
 
     MCPTool {
         name: "runPowerShell".to_string(),
         title: Some("Run PowerShell Command (Isolated)".to_string()),
-        description: "Execute a synchronous PowerShell command on Windows. This is the primary tool for Windows command-line tasks.
-
-Guidelines:
-- Use ';' to chain multiple commands (e.g. 'cd src; pnpm test'). Note: '&&' is not supported in PowerShell 5.1.
-- Access environment variables using '$env:VARNAME'.
-- Each call starts fresh at the workspace root. For persistent state, use runInPersistentPowerShell.
-- For longer or non-blocking tasks: spawnProcess."
+        description: "Execute a synchronous PowerShell command on Windows. This is the primary tool for Windows command-line tasks.\n\
+                       Guidelines:\n\
+                       - Use ';' to chain multiple commands (e.g. 'cd src; pnpm test'). Note: '&&' is not supported in PowerShell 5.1.\n\
+                       - Access environment variables using '$env:VARNAME'.\n\
+                       - Each call starts fresh at the workspace root. For persistent state, use runInPersistentPowerShell.\n\
+                       Two outcomes:\n\
+                       1) Finished within timeout (exit success or failure): this response already has stdout/stderr and exit code. No processId — do not call waitForProcess/readProcessOutput for this run.\n\
+                       2) Still running after the sync timeout: response includes processId; only then use waitForProcess/readProcessOutput/stopProcess.\n\
+                       - For explicitly non-blocking tasks: spawnProcess."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,
@@ -309,9 +317,9 @@ pub fn create_spawn_process_tool() -> MCPTool {
         name: "spawnProcess".to_string(),
         title: Some("Spawn Background Process".to_string()),
         description: "Start a command as a non-blocking background process. Returns the background process ID immediately.\n\
-                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require process_id.\n\
+                       Optional name is a label only; waitForProcess, stopProcess, and readProcessOutput still require processId.\n\
                        Stateless — starts from workspace root each call. No interactive input.\n\
-                       Use waitForProcess(id) to wait for completion, readProcessOutput(id) to get output."
+                       Use waitForProcess(processId) to wait for completion, readProcessOutput(processId) to get output."
             .to_string(),
         input_schema: object_schema(props, vec!["command".to_string()]),
         output_schema: None,

--- a/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/terminal_tools.rs
@@ -1,12 +1,14 @@
 use crate::mcp::{schema::SchemaProperties, utils::schema_builder::*, MCPTool};
 
+const PROCESS_ID_PROP: &str = "Process ID from spawnProcess, a sync-timeout handoff response, or listProcesses. Never invent an ID.";
+
 /// Create read_process_output tool
 pub fn create_read_process_output_tool() -> MCPTool {
     let mut props = SchemaProperties::new();
 
     props.insert(
         "processId".to_string(),
-        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
+        string_prop_required(PROCESS_ID_PROP),
     );
 
     props.insert(
@@ -49,7 +51,7 @@ pub fn create_wait_for_process_tool() -> MCPTool {
 
     props.insert(
         "processId".to_string(),
-        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
+        string_prop_required(PROCESS_ID_PROP),
     );
     props.insert(
         "timeout".to_string(),
@@ -66,7 +68,7 @@ pub fn create_wait_for_process_tool() -> MCPTool {
     MCPTool {
         name: "waitForProcess".to_string(),
         title: Some("Wait For Process".to_string()),
-        description: "Block until a background process finishes or times out. Returns process status and metadata."
+        description: "Block until a background process finishes or times out. Requires a processId from spawnProcess, a sync-timeout handoff, or listProcesses — not for completed sync runShell/runPowerShell results (those have no processId)."
             .to_string(),
         input_schema: object_schema(props, vec!["processId".to_string()]),
         output_schema: None,
@@ -103,13 +105,14 @@ pub fn create_stop_process_tool() -> MCPTool {
 
     props.insert(
         "processId".to_string(),
-        string_prop_required("Process ID returned by spawnProcess or listProcesses"),
+        string_prop_required(PROCESS_ID_PROP),
     );
 
     MCPTool {
         name: "stopProcess".to_string(),
         title: Some("Stop Process".to_string()),
-        description: "Terminate a running background process immediately.".to_string(),
+        description: "Terminate a running background process immediately. Requires a processId from spawnProcess, a sync-timeout handoff, or listProcesses."
+            .to_string(),
         input_schema: object_schema(props, vec!["processId".to_string()]),
         output_schema: None,
         annotations: None,

--- a/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
+++ b/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
@@ -229,7 +229,7 @@ async fn run_shell_timeout_hands_off_to_background_process() {
 
     let text = extract_text_content(&result);
     assert!(
-        text.contains("still running in background"),
+        text.contains("Sync timeout handoff") && text.contains("continues in background"),
         "timeout handoff should be explicit in text: {text}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- Clarify sync completion vs sync-timeout handoff for `runShell`/`runPowerShell`, and keep wait/readProcess only when a real `processId` is returned
- Fix stale process tooling copy (`processId` sources, `process_id` → `processId`, `pollProcess` success hints → `waitForProcess`)
- Drop misleading `Total Processes` from workspace service context; refresh `readFile`/`listProcesses` default next-step hints

## Test plan
- [x] Confirm `runShell` tool description shows the two-outcome sync vs handoff wording
- [x] Confirm timeout handoff text includes `Sync timeout handoff` and a concrete processId
- [x] Call `readProcessOutput`/`waitForProcess` with a fake ID and verify not-found guidance does not invent unfinished/TTL narratives
- [x] Inspect workspace service context with no running processes: no `Total Processes` line
- [x] `cargo check` in `src-tauri` if needed
