### PR TITLE
feat: refactor workspace environment variable isolation and temp directory handling

### DIFF
--- a/src-tauri/src/session_isolation/platforms/unix.rs
+++ b/src-tauri/src/session_isolation/platforms/unix.rs
@@ -67,13 +67,11 @@ pub async fn create_basic_isolated_command(
         }
     }
 
-    // Keep the host home directory for tool config discovery, but pin shell state to the workspace.
-    let tmp_dir = config.workspace_path.join(".libragent/tmp");
-    tokio::fs::create_dir_all(&tmp_dir)
-        .await
-        .map_err(|e| format!("Failed to create tmp dir: {}", e))?;
+    // Keep the host home directory for tool config discovery, and pass through host temp variable.
     cmd.env("PWD", &config.workspace_path);
-    cmd.env("TMPDIR", &tmp_dir);
+    if let Ok(sys_tmpdir) = std::env::var("TMPDIR") {
+        cmd.env("TMPDIR", sys_tmpdir);
+    }
     // Force English output for consistent AI reasoning
     cmd.env("LC_ALL", "C.UTF-8");
     cmd.env("LANG", "C.UTF-8");

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -57,9 +57,13 @@ pub async fn create_basic_isolated_command(
         cmd.env(k, v);
     }
 
-    // Keep host home directories so CLI tools can discover their config, but isolate temp files.
-    cmd.env("TEMP", clean_workspace.join(".libragent/tmp"));
-    cmd.env("TMP", clean_workspace.join(".libragent/tmp"));
+    // Keep host home directories so CLI tools can discover their config, and pass through host temp variables.
+    if let Ok(sys_temp) = std::env::var("TEMP") {
+        cmd.env("TEMP", sys_temp);
+    }
+    if let Ok(sys_tmp) = std::env::var("TMP") {
+        cmd.env("TMP", sys_tmp);
+    }
 
     // Add user-specified environment variables
     for (key, value) in &config.env_vars {

--- a/src-tauri/src/utils/env.rs
+++ b/src-tauri/src/utils/env.rs
@@ -160,39 +160,79 @@ pub fn get_effective_path() -> String {
 /// Returns a list of environment variables that are safe to pass to external processes
 /// (whitelisted essential system variables), preventing the leakage of host secrets.
 pub fn get_isolated_env() -> Vec<(String, String)> {
-    let preserved_vars = [
-        "PATH",
-        "SystemRoot",              // Windows
-        "COMSPEC",                 // Windows
-        "PATHEXT",                 // Windows
-        "WINDIR",                  // Windows
-        "APPDATA",                 // Windows
-        "LOCALAPPDATA",            // Windows
-        "ProgramData",             // Windows
-        "ProgramFiles",            // Windows
-        "ProgramFiles(x86)",       // Windows
-        "CommonProgramFiles",      // Windows
-        "CommonProgramFiles(x86)", // Windows
+    #[cfg(windows)]
+    let platform_preserved = [
+        "SystemRoot",
+        "COMSPEC",
+        "PATHEXT",
+        "WINDIR",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "ProgramData",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "CommonProgramFiles",
+        "CommonProgramFiles(x86)",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "PSModulePath", // PowerShell module path (essential for PS tools)
+    ];
+
+    #[cfg(not(windows))]
+    let platform_preserved = [
         "HOME",
-        "USERPROFILE", // Windows
-        "HOMEDRIVE",   // Windows
-        "HOMEPATH",    // Windows
-        "TEMP",
-        "TMP",
-        "TMPDIR",
-        "TERM",
-        "LANG",
+        "USER",
+        "LOGNAME",
         "DISPLAY",                  // GUI session (Unix)
         "WAYLAND_DISPLAY",          // GUI session (Unix)
         "DBUS_SESSION_BUS_ADDRESS", // GUI session (Unix)
     ];
 
+    let common_preserved = [
+        "PATH",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "TERM",
+        "LANG",
+        // Network Proxies (Crucial for CLI tools and MCP servers under VPN/Proxy)
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    ];
+
+    let dynamic_prefixes = ["GIT_", "CONDA_", "npm_config_"];
+
+    let dynamic_exact = ["PYTHONPATH", "VIRTUAL_ENV"];
+
     let mut envs = Vec::new();
     for (key, value) in std::env::vars() {
-        #[cfg(windows)]
-        let is_preserved = preserved_vars.iter().any(|&p| p.eq_ignore_ascii_case(&key));
-        #[cfg(not(windows))]
-        let is_preserved = preserved_vars.contains(&key.as_str());
+        let is_preserved = {
+            #[cfg(windows)]
+            {
+                common_preserved
+                    .iter()
+                    .any(|&p| p.eq_ignore_ascii_case(&key))
+                    || platform_preserved
+                        .iter()
+                        .any(|&p| p.eq_ignore_ascii_case(&key))
+                    || dynamic_exact.iter().any(|&p| p.eq_ignore_ascii_case(&key))
+                    || dynamic_prefixes
+                        .iter()
+                        .any(|&p| key.len() >= p.len() && key[..p.len()].eq_ignore_ascii_case(p))
+            }
+            #[cfg(not(windows))]
+            {
+                common_preserved.contains(&key.as_str())
+                    || platform_preserved.contains(&key.as_str())
+                    || dynamic_exact.contains(&key.as_str())
+                    || dynamic_prefixes.iter().any(|&p| key.starts_with(p))
+            }
+        };
 
         // XDG_RUNTIME_DIR exposes live D-Bus / Wayland sockets under /run/user/<uid>;
         // isolated processes have no business accessing them.


### PR DESCRIPTION
## Description

This Pull Request contains only the workspace environment variable filtering and temp directory isolation refactoring.

### Changes Included:
- **Temp Directory Pass-through**: Discards the local \.libragent/tmp\ override for \TEMP\ / \TMP\ / \TMPDIR\ during host-mode executions in [windows.rs](file:///C:/Users/SKTelecom/my_works/libr-agent/src-tauri/src/session_isolation/platforms/windows.rs) and [unix.rs](file:///C:/Users/SKTelecom/my_works/libr-agent/src-tauri/src/session_isolation/platforms/unix.rs), resolving host-environment tool crashes (e.g. Node.js v22/pnpm \lstat 'C:\\'\ EISDIR error) and silent linter bypasses.
- **Hybrid Env Filtering**: Rewrites \get_isolated_env\ in [env.rs](file:///C:/Users/SKTelecom/my_works/libr-agent/src-tauri/src/utils/env.rs) to split Windows-specific and Unix-specific preserved variables.
- **Proxy and Tool support**: Resolves network accessibility blockages in VPN/Proxy setups by whitelisting \HTTP_PROXY\ / \HTTPS_PROXY\ / \NO_PROXY\. Also adds dynamic prefix whitelisting (\GIT_\, \CONDA_\, \
pm_config_\) and virtual env configuration passing (\PYTHONPATH\, \VIRTUAL_ENV\) to guarantee seamless integration with ecosystem packages.