### PR TITLE
feat(workspace): flatten editFile to start/end N:anchor refs

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
+++ b/src-tauri/src/mcp/builtin/workspace/edit_mode.rs
@@ -37,7 +37,7 @@ pub fn read_file_tool_hint() -> &'static str {
     not(feature = "workspace-str-replace")
 ))]
 pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
-    "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. For editFile, pass only the 6-character anchor (for example 'a31f2c'), not '42:a31f2c' or the trailing '|...'."
+    "Optional: include opaque edit anchors for each line in the form '42:a31f2c|...'. For editFile, pass the full '42:a31f2c' (line + anchor) — omit only the trailing '|...'."
 }
 
 #[cfg(all(
@@ -45,13 +45,13 @@ pub fn read_file_show_line_anchors_schema_hint() -> &'static str {
     not(feature = "workspace-str-replace")
 ))]
 pub fn search_show_line_anchors_schema_hint() -> &'static str {
-    "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for edit tools, pass only the 6-character anchor (for example 'a31f2c')."
+    "Include edit anchors in results for use with editFile (default: false). Anchored lines look like '42:a31f2c|...'; for editFile, pass '42:a31f2c' (line:anchor prefix only)."
 }
 
 pub fn search_inline_match_footer(show_hashes: bool) -> String {
     if LINE_ANCHORS_ENABLED {
         if show_hashes {
-            "Anchors above can be passed to editFile; include endAnchor for range edits.\n"
+            "Copy each line's N:anchor prefix into editFile start/end (omit '|content'); include end for range edits.\n"
                 .to_string()
         } else {
             "For targeted edits, rerun with showLineAnchors=true to get anchors.\n".to_string()
@@ -84,5 +84,5 @@ pub fn read_file_anchor_prefix_note() -> &'static str {
 }
 
 pub fn read_file_anchor_output_suffix() -> &'static str {
-    "\n\nFor edit tools, pass only the 6-character anchor (example: `792c6f`). Do not pass `1:792c6f` or `|{content}`."
+    "\n\nFor editFile, pass the full `N:anchor` from each line (e.g. `42:a31f2c`). Omit the trailing `|{content}`."
 }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
@@ -194,7 +194,7 @@ fn validate_edit_anchors(
             .guidance(vec![
                 "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
                     .to_string(),
-                "Copy only the 6-character anchor from the returned line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'."
+                "Pass start as \"N:anchor\" from readFile (e.g. from '42:a31f2c|let x = 1;', use \"start\": \"42:a31f2c\")."
                     .to_string(),
             ])
             .to_mcp_result());
@@ -216,8 +216,8 @@ fn validate_edit_anchors(
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "Run readFile with showLineAnchors=true to get current anchors".to_string(),
-            "Rebuild the edit using the latest anchor".to_string(),
+            "Run readFile with showLineAnchors=true to get current line prefixes".to_string(),
+            "Rebuild the edit with an updated start: \"N:anchor\"".to_string(),
         ])
         .to_mcp_result());
     }
@@ -236,8 +236,8 @@ fn validate_edit_anchors(
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "Run readFile with showLineAnchors=true to get current anchors".to_string(),
-            "Rebuild the edit using the latest anchor".to_string(),
+            "Run readFile with showLineAnchors=true to get current line prefixes".to_string(),
+            "Rebuild the edit with an updated start: \"N:anchor\"".to_string(),
         ])
         .to_mcp_result());
     }
@@ -263,7 +263,8 @@ fn validate_edit_anchors(
                 .guidance(vec![
                     "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) again"
                         .to_string(),
-                    "Copy only the 6-character endAnchor from the returned line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'.".to_string(),
+                    "Pass end as \"N:anchor\" from readFile (e.g. from '72:b47aa1|...;', use \"end\": \"72:b47aa1\")."
+                        .to_string(),
                 ])
                 .to_mcp_result());
             }
@@ -284,8 +285,9 @@ fn validate_edit_anchors(
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Run readFile with showLineAnchors=true to get the current end anchor".to_string(),
-                "Rebuild the edit with an updated endAnchor".to_string(),
+                "Run readFile with showLineAnchors=true to get the current end line prefix"
+                    .to_string(),
+                "Rebuild the edit with an updated end: \"N:anchor\"".to_string(),
             ])
             .to_mcp_result());
         }
@@ -304,8 +306,9 @@ fn validate_edit_anchors(
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Run readFile with showLineAnchors=true to get the current end anchor".to_string(),
-                "Rebuild the edit with an updated endAnchor".to_string(),
+                "Run readFile with showLineAnchors=true to get the current end line prefix"
+                    .to_string(),
+                "Rebuild the edit with an updated end: \"N:anchor\"".to_string(),
             ])
             .to_mcp_result());
         }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/args.rs
@@ -1,9 +1,11 @@
-use super::super::super::tools::file_tools::create_edit_file_input_schema;
+use super::super::super::tools::file_tools::{
+    create_edit_file_input_schema, create_edit_file_validation_schema,
+};
 use super::types::{EditAction, LineEdit};
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, ToolGroup};
 use crate::mcp::types::MCPResult;
 use once_cell::sync::Lazy;
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 fn normalize_edit_op_value(value: &str) -> String {
     match value {
@@ -32,22 +34,121 @@ fn infer_legacy_edit_op(edit_obj: &Map<String, Value>) -> Option<&'static str> {
     }
 }
 
