### PR TITLE
feat(docker): attach LibrAgent to Harbor task containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 🚀 Features
 
+- **Harbor Docker Attach**: Harbor Docker trials attach LibrAgent to the existing Compose `main` container (`attachContainer` + `workdir`, usually `/app`) so shell/file tools share the verifier filesystem; host pull/push sync is skipped on that path.
 - **Harbor Benchmark Runner**: Added a Harbor / Terminal-Bench adapter and `pnpm bench:*` scripts that spawn Session API runs with `executionMode` (default `unsafe` for unattended hard-approval tools).
 - **Session API `executionMode`**: `POST /api/sessions` now accepts `executionMode` (`normal` | `yolo` | `unsafe`) before the initial workflow starts.
 - **Flattened `editFile` Anchors**: `editFile` now uses start/end `N:anchor` refs for clearer, flatter line edits.
@@ -12,11 +13,13 @@
 - **Thinking-Only Stuck Turns**: Thinking-only LLM completions no longer stop the workflow as finished — they forward to Rust recovery and retry with the shared thinking retry budget. Content-array thinking is no longer misclassified as renderable output.
 - **Harbor Incomplete Harvest**: Harbor agent timeouts no longer harvest workspace/messages as a successful finish; only `idle`/`error` complete a trial. Timeout multipliers are exposed on the bench scripts.
 - **Loop Detection Threshold**: Thinking/text loop recovery now requires 3 repetitions before cancel-and-retry, reducing false positives.
+- **Cross-Platform Bench Scripts**: `pnpm bench:*` now runs via a Node dispatcher on Windows (PowerShell), Linux, and macOS (bash), instead of requiring PowerShell everywhere.
 
 ### 🔧 Internal
 
+- **Docker Attach Config**: `DockerWorkspaceConfig` supports optional `attachContainer` / `workdir` / `manageLifecycle` for attaching to an existing container without creating or destroying it.
 - **Assistant Message Shape Helper**: Extracted `inspect_assistant_message_shape` for consistent empty / thinking-only detection.
-- **Bench Bootstrap**: Harbor CLI can be installed on demand from the PowerShell runner; typo aliases for `bench:terminal` remain available.
+- **Bench Bootstrap**: Harbor CLI can be installed on demand from the PowerShell and bash runners; typo aliases for `bench:terminal` remain available.
 
 ## [0.8.32] - 2026-07-19
 

