### PR TITLE
fix(recovery): unblock stuck tool spinners after crash recovery

### DIFF
--- a/src-tauri/src/agent/lifecycle/recovery.rs
+++ b/src-tauri/src/agent/lifecycle/recovery.rs
@@ -1,5 +1,5 @@
 use crate::agent::context::registry::ContextRegistry;
-use crate::agent::events::AgentEventDispatcher;
+use crate::agent::events::{AgentEvent, AgentEventDispatcher};
 use crate::agent::state::{AgentSession, MAX_CACHED_MESSAGES};
 use crate::agent::tauri_events::TauriEventDispatcher;
 use crate::models::chat::MessageSource;
@@ -18,7 +18,10 @@ use super::management::update_session_status_with_dispatcher;
 
 /// Close orphaned tool calls for a recovered session by injecting synthetic error responses.
 /// Prevents the UI from showing stuck running spinners after a crash recovery.
-async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
+async fn close_orphaned_tool_calls(
+    session_id: &str,
+    dispatcher: &dyn AgentEventDispatcher,
+) -> Result<(), String> {
     let message_repo = crate::state::get_message_repository();
 
     // Only the most recent causal window matters for unresolved tool-call recovery.
@@ -40,6 +43,9 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64;
+
+    // Matches create_error_tool_result / frontend useMessageGrouping toolError contract.
+    let tool_error_metadata = Some(serde_json::json!({ "toolError": true }));
 
     let mut tombstones: Vec<crate::models::chat::Message> = Vec::new();
 
@@ -79,7 +85,7 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
                 updated_at: now,
                 source: Some(MessageSource::Recovery),
                 error: None,
-                metadata: None,
+                metadata: tool_error_metadata.clone(),
             });
         }
     }
@@ -95,9 +101,18 @@ async fn close_orphaned_tool_calls(session_id: &str) -> Result<(), String> {
     );
 
     message_repo
-        .insert_many(tombstones)
+        .insert_many(tombstones.clone())
         .await
         .map_err(|e| format!("Failed to insert tombstone messages: {}", e))?;
+
+    for tombstone in &tombstones {
+        dispatcher
+            .emit_agent_event(AgentEvent::MessageAdded {
+                session_id: session_id.to_string(),
+                message: Box::new(tombstone.clone()),
+            })
+            .map_err(|e| format!("Failed to emit MessageAdded for recovery tombstone: {}", e))?;
+    }
 
     Ok(())
 }