-static EDIT_FILE_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
+/// Parse `start` / `end` values copied from readFile output (`N:anchor`).
+///
+/// Special case: `"0"` means prepend / top insert and carries no anchor.
+fn parse_line_ref(raw: &str, field_name: &str) -> Result<(usize, Option<String>), String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "'{field_name}' must be a non-empty \"N:anchor\" string"
+        ));
+    }
+    if trimmed.contains('|') {
+        return Err(format!(
+            "'{field_name}' must be only the \"N:anchor\" prefix from readFile output \
+(e.g. \"42:a31f2c\"), not the trailing '|content'"
+        ));
+    }
+    if trimmed == "0" {
+        return Ok((0, None));
+    }
+
+    let mut parts = trimmed.splitn(2, ':');
+    let line_part = parts.next().unwrap_or("");
+    let anchor_part = parts.next();
+
+    let Some(anchor_part) = anchor_part else {
+        return Err(format!(
+            "'{field_name}' must use \"N:anchor\" format (e.g. \"42:a31f2c\"). \
+Copy the prefix before '|' from readFile(showLineAnchors=true)."
+        ));
+    };
+
+    let line = line_part.parse::<usize>().map_err(|_| {
+        format!(
+            "'{field_name}' line number must be an integer (e.g. \"42:a31f2c\"), got '{line_part}'"
+        )
+    })?;
+
+    let anchor = anchor_part.trim();
+    if anchor.is_empty() {
+        return Err(format!(
+            "'{field_name}' is missing the anchor after ':' (e.g. \"42:a31f2c\")"
+        ));
+    }
+    if anchor.len() != 6 || !anchor.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "'{field_name}' anchor must be the 6-character hex code from readFile \
+(e.g. \"42:a31f2c\"), got '{anchor}'"
+        ));
+    }
+
+    Ok((line, Some(anchor.to_string())))
+}
+
+fn expand_line_ref_fields(canonical: &mut Map<String, Value>) -> Result<(), String> {
+    if let Some(start_value) = canonical.remove("start") {
+        let start_str = start_value
+            .as_str()
+            .ok_or_else(|| "'start' must be a string (e.g. \"42:a31f2c\")".to_string())?;
+        let (line, anchor) = parse_line_ref(start_str, "start")?;
+        canonical.insert("startLine".to_string(), json!(line));
+        if let Some(anchor) = anchor {
+            canonical.insert("startAnchor".to_string(), Value::String(anchor));
+        }
+    }
+
+    if let Some(end_value) = canonical.remove("end") {
+        let end_str = end_value
+            .as_str()
+            .ok_or_else(|| "'end' must be a string (e.g. \"72:b47aa1\")".to_string())?;
+        let (line, anchor) = parse_line_ref(end_str, "end")?;
+        if line == 0 {
+            return Err(
+                "'end' cannot be \"0\"; omit end for single-line edits or use a 1-based range"
+                    .to_string(),
+            );
+        }
+        let Some(anchor) = anchor else {
+            return Err("'end' must use \"N:anchor\" format (e.g. \"72:b47aa1\")".to_string());
+        };
+        canonical.insert("endLine".to_string(), json!(line));
+        canonical.insert("endAnchor".to_string(), Value::String(anchor));
+    }
+
+    Ok(())
+}
+
+static EDIT_FILE_DISCOVERY_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
     serde_json::to_value(create_edit_file_input_schema())
-        .map_err(|error| format!("Failed to serialize editFile schema: {error}"))
+        .map_err(|error| format!("Failed to serialize editFile discovery schema: {error}"))
 });
 
-static EDIT_FILE_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
-    let schema_json = EDIT_FILE_SCHEMA_JSON
+static EDIT_FILE_VALIDATION_SCHEMA_JSON: Lazy<Result<Value, String>> = Lazy::new(|| {
+    serde_json::to_value(create_edit_file_validation_schema())
+        .map_err(|error| format!("Failed to serialize editFile validation schema: {error}"))
+});
+
+static EDIT_FILE_FLAT_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
+    let schema_json = EDIT_FILE_DISCOVERY_SCHEMA_JSON
         .as_ref()
         .map_err(|error| error.clone())?;
     jsonschema::validator_for(schema_json)
-        .map_err(|error| format!("Failed to build editFile validator: {error}"))
+        .map_err(|error| format!("Failed to build editFile flat validator: {error}"))
 });
 
