### PR TITLE
refactor(compaction): deliverable-first handoff, drop continue bias

### DIFF
--- a/src-tauri/src/agent/compaction_text.rs
+++ b/src-tauri/src/agent/compaction_text.rs
@@ -68,6 +68,7 @@ pub fn is_compaction_artifact_line(line: &str) -> bool {
             | "요약"
             | "### Previous Conversation Summary"
             | "## Compacted Context"
+            // Legacy wrapper kept for sanitizing older compact summaries.
             | "## Continue From Below"
             | "### Recent Tool Call Snapshot (latest 5)"
     ) {

--- a/src-tauri/src/agent/llm/completion/compaction/hints.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/hints.rs
@@ -127,6 +127,7 @@ fn extract_compact_summary_body(message: &Message) -> Option<String> {
         .or_else(|| text.strip_prefix("### Previous Conversation Summary\n\n"))?;
 
     let summary_only = body
+        // Legacy delimiter from older compact summaries.
         .split("\n\n## Continue From Below\n")
         .next()
         .unwrap_or(body)

--- a/src-tauri/src/agent/llm/completion/compaction/instruction.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/instruction.rs
@@ -6,6 +6,9 @@ use super::hints::build_compaction_preservation_hints_from_parts;
 const COMPACTION_SECTION_SCHEMA: &str = "Write plain Markdown summary text for a later resume.\n\
  Use headings only when helpful. Do not force all sections.\n\
 Keep these section titles unchanged when you use them so later compaction can recognize them:\n\
+- Target Deliverable\n\
+- Progress\n\
+- Completion Criteria\n\
 - Active Request\n\
 - Required References\n\
 - Next Actions\n\
@@ -19,18 +22,25 @@ const COMPACTION_RULES: &[&str] = &[
     "Pause first. You are not continuing the workflow; you are only compressing it into a handoff.",
     "Write a dense handoff for later resume. Brief bullets or short note fragments are fine.",
     "Keep only the details needed to resume safely: durable facts, decisions, constraints, user preferences, unresolved work, and exact file paths or identifiers.",
+    "Lead with the end-state: Target Deliverable and Completion Criteria before local next steps.",
     "You do not need to emit every possible section. Omit empty or low-value sections, and keep short sections brief.",
+    "Target Deliverable: list the CONCRETE final outputs the user wants. Not steps — the actual things the user cares about.",
+    "Progress: if the workflow has clear phases or milestones, include a Markdown table with columns Phase, Status, Notes. Use status values Done, In Progress, Not Started, or Blocked. If the workflow is too fluid, omit this section.",
+    "Completion Criteria: list verifiable checkpoints that define done. Prefer checkbox lines like `- [ ] ...`. Each criterion must be objectively testable. Remove criteria that are already satisfied.",
     "Active Request: keep only the current unresolved user ask. Remove resolved asks.",
     "Required References: keep only the minimum paths, symbols, or IDs needed for the active request.",
     "Put fast-changing details in Current State, Recent Tool Results, or Next Actions.",
     "Do not call tools. Even if tool definitions are visible, ignore them for this request.",
     "Do not emit XML, JSON, pseudo tool-call markup, command blocks, or meta commentary.",
-    "After generating the summary, explicitly state the next action the agent should take to continue the workflow.",
+    "Do not tell the agent to continue from later messages or otherwise prime continuation. If the work appears complete, say so via empty Active Request and satisfied Completion Criteria.",
 ];
 
 const COMPACTION_SECTION_LIMITS: &[&str] = &[
     "Keep the summary compact, but completeness matters more than rigid symmetry.",
     "Usually 1-5 bullets or note fragments per section.",
+    "Target Deliverable: at most 6 items.",
+    "Progress: at most 10 phases.",
+    "Completion Criteria: at most 8 items.",
     "Active Request: at most 4 items.",
     "Required References: at most 5 items.",
 ];
@@ -40,9 +50,9 @@ const COMPACTION_OUTPUT_CONSTRAINT: &str =
 
 const INCREMENTAL_COMPACTION_RESIDUAL_PREFIX: &str =
     "The first message is the prior compact summary for all earlier history.\n\
-Keep its Active Request and Required References unless newer messages clearly replace or resolve them.\n\
+Keep its Target Deliverable, Completion Criteria, Active Request, and Required References unless newer messages clearly replace or resolve them.\n\
+Merge deliverables and criteria across rounds; remove completed criteria and refresh Progress status from newer messages.\n\
 Preserve its durable facts, decisions, and constraints when merging the newer messages.";
-
 pub(super) const ACTIVE_REQUEST_BULLET_LIMIT: usize = 4;
 pub(super) const REQUIRED_REFERENCE_BULLET_LIMIT: usize = 5;
 pub(super) const REFERENCE_CONTEXT_WINDOW_MESSAGES: usize = 8;

--- a/src-tauri/src/agent/llm/completion/request/compact.rs
+++ b/src-tauri/src/agent/llm/completion/request/compact.rs
@@ -62,13 +62,10 @@ pub fn apply_compact_summary_projection(
 pub fn build_compact_summary_text(summary: &str, compacted_messages: &[Message]) -> String {
     let mut text = format!("## Compacted Context\n\n{}", summary.trim());
 
-    text.push_str("\n\n## Continue From Below\n\n");
-    text.push_str("The messages below contain the most recent state. Continue from there.\n\n");
-
     let recent_tool_snapshot = summarize_recent_tool_calls(compacted_messages);
 
     if !recent_tool_snapshot.is_empty() {
-        text.push_str("### Recent Tool Call Snapshot (latest 5)\n");
+        text.push_str("\n\n### Recent Tool Call Snapshot (latest 5)\n");
         text.push_str(
             &recent_tool_snapshot
                 .into_iter()

--- a/src-tauri/tests/integration/llm_context_tests.rs
+++ b/src-tauri/tests/integration/llm_context_tests.rs
@@ -393,8 +393,8 @@ fn test_build_compaction_request_payload_incremental_path_injects_latest_externa
     assert!(
         payload
             .instruction_text
-            .contains("Keep its Active Request and Required References unless newer messages clearly replace or resolve them."),
-        "incremental compaction should explicitly preserve prior active-request and reference anchors"
+            .contains("Keep its Target Deliverable, Completion Criteria, Active Request, and Required References unless newer messages clearly replace or resolve them."),
+        "incremental compaction should explicitly preserve prior deliverable, criteria, active-request and reference anchors"
     );
     assert!(
         payload
@@ -446,6 +446,20 @@ fn test_build_compaction_request_payload_uses_simplified_instruction_template() 
     assert!(
         payload.instruction_text.contains("- Active Request"),
         "instruction should keep the Active Request anchor visible for downstream parsing"
+    );
+    assert!(
+        payload.instruction_text.contains("- Target Deliverable"),
+        "instruction should keep the Target Deliverable anchor visible"
+    );
+    assert!(
+        payload.instruction_text.contains("- Completion Criteria"),
+        "instruction should keep the Completion Criteria anchor visible"
+    );
+    assert!(
+        !payload.instruction_text.contains(
+            "explicitly state the next action the agent should take to continue the workflow"
+        ),
+        "instruction should not prime continuation after the summary"
     );
     assert!(
         payload
@@ -2986,7 +3000,8 @@ fn test_build_compact_summary_text_includes_recent_tool_snapshot() {
     let summary = build_compact_summary_text("User asked for an update.", &[assistant, tool]);
 
     assert!(summary.contains("## Compacted Context"));
-    assert!(summary.contains("## Continue From Below"));
+    assert!(!summary.contains("## Continue From Below"));
+    assert!(!summary.contains("Continue from there."));
     assert!(summary.contains("### Recent Tool Call Snapshot (latest 5)"));
     assert!(summary.contains("workspace__writeFile(content=updated, path=src/app.tsx) -> success: Successfully wrote src/app.tsx"));
 }
@@ -3248,7 +3263,8 @@ fn test_build_compact_summary_message_for_messages_reuses_normal_request_wrapper
         panic!("expected compact summary text");
     };
     assert!(text.contains("## Compacted Context"));
-    assert!(text.contains("## Continue From Below"));
+    assert!(!text.contains("## Continue From Below"));
+    assert!(!text.contains("Continue from there."));
     assert!(text.contains("### Recent Tool Call Snapshot (latest 5)"));
     assert!(
         text.contains("workspace__runCommand(command=git status) -> success: On branch dev/0.7.x")


### PR DESCRIPTION
## Summary
- Restructure compaction instructions to lead with Target Deliverable, Progress, and Completion Criteria so agents retain the end-state near completion.
- Remove the `## Continue From Below` footer and the instruction that primed continuation after summarization.
- Update incremental merge guidance and related llm_context tests for the new anchors.

## Test plan
- [ ] `cargo check --tests` (Windows)
- [ ] CI `cargo test --tests` on Linux for `llm_context_tests` compaction cases
- [ ] Manual: trigger compaction mid-workflow and confirm summary has deliverable/criteria sections and no Continue From Below
- [ ] Manual: near-complete task after compaction — agent should check criteria instead of inventing more work
