### PR TITLE
fix(agent): suppress read-only tool hints and close batch loop blind spot

### DIFF
--- a/src-tauri/src/agent/llm/circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/circuit_breaker.rs
@@ -18,10 +18,7 @@ pub enum CircuitBreakerAction {
         args: String,
     },
     /// Same (name, args) already present earlier in the current tool_calls batch.
-    DuplicateInBatch {
-        tool_name: String,
-        args: String,
-    },
+    DuplicateInBatch { tool_name: String, args: String },
     /// Entire assistant tool_calls batch fingerprint repeated across turns.
     RepeatedBatchSequence {
         count: usize,

--- a/src-tauri/src/agent/llm/circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/circuit_breaker.rs
@@ -2,6 +2,9 @@ use crate::agent::types::ToolCall;
 use crate::agent::AgentConfig;
 use crate::models::chat::Message;
 use crate::repositories::settings_repository::SettingsRepository;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
 #[derive(Debug, PartialEq)]
 pub enum CircuitBreakerAction {
     NaturalRecoveryError {
@@ -10,6 +13,17 @@ pub enum CircuitBreakerAction {
         args: String,
     },
     NaturalRecoverySuccess {
+        count: usize,
+        tool_name: String,
+        args: String,
+    },
+    /// Same (name, args) already present earlier in the current tool_calls batch.
+    DuplicateInBatch {
+        tool_name: String,
+        args: String,
+    },
+    /// Entire assistant tool_calls batch fingerprint repeated across turns.
+    RepeatedBatchSequence {
         count: usize,
         tool_name: String,
         args: String,
@@ -52,6 +66,81 @@ fn is_tool_error_message(message: &Message) -> bool {
     })
 }
 
+/// Canonicalize tool arguments so key-order differences do not evade signatures.
+///
+/// `serde_json::from_str` already rejects nesting deeper than 128; we still pass an
+/// explicit depth budget as defense-in-depth for any future Value sources.
+pub fn normalize_tool_arguments(args: &str) -> String {
+    match serde_json::from_str::<Value>(args) {
+        Ok(value) => canonical_json_value(&value, 0),
+        Err(_) => args.to_string(),
+    }
+}
+
+/// Matches `serde_json`'s default recursion limit so we never walk deeper than the parser allows.
+const CANONICAL_JSON_MAX_DEPTH: usize = 128;
+
+/// Soft cap for batch fingerprints. Larger batches collapse to a length-tagged hash so
+/// pathological agent outputs cannot amplify memory while identical batches still match.
+const MAX_BATCH_FINGERPRINT_BYTES: usize = 64 * 1024;
+
+fn canonical_json_value(value: &Value, depth: usize) -> String {
+    if depth >= CANONICAL_JSON_MAX_DEPTH {
+        return "\"__max_depth__\"".to_string();
+    }
+
+    match value {
+        Value::Object(map) => {
+            let sorted: BTreeMap<&str, String> = map
+                .iter()
+                .map(|(key, child)| (key.as_str(), canonical_json_value(child, depth + 1)))
+                .collect();
+            let body = sorted
+                .into_iter()
+                .map(|(key, child)| format!("\"{}\":{}", key, child))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{}}}", body)
+        }
+        Value::Array(items) => {
+            let body = items
+                .iter()
+                .map(|child| canonical_json_value(child, depth + 1))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("[{}]", body)
+        }
+        other => other.to_string(),
+    }
+}
+
+pub fn tool_call_signature(tool_call: &ToolCall) -> String {
+    format!(
+        "{}:{}",
+        tool_call.function.name,
+        normalize_tool_arguments(&tool_call.function.arguments)
+    )
+}
+
+/// Ordered fingerprint of an assistant tool_calls batch (name+args per call).
+pub fn batch_fingerprint(tool_calls: &[ToolCall]) -> String {
+    let full = tool_calls
+        .iter()
+        .map(tool_call_signature)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if full.len() <= MAX_BATCH_FINGERPRINT_BYTES {
+        return full;
+    }
+
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    full.hash(&mut hasher);
+    format!("hashed:{:016x}:len={}", hasher.finish(), full.len())
+}
+
 /// Build signature_by_id lookup map from message history in a single pass.
 pub fn build_tool_call_indices(messages: &[Message]) -> std::collections::HashMap<String, String> {
     let mut call_signature_by_id = std::collections::HashMap::new();
@@ -59,13 +148,7 @@ pub fn build_tool_call_indices(messages: &[Message]) -> std::collections::HashMa
     for message in messages {
         if let Some(tool_calls) = &message.tool_calls {
             for tool_call in tool_calls {
-                call_signature_by_id.insert(
-                    tool_call.id.clone(),
-                    format!(
-                        "{}:{}",
-                        tool_call.function.name, tool_call.function.arguments
-                    ),
-                );
+                call_signature_by_id.insert(tool_call.id.clone(), tool_call_signature(tool_call));
             }
         }
     }
@@ -234,6 +317,143 @@ where
     Some((consecutive_matches, outcome))
 }
 