-fn canonicalize_edit_object(edit: &Value) -> Value {
+static EDIT_FILE_BATCH_VALIDATOR: Lazy<Result<jsonschema::Validator, String>> = Lazy::new(|| {
+    let schema_json = EDIT_FILE_VALIDATION_SCHEMA_JSON
+        .as_ref()
+        .map_err(|error| error.clone())?;
+    jsonschema::validator_for(schema_json)
+        .map_err(|error| format!("Failed to build editFile batch validator: {error}"))
+});
+
+fn canonicalize_edit_object(edit: &Value) -> Result<Value, String> {
     let Some(edit_obj) = edit.as_object() else {
-        return edit.clone();
+        return Ok(edit.clone());
     };
 
     let mut canonical = Map::new();
@@ -55,6 +156,7 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
 
     for (key, value) in edit_obj {
         match key.as_str() {
+            "path" => {}
             "op" => {
                 if value.is_null() {
                     continue;
@@ -100,6 +202,11 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
                     canonical.insert("endAnchor".to_string(), value.clone());
                 }
             }
+            "start" | "end" => {
+                if !value.is_null() {
+                    canonical.insert(key.clone(), value.clone());
+                }
+            }
             "new_value" | "content" => {
                 if !value.is_null() {
                     if key == "new_value" && inferred_legacy_op == Some("delete") {
@@ -121,6 +228,8 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
         }
     }
 
+    expand_line_ref_fields(&mut canonical)?;
+
     if !canonical.contains_key("startLine") {
         let is_insert_after = canonical
             .get("op")
@@ -139,32 +248,48 @@ fn canonicalize_edit_object(edit: &Value) -> Value {
         }
     }
 
-    Value::Object(canonical)
+    Ok(Value::Object(canonical))
 }
 
-pub(super) fn canonicalize_edit_file_args(args: &Value) -> Value {
+/// Normalize editFile args into `{ path, edits: [...] }`.
+///
+/// Flat single-edit calls (`path` + `start`/`content`/…) are wrapped into a
+/// one-element `edits` array. Legacy `edits` arrays (hidden dispatch aliases)
+/// are preserved.
+pub(super) fn canonicalize_edit_file_args(args: &Value) -> Result<Value, String> {
     let Some(args_obj) = args.as_object() else {
-        return args.clone();
+        return Ok(args.clone());
     };
 
-    let mut canonical = Map::new();
-
-    for (key, value) in args_obj {
-        if key == "edits" {
-            if let Some(edits) = value.as_array() {
-                canonical.insert(
-                    "edits".to_string(),
-                    Value::Array(edits.iter().map(canonicalize_edit_object).collect()),
-                );
-            } else {
-                canonical.insert("edits".to_string(), value.clone());
+    if let Some(edits) = args_obj.get("edits") {
+        let mut canonical = Map::new();
+        for (key, value) in args_obj {
+            if key == "edits" {
+                continue;
             }
-        } else {
             canonical.insert(key.clone(), value.clone());
         }
+
+        if let Some(edits_array) = edits.as_array() {
+            let mut normalized = Vec::with_capacity(edits_array.len());
+            for edit in edits_array {
+                normalized.push(canonicalize_edit_object(edit)?);
+            }
+            canonical.insert("edits".to_string(), Value::Array(normalized));
+        } else {
+            canonical.insert("edits".to_string(), edits.clone());
+        }
+
+        return Ok(Value::Object(canonical));
     }
 
-    Value::Object(canonical)
+    // Flat single-edit form advertised by the discovery schema.
+    let path = args_obj.get("path").cloned().unwrap_or(Value::Null);
+    let edit = canonicalize_edit_object(&Value::Object(args_obj.clone()))?;
+    Ok(json!({
+        "path": path,
+        "edits": [edit],
+    }))
 }
 
 pub(super) fn format_edit_label(edit_obj: &Map<String, Value>, idx: usize) -> String {
@@ -198,20 +323,41 @@ pub(super) fn format_edit_label(edit_obj: &Map<String, Value>, idx: usize) -> St
     }
 }
 
-pub(super) fn validate_edit_file_arguments(args: &Value) -> Result<(), String> {
-    let validator = EDIT_FILE_VALIDATOR
-        .as_ref()
-        .map_err(|error| error.clone())?;
-    let errors = validator
+fn format_schema_errors(validator: &jsonschema::Validator, args: &Value) -> String {
+    validator
         .iter_errors(args)
         .take(3)
         .map(|error| error.to_string())
-        .collect::<Vec<_>>();
+        .collect::<Vec<_>>()
+        .join("; ")
+}
 
+pub(super) fn validate_edit_file_arguments(
+    original_args: &Value,
+    canonical_args: &Value,
+) -> Result<(), String> {
+    let used_flat_form = original_args
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("edits"));
+
+    if used_flat_form {
+        let validator = EDIT_FILE_FLAT_VALIDATOR
+            .as_ref()
+            .map_err(|error| error.clone())?;
+        let errors = format_schema_errors(validator, original_args);
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+    }
+
+    let validator = EDIT_FILE_BATCH_VALIDATOR
+        .as_ref()
+        .map_err(|error| error.clone())?;
+    let errors = format_schema_errors(validator, canonical_args);
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(errors.join("; "))
+        Err(errors)
     }
 }
 
@@ -225,13 +371,14 @@ pub(super) fn parse_line_edit(
         _ => {
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
-                format!("{edit_label}: 'startLine' field is required and must be an integer"),
+                format!("{edit_label}: 'start' (or startLine) is required"),
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Provide startLine as an integer (e.g., \"startLine\": 10)".to_string(),
-                "Existing lines are 1-based: use startLine: 1 for the first line".to_string(),
-                "Use startLine: 0 only to prepend at the beginning of the file".to_string(),
+                "Provide start as \"N:anchor\" (e.g. \"start\": \"42:a31f2c\")".to_string(),
+                "Copy the \"42:a31f2c\" prefix from readFile output: 42:a31f2c|content".to_string(),
+                "Existing lines are 1-based; use start: \"0\" only to prepend at the file top"
+                    .to_string(),
             ])
             .to_mcp_result());
         }
@@ -281,15 +428,14 @@ pub(super) fn parse_line_edit(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "{edit_label}: 'startLine' must be >= 1 for '{}' edits",
+                "{edit_label}: 'start' must be a 1-based \"N:anchor\" for '{}' edits",
                 action_name
             ),
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "Use startLine: 0 only with op='insert_after' to prepend before the first line"
-                .to_string(),
-            "Use startLine >= 1 for replace and delete edits".to_string(),
+            "Use start: \"0\" only with op='insert_after' (or content-only prepend)".to_string(),
+            "Use start: \"N:anchor\" for replace and delete edits".to_string(),
         ])
         .to_mcp_result());
     }
@@ -301,12 +447,12 @@ pub(super) fn parse_line_edit(
             return Err(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
-                    "{edit_label}: 'endLine' ({}) must be ≥ 'startLine' ({})",
+                    "{edit_label}: 'end' line ({}) must be ≥ 'start' line ({})",
                     line, start_line
                 ),
                 ToolGroup::Workspace,
             )
-            .guidance(vec!["endLine must be ≥ startLine".to_string()])
+            .guidance(vec!["end must be ≥ start".to_string()])
             .to_mcp_result());
         }
         None => {
@@ -326,15 +472,16 @@ pub(super) fn parse_line_edit(
         return Err(guided_error(
             ErrorCategory::InvalidInput,
             format!(
-                "{edit_label}: 'endLine' must be omitted for single-line {} edits",
+                "{edit_label}: 'end' must be omitted for single-line {} edits",
                 action_name
             ),
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "For single-line replace: {\"startLine\": 10, \"startAnchor\": \"a31f2c\", \"content\": \"new text\"}".to_string(),
-            "For single-line delete: {\"startLine\": 10, \"startAnchor\": \"a31f2c\"}".to_string(),
-            "Use endLine only for multi-line ranges (endLine > startLine)".to_string(),
+            "For single-line replace: {\"start\": \"10:a31f2c\", \"content\": \"new text\"}"
+                .to_string(),
+            "For single-line delete: {\"start\": \"10:a31f2c\"}".to_string(),
+            "Use end only for multi-line ranges".to_string(),
         ])
         .to_mcp_result());
     }
@@ -342,11 +489,11 @@ pub(super) fn parse_line_edit(
     if action == EditAction::InsertAfter && has_end_line {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!("{edit_label}: 'endLine' cannot be used with op 'insert_after'"),
+            format!("{edit_label}: 'end' cannot be used with op 'insert_after'"),
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "insert_after only targets one line (or startLine 0). Remove 'endLine'.".to_string(),
+            "insert_after only targets one line (or start \"0\"). Remove 'end'.".to_string(),
         ])
         .to_mcp_result());
     }