--- a/README.de.md
+++ b/README.de.md
@@ -205,6 +205,7 @@ _Wichtig: `bootstrap` ist eine eingebaute Fähigkeit, die häufig zusammen mit d
 Lade das neueste Installationsprogramm für deine Plattform von der **[Releases-Seite](https://github.com/fritzprix/libr-agent/releases/latest)** herunter.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.es.md
+++ b/README.es.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` es una capacidad integrada que se usa frecuentemente ju
 Descarga el último instalador para tu plataforma desde la **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,7 @@ _Important : `bootstrap` est une capacité intégrée souvent utilisée avec ces
 Téléchargez le dernier installateur pour votre plateforme depuis la **[page des Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows :** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon) :** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux :** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,7 @@ _重要：`bootstrap`はこれらのスキルと並行して使用される内�
 **[リリースページ](https://github.com/fritzprix/libr-agent/releases/latest)**からプラットフォーム別の最新インストーラーをダウンロード。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,7 @@ _참고: `bootstrap`은 이러한 스킬과 함께 자주 사용되는 내장 �
 [릴리스 페이지](https://github.com/fritzprix/libr-agent/releases/latest)에서 플랫폼별 최신 설치 프로그램을 다운로드하세요.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ And that's just the operator layer. LibrAgent also ships domain skills for:
 Download the latest installer for your platform from the **[Releases page](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.pt.md
+++ b/README.pt.md
@@ -205,6 +205,7 @@ _Importante: `bootstrap` é uma capacidade integrada frequentemente usada com es
 Descarrega o instalador mais recente para a tua plataforma na **[página de Releases](https://github.com/fritzprix/libr-agent/releases/latest)**.
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/README.zh.md
+++ b/README.zh.md
@@ -205,6 +205,7 @@ _重要：`bootstrap` 是经常与这些技能一起使用的内置功能。捆�
 从[发布页面](https://github.com/fritzprix/libr-agent/releases/latest)下载你平台的最新安装程序。
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows：** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS（Apple Silicon）：** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux：** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/benchmarks/harbor/README.md
+++ b/benchmarks/harbor/README.md
@@ -7,6 +7,25 @@ Benchmark sessions default to **`unsafe`** so shell and other hard-approval tool
 without manual approval. Override with Harbor `--ak execution_mode=yolo|normal` or
 `LIBRAGENT_EXECUTION_MODE`.
 
+## Workspace modes (Docker attach vs host sync)
+
+For **Docker-backed Harbor trials**, the adapter prefers attaching LibrAgent to
+Harbor’s existing Compose `main` container:
+
+- Session uses `workspaceIsolation: "docker"` with
+  `dockerConfig: { attachContainer, workdir: "/app" (or task workdir), manageLifecycle: false }`
+- Shell and file tools run **inside** that container (`docker exec -w …` /
+  `docker cp`). Absolute paths like `/app/gpt2.c` are valid.
+- LibrAgent does **not** create a second container and does **not** destroy
+  Harbor’s container on session end.
+- Host download/upload sync of `/app` is **skipped** on the attach path.
+
+If the main container ID cannot be resolved (non-Docker Harbor providers such as
+Modal/E2B, or missing Compose labels), the adapter **falls back** to the older
+host-sync path: pull `/app` to a host trial workspace, run a host session, then
+push changes back. On that path, prefer relative paths under the synced
+workspace rather than absolute `/app/...`.
+
 ## Prerequisites
 
 1. `pnpm tauri dev` (HTTP API on `http://localhost:3030/api`)
@@ -15,9 +34,9 @@ without manual approval. Override with Harbor `--ak execution_mode=yolo|normal` 
 
 ## Quick start (recommended)
 
-From the repo root, with LibrAgent already running:
+From the repo root, with LibrAgent already running (`pnpm` works on Windows, Linux, and macOS):
 
-```powershell
+```sh
 # Smoke: Harbor hello-world (expect reward=1)
 pnpm bench:hello
 
@@ -28,24 +47,39 @@ pnpm bench:terminal
 pnpm bench:terminal:all
 ```
 
-Or call the script directly:
+`pnpm bench:*` dispatches via `scripts/run-harbor-bench.cjs` to PowerShell on Windows
+and bash on Linux/macOS.
 
-```powershell
-# Named Terminal-Bench task(s)
-.\scripts\run-harbor-bench.ps1 -Preset terminal-bench -Include "hello*" -NTasks 3
+Or call the platform script directly:
 
-# Custom assistant / API
+```sh
+# Cross-platform (Node dispatcher)
+node scripts/run-harbor-bench.cjs --preset terminal-bench --include "hello*" --n-tasks 3
+node scripts/run-harbor-bench.cjs --preset hello --dry-run
+
+# Linux / macOS
+./scripts/run-harbor-bench.sh --preset terminal-bench --n-tasks 1 \
+  --api-url http://localhost:3030/api \
+  --assistant-id <uuid> \
+  --execution-mode unsafe
+
+# Windows PowerShell
 .\scripts\run-harbor-bench.ps1 -Preset terminal-bench -NTasks 1 `
   -ApiUrl http://localhost:3030/api `
   -AssistantId <uuid> `
   -ExecutionMode unsafe
+```
 
-# Or set globally for the shell session
-$env:LIBRAGENT_EXECUTION_MODE = "unsafe"
+Environment override example:
+
+```sh
+# bash / zsh
+export LIBRAGENT_EXECUTION_MODE=unsafe
 pnpm bench:terminal
 
-# Dry-run (print harbor command only)
-.\scripts\run-harbor-bench.ps1 -Preset hello -DryRun
+# PowerShell
+$env:LIBRAGENT_EXECUTION_MODE = "unsafe"
+pnpm bench:terminal
 ```
 
 Environment overrides:
@@ -66,27 +100,29 @@ were scoring unfinished runs as finished.
 - On Harbor cancel (`CancelledError`), the adapter re-raises and skips harvest.
 - For long Terminal-Bench tasks, increase the agent budget, e.g.:
 
-```powershell
-.\scripts\run-harbor-bench.ps1 -Preset terminal-bench -NTasks 1 `
-  -AgentTimeoutMultiplier 3
+```sh
+# Cross-platform
+node scripts/run-harbor-bench.cjs --preset terminal-bench --n-tasks 1 \
+  --agent-timeout-multiplier 3
 # or
-$env:LIBRAGENT_AGENT_TIMEOUT_MULTIPLIER = "3"
+export LIBRAGENT_AGENT_TIMEOUT_MULTIPLIER=3   # bash
+# $env:LIBRAGENT_AGENT_TIMEOUT_MULTIPLIER = "3"  # PowerShell
 pnpm bench:terminal
 ```
 
 ## Manual Harbor CLI
 
-```powershell
-$env:PYTHONPATH = (Get-Location).Path
-$env:PYTHONUTF8 = "1"
-harbor run `
-  -a benchmarks.harbor.libragent_agent:LibrAgentHarborAdapter `
-  --ak api_url=http://localhost:3030/api `
-  --ak assistant_id=<CODING_EXPERT_UUID> `
-  --ak execution_mode=unsafe `
-  --agent-timeout-multiplier 3 `
-  -d terminal-bench@2.0 `
-  -l 1 `
+```sh
+export PYTHONPATH="$(pwd)"
+export PYTHONUTF8=1
+harbor run \
+  -a benchmarks.harbor.libragent_agent:LibrAgentHarborAdapter \
+  --ak api_url=http://localhost:3030/api \
+  --ak assistant_id=<CODING_EXPERT_UUID> \
+  --ak execution_mode=unsafe \
+  --agent-timeout-multiplier 3 \
+  -d terminal-bench@2.0 \
+  -l 1 \
   -n 1
 ```
 

--- a/benchmarks/harbor/libragent_agent.py
+++ b/benchmarks/harbor/libragent_agent.py
@@ -1,14 +1,20 @@
 """Harbor Framework adapter for LibrAgent.
 
 Bridges Harbor's terminal-benchmark loop to LibrAgent's headless Session API.
-The agent runs on a host workspace; files are synced to/from the Harbor
-container so the verifier sees the same tree under the task workdir (usually /app).
+
+When the Harbor environment is a local Docker Compose trial, the adapter attaches
+LibrAgent's Docker session to Harbor's existing main container (workdir usually
+`/app`) so absolute task paths work without host↔container sync.
+
+Non-Docker Harbor backends fall back to the legacy host-workspace sync path.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +38,7 @@ DEFAULT_EXECUTION_MODE = "unsafe"
 # Idle/error end the workflow. Paused means approval wait — not done for benchmarks.
 TERMINAL_WORKFLOW_STATUSES = frozenset({"idle", "error"})
 DEFAULT_POLL_INTERVAL_SEC = 3.0
+MAIN_COMPOSE_SERVICE = "main"
 
 
 def resolve_execution_mode(
@@ -80,6 +87,79 @@ def resolve_poll_timeout_sec(
     return float(raw)
 
 
+def sanitize_docker_compose_project_name(name: str) -> str:
+    """Mirror Harbor's compose project-name sanitizer."""
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "", name.lower().replace(" ", ""))
+    if not sanitized:
+        return "harbor"
+    if sanitized[0].isdigit() or sanitized[0] == "-":
+        sanitized = f"p{sanitized}"
+    return sanitized[:63]
+
+
+def resolve_container_workdir(environment: BaseEnvironment) -> str:
+    workdir = "/app"
+    if hasattr(environment, "task_env_config") and environment.task_env_config:
+        workdir = getattr(environment.task_env_config, "workdir", None) or "/app"
+    return workdir
+
+
+def resolve_harbor_main_container_id(environment: BaseEnvironment) -> str | None:
+    """Resolve Harbor's Docker Compose `main` container id, if available."""
+    session_id = getattr(environment, "session_id", None)
+    if not session_id:
+        print(
+            "[LibrAgent] Warning: Harbor environment has no session_id; "
+            "cannot resolve Compose main container for attach."
+        )
+        return None
+
+    project = sanitize_docker_compose_project_name(str(session_id))
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-q",
+                "--filter",
+                f"label=com.docker.compose.project={project}",
+                "--filter",
+                f"label=com.docker.compose.service={MAIN_COMPOSE_SERVICE}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(
+            f"[LibrAgent] Warning: docker ps failed while resolving Harbor main "
+            f"container (project={project!r}): {exc}"
+        )
+        return None
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        print(
+            f"[LibrAgent] Warning: docker ps returned {result.returncode} while "
+            f"resolving Harbor main container (project={project!r})"
+            + (f": {stderr}" if stderr else "")
+        )
+        return None
+
+    for line in (result.stdout or "").splitlines():
+        cid = line.strip()
+        if cid:
+            return cid
+
+    print(
+        f"[LibrAgent] Warning: no running Compose service '{MAIN_COMPOSE_SERVICE}' "
+        f"for project={project!r} (session_id={session_id!r}). "
+        "If Harbor's sanitizer differs, attach will be skipped and host-sync fallback used."
+    )
+    return None
+
+
 class LibrAgentHarborAdapter(BaseAgent):
     """
     Harbor Framework Adapter for LibrAgent.
@@ -123,7 +203,7 @@ class LibrAgentHarborAdapter(BaseAgent):
         return "LibrAgent"
 
     def version(self) -> str | None:
-        return "0.8.32"
+        return "0.8.33"
 
     async def setup(self, environment: BaseEnvironment) -> None:
         """Validates connection with the running LibrAgent daemon."""
@@ -160,45 +240,67 @@ class LibrAgentHarborAdapter(BaseAgent):
         if httpx is None:
             raise RuntimeError("Python library 'httpx' is missing.")
 
-        local_workspace = self._resolve_local_workspace(environment, context)
-        local_workspace_str = str(local_workspace.resolve().absolute())
-        os.makedirs(local_workspace_str, exist_ok=True)
+        container_workdir = resolve_container_workdir(environment)
+        attach_container_id = resolve_harbor_main_container_id(environment)
+        use_attach = attach_container_id is not None
 
-        container_workdir = "/app"
-        if hasattr(environment, "task_env_config") and environment.task_env_config:
-            container_workdir = (
-                getattr(environment.task_env_config, "workdir", None) or "/app"
-            )
+        local_workspace: Path | None = None
+        local_workspace_str: str | None = None
 
-        print(
-            f"[{self.name()}] Pulling initial container files from "
-            f"{container_workdir} to {local_workspace_str}..."
-        )
-        try:
-            await environment.download_dir(
-                source_dir=container_workdir,
-                target_dir=local_workspace_str,
-            )
-            print(f"[{self.name()}] Successfully pulled initial files.")
-        except Exception as e:
+        if use_attach:
             print(
-                f"[{self.name()}] Warning: failed to pull initial container files: {e}"
+                f"[{self.name()}] Attaching LibrAgent Docker session to Harbor "
+                f"container {attach_container_id} (workdir={container_workdir})..."
             )
+        else:
+            local_workspace = self._resolve_local_workspace(environment, context)
+            local_workspace_str = str(local_workspace.resolve().absolute())
+            os.makedirs(local_workspace_str, exist_ok=True)
+            print(
+                f"[{self.name()}] Harbor container id not resolved; falling back to "
+                f"host workspace sync ({local_workspace_str})."
+            )
+            print(
+                f"[{self.name()}] Pulling initial container files from "
+                f"{container_workdir} to {local_workspace_str}..."
+            )
+            try:
+                await environment.download_dir(
+                    source_dir=container_workdir,
+                    target_dir=local_workspace_str,
+                )
+                print(f"[{self.name()}] Successfully pulled initial files.")
+            except Exception as e:
+                print(
+                    f"[{self.name()}] Warning: failed to pull initial container files: {e}"
+                )
 
         task_id = getattr(context, "task_id", None) or "bench"
-        payload = {
+        payload: dict[str, Any] = {
             "assistantId": self.assistant_id,
             "name": f"Harbor Benchmark Task: {task_id}",
-            "workspacePath": local_workspace_str,
-            "workspaceIsolation": "host",
             "request": instruction,
             "executionMode": self.execution_mode,
         }
 
+        if use_attach and attach_container_id is not None:
+            payload["workspaceIsolation"] = "docker"
+            payload["dockerConfig"] = {
+                "attachContainer": attach_container_id,
+                "workdir": container_workdir,
+                "manageLifecycle": False,
+            }
+        else:
+            payload["workspacePath"] = local_workspace_str
+            payload["workspaceIsolation"] = "host"
+
         async with httpx.AsyncClient(timeout=600.0) as client:
-            print(
-                f"[{self.name()}] Creating session on workspace: {local_workspace_str}..."
+            mode_desc = (
+                f"attach:{attach_container_id}"
+                if use_attach
+                else f"host:{local_workspace_str}"
             )
+            print(f"[{self.name()}] Creating session ({mode_desc})...")
             res = await client.post(f"{self.api_url}/sessions", json=payload)
             if res.status_code != 201:
                 raise RuntimeError(
@@ -295,21 +397,27 @@ class LibrAgentHarborAdapter(BaseAgent):
                     f"workflow (last status={last_status})."
                 )
 
-            print(
-                f"[{self.name()}] Pushing updated workspace files from "
-                f"{local_workspace_str} to container {container_workdir}..."
-            )
-            try:
-                await self._upload_workspace(
-                    environment,
-                    Path(local_workspace_str),
-                    container_workdir,
+            if not use_attach and local_workspace is not None:
+                print(
+                    f"[{self.name()}] Pushing updated workspace files from "
+                    f"{local_workspace} to container {container_workdir}..."
                 )
-                print(f"[{self.name()}] Successfully pushed workspace files.")
-            except Exception as e:
-                raise RuntimeError(
-                    f"Error pushing workspace files back to container: {e}"
-                ) from e
+                try:
+                    await self._upload_workspace(
+                        environment,
+                        local_workspace,
+                        container_workdir,
+                    )
+                    print(f"[{self.name()}] Successfully pushed workspace files.")
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Error pushing workspace files back to container: {e}"
+                    ) from e
+            elif use_attach:
+                print(
+                    f"[{self.name()}] Attach mode: skipping host→container upload "
+                    f"(agent wrote in-place under {container_workdir})."
+                )
 
             messages_res = await client.get(
                 f"{self.api_url}/sessions/{session_id}/messages"
@@ -342,6 +450,8 @@ class LibrAgentHarborAdapter(BaseAgent):
                 "sessionId": session_id,
                 "finalStatus": last_status,
                 "completed": True,
+                "attachContainer": attach_container_id,
+                "workspaceMode": "attach" if use_attach else "host-sync",
             }
             print(
                 f"[{self.name()}] Task complete. Response harvested successfully "

--- a/benchmarks/harbor/test_libragent_agent.py
+++ b/benchmarks/harbor/test_libragent_agent.py
@@ -7,6 +7,7 @@ from benchmarks.harbor.libragent_agent import (
     is_workflow_complete,
     resolve_execution_mode,
     resolve_poll_timeout_sec,
+    sanitize_docker_compose_project_name,
 )
 
 
@@ -51,3 +52,30 @@ def test_resolve_poll_timeout_sec_from_env() -> None:
     assert resolve_poll_timeout_sec(None, env={}) is None
     assert resolve_poll_timeout_sec(None, env={"LIBRAGENT_POLL_TIMEOUT_SEC": "900"}) == 900.0
     assert resolve_poll_timeout_sec(120.0, env={"LIBRAGENT_POLL_TIMEOUT_SEC": "900"}) == 120.0
+
+
+def test_sanitize_docker_compose_project_name() -> None:
+    assert (
+        sanitize_docker_compose_project_name("hello-world__bZZeEkw__env")
+        == "hello-world__bzzeekw__env"
+    )
+    assert sanitize_docker_compose_project_name("  My Task ") == "mytask"
+    assert sanitize_docker_compose_project_name("9bad") == "p9bad"
+    assert sanitize_docker_compose_project_name("---") == "p---"
+    assert sanitize_docker_compose_project_name("@@@") == "harbor"
+    assert len(sanitize_docker_compose_project_name("a" * 100)) == 63
+
+
+def test_attach_session_payload_shape() -> None:
+    """Document expected dockerConfig when Harbor main container is resolved."""
+    payload = {
+        "workspaceIsolation": "docker",
+        "dockerConfig": {
+            "attachContainer": "cid123",
+            "workdir": "/app",
+            "manageLifecycle": False,
+        },
+    }
+    assert payload["dockerConfig"]["manageLifecycle"] is False
+    assert payload["dockerConfig"]["workdir"] == "/app"
+    assert "image" not in payload["dockerConfig"]

--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
     "preinstall": "node scripts/enforce-pnpm-version.cjs",
     "prepare": "node scripts/setup-git-hooks.cjs",
     "lockfile:check": "pnpm install --frozen-lockfile",
-    "bench:hello": "powershell -ExecutionPolicy Bypass -File scripts/run-harbor-bench.ps1 -Preset hello",
-    "bench:terminal": "powershell -ExecutionPolicy Bypass -File scripts/run-harbor-bench.ps1 -Preset terminal-bench -NTasks 1",
-    "bench:terminal:all": "powershell -ExecutionPolicy Bypass -File scripts/run-harbor-bench.ps1 -Preset terminal-bench",
+    "bench:hello": "node scripts/run-harbor-bench.cjs --preset hello",
+    "bench:terminal": "node scripts/run-harbor-bench.cjs --preset terminal-bench --n-tasks 1",
+    "bench:terminal:all": "node scripts/run-harbor-bench.cjs --preset terminal-bench",
     "bench:termial": "pnpm bench:terminal",
     "bench:termial:all": "pnpm bench:terminal:all"
   },

--- a/scripts/run-harbor-bench.cjs
+++ b/scripts/run-harbor-bench.cjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform Harbor / Terminal-Bench runner.
+ * Dispatches to run-harbor-bench.ps1 on Windows and run-harbor-bench.sh elsewhere.
+ *
+ * Usage (same flags as the bash runner):
+ *   node scripts/run-harbor-bench.cjs --preset terminal-bench --n-tasks 1
+ */
+'use strict';
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const isWindows = process.platform === 'win32';
+
+/** @type {Record<string, string>} */
+const FLAG_TO_PS = {
+  '--preset': '-Preset',
+  '--dataset': '-Dataset',
+  '--path': '-Path',
+  '--include': '-Include',
+  '--n-tasks': '-NTasks',
+  '--concurrent': '-Concurrent',
+  '--api-url': '-ApiUrl',
+  '--assistant-id': '-AssistantId',
+  '--execution-mode': '-ExecutionMode',
+  '--timeout-multiplier': '-TimeoutMultiplier',
+  '--agent-timeout-multiplier': '-AgentTimeoutMultiplier',
+};
+
+/** @type {Record<string, string>} */
+const SWITCH_TO_PS = {
+  '--skip-health-check': '-SkipHealthCheck',
+  '--dry-run': '-DryRun',
+  '--debug': '-DebugHarbor',
+};
+
+/**
+ * @param {string[]} argv
+ * @returns {string[]}
+ */
+function toPowerShellArgs(argv) {
+  /** @type {string[]} */
+  const out = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') {
+      out.push('-?');
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(SWITCH_TO_PS, arg)) {
+      out.push(SWITCH_TO_PS[arg]);
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(FLAG_TO_PS, arg)) {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith('-')) {
+        console.error(`Missing value for ${arg}`);
+        process.exit(1);
+      }
+      out.push(FLAG_TO_PS[arg], value);
+      i += 1;
+      continue;
+    }
+    console.error(`Unknown arg: ${arg}`);
+    process.exit(1);
+  }
+  return out;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ */
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    shell: isWindows,
+    env: process.env,
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+const argv = process.argv.slice(2);
+
+if (isWindows) {
+  const ps1 = path.join(repoRoot, 'scripts', 'run-harbor-bench.ps1');
+  const psArgs = toPowerShellArgs(argv);
+  run('powershell', [
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    ps1,
+    ...psArgs,
+  ]);
+} else {
+  const sh = path.join(repoRoot, 'scripts', 'run-harbor-bench.sh');
+  run('bash', [sh, ...argv]);
+}

--- a/scripts/run-harbor-bench.sh
+++ b/scripts/run-harbor-bench.sh
@@ -71,9 +71,52 @@ export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
 need() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
 }
-need harbor
-need python
+
+resolve_python() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+  elif command -v python >/dev/null 2>&1; then
+    command -v python
+  else
+    echo "Missing required command: python3 or python" >&2
+    exit 1
+  fi
+}
+
+PYTHON="$(resolve_python)"
+
+ensure_harbor() {
+  if command -v harbor >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "==> harbor command not found. Attempting to bootstrap/install..."
+
+  if command -v uv >/dev/null 2>&1; then
+    echo "Installing harbor and httpx using uv..."
+    uv pip install harbor httpx --system
+  else
+    echo "Installing harbor and httpx using pip..."
+    "$PYTHON" -m pip install harbor httpx
+  fi
+
+  if ! command -v harbor >/dev/null 2>&1; then
+    scripts_dir="$("$PYTHON" -c "import sysconfig; print(sysconfig.get_path('scripts'))" 2>/dev/null || true)"
+    if [[ -n "$scripts_dir" && -d "$scripts_dir" ]]; then
+      echo "Adding $scripts_dir to PATH for this session" >&2
+      export PATH="$scripts_dir:$PATH"
+    fi
+  fi
+
+  if ! command -v harbor >/dev/null 2>&1; then
+    echo "Could not bootstrap harbor. Please install manually (e.g. 'pip install harbor httpx')." >&2
+    exit 1
+  fi
+  echo "==> harbor successfully bootstrapped and ready!"
+}
+
 need curl
+ensure_harbor
 
 resolve_assistant_id() {
   if [[ -n "$ASSISTANT_ID" ]]; then
@@ -81,7 +124,7 @@ resolve_assistant_id() {
     return
   fi
   echo "==> Resolving assistant '$ASSISTANT_NAME'" >&2
-  python - "$API_URL" "$ASSISTANT_NAME" <<'PY'
+  "$PYTHON" - "$API_URL" "$ASSISTANT_NAME" <<'PY'
 import json, sys, urllib.request
 api, name = sys.argv[1], sys.argv[2]
 with urllib.request.urlopen(f"{api}/assistants", timeout=15) as resp:
@@ -105,7 +148,7 @@ if [[ "$SKIP_HEALTH" -eq 0 ]]; then
   echo "==> Smoke-checking executionMode=$EXECUTION_MODE"
   CREATE=$(curl -fsS -X POST "$API_URL/sessions" \
     -H 'Content-Type: application/json' \
-    -d "$(python - <<PY
+    -d "$("$PYTHON" - <<PY
 import json
 print(json.dumps({
   "assistantId": "$ASSISTANT_ID",
@@ -116,9 +159,9 @@ print(json.dumps({
 }))
 PY
 )")
-  SID=$(python -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$CREATE")
+  SID=$("$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$CREATE")
   sleep 1
-  MODE=$(curl -fsS "$API_URL/sessions/$SID" | python -c 'import json,sys; print(json.load(sys.stdin).get("executionMode"))')
+  MODE=$(curl -fsS "$API_URL/sessions/$SID" | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("executionMode"))')
   echo "  session=$SID executionMode=$MODE"
   if [[ "$EXECUTION_MODE" != "normal" && "$MODE" != "$EXECUTION_MODE" ]]; then
     echo "API did not apply executionMode=$EXECUTION_MODE (got $MODE)" >&2
@@ -183,7 +226,29 @@ set -e
 LATEST=$(ls -1d jobs/*/ 2>/dev/null | sort | tail -n 1 || true)
 if [[ -n "$LATEST" ]]; then
   echo "==> Latest job: $LATEST"
-  find "$LATEST" -path '*/verifier/reward.txt' -print -exec cat {} \;
+  if [[ -f "${LATEST}result.json" ]]; then
+    "$PYTHON" - "${LATEST}result.json" <<'PY' || true
+import json, sys
+path = sys.argv[1]
+try:
+    job = json.load(open(path, encoding="utf-8"))
+except Exception:
+    print("  (could not parse job result.json)")
+    raise SystemExit(0)
+evals = (job.get("stats") or {}).get("evals") or {}
+for name, value in evals.items():
+    metrics = value.get("metrics") or []
+    mean = metrics[0].get("mean") if metrics else None
+    print(
+        f"  eval {name}: mean={mean} trials={value.get('n_trials')} errors={value.get('n_errors')}"
+    )
+PY
+  fi
+  while IFS= read -r -d '' reward_file; do
+    trial="$(basename "$(dirname "$(dirname "$reward_file")")")"
+    reward="$(tr -d '[:space:]' <"$reward_file")"
+    echo "  trial ${trial}: reward=${reward}"
+  done < <(find "$LATEST" -path '*/verifier/reward.txt' -print0 2>/dev/null || true)
 fi
 
 exit "$CODE"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4129,7 +4129,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/src/agent/lifecycle/creation.rs
+++ b/src-tauri/src/agent/lifecycle/creation.rs
@@ -153,7 +153,14 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
     };
 
     let docker_container_name = if workspace_isolation == WorkspaceIsolationMode::Docker {
-        Some(format!("libragent-session-{session_id}"))
+        if let Some(attach) = docker_config
+            .as_ref()
+            .and_then(DockerWorkspaceConfig::attach_container_name)
+        {
+            Some(attach.to_string())
+        } else {
+            Some(format!("libragent-session-{session_id}"))
+        }
     } else {
         None
     };

--- a/src-tauri/src/agent/llm/assistant_message_shape.rs
+++ b/src-tauri/src/agent/llm/assistant_message_shape.rs
@@ -30,10 +30,7 @@ fn content_item_has_thinking(content: &MCPContent) -> bool {
 }
 
 pub fn inspect_assistant_message_shape(message: &Message) -> AssistantMessageShape {
-    let has_renderable_content = message
-        .content
-        .iter()
-        .any(content_item_is_renderable);
+    let has_renderable_content = message.content.iter().any(content_item_is_renderable);
     let has_thinking = message
         .thinking
         .as_ref()
@@ -45,9 +42,10 @@ pub fn inspect_assistant_message_shape(message: &Message) -> AssistantMessageSha
         .as_ref()
         .map(|tool_calls| !tool_calls.is_empty())
         .unwrap_or(false)
-        || message.content.iter().any(|content| {
-            matches!(content, MCPContent::ToolCall { .. })
-        });
+        || message
+            .content
+            .iter()
+            .any(|content| matches!(content, MCPContent::ToolCall { .. }));
 
     AssistantMessageShape {
         has_renderable_content,

--- a/src-tauri/src/agent/runtime_state.rs
+++ b/src-tauri/src/agent/runtime_state.rs
@@ -56,7 +56,9 @@ pub struct SessionRuntimeProxyState {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionRuntimeDockerState {
-    pub image: String,
+    /// Managed image ref, or `attach:<container>` for attach sessions. Absent when unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
     pub step: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub progress: Option<u8>,

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/persistent.rs
@@ -248,9 +248,16 @@ async fn docker_path_mapper_for_session(
         .as_ref()
         .ok_or_else(|| format!("Missing Docker host workspace path for session {session_id}"))?;
 
-    Ok(Some(PathMappingLayer::new(std::path::PathBuf::from(
-        host_workspace,
-    ))))
+    let workdir = session
+        .docker_config
+        .as_ref()
+        .map(|config| config.workdir().to_string())
+        .unwrap_or_else(|| crate::models::workspace_isolation::DEFAULT_DOCKER_WORKDIR.to_string());
+
+    Ok(Some(PathMappingLayer::with_container_root(
+        std::path::PathBuf::from(host_workspace),
+        workdir,
+    )))
 }
 
 fn display_shell_cwd(

--- a/src-tauri/src/mcp/builtin/workspace/context.rs
+++ b/src-tauri/src/mcp/builtin/workspace/context.rs
@@ -96,9 +96,13 @@ pub async fn build_workspace_live_state(
     session_manager: &SessionManager,
     shell_manager: &persistent_shell::PersistentShellManager,
 ) -> WorkspaceLiveState {
-    let is_docker = super::utils::is_session_docker_isolated(session_id).await;
+    let (is_docker, docker_root) = super::utils::session_docker_root(session_id).await;
     let host_workspace = session_manager.get_session_workspace_dir_by_id(session_id);
-    let workspace_dir = super::utils::effective_workspace_root(is_docker, &host_workspace);
+    let workspace_dir = super::utils::effective_workspace_root_with_docker_root(
+        is_docker,
+        &host_workspace,
+        &docker_root,
+    );
     let shell_cwd = match shell_manager.get_shell_cwd(session_id).await {
         Some(cwd) => super::utils::display_shell_cwd(&cwd, &workspace_dir, is_docker),
         None => ".".to_string(),
@@ -159,9 +163,10 @@ pub async fn build_context_prompt(
 
     let file_tools_list = workspace_file_tools_context_list();
     let isolation_lines = if state.is_docker {
+        let root = &state.workspace_dir;
         format!(
-            "- Isolation: Docker (shell commands run in a Linux container; workspace root is /workspace)\n\
-             - File tools ({file_tools_list}) access the same /workspace files via the host bind mount; changes outside /workspace are visible to shell only, not to file tools\n"
+            "- Isolation: Docker (shell commands run in a Linux container; workspace root is {root})\n\
+             - File tools ({file_tools_list}) access the same {root} files (bind mount or attach sync); changes outside {root} are visible to shell only, not to file tools\n"
         )
     } else {
         String::new()

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/apply.rs
@@ -344,6 +344,25 @@ pub(super) async fn prepare_file_edit_batch(
         }
     };
 
+    let target_session_id = session_id
+        .clone()
+        .unwrap_or_else(|| server.session_id.clone());
+    if let Err(sync_error) = server
+        .sync_attach_before_host_read(&resolved_path, Some(target_session_id.as_str()))
+        .await
+    {
+        return Err(guided_error(
+            ErrorCategory::OperationFailed,
+            format!("Failed to sync attached container file before edit: {sync_error}"),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Verify the Harbor/Docker container is still running".to_string(),
+            "Retry editFile after confirming docker exec works".to_string(),
+        ])
+        .to_mcp_result());
+    }
+
     let original_content = match read_validated_text_file(&resolved_path).await {
         Ok(content) => content,
         Err(error) => {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/edit_line/mod.rs
@@ -53,7 +53,7 @@ async fn validate_edit_target_path(
     session_id: Option<String>,
 ) -> Result<(), MCPResult> {
     let safe_path = match server
-        .validate_write_path_with_teamwork_access(path_str, session_id)
+        .validate_write_path_with_teamwork_access(path_str, session_id.clone())
         .await
     {
         Ok(path) => path,
@@ -70,6 +70,23 @@ async fn validate_edit_target_path(
             .to_mcp_result());
         }
     };
+
+    let target_session_id = session_id.unwrap_or_else(|| server.session_id.clone());
+    if let Err(sync_error) = server
+        .sync_attach_before_host_read(&safe_path, Some(target_session_id.as_str()))
+        .await
+    {
+        return Err(guided_error(
+            ErrorCategory::OperationFailed,
+            format!("Failed to sync attached container file before edit: {sync_error}"),
+            ToolGroup::Workspace,
+        )
+        .guidance(vec![
+            "Verify the Harbor/Docker container is still running".to_string(),
+            "Retry editFile after confirming docker exec works".to_string(),
+        ])
+        .to_mcp_result());
+    }
 
     if !safe_path.exists() {
         return Err(guided_error(
@@ -139,6 +156,17 @@ async fn write_prepared_batches(
                     {
                         rollback_failures
                             .push(format!("{} ({})", previous_batch.path, rollback_error));
+                        continue;
+                    }
+                    let host_path = std::path::Path::new(&previous_batch.resolved_path);
+                    if let Err(sync_error) = server
+                        .sync_attach_after_host_write(host_path, Some(target_session_id.as_str()))
+                        .await
+                    {
+                        rollback_failures.push(format!(
+                            "{} (attach sync: {sync_error})",
+                            previous_batch.path
+                        ));
                     }
                 }
             }
@@ -159,6 +187,70 @@ async fn write_prepared_batches(
                 "Check file permissions and available disk space".to_string(),
                 "Rerun readFile(showLineAnchors=true) before retrying if files may have changed"
                     .to_string(),
+            ])
+            .to_mcp_result());
+        }
+
+        let host_path = std::path::Path::new(&resolved_path);
+        if let Err(sync_error) = server
+            .sync_attach_after_host_write(host_path, Some(target_session_id.as_str()))
+            .await
+        {
+            // Keep host + container consistent: restore this file and previously synced files.
+            let mut rollback_failures = Vec::new();
+            let _ = file_manager
+                .write_file_string(&resolved_path, &batch.original_content)
+                .await;
+            for written_path in written_paths.iter().rev() {
+                if let Some(previous_batch) = prepared_batches
+                    .iter()
+                    .find(|candidate| &candidate.resolved_path == written_path)
+                {
+                    if let Err(rollback_error) = file_manager
+                        .write_file_string(
+                            &previous_batch.resolved_path,
+                            &previous_batch.original_content,
+                        )
+                        .await
+                    {
+                        rollback_failures
+                            .push(format!("{} ({})", previous_batch.path, rollback_error));
+                        continue;
+                    }
+                    let previous_host = std::path::Path::new(&previous_batch.resolved_path);
+                    if let Err(previous_sync_error) = server
+                        .sync_attach_after_host_write(
+                            previous_host,
+                            Some(target_session_id.as_str()),
+                        )
+                        .await
+                    {
+                        rollback_failures.push(format!(
+                            "{} (attach sync: {previous_sync_error})",
+                            previous_batch.path
+                        ));
+                    }
+                }
+            }
+
+            let rollback_note = if rollback_failures.is_empty() {
+                "Earlier synced edits in this request were rolled back.".to_string()
+            } else {
+                format!("Rollback failed for: {}", rollback_failures.join(", "))
+            };
+
+            return Err(guided_error(
+                ErrorCategory::OperationFailed,
+                format!(
+                    "File '{}' was updated locally but failed to sync into the attached container: {sync_error}",
+                    batch.path
+                ),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                rollback_note,
+                "Verify the Harbor/Docker container is still running".to_string(),
+                "Retry the edit after confirming docker exec works".to_string(),
             ])
             .to_mcp_result());
         }

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/list_dir.rs
@@ -46,7 +46,7 @@ impl WorkspaceServer {
         let workspace_root = self.get_workspace_dir(&target_session_id);
 
         let safe_path = match self
-            .validate_read_path_with_skill_access(&path_str, Some(target_session_id))
+            .validate_read_path_with_skill_access(&path_str, Some(target_session_id.clone()))
             .await
         {
             Ok(path) => path,
@@ -64,6 +64,90 @@ impl WorkspaceServer {
                 .to_mcp_result());
             }
         };
+
+        if let Some(session) =
+            crate::services::container_attach_fs::load_session(&target_session_id)
+                .await
+                .ok()
+                .flatten()
+        {
+            match crate::services::container_attach_fs::list_container_directory(
+                &session, &safe_path,
+            )
+            .await
+            {
+                Ok(Some(entries)) => {
+                    let total = entries.len();
+                    let page: Vec<_> = entries
+                        .into_iter()
+                        .skip(offset)
+                        .take(limit)
+                        .map(|entry| {
+                            json!({
+                                "name": entry.name,
+                                "type": entry.entry_type,
+                                "size": null,
+                            })
+                        })
+                        .collect();
+                    let shown = page.len();
+                    let message = if total == 0 {
+                        format!("Directory listing for '{path_str}':\n\n(This directory is empty)")
+                    } else {
+                        format!(
+                            "Directory listing for '{path_str}' (attached container, showing {shown} of {total}):\n\n{}",
+                            page.iter()
+                                .map(|item| {
+                                    let name =
+                                        item.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                                    let kind =
+                                        item.get("type").and_then(|v| v.as_str()).unwrap_or("file");
+                                    if kind == "directory" {
+                                        format!("- {name}/")
+                                    } else {
+                                        format!("- {name}")
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        )
+                    };
+                    return Ok(SuccessHint::new(
+                        message,
+                        vec![
+                            "Use readFile on files (not directories) to inspect contents"
+                                .to_string(),
+                            "Use listDirectory on subdirectory names ending with '/'".to_string(),
+                        ],
+                    )
+                    .to_mcp_result_with_data(Some(json!({
+                        "path": path_str,
+                        "entries": page,
+                        "total": total,
+                        "offset": offset,
+                        "limit": limit,
+                        "source": "attach-container",
+                    }))));
+                }
+                Ok(None) => {
+                    // Not attach, or path is host-only (skills/teamwork) — fall through.
+                }
+                Err(error) => {
+                    return Ok(guided_error(
+                        ErrorCategory::OperationFailed,
+                        format!(
+                            "Failed to list '{path_str}' inside the attached container: {error}"
+                        ),
+                        ToolGroup::Workspace,
+                    )
+                    .guidance(vec![
+                        "Verify the Harbor/Docker container is still running".to_string(),
+                        "Retry listDirectory after confirming docker exec works".to_string(),
+                    ])
+                    .to_mcp_result());
+                }
+            }
+        }
 
         // If the validated path is actually a file, return a clear InvalidInput-style error
         if safe_path.is_file() {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/read.rs
@@ -141,6 +141,22 @@ impl WorkspaceServer {
             }
         };
 
+        if let Err(sync_error) = self
+            .sync_attach_before_host_read(&safe_path, session_id.as_deref())
+            .await
+        {
+            return Ok(guided_error(
+                ErrorCategory::OperationFailed,
+                format!("Failed to sync attached container file before read: {sync_error}"),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Verify the Harbor/Docker container is still running".to_string(),
+                "Retry readFile after confirming docker exec works".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
         // 5. File existence check
         if !safe_path.exists() {
             return Ok(not_found_error("File", path_str, ToolGroup::Workspace));

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
@@ -132,6 +132,22 @@ impl WorkspaceServer {
             }
         };
 
+        if let Err(error) = self
+            .sync_attach_before_host_read(&safe_path, session_id.as_deref())
+            .await
+        {
+            return Ok(guided_error(
+                ErrorCategory::OperationFailed,
+                format!("Failed to sync attached container file before edit: {error}"),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Verify the Harbor/Docker container is still running".to_string(),
+                "Retry after confirming docker exec works".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
         if !safe_path.exists() {
             return Ok(not_found_error("file", path_str, ToolGroup::Workspace));
         }
@@ -200,6 +216,20 @@ impl WorkspaceServer {
             return Ok(guided_error(
                 ErrorCategory::InternalError,
                 format!("Failed to write file: {error}"),
+                ToolGroup::Workspace,
+            )
+            .to_mcp_result());
+        }
+
+        if let Err(sync_error) = self
+            .sync_attach_after_host_write(&safe_path, session_id.as_deref())
+            .await
+        {
+            return Ok(guided_error(
+                ErrorCategory::OperationFailed,
+                format!(
+                    "File was updated locally but failed to sync into the attached container: {sync_error}"
+                ),
                 ToolGroup::Workspace,
             )
             .to_mcp_result());

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -241,6 +241,22 @@ impl WorkspaceServer {
             }
         };
 
+        if let Err(sync_error) = self
+            .sync_attach_before_host_read(&safe_path, Some(target_session_id.as_str()))
+            .await
+        {
+            return Ok(guided_error(
+                ErrorCategory::OperationFailed,
+                format!("Failed to sync attached container file before write: {sync_error}"),
+                ToolGroup::Workspace,
+            )
+            .guidance(vec![
+                "Verify the Harbor/Docker container is still running".to_string(),
+                "Retry writeFile after confirming docker exec works".to_string(),
+            ])
+            .to_mcp_result());
+        }
+
         // Resolve the actual write target.
         // mode=create: if the path already exists, keep it and write to stem-N.ext instead
         // (avoids discarding already-generated content / forcing a costly retry).
@@ -359,6 +375,24 @@ impl WorkspaceServer {
 
         match result {
             Ok(()) => {
+                if let Err(sync_error) = self
+                    .sync_attach_after_host_write(&write_safe_path, Some(&target_session_id))
+                    .await
+                {
+                    return Ok(guided_error(
+                        ErrorCategory::OperationFailed,
+                        format!(
+                            "File was written to staging but failed to sync into the attached container: {sync_error}"
+                        ),
+                        ToolGroup::Workspace,
+                    )
+                    .guidance(vec![
+                        "Verify the Harbor/Docker container is still running".to_string(),
+                        "Retry writeFile after confirming docker exec works".to_string(),
+                    ])
+                    .to_mcp_result());
+                }
+
                 self.invalidate_context_cache().await;
 
                 let max_display_lines = 100;

--- a/src-tauri/src/mcp/builtin/workspace/utils.rs
+++ b/src-tauri/src/mcp/builtin/workspace/utils.rs
@@ -1,3 +1,4 @@
+use crate::models::workspace_isolation::DEFAULT_DOCKER_WORKDIR;
 use crate::session_isolation::IsolationLevel;
 use regex::Regex;
 use serde_json::Value;
@@ -8,7 +9,8 @@ pub const INTERNAL_WORKSPACE_STATE_DIR: &str = ".libragent";
 pub const INTERNAL_WORKSPACE_TMP_DIR: &str = "tmp";
 pub const INTERNAL_WORKSPACE_EXPORTS_DIR: &str = "exports";
 pub const MAX_SYNC_EXECUTION_TIMEOUT_SECONDS: u64 = 300;
-pub const DOCKER_WORKSPACE_ROOT: &str = "/workspace";
+/// Alias kept for call sites; single source of truth is `DEFAULT_DOCKER_WORKDIR`.
+pub const DOCKER_WORKSPACE_ROOT: &str = DEFAULT_DOCKER_WORKDIR;
 
 /// Get configured shell isolation level from settings
 /// Returns the configured isolation level or Medium as default
@@ -183,8 +185,16 @@ pub fn normalize_workspace_path(path: &str) -> String {
 
 /// Resolve the workspace root shown to the agent and returned in shell tool responses.
 pub fn effective_workspace_root(is_docker: bool, host_workspace: &Path) -> String {
+    effective_workspace_root_with_docker_root(is_docker, host_workspace, DOCKER_WORKSPACE_ROOT)
+}
+
+pub fn effective_workspace_root_with_docker_root(
+    is_docker: bool,
+    host_workspace: &Path,
+    docker_root: &str,
+) -> String {
     if is_docker {
-        DOCKER_WORKSPACE_ROOT.to_string()
+        docker_root.trim_end_matches('/').to_string()
     } else {
         normalize_workspace_path(&host_workspace.to_string_lossy())
     }
@@ -193,11 +203,12 @@ pub fn effective_workspace_root(is_docker: bool, host_workspace: &Path) -> Strin
 /// Format persistent-shell CWD for agent context (relative to workspace root when possible).
 pub fn display_shell_cwd(raw_cwd: &str, workspace_dir: &str, is_docker: bool) -> String {
     let cwd = normalize_workspace_path(raw_cwd);
+    let root = workspace_dir.trim_end_matches('/');
 
     if is_docker {
-        if cwd == DOCKER_WORKSPACE_ROOT {
+        if cwd == root {
             ".".to_string()
-        } else if let Some(relative) = cwd.strip_prefix("/workspace/") {
+        } else if let Some(relative) = cwd.strip_prefix(&format!("{root}/")) {
             format!("./{relative}")
         } else {
             cwd
@@ -211,22 +222,32 @@ pub fn display_shell_cwd(raw_cwd: &str, workspace_dir: &str, is_docker: bool) ->
 
 /// Helper to check if a session is Docker isolated.
 pub async fn is_session_docker_isolated(session_id: &str) -> bool {
+    session_docker_root(session_id).await.0
+}
+
+/// Single DB read for Docker isolation + configured workdir (`/workspace` or attach `/app`).
+pub async fn session_docker_root(session_id: &str) -> (bool, String) {
     use crate::models::workspace_isolation::WorkspaceIsolationMode;
     use crate::repositories::session_repository::SessionRepository;
 
     if let Some(session_repo) = crate::state::try_get_session_repository() {
-        match session_repo.get_session(session_id).await {
-            Ok(Some(session)) => session.workspace_isolation == WorkspaceIsolationMode::Docker,
-            Ok(None) | Err(_) => false,
+        if let Ok(Some(session)) = session_repo.get_session(session_id).await {
+            let is_docker = session.workspace_isolation == WorkspaceIsolationMode::Docker;
+            let workdir = session
+                .docker_config
+                .as_ref()
+                .map(|config| config.workdir().to_string())
+                .unwrap_or_else(|| DEFAULT_DOCKER_WORKDIR.to_string());
+            return (is_docker, workdir);
         }
-    } else {
-        false
     }
+    (false, DEFAULT_DOCKER_WORKDIR.to_string())
 }
 
 /// CWD reported by isolated/async shell tools for a session.
 pub async fn effective_command_cwd(session_id: &str, host_workspace: &Path) -> String {
-    effective_workspace_root(is_session_docker_isolated(session_id).await, host_workspace)
+    let (is_docker, docker_root) = session_docker_root(session_id).await;
+    effective_workspace_root_with_docker_root(is_docker, host_workspace, &docker_root)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
+++ b/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
@@ -602,14 +602,52 @@ impl WorkspaceServer {
         let host_workspace = session.docker_host_workspace_path.as_ref().ok_or_else(|| {
             format!("Missing Docker host workspace path for session {target_session_id}")
         })?;
-        let mapper = PathMappingLayer::new(PathBuf::from(host_workspace));
+        let workdir = session
+            .docker_config
+            .as_ref()
+            .map(|config| config.workdir().to_string())
+            .unwrap_or_else(|| {
+                crate::models::workspace_isolation::DEFAULT_DOCKER_WORKDIR.to_string()
+            });
+        let mapper = PathMappingLayer::with_container_root(PathBuf::from(host_workspace), &workdir);
         let Some(host_path) = mapper.container_to_host(path_str) else {
             return Err(format!(
-                "Docker container path '{path_str}' is outside /workspace. Shell commands may access it, but workspace file tools only map /workspace paths to the host workspace."
+                "Docker container path '{path_str}' is outside {workdir}. Shell commands may access it, but workspace file tools only map {workdir} paths to the host workspace."
             ));
         };
 
         Ok(Some(host_path.to_string_lossy().to_string()))
+    }
+
+    /// After a mutating file tool write, push staging → attach container when needed.
+    pub async fn sync_attach_after_host_write(
+        &self,
+        host_path: &std::path::Path,
+        session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let target_session_id = session_id.unwrap_or(self.session_id.as_str());
+        let Some(session) =
+            crate::services::container_attach_fs::load_session(target_session_id).await?
+        else {
+            return Ok(());
+        };
+        crate::services::container_attach_fs::push_host_file_to_container(&session, host_path).await
+    }
+
+    /// Before reading a staged path, pull attach container → staging when needed.
+    /// Propagates docker failures for workdir paths so tools do not read stale staging.
+    pub async fn sync_attach_before_host_read(
+        &self,
+        host_path: &std::path::Path,
+        session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let target_session_id = session_id.unwrap_or(self.session_id.as_str());
+        let Some(session) =
+            crate::services::container_attach_fs::load_session(target_session_id).await?
+        else {
+            return Ok(());
+        };
+        crate::services::container_attach_fs::pull_container_file_to_host(&session, host_path).await
     }
 
     /// Validate path with security checks (helper for file operations)

--- a/src-tauri/src/models/workspace_isolation.rs
+++ b/src-tauri/src/models/workspace_isolation.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
+pub const DEFAULT_DOCKER_WORKDIR: &str = "/workspace";
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkspaceIsolationMode {
@@ -41,7 +43,20 @@ impl FromStr for WorkspaceIsolationMode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DockerWorkspaceConfig {
-    pub image: String,
+    /// Image for managed LibrAgent Docker sessions. Optional when attaching to an
+    /// existing container (`attach_container`).
+    #[serde(default)]
+    pub image: Option<String>,
+    /// Existing Docker container id/name to attach instead of creating one.
+    #[serde(default)]
+    pub attach_container: Option<String>,
+    /// Container working directory / file-tool root. Defaults to `/workspace`.
+    #[serde(default)]
+    pub workdir: Option<String>,
+    /// When false, session cleanup must not stop/remove the container.
+    /// Defaults to true for managed containers.
+    #[serde(default)]
+    pub manage_lifecycle: Option<bool>,
     #[serde(default)]
     pub env: HashMap<String, String>,
     #[serde(default)]
@@ -56,9 +71,59 @@ pub struct DockerPortBinding {
 }
 
 impl DockerWorkspaceConfig {
+    pub fn is_attach(&self) -> bool {
+        self.attach_container
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    pub fn attach_container_name(&self) -> Option<&str> {
+        self.attach_container
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn image_ref(&self) -> Option<&str> {
+        self.image
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn workdir(&self) -> &str {
+        self.workdir
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_DOCKER_WORKDIR)
+    }
+
+    pub fn manage_lifecycle(&self) -> bool {
+        self.manage_lifecycle.unwrap_or(true)
+    }
+
     pub fn validate(&self) -> Result<(), String> {
-        if self.image.trim().is_empty() {
-            return Err("Docker image cannot be empty".to_string());
+        let has_attach = self.is_attach();
+        let has_image = self.image_ref().is_some();
+
+        if !has_attach && !has_image {
+            return Err(
+                "Docker config requires either 'image' (managed) or 'attachContainer' (attach)"
+                    .to_string(),
+            );
+        }
+
+        if has_attach {
+            let workdir = self.workdir();
+            if !workdir.starts_with('/') {
+                return Err(format!(
+                    "Docker workdir must be an absolute Unix path, got '{workdir}'"
+                ));
+            }
+            if workdir.contains('\0') {
+                return Err("Docker workdir must not contain NUL bytes".to_string());
+            }
         }
 
         for (key, value) in &self.env {

--- a/src-tauri/src/services/container_attach_fs.rs
+++ b/src-tauri/src/services/container_attach_fs.rs
@@ -237,13 +237,25 @@ fn parse_ls_apf_entry(raw: &str) -> ContainerDirEntry {
 }
 
 /// Resolve session metadata for attach sync helpers.
+///
+/// Returns `Ok(None)` when the repository is unavailable, the session is missing,
+/// or metadata cannot be loaded. Callers must only treat docker sync failures as
+/// hard errors after confirming the session is attach-mode.
 pub async fn load_session(session_id: &str) -> Result<Option<SessionMetadata>, String> {
     let Some(repo) = crate::state::try_get_session_repository() else {
         return Ok(None);
     };
-    repo.get_session(session_id)
-        .await
-        .map_err(|e| format!("Failed to load session for attach sync: {e}"))
+    match repo.get_session(session_id).await {
+        Ok(session) => Ok(session),
+        Err(error) => {
+            tracing::warn!(
+                session_id,
+                error = %error,
+                "Skipping attach sync; failed to load session metadata"
+            );
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/container_attach_fs.rs
+++ b/src-tauri/src/services/container_attach_fs.rs
@@ -1,0 +1,316 @@
+//! File sync helpers for Docker attach mode (Harbor task containers).
+//!
+//! Staging host workspace is a buffer; the attached container workdir is source of truth.
+
+use std::path::Path;
+
+use crate::models::workspace_isolation::WorkspaceIsolationMode;
+use crate::repositories::session_repository::SessionRepository;
+use crate::repositories::SessionMetadata;
+use tokio::process::Command as AsyncCommand;
+
+fn apply_docker_cli_env(cmd: &mut AsyncCommand) {
+    if let Ok(host) = std::env::var("DOCKER_HOST") {
+        cmd.env("DOCKER_HOST", host);
+    }
+    if let Ok(context) = std::env::var("DOCKER_CONTEXT") {
+        cmd.env("DOCKER_CONTEXT", context);
+    }
+}
+
+/// Returns attach session metadata when the session is Docker-attach mode.
+pub fn attach_session_info(session: &SessionMetadata) -> Option<AttachSessionInfo<'_>> {
+    if session.workspace_isolation != WorkspaceIsolationMode::Docker {
+        return None;
+    }
+    let config = session.docker_config.as_ref()?;
+    if !config.is_attach() {
+        return None;
+    }
+    let container = config.attach_container_name()?;
+    let host_workspace = session.docker_host_workspace_path.as_deref()?;
+    Some(AttachSessionInfo {
+        container,
+        workdir: config.workdir(),
+        host_workspace: Path::new(host_workspace),
+    })
+}
+
+pub struct AttachSessionInfo<'a> {
+    pub container: &'a str,
+    pub workdir: &'a str,
+    pub host_workspace: &'a Path,
+}
+
+impl AttachSessionInfo<'_> {
+    pub fn container_path_for_host_file(&self, host_file: &Path) -> Result<String, String> {
+        let relative = host_file.strip_prefix(self.host_workspace).map_err(|_| {
+            format!(
+                "Host path '{}' is outside attach staging workspace '{}'",
+                host_file.display(),
+                self.host_workspace.display()
+            )
+        })?;
+        let rel = relative.to_string_lossy().replace('\\', "/");
+        if rel.is_empty() || rel == "." {
+            Ok(self.workdir.trim_end_matches('/').to_string())
+        } else {
+            Ok(format!(
+                "{}/{}",
+                self.workdir.trim_end_matches('/'),
+                rel.trim_start_matches('/')
+            ))
+        }
+    }
+}
+
+async fn run_docker(args: &[&str]) -> Result<(), String> {
+    let mut cmd = AsyncCommand::new("docker");
+    apply_docker_cli_env(&mut cmd);
+    cmd.args(args);
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run docker {}: {e}", args.join(" ")))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Err(format!(
+        "docker {} failed: {}{}",
+        args.join(" "),
+        stderr.trim(),
+        if stderr.is_empty() { stdout.trim() } else { "" }
+    ))
+}
+
+async fn run_docker_stdout(args: &[&str]) -> Result<String, String> {
+    let mut cmd = AsyncCommand::new("docker");
+    apply_docker_cli_env(&mut cmd);
+    cmd.args(args);
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run docker {}: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "docker {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Ensure parent directories exist inside the container for `container_path`.
+async fn ensure_container_parent_dirs(container: &str, container_path: &str) -> Result<(), String> {
+    let parent = Path::new(container_path)
+        .parent()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .filter(|p| !p.is_empty() && p != "/");
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    run_docker(&["exec", container, "mkdir", "-p", &parent]).await
+}
+
+/// Push a staged host file into the attached container.
+pub async fn push_host_file_to_container(
+    session: &SessionMetadata,
+    host_file: &Path,
+) -> Result<(), String> {
+    let Some(info) = attach_session_info(session) else {
+        return Ok(());
+    };
+    if host_file.strip_prefix(info.host_workspace).is_err() {
+        // Teamwork / skill / other host-only roots — not mirrored into the task container.
+        return Ok(());
+    }
+    if !host_file.is_file() {
+        return Err(format!(
+            "Cannot push missing host file '{}' to attach container",
+            host_file.display()
+        ));
+    }
+    let container_path = info.container_path_for_host_file(host_file)?;
+    ensure_container_parent_dirs(info.container, &container_path).await?;
+    let dest = format!("{}:{}", info.container, container_path);
+    run_docker(&["cp", &host_file.to_string_lossy(), &dest]).await
+}
+
+/// Pull a container file into the staging host workspace.
+///
+/// Returns `Ok(())` when the session is not attach-mode, or the path is host-only
+/// (skills/teamwork outside staging). Missing remote files are soft-ok; other docker
+/// failures propagate so callers do not silently read stale staging content.
+pub async fn pull_container_file_to_host(
+    session: &SessionMetadata,
+    host_file: &Path,
+) -> Result<(), String> {
+    let Some(info) = attach_session_info(session) else {
+        return Ok(());
+    };
+    if host_file.strip_prefix(info.host_workspace).is_err() {
+        // Skill / teamwork / other host-only roots — no container sync.
+        return Ok(());
+    }
+    let container_path = info.container_path_for_host_file(host_file)?;
+    if let Some(parent) = host_file.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            format!(
+                "Failed to create staging parent '{}': {e}",
+                parent.display()
+            )
+        })?;
+    }
+    let source = format!("{}:{}", info.container, container_path);
+    match run_docker(&["cp", &source, &host_file.to_string_lossy()]).await {
+        Ok(()) => Ok(()),
+        Err(err) if is_missing_container_path_error(&err) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+fn is_missing_container_path_error(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("no such file")
+        || lower.contains("cannot find the file")
+        || lower.contains("could not find the file")
+        || lower.contains("does not exist")
+}
+
+/// List directory entries inside the attached container.
+///
+/// - `Ok(None)` — not an attach session, or path is outside staging (use host listing).
+/// - `Ok(Some(_))` — container listing.
+/// - `Err(_)` — attach path under staging but docker listing failed (do not fall back).
+pub async fn list_container_directory(
+    session: &SessionMetadata,
+    host_dir: &Path,
+) -> Result<Option<Vec<ContainerDirEntry>>, String> {
+    let Some(info) = attach_session_info(session) else {
+        return Ok(None);
+    };
+    if host_dir.strip_prefix(info.host_workspace).is_err() {
+        return Ok(None);
+    }
+    let container_path = info.container_path_for_host_file(host_dir)?;
+    let output =
+        run_docker_stdout(&["exec", info.container, "ls", "-1ApF", &container_path]).await?;
+    let entries = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(parse_ls_apf_entry)
+        .collect();
+    Ok(Some(entries))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerDirEntry {
+    pub name: String,
+    /// `"file"` or `"directory"` for agent tool consumers.
+    pub entry_type: &'static str,
+}
+
+/// Parse `ls -1ApF` output: directories end with `/`; strip other `-F` indicators.
+fn parse_ls_apf_entry(raw: &str) -> ContainerDirEntry {
+    if let Some(name) = raw.strip_suffix('/') {
+        return ContainerDirEntry {
+            name: name.to_string(),
+            entry_type: "directory",
+        };
+    }
+    let name = raw
+        .strip_suffix('*')
+        .or_else(|| raw.strip_suffix('@'))
+        .or_else(|| raw.strip_suffix('|'))
+        .or_else(|| raw.strip_suffix('='))
+        .or_else(|| raw.strip_suffix('>'))
+        .unwrap_or(raw);
+    ContainerDirEntry {
+        name: name.to_string(),
+        entry_type: "file",
+    }
+}
+
+/// Resolve session metadata for attach sync helpers.
+pub async fn load_session(session_id: &str) -> Result<Option<SessionMetadata>, String> {
+    let Some(repo) = crate::state::try_get_session_repository() else {
+        return Ok(None);
+    };
+    repo.get_session(session_id)
+        .await
+        .map_err(|e| format!("Failed to load session for attach sync: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attach_session_info_builds_container_paths_under_workdir() {
+        let info = AttachSessionInfo {
+            container: "abc",
+            workdir: "/app",
+            host_workspace: Path::new("/tmp/staging"),
+        };
+        assert_eq!(
+            info.container_path_for_host_file(Path::new("/tmp/staging/gpt2.c"))
+                .expect("path under staging"),
+            "/app/gpt2.c"
+        );
+        assert_eq!(
+            info.container_path_for_host_file(Path::new("/tmp/staging"))
+                .expect("staging root"),
+            "/app"
+        );
+        assert!(info
+            .container_path_for_host_file(Path::new("/tmp/other/file"))
+            .is_err());
+    }
+
+    #[test]
+    fn parse_ls_apf_entry_distinguishes_directories() {
+        assert_eq!(
+            parse_ls_apf_entry("src/"),
+            ContainerDirEntry {
+                name: "src".to_string(),
+                entry_type: "directory",
+            }
+        );
+        assert_eq!(
+            parse_ls_apf_entry("gpt2.c"),
+            ContainerDirEntry {
+                name: "gpt2.c".to_string(),
+                entry_type: "file",
+            }
+        );
+        assert_eq!(
+            parse_ls_apf_entry("run*"),
+            ContainerDirEntry {
+                name: "run".to_string(),
+                entry_type: "file",
+            }
+        );
+        assert_eq!(
+            parse_ls_apf_entry("link@"),
+            ContainerDirEntry {
+                name: "link".to_string(),
+                entry_type: "file",
+            }
+        );
+    }
+
+    #[test]
+    fn missing_container_path_errors_are_detected() {
+        assert!(is_missing_container_path_error(
+            "docker cp failed: No such file or directory"
+        ));
+        assert!(!is_missing_container_path_error(
+            "docker cp failed: permission denied"
+        ));
+    }
+}

--- a/src-tauri/src/services/docker_provisioning.rs
+++ b/src-tauri/src/services/docker_provisioning.rs
@@ -24,11 +24,23 @@ pub struct DockerProvisioningDeps {
 
 struct DockerRuntimeStepParams<'a> {
     session_id: &'a str,
-    image: &'a str,
+    /// Managed image or `attach:<container>`; `None` when unavailable (never a fake sentinel).
+    image: Option<&'a str>,
     step: &'a str,
     failed: bool,
     is_final: bool,
     error: Option<&'a str>,
+}
+
+fn docker_runtime_image_label(
+    config: &crate::models::workspace_isolation::DockerWorkspaceConfig,
+) -> Option<String> {
+    if let Some(image) = config.image_ref() {
+        return Some(image.to_string());
+    }
+    config
+        .attach_container_name()
+        .map(|name| format!("attach:{name}"))
 }
 
 pub fn spawn_docker_provisioning(
@@ -137,15 +149,14 @@ async fn run_docker_provisioning(
     let image = session
         .docker_config
         .as_ref()
-        .map(|config| config.image.clone())
-        .ok_or_else(|| "dockerConfig is required for Docker workspace isolation".to_string())?;
+        .and_then(docker_runtime_image_label);
 
     emit_docker_runtime_step(
         &deps.proxy_manager,
         Some(&deps.app_handle),
         DockerRuntimeStepParams {
             session_id: &session.id,
-            image: &image,
+            image: image.as_deref(),
             step: "Preparing Docker workspace",
             failed: false,
             is_final: false,
@@ -171,7 +182,7 @@ async fn run_docker_provisioning(
                 Some(&app_handle),
                 DockerRuntimeStepParams {
                     session_id: &session_id,
-                    image: &image,
+                    image: image.as_deref(),
                     step: &step,
                     failed: false,
                     is_final: false,
@@ -196,24 +207,22 @@ async fn complete_docker_provisioning(
         active
             .get(session_id)
             .and_then(|session| session.metadata.docker_config.as_ref())
-            .map(|config| config.image.clone())
+            .and_then(docker_runtime_image_label)
     };
 
-    if let Some(image) = image.as_ref() {
-        emit_docker_runtime_step(
-            &deps.proxy_manager,
-            Some(&deps.app_handle),
-            DockerRuntimeStepParams {
-                session_id,
-                image,
-                step: "Docker workspace ready",
-                failed: false,
-                is_final: true,
-                error: None,
-            },
-        )
-        .await;
-    }
+    emit_docker_runtime_step(
+        &deps.proxy_manager,
+        Some(&deps.app_handle),
+        DockerRuntimeStepParams {
+            session_id,
+            image: image.as_deref(),
+            step: "Docker workspace ready",
+            failed: false,
+            is_final: true,
+            error: None,
+        },
+    )
+    .await;
 
     crate::agent::lifecycle::update_session_status(
         &deps.session_repo,
@@ -236,15 +245,14 @@ async fn fail_docker_provisioning(
     let image = session
         .docker_config
         .as_ref()
-        .map(|config| config.image.clone())
-        .unwrap_or_else(|| "unknown".to_string());
+        .and_then(docker_runtime_image_label);
 
     emit_docker_runtime_step(
         &deps.proxy_manager,
         Some(&deps.app_handle),
         DockerRuntimeStepParams {
             session_id: &session.id,
-            image: &image,
+            image: image.as_deref(),
             step: "Docker workspace setup failed",
             failed: true,
             is_final: false,
@@ -287,7 +295,7 @@ async fn emit_docker_runtime_step(
         is_final,
         error,
     } = params;
-    let image = image.to_string();
+    let image = image.map(str::to_string);
     let step = step.to_string();
     let error = error.map(str::to_string);
 
@@ -310,7 +318,7 @@ async fn emit_docker_runtime_step(
             };
             state.initialization.error = error.clone();
             state.initialization.docker = Some(SessionRuntimeDockerState {
-                image,
+                image: image.clone(),
                 step: Some(step),
                 progress: None,
                 error,

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod assistant_init;
 pub mod assistant_service;
 pub mod attachments_service;
 pub mod browser_error;
+pub mod container_attach_fs;
 pub mod docker_provisioning;
 pub mod dropped_file_service;
 pub mod file_export_service;

--- a/src-tauri/src/services/workspace_runtime_manager.rs
+++ b/src-tauri/src/services/workspace_runtime_manager.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::models::workspace_isolation::{
-    validate_env_key, validate_env_value, WorkspaceIsolationMode,
+    validate_env_key, validate_env_value, WorkspaceIsolationMode, DEFAULT_DOCKER_WORKDIR,
 };
 use crate::repositories::{SessionMetadata, SessionRepository};
 use crate::session_isolation::{PathMappingLayer, ShellDialect, ShellType, SpawnedShell};
@@ -175,9 +175,10 @@ impl WorkspaceRuntimeManager {
         let shell = prepare_docker_runtime(session, true, true, None).await?;
 
         let container_name = docker_container_name(session)?;
+        let workdir = session_docker_workdir(session);
         let mut cmd = AsyncCommand::new("docker");
         apply_docker_cli_env(&mut cmd);
-        cmd.args(["exec", "-i", "-w", "/workspace"]);
+        cmd.args(["exec", "-i", "-w", &workdir]);
 
         let mut merged_env = session
             .docker_config
@@ -209,9 +210,10 @@ impl WorkspaceRuntimeManager {
 
         let container_name = docker_container_name(session)?;
         let host_workspace = docker_host_workspace_path(session)?;
+        let workdir = session_docker_workdir(session);
         let mut cmd = AsyncCommand::new("docker");
         apply_docker_cli_env(&mut cmd);
-        cmd.args(["exec", "-i", "-w", "/workspace"]);
+        cmd.args(["exec", "-i", "-w", &workdir]);
 
         if let Some(config) = &session.docker_config {
             for (key, value) in &config.env {
@@ -237,8 +239,8 @@ impl WorkspaceRuntimeManager {
 
         Ok(SpawnedShell {
             child,
-            initial_cwd: "/workspace".to_string(),
-            path_mapper: PathMappingLayer::new(host_workspace),
+            initial_cwd: workdir,
+            path_mapper: path_mapper_for_session(session, host_workspace),
             shell_type: shell,
             shell_dialect: match shell {
                 ShellType::Bash => ShellDialect::Bash,
@@ -254,6 +256,10 @@ impl WorkspaceRuntimeManager {
         }
 
         clear_session_docker_caches(&session.id);
+
+        if !session_manage_lifecycle(session) {
+            return Ok(());
+        }
 
         Self::healthcheck().await?;
         let container_name = docker_container_name(session)?;
@@ -387,8 +393,9 @@ async fn prepare_docker_runtime(
     let image = session
         .docker_config
         .as_ref()
-        .map(|config| config.image.clone())
-        .unwrap_or_else(|| "unknown".to_string());
+        .and_then(|config| config.image_ref())
+        .unwrap_or("attached")
+        .to_string();
     let shell = ensure_bash_image_contract(
         &session.id,
         &container_name,
@@ -440,6 +447,24 @@ async fn ensure_bash_image_contract(
     image: &str,
     reporter: Option<&DockerStepReporter>,
 ) -> RuntimeResult<ShellType> {
+    if session_is_attach(session) {
+        if !docker_container_exists(container_name).await? {
+            return Err(WorkspaceRuntimeError::DockerCommandFailed(format!(
+                "Attach container '{container_name}' was not found"
+            )));
+        }
+        if !docker_container_running(container_name).await? {
+            if let Some(reporter) = reporter {
+                reporter("Starting attached container");
+            }
+            run_docker_status(["start", container_name]).await?;
+        }
+        if let Some(reporter) = reporter {
+            reporter("Verifying shell");
+        }
+        return ensure_supported_shell(session_id, container_name).await;
+    }
+
     if docker_container_exists(container_name).await? {
         verify_container_label(container_name, session_id).await?;
         if !docker_container_running(container_name).await? {
@@ -456,6 +481,11 @@ async fn ensure_bash_image_contract(
         config
             .validate()
             .map_err(WorkspaceRuntimeError::InvalidConfig)?;
+        let image_ref = config.image_ref().ok_or_else(|| {
+            WorkspaceRuntimeError::InvalidConfig(
+                "Managed Docker sessions require an image".to_string(),
+            )
+        })?;
 
         tokio::fs::create_dir_all(host_workspace)
             .await
@@ -489,11 +519,12 @@ async fn ensure_bash_image_contract(
 
         let volume_args = build_docker_volume_args(host_workspace, tw_dir_arg)?;
         let label = format!("com.libragent.session_id={session_id}");
+        let workdir = session_docker_workdir(session);
         let mut cmd = AsyncCommand::new("docker");
         apply_docker_cli_env(&mut cmd);
         cmd.args(["run", "-d", "--name", container_name, "--label", &label]);
         cmd.args(volume_args);
-        cmd.args(["-w", "/workspace"]);
+        cmd.args(["-w", &workdir]);
 
         if let Some(config) = &session.docker_config {
             append_port_binding_args(&mut cmd, config).await?;
@@ -507,7 +538,7 @@ async fn ensure_bash_image_contract(
             reporter("Starting container");
         }
 
-        cmd.args([&config.image, "tail", "-f", "/dev/null"]);
+        cmd.args([image_ref, "tail", "-f", "/dev/null"]);
         run_status_command(cmd).await?;
     }
 
@@ -620,6 +651,33 @@ fn docker_host_workspace_path(session: &SessionMetadata) -> RuntimeResult<PathBu
         .as_ref()
         .map(PathBuf::from)
         .ok_or_else(|| WorkspaceRuntimeError::MissingHostWorkspacePath(session.id.clone()))
+}
+
+fn session_is_attach(session: &SessionMetadata) -> bool {
+    session
+        .docker_config
+        .as_ref()
+        .is_some_and(|config| config.is_attach())
+}
+
+fn session_manage_lifecycle(session: &SessionMetadata) -> bool {
+    session
+        .docker_config
+        .as_ref()
+        .map(|config| config.manage_lifecycle())
+        .unwrap_or(true)
+}
+
+pub(crate) fn session_docker_workdir(session: &SessionMetadata) -> String {
+    session
+        .docker_config
+        .as_ref()
+        .map(|config| config.workdir().to_string())
+        .unwrap_or_else(|| DEFAULT_DOCKER_WORKDIR.to_string())
+}
+
+fn path_mapper_for_session(session: &SessionMetadata, host_workspace: PathBuf) -> PathMappingLayer {
+    PathMappingLayer::with_container_root(host_workspace, session_docker_workdir(session))
 }
 
 fn docker_mount_path(path: &Path) -> RuntimeResult<String> {

--- a/src-tauri/src/session_isolation/path_mapper.rs
+++ b/src-tauri/src/session_isolation/path_mapper.rs
@@ -1,6 +1,8 @@
 use path_clean::PathClean;
 use std::path::{Path, PathBuf};
 
+use crate::models::workspace_isolation::DEFAULT_DOCKER_WORKDIR;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathMappingLayer {
     host_workspace: PathBuf,
@@ -9,9 +11,16 @@ pub struct PathMappingLayer {
 
 impl PathMappingLayer {
     pub fn new(host_workspace: PathBuf) -> Self {
+        Self::with_container_root(host_workspace, DEFAULT_DOCKER_WORKDIR)
+    }
+
+    pub fn with_container_root(
+        host_workspace: PathBuf,
+        container_workspace: impl AsRef<Path>,
+    ) -> Self {
         Self {
             host_workspace,
-            container_workspace: PathBuf::from("/workspace"),
+            container_workspace: PathBuf::from(container_workspace.as_ref()),
         }
     }
 
@@ -21,6 +30,14 @@ impl PathMappingLayer {
 
     pub fn container_workspace(&self) -> &Path {
         &self.container_workspace
+    }
+
+    fn container_root_unix(&self) -> String {
+        self.container_workspace
+            .to_string_lossy()
+            .replace('\\', "/")
+            .trim_end_matches('/')
+            .to_string()
     }
 
     pub fn container_to_host(&self, container_path: &str) -> Option<PathBuf> {
@@ -42,12 +59,13 @@ impl PathMappingLayer {
                 .replace('\\', "/")
         };
 
-        // Strict prefix matching against "/workspace"
-        if normalized == "/workspace" {
+        let root = self.container_root_unix();
+        if normalized == root {
             return Some(self.host_workspace.clone());
         }
 
-        if let Some(relative_str) = normalized.strip_prefix("/workspace/") {
+        let prefix = format!("{root}/");
+        if let Some(relative_str) = normalized.strip_prefix(&prefix) {
             if relative_str.is_empty() {
                 return Some(self.host_workspace.clone());
             }
@@ -88,5 +106,18 @@ mod tests {
         // Outside workspace or relative breakout attempts
         assert_eq!(mapper.container_to_host("/workspace/../outside"), None);
         assert_eq!(mapper.container_to_host("/other/path"), None);
+    }
+
+    #[test]
+    fn test_container_to_host_mapping_custom_root() {
+        let host = PathBuf::from("/tmp/staging");
+        let mapper = PathMappingLayer::with_container_root(host.clone(), "/app");
+
+        assert_eq!(mapper.container_to_host("/app"), Some(host.clone()));
+        assert_eq!(
+            mapper.container_to_host("/app/gpt2.c"),
+            Some(host.join("gpt2.c"))
+        );
+        assert_eq!(mapper.container_to_host("/workspace/gpt2.c"), None);
     }
 }

--- a/src-tauri/tests/integration/docker_workspace_isolation_smoke_tests.rs
+++ b/src-tauri/tests/integration/docker_workspace_isolation_smoke_tests.rs
@@ -66,7 +66,10 @@ async fn docker_workspace_run_shell_smoke_test() {
         workspace_override: None,
         workspace_isolation: WorkspaceIsolationMode::Docker,
         docker_config: Some(DockerWorkspaceConfig {
-            image: "ubuntu:24.04".to_string(),
+            image: Some("ubuntu:24.04".to_string()),
+            attach_container: None,
+            workdir: None,
+            manage_lifecycle: None,
             env: docker_env,
             port_bindings: Vec::new(),
         }),
@@ -176,7 +179,10 @@ async fn docker_workspace_persistent_shell_smoke_test() {
         workspace_override: None,
         workspace_isolation: WorkspaceIsolationMode::Docker,
         docker_config: Some(DockerWorkspaceConfig {
-            image: "ubuntu:24.04".to_string(),
+            image: Some("ubuntu:24.04".to_string()),
+            attach_container: None,
+            workdir: None,
+            manage_lifecycle: None,
             env: HashMap::new(),
             port_bindings: Vec::new(),
         }),
@@ -294,7 +300,10 @@ async fn docker_workspace_loopback_dynamic_port_smoke_test() {
         workspace_override: None,
         workspace_isolation: WorkspaceIsolationMode::Docker,
         docker_config: Some(DockerWorkspaceConfig {
-            image: "ubuntu:24.04".to_string(),
+            image: Some("ubuntu:24.04".to_string()),
+            attach_container: None,
+            workdir: None,
+            manage_lifecycle: None,
             env: HashMap::new(),
             port_bindings: vec![DockerPortBinding {
                 container_port: 8080,
@@ -379,7 +388,10 @@ async fn docker_workspace_sh_fallback_smoke_test() {
         workspace_override: None,
         workspace_isolation: WorkspaceIsolationMode::Docker,
         docker_config: Some(DockerWorkspaceConfig {
-            image: "alpine:3.20".to_string(),
+            image: Some("alpine:3.20".to_string()),
+            attach_container: None,
+            workdir: None,
+            manage_lifecycle: None,
             env: HashMap::new(),
             port_bindings: Vec::new(),
         }),

--- a/src-tauri/tests/integration/workspace_isolation_model_tests.rs
+++ b/src-tauri/tests/integration/workspace_isolation_model_tests.rs
@@ -27,14 +27,17 @@ fn docker_workspace_config_defaults_missing_env_to_empty_map() {
     }))
     .expect("config should deserialize");
 
-    assert_eq!(config.image, "ubuntu:24.04");
+    assert_eq!(config.image.as_deref(), Some("ubuntu:24.04"));
     assert!(config.env.is_empty());
 }
 
 #[test]
 fn docker_workspace_config_rejects_empty_image() {
     let config = DockerWorkspaceConfig {
-        image: "   ".to_string(),
+        image: Some("   ".to_string()),
+        attach_container: None,
+        workdir: None,
+        manage_lifecycle: None,
         env: Default::default(),
         port_bindings: Vec::new(),
     };
@@ -72,7 +75,10 @@ fn docker_workspace_config_accepts_loopback_port_bindings() {
 #[test]
 fn docker_workspace_config_rejects_duplicate_port_bindings() {
     let duplicate_container_port = DockerWorkspaceConfig {
-        image: "ubuntu:24.04".to_string(),
+        image: Some("ubuntu:24.04".to_string()),
+        attach_container: None,
+        workdir: None,
+        manage_lifecycle: None,
         env: Default::default(),
         port_bindings: vec![
             DockerPortBinding {
@@ -88,7 +94,10 @@ fn docker_workspace_config_rejects_duplicate_port_bindings() {
     assert!(duplicate_container_port.validate().is_err());
 
     let duplicate_host_port = DockerWorkspaceConfig {
-        image: "ubuntu:24.04".to_string(),
+        image: Some("ubuntu:24.04".to_string()),
+        attach_container: None,
+        workdir: None,
+        manage_lifecycle: None,
         env: Default::default(),
         port_bindings: vec![
             DockerPortBinding {
@@ -125,6 +134,45 @@ fn docker_env_key_validation_rejects_flag_like_or_invalid_names() {
 fn docker_env_value_validation_rejects_nul_bytes() {
     validate_env_value("TOKEN", "abc").expect("normal values should pass");
     assert!(validate_env_value("TOKEN", "abc\0def").is_err());
+}
+
+#[test]
+fn docker_workspace_config_accepts_attach_without_image() {
+    let config: DockerWorkspaceConfig = serde_json::from_value(serde_json::json!({
+        "attachContainer": "abc123",
+        "workdir": "/app",
+        "manageLifecycle": false
+    }))
+    .expect("attach config should deserialize");
+
+    assert!(config.is_attach());
+    assert_eq!(config.attach_container_name(), Some("abc123"));
+    assert_eq!(config.workdir(), "/app");
+    assert!(!config.manage_lifecycle());
+    config.validate().expect("attach config should validate");
+}
+
+#[test]
+fn docker_workspace_config_rejects_neither_image_nor_attach() {
+    let config = DockerWorkspaceConfig {
+        image: None,
+        attach_container: None,
+        workdir: None,
+        manage_lifecycle: None,
+        env: Default::default(),
+        port_bindings: Vec::new(),
+    };
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn path_mapping_maps_custom_app_root() {
+    let mapper = PathMappingLayer::with_container_root("/tmp/staging".into(), "/app");
+    assert_eq!(
+        mapper.container_to_host("/app/gpt2.c").as_deref(),
+        Some(std::path::Path::new("/tmp/staging/gpt2.c"))
+    );
+    assert!(mapper.container_to_host("/workspace/gpt2.c").is_none());
 }
 
 #[test]

--- a/src/README.md
+++ b/src/README.md
@@ -268,6 +268,7 @@ for await (const messageStreamEvent of stream) {
 To run these integration examples, you need the desktop application running locally. Download the latest installer for your platform:
 
 <!-- RELEASE_DOWNLOADS_START -->
+
 - **Windows:** [`LibrAgent_0.8.33_x64-setup.exe`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64-setup.exe) · [`LibrAgent_0.8.33_x64_en-US.msi`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_x64_en-US.msi)
 - **macOS (Apple Silicon):** [`LibrAgent_0.8.33_aarch64.dmg`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_aarch64.dmg)
 - **Linux:** [`LibrAgent_0.8.33_amd64.AppImage`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.AppImage) · [`LibrAgent_0.8.33_amd64.deb`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent_0.8.33_amd64.deb) · [`LibrAgent-0.8.33-1.x86_64.rpm`](https://github.com/fritzprix/libr-agent/releases/download/v0.8.33/LibrAgent-0.8.33-1.x86_64.rpm)

--- a/src/features/agent/AgentChatView.tsx
+++ b/src/features/agent/AgentChatView.tsx
@@ -558,6 +558,9 @@ export default function AgentChatView() {
     isStartingSession,
     isDockerProvisioning,
     session?.dockerConfig?.image ??
+      (session?.dockerConfig?.attachContainer
+        ? `attach:${session.dockerConfig.attachContainer}`
+        : undefined) ??
       optionalSessionState.runtimeState.initialization.docker?.image,
     t,
   );

--- a/src/features/agent/components/AgentWorkspacePanel.tsx
+++ b/src/features/agent/components/AgentWorkspacePanel.tsx
@@ -461,12 +461,21 @@ export function AgentWorkspacePanel({
                     {session?.workspaceIsolation === 'docker' && (
                       <div
                         className="inline-flex items-center gap-1 text-[9px] font-mono text-primary bg-primary/10 rounded px-1.5 py-0.5 border border-primary/20 max-w-[180px] truncate"
-                        title={session.dockerConfig?.image}
+                        title={
+                          session.dockerConfig?.image ??
+                          (session.dockerConfig?.attachContainer
+                            ? `attach:${session.dockerConfig.attachContainer}`
+                            : undefined)
+                        }
                       >
                         <span>🐳 Docker</span>
-                        {session.dockerConfig?.image && (
+                        {(session.dockerConfig?.image ||
+                          session.dockerConfig?.attachContainer) && (
                           <span className="opacity-70">
-                            ({session.dockerConfig.image})
+                            (
+                            {session.dockerConfig.image ??
+                              `attach:${session.dockerConfig.attachContainer}`}
+                            )
                           </span>
                         )}
                       </div>

--- a/src/lib/generated/builtin-services.ts
+++ b/src/lib/generated/builtin-services.ts
@@ -23,7 +23,8 @@ export const BUILTIN_SERVICE_CANONICAL_NAMES = [
   'media',
 ] as const;
 
-export type BuiltinServiceCanonicalName = typeof BUILTIN_SERVICE_CANONICAL_NAMES[number];
+export type BuiltinServiceCanonicalName =
+  (typeof BUILTIN_SERVICE_CANONICAL_NAMES)[number];
 
 /** All recognized builtin service aliases */
 export const ALL_BUILTIN_SERVICE_ALIASES = [
@@ -48,7 +49,7 @@ export const ALL_BUILTIN_SERVICE_ALIASES = [
   'media',
 ] as const;
 
-export type BuiltinServiceAlias = typeof ALL_BUILTIN_SERVICE_ALIASES[number];
+export type BuiltinServiceAlias = (typeof ALL_BUILTIN_SERVICE_ALIASES)[number];
 
 /** Core builtin services (optional: false in Rust) */
 export const CORE_BUILTIN_SERVICE_ALIASES = [

--- a/src/lib/generated/execution-mode.ts
+++ b/src/lib/generated/execution-mode.ts
@@ -5,11 +5,7 @@
  */
 
 /** Canonical execution mode values shared with the Rust backend and SQLite schema */
-export const EXECUTION_MODE_VALUES = [
-  'normal',
-  'yolo',
-  'unsafe',
-] as const;
+export const EXECUTION_MODE_VALUES = ['normal', 'yolo', 'unsafe'] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODE_VALUES)[number];
 

--- a/src/models/agent-ipc.ts
+++ b/src/models/agent-ipc.ts
@@ -42,7 +42,14 @@ export interface AgentConfig {
 export type WorkspaceIsolationMode = 'host' | 'docker';
 
 export interface DockerWorkspaceConfig {
-  image: string;
+  /** Required for managed Docker sessions; omit when attaching to an existing container. */
+  image?: string;
+  /** Existing container id/name to attach (Harbor task containers). */
+  attachContainer?: string;
+  /** Container workdir / file-tool root. Defaults to `/workspace`. */
+  workdir?: string;
+  /** When false, session cleanup must not stop/remove the container. */
+  manageLifecycle?: boolean;
   env?: Record<string, string>;
   portBindings?: DockerPortBinding[];
 }
@@ -199,7 +206,8 @@ export interface SessionRuntimeProxyState {
 }
 
 export interface SessionRuntimeDockerState {
-  image: string;
+  /** Managed image ref, or `attach:<container>`. Absent when unknown. */
+  image?: string;
   step?: string;
   progress?: number;
   error?: string;


### PR DESCRIPTION
## Summary
- Add Docker attach mode (`attachContainer` / `workdir` / `manageLifecycle`) so Harbor Docker trials share the verifier filesystem under `/app` instead of creating a second LibrAgent container.
- File tools sync staging ↔ container via `docker cp`/`exec`; shell uses `docker exec -w {workdir}`. External containers are not destroyed when `manageLifecycle: false`.
- Harbor adapter resolves Compose `main`, prefers attach (skips host pull/push), and falls back to host-sync when the container id cannot be resolved. Cross-platform `pnpm bench:*` dispatcher included.

## Test plan
- [ ] `cargo check` / workspace isolation model tests (attach config + `/app` path mapping)
- [ ] `python -m pytest benchmarks/harbor/test_libragent_agent.py`
- [ ] With `pnpm tauri dev` + Docker: `pnpm bench:hello` (expect attach log + reward)
- [ ] Confirm session cleanup does **not** `docker rm` Harbor’s main container
- [ ] Managed Docker (`image` + `/workspace`) still provisions and cleans up as before
- [ ] `writeFile("/app/...")` / `listDirectory` work under attach workdir; skill aliases still read host skill roots


Made with [Cursor](https://cursor.com)