+/// Maximum trailing assistant tool_calls batches to inspect when computing a
+/// batch-repetition streak. Threshold is clamped to ≤20, so this is ample and
+/// bounds work on very long sessions. User/system messages still reset the streak.
+const MAX_ASSISTANT_BATCHES_TO_SCAN: usize = 32;
+
+/// Count consecutive prior assistant batches whose fingerprint matches `fingerprint`.
+///
+/// Intervening tool results are ignored. A different non-empty tool_calls batch ends
+/// the streak. User/system messages after a seen batch also end the streak (same
+/// reset semantics as the per-tool scanner). This catches `[a,b,c] → [a,b,c]` which
+/// the per-tool result scan misses.
+///
+/// Like the per-tool streak, matching is on call identity (name+args fingerprint),
+/// not on identical result text — outcome text differences do not clear the streak.
+pub fn count_consecutive_identical_batches(messages: &[Message], fingerprint: &str) -> usize {
+    let mut consecutive = 0;
+    let mut saw_assistant_batch = false;
+    let mut assistant_batches_scanned = 0;
+
+    for message in messages.iter().rev() {
+        match message.role.as_str() {
+            "assistant" => {
+                let Some(tool_calls) = message.tool_calls.as_ref() else {
+                    if saw_assistant_batch {
+                        break;
+                    }
+                    continue;
+                };
+                if tool_calls.is_empty() {
+                    if saw_assistant_batch {
+                        break;
+                    }
+                    continue;
+                }
+                saw_assistant_batch = true;
+                assistant_batches_scanned += 1;
+                if assistant_batches_scanned > MAX_ASSISTANT_BATCHES_TO_SCAN {
+                    break;
+                }
+                if batch_fingerprint(tool_calls) == fingerprint {
+                    consecutive += 1;
+                } else {
+                    break;
+                }
+            }
+            "tool" => {}
+            _ => {
+                if saw_assistant_batch {
+                    break;
+                }
+            }
+        }
+    }
+
+    consecutive
+}
+
+/// Collect later-in-batch duplicates of an earlier (name, args) signature.
+///
+/// Signatures are computed once per call (O(n)), then checked with a set.
+pub fn find_intra_batch_duplicates(
+    tool_calls: &[ToolCall],
+) -> std::collections::HashMap<String, CircuitBreakerAction> {
+    let mut seen_signatures = std::collections::HashSet::new();
+    let mut duplicates = std::collections::HashMap::new();
+
+    for tool_call in tool_calls {
+        let signature = tool_call_signature(tool_call);
+        if !seen_signatures.insert(signature) {
+            duplicates.insert(
+                tool_call.id.clone(),
+                CircuitBreakerAction::DuplicateInBatch {
+                    tool_name: tool_call.function.name.clone(),
+                    args: tool_call.function.arguments.clone(),
+                },
+            );
+        }
+    }
+
+    duplicates
+}
+
+/// Detect repeated identical tool_calls batches across consecutive turns.
+///
+/// Triggers on structural fingerprint identity (ordered name+args), consistent with
+/// per-tool streak matching on call signature rather than identical result payloads.
+/// When the fingerprint matches, every call in the batch is part of the loop — the
+/// preprocess layer therefore short-circuits the whole batch (not a subset).
+pub fn evaluate_batch_circuit_breaker(
+    messages: &[Message],
+    tool_calls: &[ToolCall],
+    threshold: usize,
+    hard_break_offset: usize,
+) -> Option<CircuitBreakerAction> {
+    if tool_calls.is_empty() {
+        return None;
+    }
+
+    // Single-tool batches are already covered by per-call streak scanning.
+    if tool_calls.len() < 2 {
+        return None;
+    }
+
+    let first = &tool_calls[0];
+    if first.function.name == "ui__circuitBreak"
+        || first.function.name == "scratchpad__think"
+        || first.function.name == "planning__reflect"
+    {
+        return None;
+    }
+
+    let fingerprint = batch_fingerprint(tool_calls);
+    let previous = count_consecutive_identical_batches(messages, &fingerprint);
+    if previous == 0 {
+        return None;
+    }
+
+    let total_count = previous + 1;
+    let hard_break_at = threshold + hard_break_offset;
+
+    if total_count >= hard_break_at {
+        Some(CircuitBreakerAction::HardBreak {
+            count: total_count,
+            tool_name: first.function.name.clone(),
+            args: first.function.arguments.clone(),
+        })
+    } else if total_count >= threshold {
+        Some(CircuitBreakerAction::RepeatedBatchSequence {
+            count: total_count,
+            tool_name: first.function.name.clone(),
+            args: first.function.arguments.clone(),
+        })
+    } else {
+        None
+    }
+}
+
 pub fn evaluate_circuit_breaker_action(
     messages: &[Message],
     tool_call: &ToolCall,
@@ -251,7 +471,7 @@ pub fn evaluate_circuit_breaker_action(
         return None;
     }
 
-    let current_signature = format!("{}:{}", tool_name, args);
+    let current_signature = tool_call_signature(tool_call);
     if let Some((consecutive_identical_signature, outcome)) =
         count_consecutive_identical_call_outcomes(messages, |tool_call_id| {
             call_signature_by_id.get(tool_call_id) == Some(&current_signature)

--- a/src-tauri/src/agent/llm/natural_recovery.rs
+++ b/src-tauri/src/agent/llm/natural_recovery.rs
@@ -5,6 +5,10 @@ use crate::mcp::types::MCPContent;
 pub enum LoopPreventionKind {
     RepeatedErrorOutcome,
     RepeatedSuccessOutcome,
+    /// Same (name, args) appeared earlier in the current assistant tool_calls batch.
+    DuplicateInBatch,
+    /// The whole tool_calls batch fingerprint repeated across consecutive turns.
+    RepeatedBatchSequence,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +35,18 @@ pub fn build_loop_prevention_guidance(short_circuit: &LoopPreventionShortCircuit
             state change, use a delay first (for example `workspace__runShell` with `sleep 5`, or \
             `workspace__waitForProcess` for background processes), then retry with updated parameters if needed. \
             Otherwise choose a different tool or approach.",
+            short_circuit.tool_name, short_circuit.count
+        ),
+        LoopPreventionKind::DuplicateInBatch => format!(
+            "Loop prevention: '{}' appears more than once in this tool-call batch with identical parameters.\n\n\
+            Duplicate calls in the same turn were blocked. Keep a single call per unique (tool, arguments) pair, \
+            then continue with a different tool or updated arguments.",
+            short_circuit.tool_name
+        ),
+        LoopPreventionKind::RepeatedBatchSequence => format!(
+            "Loop prevention: the same tool-call batch (including '{}') was repeated {} times across consecutive turns.\n\n\
+            This call was blocked. Repeating the identical mixed batch will not change the outcome. \
+            Change at least one tool or its arguments, or choose a different approach based on results you already have.",
             short_circuit.tool_name, short_circuit.count
         ),
     }

--- a/src-tauri/src/agent/llm/response_circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/response_circuit_breaker.rs
@@ -59,53 +59,116 @@ pub(crate) async fn preprocess_assistant_tool_calls(
                     let call_signature_by_id = circuit_breaker::build_tool_call_indices(&messages);
 
                     let mut hard_break = None;
-                    for (index, tool_call) in tool_calls.iter().enumerate() {
-                        let Some(action) = circuit_breaker::evaluate_circuit_breaker_action(
-                            &messages,
-                            tool_call,
-                            &call_signature_by_id,
-                            loop_threshold,
-                            loop_break_offset,
-                        ) else {
-                            continue;
-                        };
 
+                    // Cross-turn identical mixed batches ([a,b,c] → [a,b,c]) are invisible
+                    // to the per-tool result streak scanner — check batch fingerprints first.
+                    if let Some(action) = circuit_breaker::evaluate_batch_circuit_breaker(
+                        &messages,
+                        tool_calls,
+                        loop_threshold,
+                        loop_break_offset,
+                    ) {
                         match action {
                             circuit_breaker::CircuitBreakerAction::HardBreak {
                                 count,
                                 tool_name,
                                 args,
                             } => {
-                                hard_break = Some((index, count, tool_name, args));
-                                break;
+                                hard_break = Some((0, count, tool_name, args));
                             }
-                            circuit_breaker::CircuitBreakerAction::NaturalRecoveryError {
+                            circuit_breaker::CircuitBreakerAction::RepeatedBatchSequence {
                                 count,
                                 tool_name,
                                 ..
                             } => {
-                                loop_prevention_short_circuits.insert(
-                                    tool_call.id.clone(),
-                                    LoopPreventionShortCircuit {
-                                        kind: LoopPreventionKind::RepeatedErrorOutcome,
-                                        tool_name,
-                                        count,
-                                    },
-                                );
+                                // Identical batch fingerprint ⇒ every call is part of
+                                // the repeated sequence; short-circuit the whole batch.
+                                for tool_call in tool_calls.iter() {
+                                    loop_prevention_short_circuits.insert(
+                                        tool_call.id.clone(),
+                                        LoopPreventionShortCircuit {
+                                            kind: LoopPreventionKind::RepeatedBatchSequence,
+                                            tool_name: tool_name.clone(),
+                                            count,
+                                        },
+                                    );
+                                }
                             }
-                            circuit_breaker::CircuitBreakerAction::NaturalRecoverySuccess {
-                                count,
-                                tool_name,
-                                ..
-                            } => {
+                            _ => {}
+                        }
+                    }
+
+                    if hard_break.is_none() && loop_prevention_short_circuits.is_empty() {
+                        let intra_batch_duplicates =
+                            circuit_breaker::find_intra_batch_duplicates(tool_calls);
+
+                        for (index, tool_call) in tool_calls.iter().enumerate() {
+                            if let Some(
+                                circuit_breaker::CircuitBreakerAction::DuplicateInBatch {
+                                    tool_name,
+                                    ..
+                                },
+                            ) = intra_batch_duplicates.get(&tool_call.id)
+                            {
                                 loop_prevention_short_circuits.insert(
                                     tool_call.id.clone(),
                                     LoopPreventionShortCircuit {
-                                        kind: LoopPreventionKind::RepeatedSuccessOutcome,
-                                        tool_name,
-                                        count,
+                                        kind: LoopPreventionKind::DuplicateInBatch,
+                                        tool_name: tool_name.clone(),
+                                        count: 2,
                                     },
                                 );
+                                continue;
+                            }
+
+                            let Some(action) = circuit_breaker::evaluate_circuit_breaker_action(
+                                &messages,
+                                tool_call,
+                                &call_signature_by_id,
+                                loop_threshold,
+                                loop_break_offset,
+                            ) else {
+                                continue;
+                            };
+
+                            match action {
+                                circuit_breaker::CircuitBreakerAction::HardBreak {
+                                    count,
+                                    tool_name,
+                                    args,
+                                } => {
+                                    hard_break = Some((index, count, tool_name, args));
+                                    break;
+                                }
+                                circuit_breaker::CircuitBreakerAction::NaturalRecoveryError {
+                                    count,
+                                    tool_name,
+                                    ..
+                                } => {
+                                    loop_prevention_short_circuits.insert(
+                                        tool_call.id.clone(),
+                                        LoopPreventionShortCircuit {
+                                            kind: LoopPreventionKind::RepeatedErrorOutcome,
+                                            tool_name,
+                                            count,
+                                        },
+                                    );
+                                }
+                                circuit_breaker::CircuitBreakerAction::NaturalRecoverySuccess {
+                                    count,
+                                    tool_name,
+                                    ..
+                                } => {
+                                    loop_prevention_short_circuits.insert(
+                                        tool_call.id.clone(),
+                                        LoopPreventionShortCircuit {
+                                            kind: LoopPreventionKind::RepeatedSuccessOutcome,
+                                            tool_name,
+                                            count,
+                                        },
+                                    );
+                                }
+                                _ => {}
                             }
                         }
                     }

--- a/src-tauri/src/agent/llm/response_circuit_breaker.rs
+++ b/src-tauri/src/agent/llm/response_circuit_breaker.rs
@@ -103,12 +103,10 @@ pub(crate) async fn preprocess_assistant_tool_calls(
                             circuit_breaker::find_intra_batch_duplicates(tool_calls);
 
                         for (index, tool_call) in tool_calls.iter().enumerate() {
-                            if let Some(
-                                circuit_breaker::CircuitBreakerAction::DuplicateInBatch {
-                                    tool_name,
-                                    ..
-                                },
-                            ) = intra_batch_duplicates.get(&tool_call.id)
+                            if let Some(circuit_breaker::CircuitBreakerAction::DuplicateInBatch {
+                                tool_name,
+                                ..
+                            }) = intra_batch_duplicates.get(&tool_call.id)
                             {
                                 loop_prevention_short_circuits.insert(
                                     tool_call.id.clone(),

--- a/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
+++ b/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
@@ -26,7 +26,9 @@ pub fn read_file_tool_hint() -> &'static str {
     if LINE_ANCHORS_ENABLED {
         "Use showLineAnchors=true when you need anchors for editFile."
     } else {
-        "Read files before strReplace so old_string matches the on-disk content exactly."
+        // Kept in the tool schema (not success next-actions) so edit workflows
+        // still see a minimal affordance without padding every read result.
+        "When editing afterward, copy the exact on-disk text into strReplace."
     }
 }
 
@@ -46,52 +48,18 @@ pub fn search_show_line_anchors_schema_hint() -> &'static str {
     "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c')."
 }
 
-pub fn read_file_primary_next_action(show_line_anchors: bool) -> String {
-    if LINE_ANCHORS_ENABLED {
-        if show_line_anchors {
-            "Use editFile with only the 6-character startAnchor in edits[]; for ranges, also copy only the 6-character endAnchor from the final line".to_string()
-        } else {
-            "If you plan to use editFile next, rerun with showLineAnchors=true to get anchors"
-                .to_string()
-        }
-    } else {
-        "Copy the exact text block you want to change into strReplace.old_string".to_string()
-    }
-}
-
-pub fn read_file_secondary_next_action() -> &'static str {
-    if LINE_ANCHORS_ENABLED {
-        "Use editFile with op='insert_after', startLine, and startAnchor in edits[] to insert below an existing line"
-    } else {
-        "Use strReplace when you already know the exact old_string to replace"
-    }
-}
-
 pub fn search_inline_match_footer(show_hashes: bool) -> String {
     if LINE_ANCHORS_ENABLED {
         if show_hashes {
-            "Use the returned anchors with editFile. For range replacement/deletion, also copy endAnchor from the exact end line.\n".to_string()
-        } else {
-            "If you plan to use editFile next, run again with `showLineAnchors: true` to get anchors.\n"
+            "Anchors above can be passed to editFile; include endAnchor for range edits.\n"
                 .to_string()
-        }
-    } else {
-        let _ = show_hashes;
-        "Use readFile on a match, then strReplace with the exact old_string copied from that output.\n"
-            .to_string()
-    }
-}
-
-pub fn search_directory_next_step(show_hashes: bool) -> &'static str {
-    if LINE_ANCHORS_ENABLED {
-        if show_hashes {
-            "Use the returned anchors with editFile; add endAnchor for range replacement/deletion"
         } else {
-            "Run with `showLineAnchors: true` to get anchors for targeted editing tools"
+            "For targeted edits, rerun with showLineAnchors=true to get anchors.\n".to_string()
         }
     } else {
         let _ = show_hashes;
-        "Use readFile on a hit, then strReplace with old_string copied verbatim from the file"
+        "To edit a match, read the file and copy the exact on-disk text into strReplace.\n"
+            .to_string()
     }
 }
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
@@ -203,19 +203,15 @@ impl WorkspaceServer {
                     safe_path, total_items, offset, limit
                 );
 
-                // ✅ ENHANCED: Clear messaging for empty directories
+                // Omit generic next-action hints — listing is read-only and
+                // pagination/empty status is already clear in the message body.
                 let hint = if total_items == 0 {
                     SuccessHint::new(
                         format!(
                             "Directory listing for '{}':\n\n(This directory is empty)\n\nThis is a valid empty directory.",
                             path_str
                         ),
-                        vec![
-                            format!(
-                                "Use writeFile with {{\"path\": \"{}/filename.txt\", \"content\": \"...\"}} to create a file",
-                                path_str
-                            )
-                        ],
+                        vec![],
                     )
                 } else {
                     SuccessHint::new(
@@ -223,14 +219,7 @@ impl WorkspaceServer {
                             "Directory listing for '{}':\n\n{}{}",
                             path_str, listing_str, truncation_note
                         ),
-                        vec![
-                            format!("Use readFile('{}/filename') to read a file", path_str),
-                            format!(
-                                "Use listDirectory('{}/subdir') to explore subdirectories",
-                                path_str
-                            ),
-                            "Use search to search for content in files".to_string(),
-                        ],
+                        vec![],
                     )
                 };
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -1,6 +1,5 @@
 use super::super::edit_mode::{
-    read_file_anchor_output_suffix, read_file_anchor_prefix_note, read_file_primary_next_action,
-    read_file_secondary_next_action, LINE_ANCHORS_ENABLED,
+    read_file_anchor_output_suffix, read_file_anchor_prefix_note, LINE_ANCHORS_ENABLED,
 };
 use super::super::WorkspaceServer;
 use super::utils::{
@@ -268,20 +267,9 @@ impl WorkspaceServer {
                     )
                 };
 
-                let first_hint = read_file_primary_next_action(show_line_anchors);
-                let mut next_actions = vec![first_hint];
-                next_actions.push(read_file_secondary_next_action().to_string());
-                next_actions.push("writeFile for full file replacement".to_string());
-                if let Some(next_start_line) = chunk.next_start_line {
-                    next_actions.insert(
-                        0,
-                        format!(
-                            "Read the next chunk with readFile({{\"path\": \"{}\", \"offset\": {}, \"size\": {}}})",
-                            path_str, next_start_line, chunk.displayed_line_count
-                        ),
-                    );
-                }
-                let hint = SuccessHint::new(text_message, next_actions);
+                // Omit edit-promotion next-action hints on successful reads.
+                // Truncation / next-chunk coaching stays in the message body above.
+                let hint = SuccessHint::new(text_message, vec![]);
 
                 Ok(hint.to_mcp_result_with_data(Some(json!({
                     "content": chunk.content,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/content.rs
@@ -1,4 +1,4 @@
-use super::super::super::edit_mode::{search_directory_next_step, search_inline_match_footer};
+use super::super::super::edit_mode::search_inline_match_footer;
 use super::super::utils::{
     compute_anchor, detect_language, format_file_size, initial_prefix_hash_state,
     update_prefix_hash_state,
@@ -615,9 +615,6 @@ pub(super) async fn search_content_in_dir(
         })).collect::<Vec<_>>(),
     });
 
-    let mut next_steps =
-        vec!["Use search with a specific file path to see all matches in that file".to_string()];
-    next_steps.push(search_directory_next_step(show_hashes).to_string());
-
-    Ok(SuccessHint::new(text, next_steps).to_mcp_result_with_data(Some(structured)))
+    // Matches already include pagination notes in the body; omit edit-promotion hints.
+    Ok(SuccessHint::new(text, vec![]).to_mcp_result_with_data(Some(structured)))
 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/search/files.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/search/files.rs
@@ -181,14 +181,8 @@ pub(super) async fn search_files_only(
                 },
             ));
         }
-        (
-            text,
-            vec![
-                "Refine search query or filePattern if too many results were returned".to_string(),
-                "Use offset and limit to paginate through results if truncated".to_string(),
-                "Use search on specific directories to narrow down".to_string(),
-            ],
-        )
+        // Pagination notes are already in the body; omit generic next-action hints.
+        (text, vec![])
     };
 
     Ok(

--- a/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
+++ b/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
@@ -110,9 +110,33 @@ fn mixed_batch_history() -> Vec<Message> {
             "",
             None,
         ),
-        test_message("tool-1a", "tool", None, Some("tc-1a"), None, "ok a", Some(false)),
-        test_message("tool-1b", "tool", None, Some("tc-1b"), None, "ok b", Some(false)),
-        test_message("tool-1c", "tool", None, Some("tc-1c"), None, "ok c", Some(false)),
+        test_message(
+            "tool-1a",
+            "tool",
+            None,
+            Some("tc-1a"),
+            None,
+            "ok a",
+            Some(false),
+        ),
+        test_message(
+            "tool-1b",
+            "tool",
+            None,
+            Some("tc-1b"),
+            None,
+            "ok b",
+            Some(false),
+        ),
+        test_message(
+            "tool-1c",
+            "tool",
+            None,
+            Some("tc-1c"),
+            None,
+            "ok c",
+            Some(false),
+        ),
         test_message(
             "assistant-2",
             "assistant",
@@ -122,9 +146,33 @@ fn mixed_batch_history() -> Vec<Message> {
             "",
             None,
         ),
-        test_message("tool-2a", "tool", None, Some("tc-2a"), None, "ok a", Some(false)),
-        test_message("tool-2b", "tool", None, Some("tc-2b"), None, "ok b", Some(false)),
-        test_message("tool-2c", "tool", None, Some("tc-2c"), None, "ok c", Some(false)),
+        test_message(
+            "tool-2a",
+            "tool",
+            None,
+            Some("tc-2a"),
+            None,
+            "ok a",
+            Some(false),
+        ),
+        test_message(
+            "tool-2b",
+            "tool",
+            None,
+            Some("tc-2b"),
+            None,
+            "ok b",
+            Some(false),
+        ),
+        test_message(
+            "tool-2c",
+            "tool",
+            None,
+            Some("tc-2c"),
+            None,
+            "ok c",
+            Some(false),
+        ),
     ]
 }
 
@@ -320,13 +368,7 @@ fn batch_fingerprint_hashes_when_over_size_cap() {
     // Build a batch whose joined signatures exceed MAX_BATCH_FINGERPRINT_BYTES.
     let huge_args = format!(r#"{{"blob":"{}"}}"#, "x".repeat(40_000));
     let tool_calls: Vec<_> = (0..3)
-        .map(|i| {
-            test_tool_call(
-                &format!("tc-{i}"),
-                "workspace__readFile",
-                &huge_args,
-            )
-        })
+        .map(|i| test_tool_call(&format!("tc-{i}"), "workspace__readFile", &huge_args))
         .collect();
 
     let fingerprint = batch_fingerprint(&tool_calls);

--- a/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
+++ b/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
@@ -1,0 +1,405 @@
+//! Windows-safe circuit-breaker batch-loop coverage.
+//!
+//! The consolidated `integration_tests` binary is `#![cfg(not(windows))]` because
+//! it links the full Tauri/WebView path. These cases stay runnable on Windows.
+
+#[path = "common/circuit_breaker_fixtures.rs"]
+mod circuit_breaker_fixtures;
+
+use circuit_breaker_fixtures::{mixed_batch, test_message, test_tool_call};
+use std::collections::HashMap;
+use std::sync::{atomic::AtomicBool, Arc};
+use tauri_mcp_agent_lib::agent::context::registry::ContextRegistry;
+use tauri_mcp_agent_lib::agent::llm::circuit_breaker::{
+    batch_fingerprint, evaluate_batch_circuit_breaker, find_intra_batch_duplicates,
+    normalize_tool_arguments, CircuitBreakerAction,
+};
+use tauri_mcp_agent_lib::agent::llm::natural_recovery::LoopPreventionKind;
+use tauri_mcp_agent_lib::agent::llm::preprocess_assistant_tool_calls_for_testing;
+use tauri_mcp_agent_lib::agent::state::{
+    AgentSession, CompactionRuntimeState, PendingEventManager,
+};
+use tauri_mcp_agent_lib::agent::ExecutionMode;
+use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+use tauri_mcp_agent_lib::{init_active_sessions, try_get_active_sessions};
+use tokio::sync::{Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
+
+fn build_session_metadata(session_id: &str) -> SessionMetadata {
+    let now = chrono::Utc::now().timestamp_millis();
+    SessionMetadata {
+        id: session_id.to_string(),
+        name: Some("batch-loop".to_string()),
+        status: SessionStatus::Idle,
+        model: "gemini-2.5-pro".to_string(),
+        provider: "google".to_string(),
+        assistant_id: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        execution_mode: ExecutionMode::Unsafe,
+        workspace_override: None,
+        workspace_isolation:
+            tauri_mcp_agent_lib::models::workspace_isolation::WorkspaceIsolationMode::Host,
+        docker_config: None,
+        docker_container_name: None,
+        docker_host_workspace_path: None,
+    }
+}
+
+fn build_active_session(session_id: &str, messages: Vec<Message>) -> AgentSession {
+    AgentSession {
+        metadata: build_session_metadata(session_id),
+        is_running: false,
+        active_permit: None,
+        status_transition: Arc::new(RwLock::new(None)),
+        transition_lock: Arc::new(Mutex::new(())),
+        cancellation_token: CancellationToken::new(),
+        yolo_mode: Arc::new(AtomicBool::new(false)),
+        unsafe_mode: Arc::new(AtomicBool::new(true)),
+        cancel_pending: Arc::new(AtomicBool::new(false)),
+        pending_execution: None,
+        messages: Arc::new(RwLock::new(messages)),
+        cache_initialized: Arc::new(AtomicBool::new(true)),
+        last_synced_at: Arc::new(RwLock::new(None)),
+        repeated_thinking_retry_count: Arc::new(RwLock::new(0)),
+        repeated_text_loop_retry_count: Arc::new(RwLock::new(0)),
+        pending_events: Arc::new(RwLock::new(PendingEventManager::new())),
+        pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+        context_registry: Arc::new(ContextRegistry::new()),
+        compact_context: Arc::new(RwLock::new(None)),
+        compaction: CompactionRuntimeState::new(),
+        expected_response_id: Arc::new(RwLock::new(None)),
+        cached_stable_prompt: Arc::new(RwLock::new(None)),
+        last_completion_request: Arc::new(RwLock::new(None)),
+        last_submitted_input_message_id: Arc::new(RwLock::new(None)),
+    }
+}
+
+fn ensure_active_sessions() -> Arc<RwLock<HashMap<String, AgentSession>>> {
+    if let Some(existing) = try_get_active_sessions() {
+        return existing.clone();
+    }
+
+    let sessions = Arc::new(RwLock::new(HashMap::new()));
+    init_active_sessions(sessions.clone());
+    sessions
+}
+
+fn mixed_batch_history() -> Vec<Message> {
+    vec![
+        test_message(
+            "assistant-1",
+            "assistant",
+            Some(mixed_batch(["tc-1a", "tc-1b", "tc-1c"], "")),
+            None,
+            None,
+            "",
+            None,
+        ),
+        test_message("tool-1a", "tool", None, Some("tc-1a"), None, "ok a", Some(false)),
+        test_message("tool-1b", "tool", None, Some("tc-1b"), None, "ok b", Some(false)),
+        test_message("tool-1c", "tool", None, Some("tc-1c"), None, "ok c", Some(false)),
+        test_message(
+            "assistant-2",
+            "assistant",
+            Some(mixed_batch(["tc-2a", "tc-2b", "tc-2c"], "")),
+            None,
+            None,
+            "",
+            None,
+        ),
+        test_message("tool-2a", "tool", None, Some("tc-2a"), None, "ok a", Some(false)),
+        test_message("tool-2b", "tool", None, Some("tc-2b"), None, "ok b", Some(false)),
+        test_message("tool-2c", "tool", None, Some("tc-2c"), None, "ok c", Some(false)),
+    ]
+}
+
+#[test]
+fn mixed_batch_repetition_is_detected_across_turns() {
+    let messages = mixed_batch_history();
+    let current = mixed_batch(["tc-3a", "tc-3b", "tc-3c"], "");
+
+    assert_eq!(
+        evaluate_batch_circuit_breaker(&messages, &current, 3, 1),
+        Some(CircuitBreakerAction::RepeatedBatchSequence {
+            count: 3,
+            tool_name: "workspace__readFile".to_string(),
+            args: r#"{"path":"a.ts"}"#.to_string(),
+        })
+    );
+}
+
+#[test]
+fn mixed_batch_hard_breaks_after_threshold_plus_offset() {
+    let mut messages = mixed_batch_history();
+    messages.push(test_message(
+        "assistant-3",
+        "assistant",
+        Some(mixed_batch(["tc-3a", "tc-3b", "tc-3c"], "")),
+        None,
+        None,
+        "",
+        None,
+    ));
+    messages.push(test_message(
+        "tool-3a",
+        "tool",
+        None,
+        Some("tc-3a"),
+        None,
+        "ok",
+        Some(false),
+    ));
+    let current = mixed_batch(["tc-4a", "tc-4b", "tc-4c"], "");
+
+    assert_eq!(
+        evaluate_batch_circuit_breaker(&messages, &current, 3, 1),
+        Some(CircuitBreakerAction::HardBreak {
+            count: 4,
+            tool_name: "workspace__readFile".to_string(),
+            args: r#"{"path":"a.ts"}"#.to_string(),
+        })
+    );
+}
+
+#[test]
+fn user_message_resets_batch_streak() {
+    let mut messages = mixed_batch_history();
+    messages.push(test_message(
+        "user-1",
+        "user",
+        None,
+        None,
+        None,
+        "please continue",
+        None,
+    ));
+    messages.push(test_message(
+        "assistant-3",
+        "assistant",
+        Some(mixed_batch(["tc-3a", "tc-3b", "tc-3c"], "")),
+        None,
+        None,
+        "",
+        None,
+    ));
+    messages.push(test_message(
+        "tool-3a",
+        "tool",
+        None,
+        Some("tc-3a"),
+        None,
+        "ok",
+        Some(false),
+    ));
+
+    let current = mixed_batch(["tc-4a", "tc-4b", "tc-4c"], "");
+    // After a user turn, only one prior matching batch remains consecutive.
+    assert_eq!(
+        evaluate_batch_circuit_breaker(&messages, &current, 3, 1),
+        None
+    );
+}
+
+#[test]
+fn intra_batch_duplicate_signatures_are_detected() {
+    let tool_calls = vec![
+        test_tool_call("tc-1", "workspace__readFile", r#"{"path":"a.ts"}"#),
+        test_tool_call("tc-2", "workspace__listDirectory", r#"{"path":"."}"#),
+        test_tool_call("tc-3", "workspace__readFile", r#"{"path":"a.ts"}"#),
+    ];
+
+    let duplicates = find_intra_batch_duplicates(&tool_calls);
+    assert!(!duplicates.contains_key("tc-1"));
+    assert!(!duplicates.contains_key("tc-2"));
+    assert_eq!(
+        duplicates.get("tc-3"),
+        Some(&CircuitBreakerAction::DuplicateInBatch {
+            tool_name: "workspace__readFile".to_string(),
+            args: r#"{"path":"a.ts"}"#.to_string(),
+        })
+    );
+}
+
+#[test]
+fn intra_batch_duplicate_ignores_json_key_order() {
+    let tool_calls = vec![
+        test_tool_call(
+            "tc-1",
+            "workspace__readFile",
+            r#"{"path":"a.ts","offset":1}"#,
+        ),
+        test_tool_call(
+            "tc-2",
+            "workspace__readFile",
+            r#"{"offset":1,"path":"a.ts"}"#,
+        ),
+    ];
+
+    let duplicates = find_intra_batch_duplicates(&tool_calls);
+    assert_eq!(
+        duplicates.get("tc-2"),
+        Some(&CircuitBreakerAction::DuplicateInBatch {
+            tool_name: "workspace__readFile".to_string(),
+            args: r#"{"offset":1,"path":"a.ts"}"#.to_string(),
+        })
+    );
+}
+
+#[tokio::test]
+async fn preprocess_short_circuits_whole_repeated_batch() {
+    let session_id = "batch-loop-preprocess-session";
+    let history = mixed_batch_history();
+    let active_sessions = ensure_active_sessions();
+    {
+        let mut sessions = active_sessions.write().await;
+        sessions.insert(
+            session_id.to_string(),
+            build_active_session(session_id, history),
+        );
+    }
+
+    let current = mixed_batch(["tc-3a", "tc-3b", "tc-3c"], "");
+    let mut assistant_message = test_message(
+        "assistant-3",
+        "assistant",
+        Some(current.clone()),
+        None,
+        None,
+        "",
+        None,
+    );
+
+    let preprocess_result = preprocess_assistant_tool_calls_for_testing(
+        &active_sessions,
+        session_id,
+        &mut assistant_message,
+    )
+    .await;
+
+    assert!(preprocess_result.forced_stop.is_none());
+    assert_eq!(preprocess_result.loop_prevention_short_circuits.len(), 3);
+    for tool_call in &current {
+        let short_circuit = preprocess_result
+            .loop_prevention_short_circuits
+            .get(&tool_call.id)
+            .expect("each identical-batch call is short-circuited");
+        assert_eq!(
+            short_circuit.kind,
+            LoopPreventionKind::RepeatedBatchSequence
+        );
+        assert_eq!(short_circuit.count, 3);
+    }
+
+    // Tool call list is preserved (execution layer applies short-circuits).
+    assert_eq!(
+        assistant_message
+            .tool_calls
+            .as_ref()
+            .map(|calls| calls.len()),
+        Some(3)
+    );
+}
+
+#[test]
+fn batch_fingerprint_hashes_when_over_size_cap() {
+    // Build a batch whose joined signatures exceed MAX_BATCH_FINGERPRINT_BYTES.
+    let huge_args = format!(r#"{{"blob":"{}"}}"#, "x".repeat(40_000));
+    let tool_calls: Vec<_> = (0..3)
+        .map(|i| {
+            test_tool_call(
+                &format!("tc-{i}"),
+                "workspace__readFile",
+                &huge_args,
+            )
+        })
+        .collect();
+
+    let fingerprint = batch_fingerprint(&tool_calls);
+    assert!(
+        fingerprint.starts_with("hashed:"),
+        "oversized fingerprints should collapse to a hash: {fingerprint}"
+    );
+    assert_eq!(
+        batch_fingerprint(&tool_calls),
+        fingerprint,
+        "identical oversized batches must still fingerprint-equal"
+    );
+}
+
+#[test]
+fn normalize_tool_arguments_is_stable_for_nested_objects() {
+    let left = r#"{"a":{"z":1,"y":2},"b":[3,4]}"#;
+    let right = r#"{"b":[3,4],"a":{"y":2,"z":1}}"#;
+    assert_eq!(
+        normalize_tool_arguments(left),
+        normalize_tool_arguments(right)
+    );
+}
+
+#[tokio::test]
+async fn preprocess_only_short_circuits_intra_batch_duplicates() {
+    let session_id = "intra-batch-preprocess-session";
+    let active_sessions = ensure_active_sessions();
+    {
+        let mut sessions = active_sessions.write().await;
+        sessions.insert(
+            session_id.to_string(),
+            build_active_session(session_id, Vec::new()),
+        );
+    }
+
+    let mut assistant_message = test_message(
+        "assistant-1",
+        "assistant",
+        Some(vec![
+            test_tool_call("tc-1", "workspace__readFile", r#"{"path":"a.ts"}"#),
+            test_tool_call("tc-2", "workspace__listDirectory", r#"{"path":"."}"#),
+            test_tool_call("tc-3", "workspace__readFile", r#"{"path":"a.ts"}"#),
+        ]),
+        None,
+        None,
+        "",
+        None,
+    );
+
+    let preprocess_result = preprocess_assistant_tool_calls_for_testing(
+        &active_sessions,
+        session_id,
+        &mut assistant_message,
+    )
+    .await;
+
+    assert!(preprocess_result.forced_stop.is_none());
+    assert!(
+        !preprocess_result
+            .loop_prevention_short_circuits
+            .contains_key("tc-1"),
+        "first unique signature must still execute"
+    );
+    assert!(
+        !preprocess_result
+            .loop_prevention_short_circuits
+            .contains_key("tc-2"),
+        "non-duplicate sibling must still execute"
+    );
+    let dup = preprocess_result
+        .loop_prevention_short_circuits
+        .get("tc-3")
+        .expect("duplicate signature is short-circuited");
+    assert_eq!(dup.kind, LoopPreventionKind::DuplicateInBatch);
+}

--- a/src-tauri/tests/common/circuit_breaker_fixtures.rs
+++ b/src-tauri/tests/common/circuit_breaker_fixtures.rs
@@ -1,0 +1,74 @@
+//! Shared Message/ToolCall builders for circuit-breaker tests.
+//!
+//! Keep this module free of Tauri/DB deps so Windows-safe standalone test
+//! binaries can `#[path]`-include it without pulling the WebView stack.
+
+use tauri_mcp_agent_lib::agent::types::{ToolCall, ToolCallFunction};
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::models::chat::Message;
+
+pub fn test_message(
+    id: &str,
+    role: &str,
+    tool_calls: Option<Vec<ToolCall>>,
+    tool_call_id: Option<&str>,
+    metadata: Option<serde_json::Value>,
+    text: &str,
+    is_error: Option<bool>,
+) -> Message {
+    Message {
+        id: id.to_string(),
+        session_id: "session-test".to_string(),
+        role: role.to_string(),
+        content: vec![MCPContent::Text {
+            text: text.to_string(),
+            is_error,
+        }],
+        tool_calls,
+        tool_call_id: tool_call_id.map(str::to_string),
+        is_streaming: Some(false),
+        thinking: None,
+        thinking_signature: None,
+        assistant_id: None,
+        attachments: None,
+        tool_use: None,
+        created_at: 0,
+        updated_at: 0,
+        source: None,
+        error: None,
+        metadata,
+        usage: None,
+        prompt_tokens: None,
+    }
+}
+
+pub fn test_tool_call(id: &str, name: &str, arguments: &str) -> ToolCall {
+    ToolCall {
+        id: id.to_string(),
+        r#type: "function".to_string(),
+        function: ToolCallFunction {
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        },
+    }
+}
+
+pub fn mixed_batch(ids: [&str; 3], args_suffix: &str) -> Vec<ToolCall> {
+    vec![
+        test_tool_call(
+            ids[0],
+            "workspace__readFile",
+            &format!(r#"{{"path":"a{args_suffix}.ts"}}"#),
+        ),
+        test_tool_call(
+            ids[1],
+            "workspace__listDirectory",
+            &format!(r#"{{"path":"b{args_suffix}"}}"#),
+        ),
+        test_tool_call(
+            ids[2],
+            "workspace__grepFiles",
+            &format!(r#"{{"query":"c{args_suffix}"}}"#),
+        ),
+    ]
+}

--- a/src-tauri/tests/common/workspace_hint_assertions.rs
+++ b/src-tauri/tests/common/workspace_hint_assertions.rs
@@ -1,0 +1,17 @@
+//! Shared assertions for read-only tool hint suppression.
+
+#[allow(dead_code)]
+pub fn assert_no_edit_promotion_next_actions(text: &str) {
+    assert!(
+        !text.contains("💡 Next:"),
+        "success response must not append next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("writeFile for full file replacement"),
+        "success response must not promote writeFile: {text}"
+    );
+    assert!(
+        !text.contains("strReplace.old_string"),
+        "success response must not expose internal param names: {text}"
+    );
+}

--- a/src-tauri/tests/integration/read_file_chunking_tests.rs
+++ b/src-tauri/tests/integration/read_file_chunking_tests.rs
@@ -73,13 +73,16 @@ async fn read_file_truncates_large_output_and_guides_next_chunk() {
         "response should tell the agent how to continue reading: {text}"
     );
     assert!(
-        text.contains(
-            tauri_mcp_agent_lib::mcp::builtin::workspace::edit_mode::read_file_primary_next_action(
-                false
-            )
-            .as_str()
-        ),
-        "plain readFile should keep edit planning guidance optional instead of sounding mandatory: {text}"
+        !text.contains("💡 Next:"),
+        "readFile success should not append edit-promotion next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("writeFile for full file replacement"),
+        "readFile success should not promote writeFile: {text}"
+    );
+    assert!(
+        !text.contains("strReplace.old_string"),
+        "readFile success should not expose internal param names: {text}"
     );
     assert!(
         !text.contains("line truncated to fit inline limit"),

--- a/src-tauri/tests/integration/workspace_guidance_tests.rs
+++ b/src-tauri/tests/integration/workspace_guidance_tests.rs
@@ -132,6 +132,14 @@ async fn list_directory_empty_response_does_not_suggest_rerunning_same_call() {
         !text.contains("💡 Next Steps:"),
         "listDirectory should not duplicate next-step rendering in the message body: {text}"
     );
+    assert!(
+        !text.contains("💡 Next:"),
+        "listDirectory success should not append generic next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("writeFile"),
+        "empty listDirectory should not promote writeFile: {text}"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -166,7 +166,9 @@ async fn workspace_file_tools_expose_str_replace_not_edit_file() {
 }
 
 #[tokio::test]
-async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
+async fn read_file_success_omits_edit_promotion_hints_on_str_replace_builds() {
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_read_file_tool;
+
     let temp_dir = tempdir().expect("temp dir");
     let session_id = "read-hint-str-replace";
     let server = build_workspace_server(temp_dir.path(), session_id);
@@ -184,12 +186,23 @@ async fn read_file_success_hint_points_to_str_replace_not_edit_file() {
 
     let text = extract_text_content(&result);
     assert!(
-        text.contains("strReplace"),
-        "readFile hint should mention strReplace: {text}"
+        !text.contains("💡 Next:"),
+        "readFile success should not append next-action hints: {text}"
     );
     assert!(
         !text.contains("editFile"),
-        "readFile hint should not mention editFile on strReplace builds: {text}"
+        "readFile success should not mention editFile on strReplace builds: {text}"
+    );
+
+    // Edit affordance remains in the tool schema, not success next-actions.
+    let description = create_read_file_tool().description;
+    assert!(
+        description.contains("strReplace"),
+        "readFile schema should still mention strReplace: {description}"
+    );
+    assert!(
+        !description.contains("editFile"),
+        "readFile schema should not mention editFile on strReplace builds: {description}"
     );
 }
 

--- a/src-tauri/tests/readonly_tool_hint_tests.rs
+++ b/src-tauri/tests/readonly_tool_hint_tests.rs
@@ -1,0 +1,87 @@
+//! Windows-safe coverage for read-only tool next-action suppression.
+//!
+//! Keeps truncation coaching in the body while omitting edit-promotion
+//! `💡 Next:` hints that previously padded every successful read/list.
+
+#[path = "common/workspace_hint_assertions.rs"]
+mod workspace_hint_assertions;
+
+use serde_json::json;
+use std::sync::Arc;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+use tauri_mcp_agent_lib::session::SessionManager;
+use tempfile::tempdir;
+use workspace_hint_assertions::assert_no_edit_promotion_next_actions;
+
+fn extract_text_content(result: &MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+    let session_manager =
+        SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+    WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+}
+
+#[tokio::test]
+async fn read_file_success_omits_edit_promotion_hints() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "read-file-hint-suppress";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+    std::fs::write(workspace_dir.join("note.txt"), "hello world\n").expect("write note.txt");
+
+    let result = server
+        .handle_read_file(json!({ "path": "note.txt" }), Some(session_id.to_string()))
+        .await
+        .expect("readFile should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("hello world"),
+        "body should include file content: {text}"
+    );
+    assert_no_edit_promotion_next_actions(&text);
+}
+
+#[tokio::test]
+async fn list_directory_success_omits_generic_next_actions() {
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "list-dir-hint-suppress";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+    std::fs::create_dir_all(workspace_dir.join("empty")).expect("create empty dir");
+
+    let result = server
+        .handle_list_directory(
+            json!({ "path": "empty" }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("listDirectory should succeed");
+
+    let text = extract_text_content(&result);
+    assert!(
+        text.contains("empty"),
+        "body should describe the empty directory: {text}"
+    );
+    assert!(
+        !text.contains("💡 Next:"),
+        "listDirectory success must not append next-action hints: {text}"
+    );
+    assert!(
+        !text.contains("writeFile"),
+        "empty listDirectory must not promote writeFile: {text}"
+    );
+}

--- a/src-tauri/tests/readonly_tool_hint_tests.rs
+++ b/src-tauri/tests/readonly_tool_hint_tests.rs
@@ -64,10 +64,7 @@ async fn list_directory_success_omits_generic_next_actions() {
     std::fs::create_dir_all(workspace_dir.join("empty")).expect("create empty dir");
 
     let result = server
-        .handle_list_directory(
-            json!({ "path": "empty" }),
-            Some(session_id.to_string()),
-        )
+        .handle_list_directory(json!({ "path": "empty" }), Some(session_id.to_string()))
         .await
         .expect("listDirectory should succeed");
 


### PR DESCRIPTION
## Summary
- Stop appending edit-promotion `💡 Next:` hints on successful `readFile` / `listDirectory` / `grepFiles` / `globFiles` responses (truncation coaching stays in the message body; schema keeps a minimal edit affordance).
- Extend the circuit breaker to detect identical cross-turn mixed batches (`[a,b,c] → [a,b,c]`) and intra-batch `(name, args)` duplicates, with canonical JSON signatures, lookback cap, and fingerprint size hash fallback.
- Add Windows-safe coverage for batch loops, preprocess short-circuits, and read-only hint suppression.

## Test plan
- [ ] `cargo test --test circuit_breaker_batch_loop_tests`
- [ ] `cargo test --test readonly_tool_hint_tests`
- [ ] Confirm `readFile` success no longer ends with `💡 Next:` / `writeFile for full file replacement`
- [ ] Confirm repeating the same multi-tool batch across turns short-circuits at threshold and hard-breaks after offset
- [ ] Confirm same-batch duplicate tool calls short-circuit only the duplicates (first unique call still runs)

Made with [Cursor](https://cursor.com)