@@ -412,16 +559,16 @@ pub(super) fn parse_line_edit(
     if requires_anchor && start_anchor.is_none() {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!("{edit_label} targets existing content and requires 'anchor' (or 'startAnchor')"),
+            format!("{edit_label} targets existing content and requires 'anchor' (use start: \"N:anchor\")"),
             ToolGroup::Workspace,
         )
         .guidance(vec![
-            "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first"
+            "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first".to_string(),
+            "Copy start as \"N:anchor\" from the line format N:anchor|content \
+(e.g. from '42:a31f2c|let x = 1;', pass \"start\": \"42:a31f2c\")."
                 .to_string(),
-            "Copy only the 6-character start-line anchor from the line format N:anchor|content. Example: from '42:a31f2c|let x = 1;', pass only 'a31f2c'.".to_string(),
-            "If the edit also uses endLine for a range, copy only the 6-character endAnchor from the exact final line"
-                .to_string(),
-            "Only insert_after with startLine: 0 may omit anchors".to_string(),
+            "For ranges, also pass end: \"M:anchor\" for the final line".to_string(),
+            "Only start: \"0\" (prepend) may omit anchors".to_string(),
         ])
         .to_mcp_result());
     }
@@ -432,14 +579,14 @@ pub(super) fn parse_line_edit(
     {
         return Err(guided_error(
             ErrorCategory::InvalidInput,
-            format!("{edit_label} uses 'endLine' and requires 'endAnchor' for the exact end line"),
+            format!("{edit_label} uses a range and requires 'end' for the exact end line"),
             ToolGroup::Workspace,
         )
         .guidance(vec![
             "Run readFile(showLineAnchors=true) or search(showLineAnchors=true) first".to_string(),
-            "Copy the start-line anchor as 'startAnchor' and the final-line anchor as 'endAnchor'"
+            "Pass start: \"N:anchor\" and end: \"M:anchor\" copied from readFile output"
                 .to_string(),
-            "Only multi-line replace and delete need 'endAnchor'".to_string(),
+            "Only multi-line replace and delete need 'end'".to_string(),
         ])
         .to_mcp_result());
     }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -262,9 +262,25 @@ impl WorkspaceServer {
         args: Value,
         session_id: Option<String>,
     ) -> Result<MCPResult, String> {
-        let canonical_args = canonicalize_edit_file_args(&args);
+        let canonical_args = match canonicalize_edit_file_args(&args) {
+            Ok(value) => value,
+            Err(error) => {
+                return Ok(guided_error(
+                    ErrorCategory::InvalidInput,
+                    format!("editFile argument error: {error}"),
+                    ToolGroup::Workspace,
+                )
+                .guidance(vec![
+                    "Provide start as \"N:anchor\" (e.g. \"start\": \"42:a31f2c\")".to_string(),
+                    "Copy the \"42:a31f2c\" prefix from readFile output: 42:a31f2c|content"
+                        .to_string(),
+                    "Replace: {\"path\": \"src/a.ts\", \"start\": \"10:a31f2c\", \"content\": \"text\"}".to_string(),
+                ])
+                .to_mcp_result());
+            }
+        };
 
-        if let Err(validation_error) = validate_edit_file_arguments(&canonical_args) {
+        if let Err(validation_error) = validate_edit_file_arguments(&args, &canonical_args) {
             return Ok(guided_error(
                 ErrorCategory::InvalidInput,
                 format!(
@@ -273,12 +289,11 @@ impl WorkspaceServer {
                 ToolGroup::Workspace,
             )
             .guidance(vec![
-                "Replace: {\"path\": \"src/a.ts\", \"edits\": [{\"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
-                "Prepend: {\"path\": \"src/a.ts\", \"edits\": [{\"content\": \"header\"}]}".to_string(),
-                "Insert below a line: {\"path\": \"src/a.ts\", \"edits\": [{\"op\": \"insert_after\", \"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}]}".to_string(),
-                "Delete range: {\"path\": \"src/b.ts\", \"edits\": [{\"startLine\": 10, \"endLine\": 15, \"anchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\"}]}".to_string(),
-                "Existing lines are 1-based; use startLine=0 only to prepend at the top".to_string(),
-                "Use readFile(showLineAnchors=true) first to get anchor values".to_string(),
+                "Replace: {\"path\": \"src/a.ts\", \"start\": \"10:a31f2c\", \"content\": \"text\"}".to_string(),
+                "Prepend: {\"path\": \"src/a.ts\", \"content\": \"header\"}".to_string(),
+                "Insert below a line: {\"path\": \"src/a.ts\", \"op\": \"insert_after\", \"start\": \"10:a31f2c\", \"content\": \"text\"}".to_string(),
+                "Delete range: {\"path\": \"src/b.ts\", \"start\": \"10:a31f2c\", \"end\": \"15:b47aa1\"}".to_string(),
+                "One edit per call; copy start/end as \"N:anchor\" from readFile(showLineAnchors=true)".to_string(),
             ])
             .to_mcp_result());
         }
@@ -350,8 +365,8 @@ impl WorkspaceServer {
                         ToolGroup::Workspace,
                     )
                     .guidance(vec![
-                        "Single-line: {\"startLine\": 10, \"anchor\": \"a31f2c\", \"content\": \"text\"}".to_string(),
-                        "Range: {\"startLine\": 10, \"endLine\": 15, \"anchor\": \"a31f2c\", \"endAnchor\": \"b47aa1\", \"content\": \"...\"}".to_string(),
+                        "Single-line: {\"start\": \"10:a31f2c\", \"content\": \"text\"}".to_string(),
+                        "Range: {\"start\": \"10:a31f2c\", \"end\": \"15:b47aa1\", \"content\": \"...\"}".to_string(),
                     ])
                     .to_mcp_result());
                 }

--- a/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
+++ b/src-tauri/src/mcp/builtin/workspace/tools/file_tools.rs
@@ -748,15 +748,45 @@ Use writeFile mode='create' for new files and mode='overwrite' only when replaci
 }
 
 #[cfg(feature = "workspace-edit-file")]
-/// Maximum number of edit operations allowed in a single editFile call.
+/// Maximum number of edit operations allowed in a legacy batch `edits` array.
 pub const EDIT_FILE_MAX_EDITS: u32 = 50;
+
+#[cfg(feature = "workspace-edit-file")]
+fn edit_file_path_prop() -> JSONSchema {
+    string_prop(
+        Some(1),
+        Some(1000),
+        Some("Path to the file to edit. Relative paths resolve from the workspace; absolute paths are also allowed unless protected. Use @teamwork/... or .libragent/teamwork/... to edit teamwork files without changing workspaceOverride."),
+    )
+}
+
+#[cfg(feature = "workspace-edit-file")]
+fn edit_start_prop(include_zero: bool) -> JSONSchema {
+    let description = if include_zero {
+        "Copy the '42:a31f2c' from readFile's '42:a31f2c|content' line format. Omit only the trailing '|content'. Use \"0\" only to prepend at the file top."
+    } else {
+        "Copy the '42:a31f2c' from readFile's '42:a31f2c|content' line format. Omit only the trailing '|content'."
+    };
+    string_prop(Some(1), Some(32), Some(description))
+}
+
+#[cfg(feature = "workspace-edit-file")]
+fn edit_end_prop() -> JSONSchema {
+    string_prop(
+        Some(1),
+        Some(32),
+        Some(
+            "Copy the end line's '72:b47aa1' from readFile's '72:b47aa1|content' format for multi-line ranges. Omit for single-line edits.",
+        ),
+    )
+}
 
 #[cfg(feature = "workspace-edit-file")]
 fn edit_anchor_props() -> SchemaProperties {
     let start_anchor_desc =
-        "6-character opaque anchor for the start line from readFile(showLineAnchors=true). Required for edits that touch an existing line. Do not include the line number or '|content'.";
+        "Legacy: 6-character opaque anchor for the start line. Prefer start: \"N:anchor\" instead.";
     let end_anchor_desc =
-        "6-character opaque anchor for the end line. Required when endLine is set for a multi-line replace/delete range.";
+        "Legacy: 6-character opaque anchor for the end line. Prefer end: \"N:anchor\" instead.";
 
     let mut props = SchemaProperties::new();
     props.insert(
@@ -765,11 +795,7 @@ fn edit_anchor_props() -> SchemaProperties {
     );
     props.insert(
         "startAnchor".to_string(),
-        string_prop(
-            None,
-            None,
-            Some("Alias for anchor. Prefer anchor for new edits."),
-        ),
+        string_prop(None, None, Some(start_anchor_desc)),
     );
     props.insert(
         "endAnchor".to_string(),
@@ -779,10 +805,102 @@ fn edit_anchor_props() -> SchemaProperties {
 }
 
 #[cfg(feature = "workspace-edit-file")]
-fn create_prepend_edit_variant() -> JSONSchema {
-    let content_desc =
-        "Content to insert at the beginning of the file. startLine defaults to 0 when omitted.";
+fn create_prepend_flat_variant() -> JSONSchema {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), edit_file_path_prop());
+    props.insert(
+        "start".to_string(),
+        string_const_prop(
+            "0",
+            Some("Optional. Must be \"0\" when provided for prepend."),
+        ),
+    );
+    props.insert(
+        "content".to_string(),
+        string_prop(
+            Some(0),
+            None,
+            Some("Content to insert at the beginning of the file."),
+        ),
+    );
 
+    let mut schema = object_schema(props, vec!["path".to_string(), "content".to_string()]);
+    schema.description = Some(
+        "Prepend content at the top of the file. Provide path + content (optionally start: \"0\")."
+            .to_string(),
+    );
+    schema
+}
+
+#[cfg(feature = "workspace-edit-file")]
+fn create_line_edit_flat_variant() -> JSONSchema {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), edit_file_path_prop());
+    props.insert("start".to_string(), edit_start_prop(false));
+    props.insert("end".to_string(), edit_end_prop());
+    props.insert(
+        "op".to_string(),
+        enum_prop_optional(
+            vec!["replace", "delete"],
+            Some("Optional hint for replace or delete. Omit to let the server infer from content."),
+        ),
+    );
+    props.insert(
+        "content".to_string(),
+        string_prop(
+            None,
+            None,
+            Some(
+                "Replacement content. Omit to delete the targeted line or range. The server infers replace vs delete from content presence when op is omitted.",
+            ),
+        ),
+    );
+
+    let mut schema = object_schema(props, vec!["path".to_string(), "start".to_string()]);
+    schema.description = Some(
+        "Replace or delete existing lines. Copy start (and optional end) as \"N:anchor\" from readFile."
+            .to_string(),
+    );
+    schema
+}
+
+#[cfg(feature = "workspace-edit-file")]
+fn create_insert_after_flat_variant() -> JSONSchema {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), edit_file_path_prop());
+    props.insert(
+        "op".to_string(),
+        string_const_prop(
+            "insert_after",
+            Some("Must be insert_after for this edit shape."),
+        ),
+    );
+    props.insert("start".to_string(), edit_start_prop(true));
+    props.insert(
+        "content".to_string(),
+        string_prop(
+            Some(0),
+            None,
+            Some("Content to insert after the anchored line (or at top when start is \"0\")."),
+        ),
+    );
+
+    let mut schema = object_schema(
+        props,
+        vec![
+            "path".to_string(),
+            "op".to_string(),
+            "start".to_string(),
+            "content".to_string(),
+        ],
+    );
+    schema.description =
+        Some("Insert content after an existing line (or prepend when start is \"0\").".to_string());
+    schema
+}
+
+#[cfg(feature = "workspace-edit-file")]
+fn create_prepend_edit_item_variant() -> JSONSchema {
     let mut props = SchemaProperties::new();
     props.insert(
         "startLine".to_string(),
@@ -793,39 +911,47 @@ fn create_prepend_edit_variant() -> JSONSchema {
     );
     props.insert(
         "content".to_string(),
-        string_prop(Some(0), None, Some(content_desc)),
+        string_prop(
+            Some(0),
+            None,
+            Some("Content to insert at the beginning of the file."),
+        ),
     );
 
     let mut schema = object_schema(props, vec!["content".to_string()]);
     schema.description = Some(
-        "Prepend content at the top of the file. Provide content only, or content with startLine: 0. Do not include anchors."
+        "Prepend content at the top of the file. Provide content only, or content with startLine: 0."
             .to_string(),
     );
     schema
 }
 
 #[cfg(feature = "workspace-edit-file")]
-fn create_line_edit_variant() -> JSONSchema {
-    let start_line_desc = "Target start line number (1-based). Use endLine only for multi-line replace/delete ranges.";
-    let end_line_desc =
-        "Inclusive end line for a multi-line replace/delete range. Omit for a single-line edit.";
-    let content_desc =
-        "Replacement content. Omit to delete the targeted line or range. The server infers replace vs delete from content presence when op is omitted.";
-
+fn create_line_edit_item_variant() -> JSONSchema {
     let mut props = SchemaProperties::new();
     props.insert(
         "startLine".to_string(),
-        integer_prop(Some(1), None, Some(start_line_desc)),
+        integer_prop(
+            Some(1),
+            None,
+            Some(
+                "Target start line number (1-based). Prefer flat start: \"N:anchor\" on editFile.",
+            ),
+        ),
     );
     props.insert(
         "endLine".to_string(),
-        integer_prop(Some(1), None, Some(end_line_desc)),
+        integer_prop(
+            Some(1),
+            None,
+            Some("Inclusive end line for a multi-line replace/delete range."),
+        ),
     );
     props.insert(
         "op".to_string(),
         enum_prop_optional(
             vec!["replace", "delete"],
-            Some("Optional hint for replace or delete. Omit to let the server infer from content."),
+            Some("Optional hint for replace or delete."),
         ),
     );
     for (key, value) in edit_anchor_props() {
@@ -833,7 +959,11 @@ fn create_line_edit_variant() -> JSONSchema {
     }
     props.insert(
         "content".to_string(),
-        string_prop(None, None, Some(content_desc)),
+        string_prop(
+            None,
+            None,
+            Some("Replacement content. Omit to delete the targeted line or range."),
+        ),
     );
 
     let mut schema = object_schema(props, vec!["startLine".to_string()]);
@@ -845,11 +975,7 @@ fn create_line_edit_variant() -> JSONSchema {
 }
 
 #[cfg(feature = "workspace-edit-file")]
-fn create_insert_after_edit_variant() -> JSONSchema {
-    let start_line_desc =
-        "Line number to insert after (1-based). Use 0 only to prepend at the file top.";
-    let content_desc = "Content to insert after the anchored line.";
-
+fn create_insert_after_edit_item_variant() -> JSONSchema {
     let mut props = SchemaProperties::new();
     props.insert(
         "op".to_string(),
@@ -860,14 +986,22 @@ fn create_insert_after_edit_variant() -> JSONSchema {
     );
     props.insert(
         "startLine".to_string(),
-        integer_prop(Some(0), None, Some(start_line_desc)),
+        integer_prop(
+            Some(0),
+            None,
+            Some("Line number to insert after (1-based). Use 0 only to prepend at the file top."),
+        ),
     );
     for (key, value) in edit_anchor_props() {
         props.insert(key, value);
     }
     props.insert(
         "content".to_string(),
-        string_prop(Some(0), None, Some(content_desc)),
+        string_prop(
+            Some(0),
+            None,
+            Some("Content to insert after the anchored line."),
+        ),
     );
 
     let mut schema = object_schema(
@@ -878,44 +1012,52 @@ fn create_insert_after_edit_variant() -> JSONSchema {
             "content".to_string(),
         ],
     );
-    schema.description = Some(
-        "Insert content after an existing line (or prepend when startLine is 0). Requires anchor unless startLine is 0."
-            .to_string(),
-    );
+    schema.description =
+        Some("Insert content after an existing line (or prepend when startLine is 0).".to_string());
     schema
 }
 
 #[cfg(feature = "workspace-edit-file")]
+/// Internal/legacy item schema used after flat args are wrapped into `edits: [one]`.
 pub fn create_edit_item_schema() -> JSONSchema {
     one_of_object_schema(
         vec![
-            create_prepend_edit_variant(),
-            create_line_edit_variant(),
-            create_insert_after_edit_variant(),
+            create_prepend_edit_item_variant(),
+            create_line_edit_item_variant(),
+            create_insert_after_edit_item_variant(),
         ],
         Some(
-            "A single edit operation. Choose the variant that matches the intent: prepend, replace/delete existing lines, or insert_after.",
+            "A single edit operation after canonicalization. Prefer the flat editFile discovery schema with start/end.",
         ),
     )
 }
 
 #[cfg(feature = "workspace-edit-file")]
+/// Model-facing schema: one flat edit object (path + start/end/content).
 pub fn create_edit_file_input_schema() -> JSONSchema {
-    let mut props = SchemaProperties::new();
-    props.insert(
-        "path".to_string(),
-        string_prop(
-            Some(1),
-            Some(1000),
-            Some("Path to the file to edit. Relative paths resolve from the workspace; absolute paths are also allowed unless protected. Use @teamwork/... or .libragent/teamwork/... to edit teamwork files without changing workspaceOverride."),
+    one_of_object_schema(
+        vec![
+            create_prepend_flat_variant(),
+            create_line_edit_flat_variant(),
+            create_insert_after_flat_variant(),
+        ],
+        Some(
+            "Edit one location in a file. Copy start/end as \"N:anchor\" from readFile(showLineAnchors=true).",
         ),
-    );
+    )
+}
+
+#[cfg(feature = "workspace-edit-file")]
+/// Runtime validation schema after flat calls are wrapped into `{ path, edits: [...] }`.
+pub fn create_edit_file_validation_schema() -> JSONSchema {
+    let mut props = SchemaProperties::new();
+    props.insert("path".to_string(), edit_file_path_prop());
     props.insert(
         "edits".to_string(),
         array_schema_with_max_items(
             create_edit_item_schema(),
             Some(EDIT_FILE_MAX_EDITS),
-            Some("Ordered list of edit operations to apply atomically to one file. All edits are schema-validated and anchor-validated before any write. Edits must not overlap."),
+            Some("Internal edit list after canonicalization. Model-facing editFile uses a single flat object."),
         ),
     );
 
@@ -926,19 +1068,19 @@ pub fn create_edit_file_input_schema() -> JSONSchema {
 pub fn create_edit_file_tool() -> MCPTool {
     MCPTool {
         name: "editFile".to_string(),
-        title: Some("Edit File (Batch)".to_string()),
-        description: "Apply multiple line edits to one file atomically in a single operation.
+        title: Some("Edit File".to_string()),
+        description: "Apply one line edit to a file.
 
-PREREQUISITE: Obtain anchors from a prior readFile(showLineAnchors=true), writeFile response, or previous editFile response. Anchored lines look like `42:a31f2c|...`; for anchors, pass only the 6-character code such as `a31f2c`, not `42:a31f2c`.
+PREREQUISITE: Obtain anchors from readFile(showLineAnchors=true), writeFile, or a previous editFile response. Anchored lines look like `42:a31f2c|...` — copy the `42:a31f2c` prefix into start (and end for ranges).
 
-Edit shapes (one per array item):
-- Prepend: `{ \"content\": \"...\" }` or `{ \"startLine\": 0, \"content\": \"...\" }`
-- Replace/delete existing lines: `{ \"startLine\": N, \"anchor\": \"...\", \"content\": \"...\" }` (omit content to delete)
-- Insert after a line: `{ \"op\": \"insert_after\", \"startLine\": N, \"anchor\": \"...\", \"content\": \"...\" }`
+Shapes:
+- Prepend: `{ \"path\": \"a.rs\", \"content\": \"...\" }`
+- Replace: `{ \"path\": \"a.rs\", \"start\": \"10:a31f2c\", \"content\": \"...\" }`
+- Delete: `{ \"path\": \"a.rs\", \"start\": \"10:a31f2c\" }`
+- Range replace: `{ \"path\": \"a.rs\", \"start\": \"10:a31f2c\", \"end\": \"15:b47aa1\", \"content\": \"...\" }`
+- Insert after: `{ \"path\": \"a.rs\", \"op\": \"insert_after\", \"start\": \"10:a31f2c\", \"content\": \"...\" }`
 
-Line numbering is 1-based for existing content. The only valid 0 value is startLine=0, which prepends at the file top.
-
-All edits are validated before any write begins."
+One edit per call. For multiple locations, call editFile again (re-read when line numbers may have shifted)."
             .to_string(),
         input_schema: create_edit_file_input_schema(),
         output_schema: None,

--- a/src-tauri/tests/integration/tool_schema_property_order_tests.rs
+++ b/src-tauri/tests/integration/tool_schema_property_order_tests.rs
@@ -161,22 +161,20 @@ fn start_session_schema_property_order_puts_task_last() {
 #[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_line_variant_property_order_puts_content_last() {
-    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_file_input_schema;
 
     let keys = edit_variant_property_keys(
-        &create_edit_item_schema(),
+        &create_edit_file_input_schema(),
         "Replace or delete existing lines",
     );
 
     assert_eq!(
         keys,
         vec![
-            "startLine".to_string(),
-            "endLine".to_string(),
+            "path".to_string(),
+            "start".to_string(),
+            "end".to_string(),
             "op".to_string(),
-            "anchor".to_string(),
-            "startAnchor".to_string(),
-            "endAnchor".to_string(),
             "content".to_string(),
         ]
     );
@@ -185,34 +183,39 @@ fn edit_file_line_variant_property_order_puts_content_last() {
 #[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_prepend_variant_property_order_puts_content_last() {
-    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_file_input_schema;
 
     let keys = edit_variant_property_keys(
-        &create_edit_item_schema(),
+        &create_edit_file_input_schema(),
         "Prepend content at the top of the file",
     );
 
-    assert_eq!(keys, vec!["startLine".to_string(), "content".to_string()]);
+    assert_eq!(
+        keys,
+        vec![
+            "path".to_string(),
+            "start".to_string(),
+            "content".to_string(),
+        ]
+    );
 }
 
 #[cfg(feature = "workspace-edit-file")]
 #[test]
 fn edit_file_insert_after_variant_property_order_puts_content_last() {
-    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_item_schema;
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::tools::file_tools::create_edit_file_input_schema;
 
     let keys = edit_variant_property_keys(
-        &create_edit_item_schema(),
+        &create_edit_file_input_schema(),
         "Insert content after an existing line",
     );
 
     assert_eq!(
         keys,
         vec![
+            "path".to_string(),
             "op".to_string(),
-            "startLine".to_string(),
-            "anchor".to_string(),
-            "startAnchor".to_string(),
-            "endAnchor".to_string(),
+            "start".to_string(),
             "content".to_string(),
         ]
     );

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -926,8 +926,7 @@ async fn edit_file_rejects_multiline_replace_without_end_hash() {
     assert_eq!(result.is_error, Some(true));
     let text = extract_text_content(&result);
     assert!(
-        text.contains("requires 'end'")
-            || text.contains("requires 'endAnchor'"),
+        text.contains("requires 'end'") || text.contains("requires 'endAnchor'"),
         "expected missing end/endAnchor error, got: {text}"
     );
 }

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -39,6 +39,11 @@ fn extract_anchor(hashlines: &str, line_index: usize) -> String {
         .to_string()
 }
 
+fn line_ref(hashlines: &str, line_number: usize) -> String {
+    let anchor = extract_anchor(hashlines, line_number - 1);
+    format!("{line_number}:{anchor}")
+}
+
 #[test]
 fn anchored_line_format_uses_single_opaque_anchor() {
     let rendered = format_as_hashlines("alpha\nbeta");
@@ -66,36 +71,13 @@ fn later_prefix_hash_changes_when_earlier_content_changes() {
 }
 
 #[test]
-fn edit_file_schema_uses_discriminated_edit_variants() {
+fn edit_file_schema_uses_flat_start_anchor_variants() {
     let schema_json =
         serde_json::to_value(create_edit_file_input_schema()).expect("serialize editFile schema");
-    let root_required = schema_json
-        .get("required")
-        .and_then(|value| value.as_array())
-        .expect("root required array");
-    assert!(root_required
-        .iter()
-        .any(|value| value.as_str() == Some("path")));
-    assert!(root_required
-        .iter()
-        .any(|value| value.as_str() == Some("edits")));
-
-    let edits_property = schema_json
-        .get("properties")
-        .and_then(|properties| properties.get("edits"))
-        .expect("edits property");
-    assert_eq!(
-        edits_property
-            .get("maxItems")
-            .and_then(|value| value.as_u64()),
-        Some(50)
-    );
-
-    let edits_items = edits_property.get("items").expect("edits.items schema");
-    let one_of = edits_items
+    let one_of = schema_json
         .get("oneOf")
         .and_then(|value| value.as_array())
-        .expect("edits.items.oneOf array");
+        .expect("root oneOf array");
     assert_eq!(
         one_of.len(),
         3,
@@ -109,12 +91,15 @@ fn edit_file_schema_uses_discriminated_edit_variants() {
         .expect("prepend required");
     assert!(prepend_required
         .iter()
+        .any(|value| value.as_str() == Some("path")));
+    assert!(prepend_required
+        .iter()
         .any(|value| value.as_str() == Some("content")));
     assert!(
         !prepend_required
             .iter()
-            .any(|value| value.as_str() == Some("startLine")),
-        "prepend variant should not require startLine"
+            .any(|value| value.as_str() == Some("start")),
+        "prepend variant should not require start"
     );
 
     let line_edit_variant = &one_of[1];
@@ -124,7 +109,31 @@ fn edit_file_schema_uses_discriminated_edit_variants() {
         .expect("line edit required");
     assert!(line_edit_required
         .iter()
-        .any(|value| value.as_str() == Some("startLine")));
+        .any(|value| value.as_str() == Some("path")));
+    assert!(line_edit_required
+        .iter()
+        .any(|value| value.as_str() == Some("start")));
+    assert!(
+        line_edit_variant
+            .get("properties")
+            .and_then(|properties| properties.get("start"))
+            .is_some(),
+        "line-edit variant should expose start"
+    );
+    assert!(
+        line_edit_variant
+            .get("properties")
+            .and_then(|properties| properties.get("end"))
+            .is_some(),
+        "line-edit variant should expose end"
+    );
+    assert!(
+        !schema_json
+            .get("properties")
+            .and_then(|properties| properties.get("edits"))
+            .is_some(),
+        "discovery schema should not expose edits array"
+    );
 
     let insert_after_variant = &one_of[2];
     let insert_after_required = insert_after_variant
@@ -136,25 +145,77 @@ fn edit_file_schema_uses_discriminated_edit_variants() {
         .any(|value| value.as_str() == Some("op")));
     assert!(insert_after_required
         .iter()
-        .any(|value| value.as_str() == Some("startLine")));
-    assert!(
-        insert_after_variant
-            .get("properties")
-            .and_then(|properties| properties.get("anchor"))
-            .is_some(),
-        "insert_after variant should expose anchor for existing-line inserts"
-    );
+        .any(|value| value.as_str() == Some("start")));
 
-    let start_line_description = line_edit_variant
+    let start_description = line_edit_variant
         .get("properties")
-        .and_then(|properties| properties.get("startLine"))
+        .and_then(|properties| properties.get("start"))
         .and_then(|value| value.get("description"))
         .and_then(|value| value.as_str())
-        .expect("startLine description");
+        .expect("start description");
     assert!(
-        start_line_description.contains("1-based"),
-        "startLine description should make the 1-based rule explicit: {start_line_description}"
+        start_description.contains("42:a31f2c")
+            || start_description.contains("N:anchor")
+            || start_description.contains("|content"),
+        "start description should map to readFile line format: {start_description}"
     );
+}
+
+#[tokio::test]
+async fn edit_file_flat_start_ref_replaces_single_line() {
+    let _env_test_read_scope = super::env_var_guard::EnvTestReadGuard::acquire();
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-flat-start-ref";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "alpha\nbeta\n").expect("write sample file");
+    let start = line_ref(&format_as_hashlines("alpha\nbeta\n"), 1);
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "start": start,
+                "content": "ALPHA"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("flat edit should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "ALPHA\nbeta\n");
+}
+
+#[tokio::test]
+async fn edit_file_flat_start_and_end_replace_range() {
+    let _env_test_read_scope = super::env_var_guard::EnvTestReadGuard::acquire();
+    let temp_dir = tempdir().expect("temp dir");
+    let session_id = "edit-file-flat-start-end";
+    let server = build_workspace_server(temp_dir.path(), session_id);
+    let workspace_dir = server.get_workspace_dir(session_id);
+
+    std::fs::write(workspace_dir.join("sample.txt"), "a\nb\nc\nd\n").expect("write sample file");
+    let hashlines = format_as_hashlines("a\nb\nc\nd\n");
+
+    let result = server
+        .handle_edit_file(
+            json!({
+                "path": "sample.txt",
+                "start": line_ref(&hashlines, 2),
+                "end": line_ref(&hashlines, 3),
+                "content": "BC"
+            }),
+            Some(session_id.to_string()),
+        )
+        .await
+        .expect("flat range edit should succeed");
+
+    assert_eq!(result.is_error, Some(false));
+    let updated = std::fs::read_to_string(workspace_dir.join("sample.txt")).expect("read updated");
+    assert_eq!(updated, "a\nBC\nd\n");
 }
 
 #[tokio::test]
@@ -365,7 +426,8 @@ async fn edit_file_rejects_start_line_zero_for_replace_and_delete() {
         let text = extract_text_content(&result);
         assert_eq!(result.is_error, Some(true));
         assert!(
-            text.contains("'startLine' must be >= 1")
+            text.contains("'start' must be a 1-based")
+                || text.contains("'startLine' must be >= 1")
                 || text.contains("do not match the declared schema"),
             "expected invalid startLine guidance for op={op}, got: {text}"
         );

--- a/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
+++ b/src-tauri/tests/integration/workspace_hash_anchor_tests.rs
@@ -926,8 +926,9 @@ async fn edit_file_rejects_multiline_replace_without_end_hash() {
     assert_eq!(result.is_error, Some(true));
     let text = extract_text_content(&result);
     assert!(
-        text.contains("requires 'endAnchor'"),
-        "expected missing endAnchor error, got: {text}"
+        text.contains("requires 'end'")
+            || text.contains("requires 'endAnchor'"),
+        "expected missing end/endAnchor error, got: {text}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Flatten model-facing `editFile` to a single edit object using `start`/`end` as "N:anchor"` copied from `readFile(showLineAnchors=true)` output
- Keep legacy `edits[]` + `startLine`/`anchor` via canonicalize for hidden dispatch aliases
- Align read/search/edit error guidance so tools no longer contradict each other on anchor format

## Note
- Only active when built with `--no-default-features --features workspace-edit-file` (default builds still expose `strReplace`)

## Test plan
- [ ] `pnpm rust:test:edit-file` (Linux/macOS CI) — schema + hash-anchor integration tests
- [ ] `cargo check --no-default-features --features workspace-edit-file`
- [ ] Manual: run with `workspace-edit-file`, `readFile(showLineAnchors=true)`, then `editFile` with `start: "N:anchor"`
- [ ] Confirm default `workspace-str-replace` build still exposes `strReplace` only