@@ -217,7 +232,7 @@ pub async fn recover_sessions_with_dispatcher(
 
             if matches!(session.status, SessionStatus::Busy) {
                 // Close any orphaned tool calls that never got a result (crash tombstones)
-                if let Err(e) = close_orphaned_tool_calls(&session.id).await {
+                if let Err(e) = close_orphaned_tool_calls(&session.id, dispatcher).await {
                     log::warn!(
                         "Failed to close orphaned tool calls for session '{}': {}",
                         session.id,

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -283,6 +283,30 @@ impl SqliteMessageRepository {
         })
     }
 
+    /// Rebuild UI-facing metadata from persisted content.
+    ///
+    /// `messages.metadata` is not a DB column; `Message.metadata.toolError` is derived at
+    /// write time (see `create_tool_result_message_with_content`) from `MCPContent::Text.is_error`.
+    /// Re-derive on read so cold session loads / crash-recovery tombstones still group as errors.
+    fn metadata_from_persisted_content(
+        content: &[crate::mcp::types::MCPContent],
+    ) -> Option<serde_json::Value> {
+        let tool_error = content.iter().any(|c| {
+            matches!(
+                c,
+                crate::mcp::types::MCPContent::Text {
+                    is_error: Some(true),
+                    ..
+                }
+            )
+        });
+        if tool_error {
+            Some(serde_json::json!({ "toolError": true }))
+        } else {
+            None
+        }
+    }
+
     /// Convert SeaORM message model to Message type
     fn model_to_message(model: message::Model) -> Message {
         let content: Vec<crate::mcp::types::MCPContent> = from_json_or_default(&model.content);
@@ -297,6 +321,8 @@ impl SqliteMessageRepository {
         let error: Option<serde_json::Value> = from_json_option(&model.error);
 
         let usage: Option<serde_json::Value> = from_json_option(&model.usage);
+
+        let metadata = Self::metadata_from_persisted_content(&content);
 
         Message {
             id: model.id,
@@ -317,7 +343,7 @@ impl SqliteMessageRepository {
             error,
             usage,
             prompt_tokens: model.prompt_tokens,
-            metadata: None,
+            metadata,
         }
     }
 
@@ -825,6 +851,40 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, "msg1");
+    }
+
+    #[tokio::test]
+    async fn test_reload_derives_tool_error_metadata_from_content_is_error() {
+        let repo = setup_test_db().await;
+        create_test_session(&repo.db, "session1").await;
+
+        let mut message = create_dummy_message("tool-err", "session1");
+        message.role = "tool".to_string();
+        message.tool_call_id = Some("call-1".to_string());
+        message.content = vec![MCPContent::Text {
+            text: "tool failed".to_string(),
+            is_error: Some(true),
+        }];
+        // metadata is not a DB column; callers may set it in memory, but reload must re-derive.
+        message.metadata = Some(serde_json::json!({ "toolError": true }));
+
+        repo.insert(&message).await.expect("Failed to insert");
+
+        let loaded = repo
+            .get_by_id("tool-err")
+            .await
+            .expect("Failed to get message")
+            .expect("message should exist");
+
+        assert_eq!(
+            loaded
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("toolError"))
+                .and_then(|value| value.as_bool()),
+            Some(true),
+            "toolError must be reconstructed from persisted content.is_error"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/tests/integration/session_recovery_tests.rs
+++ b/src-tauri/tests/integration/session_recovery_tests.rs
@@ -20,7 +20,7 @@ use tauri_mcp_agent_lib::agent::types::{ToolCall, ToolCallFunction};
 use tauri_mcp_agent_lib::agent::ExecutionMode;
 use tauri_mcp_agent_lib::entity::session;
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
-use tauri_mcp_agent_lib::models::chat::Message;
+use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
 use tauri_mcp_agent_lib::repositories::compact_context_repository::CompactContextRepository;
 use tauri_mcp_agent_lib::repositories::{
     CompactContextRecord, InMemorySessionRepository, MessageRepository as _, SessionMetadata,
@@ -410,11 +410,62 @@ async fn recover_sessions_closes_recent_orphaned_tool_calls_outside_oldest_page(
         .find(|message| message.tool_call_id.as_deref() == Some(tool_call_id))
         .expect("recovery should inject a tombstone for the recent orphaned tool call");
     assert_eq!(orphan_tombstone.role, "tool");
+    // Frontend contract: useMessageGrouping keeps source=recovery tool results visible
+    // so orphaned tool calls resolve (see useMessageGrouping.test.ts "no stuck spinner").
+    assert_eq!(
+        orphan_tombstone.source,
+        Some(MessageSource::Recovery),
+        "tombstone source must stay Recovery; filtering it in the UI recreates stuck spinners"
+    );
     assert!(
         orphan_tombstone
             .content
             .iter()
             .any(|content| matches!(content, MCPContent::Text { text, .. } if text.contains("did not complete"))),
         "tombstone text should explain the crash recovery"
+    );
+    assert_eq!(
+        orphan_tombstone
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("toolError"))
+            .and_then(|value| value.as_bool()),
+        Some(true),
+        "tombstone metadata must set toolError so the UI groups it as a tool failure"
+    );
+
+    let message_added_events: Vec<_> = dispatcher
+        .agent_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            AgentEvent::MessageAdded {
+                session_id: event_session_id,
+                message,
+            } if event_session_id == session_id
+                && message.tool_call_id.as_deref() == Some(tool_call_id) =>
+            {
+                Some(message)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        message_added_events.len(),
+        1,
+        "recovery should emit MessageAdded for each injected tombstone"
+    );
+    assert_eq!(
+        message_added_events[0].source,
+        Some(MessageSource::Recovery),
+        "emitted MessageAdded tombstone must keep source=Recovery for UI visibility"
+    );
+    assert_eq!(
+        message_added_events[0]
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("toolError"))
+            .and_then(|value| value.as_bool()),
+        Some(true),
+        "emitted MessageAdded tombstone must include toolError metadata"
     );
 }

--- a/src/hooks/__tests__/useMessageGrouping.test.ts
+++ b/src/hooks/__tests__/useMessageGrouping.test.ts
@@ -492,20 +492,72 @@ describe('useMessageGrouping', () => {
     expect(result.current.toolResultsMap).toBe(first.toolResultsMap);
   });
 
-  it('filters out internal scaffolding messages (session-context, compaction-instruction, recovery)', () => {
+  it('filters out internal scaffolding messages (session-context, compaction-instruction)', () => {
     const messages: Message[] = [
       { ...createMessage('1', 'user', 'Normal message'), source: 'ui' as MessageSource },
       { ...createMessage('2', 'user', 'Session context background info'), source: 'session-context' as MessageSource },
       { ...createMessage('3', 'user', 'Compaction request'), source: 'compaction-instruction' as MessageSource },
-      { ...createMessage('4', 'user', 'Recovery checkpoint'), source: 'recovery' as MessageSource },
+      {
+        ...createMessage(
+          '4',
+          'tool',
+          'Recovery tombstone',
+          undefined,
+          'tool_call_1',
+          { toolError: true },
+        ),
+        source: 'recovery' as MessageSource,
+      },
       { ...createMessage('5', 'assistant', 'Response message'), source: 'api' as MessageSource },
     ];
 
     const { result } = renderHook(() => useMessageGrouping(messages));
 
-    expect(result.current.groupedMessages.length).toBe(2);
+    // Recovery tombstones stay visible so orphaned tool calls can resolve.
+    // Standalone toolError results render as tool_error_group.
+    expect(result.current.groupedMessages.length).toBe(3);
     expect(result.current.groupedMessages[0].message.id).toBe('1');
-    expect(result.current.groupedMessages[1].message.id).toBe('5');
+    expect(result.current.groupedMessages[1].type).toBe('tool_error_group');
+    expect(result.current.groupedMessages[1].message.id).toBe('4');
+    expect(result.current.groupedMessages[2].message.id).toBe('5');
+  });
+
+  // Paired with session_recovery_tests.rs: backend tombstones use source=recovery + toolError.
+  // Filtering source=recovery here recreates stuck tool-call spinners after crash recovery.
+  it('matches recovery tombstones to orphaned tool calls (no stuck spinner)', () => {
+    const messages: Message[] = [
+      createMessage('1', 'assistant', '', [
+        {
+          id: 'call_orphan',
+          type: 'function',
+          function: { name: 'agent__messageToSession', arguments: '{}' },
+        },
+      ]),
+      {
+        ...createMessage(
+          '2',
+          'tool',
+          '[system] Tool call did not complete (session recovered after crash).',
+          undefined,
+          'call_orphan',
+          { toolError: true },
+        ),
+        source: 'recovery' as MessageSource,
+      },
+    ];
+
+    const { result } = renderHook(() => useMessageGrouping(messages));
+
+    expect(result.current.groupedMessages).toHaveLength(1);
+    const group = result.current.groupedMessages[0];
+    expect(group.type).toBe('tool_group');
+    if (group.type === 'tool_group') {
+      expect(group.toolGroup.results).toHaveLength(1);
+      expect(group.toolGroup.results[0]).toBeDefined();
+      expect(group.toolGroup.results[0]?.id).toBe('2');
+      expect(group.toolGroup.results[0]?.metadata?.toolError).toBe(true);
+    }
+    expect(result.current.toolResultsMap.get('call_orphan')?.id).toBe('2');
   });
 
   it('splits tool_group into separate groups at the specified boundaryId (compaction boundary)', () => {

--- a/src/hooks/useMessageGrouping.ts
+++ b/src/hooks/useMessageGrouping.ts
@@ -80,11 +80,12 @@ export function useMessageGrouping(
   boundaryId?: string,
 ): MessageGroupingResult {
   const visibleMessages = useMemo(() => {
+    // Keep source=recovery tool tombstones visible — they close orphaned tool calls after
+    // crash recovery. Filtering them leaves results[undefined] and stuck spinners.
     return messages.filter(
       (msg) =>
         msg.source !== 'session-context' &&
-        msg.source !== 'compaction-instruction' &&
-        msg.source !== 'recovery',
+        msg.source !== 'compaction-instruction',
     );
   }, [messages]);
 


### PR DESCRIPTION
## Summary
- Keep `source=recovery` tombstones visible in `useMessageGrouping` so orphaned tool calls resolve instead of leaving stuck spinners.
- Attach `metadata.toolError: true` on recovery tombstones and emit `MessageAdded` so open UIs update after crash recovery.
- Re-derive `metadata.toolError` from persisted `content.is_error` on DB load (`messages.metadata` is not a column).
- Add FE/BE regression coverage for the recovery ↔ UI contract.

Fixes #1636

## Test plan
- [x] `pnpm exec vitest run src/hooks/__tests__/useMessageGrouping.test.ts`
- [ ] `cargo test --tests recover_sessions_closes_recent_orphaned_tool_calls_outside_oldest_page` (Linux/macOS CI)
- [ ] Manually: crash mid tool-call, restart app, reopen session — tool calls show error state, no infinite spinner