### PR TITLE
fix(agent): cancel mid-tool-batch immediately and tombstone remaining calls

### DIFF
--- a/src-tauri/src/agent/llm/tool_execution.rs
+++ b/src-tauri/src/agent/llm/tool_execution.rs
@@ -9,9 +9,11 @@ use crate::commands::agent_commands::ToolExecutionResult;
 use crate::mcp::MCPServiceProxyManager;
 use crate::repositories::SessionRepository;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::sync::{oneshot, RwLock};
+use tokio_util::sync::CancellationToken;
 
 struct ToolExecutionContext<'a> {
     session_repo: &'a Arc<dyn SessionRepository>,
@@ -424,6 +426,45 @@ fn error_result(message: impl Into<String>) -> ToolExecutionResult {
     }
 }
 
+fn cancelled_tool_result() -> ToolExecutionResult {
+    error_result("Tool call cancelled by user.")
+}
+
+async fn session_cancel_requested(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+    cancellation_token: &CancellationToken,
+) -> bool {
+    if cancellation_token.is_cancelled() {
+        return true;
+    }
+    let active = active_sessions.read().await;
+    active
+        .get(session_id)
+        .map(|session| session.cancel_pending.load(Ordering::SeqCst))
+        .unwrap_or(false)
+}
+
+async fn inject_cancel_tombstones_for_remaining(
+    context: &ToolExecutionContext<'_>,
+    remaining: &[ToolCall],
+) {
+    for tool_call in remaining {
+        log::info!(
+            "Injecting cancel tombstone for tool call {} in session {}",
+            tool_call.id,
+            context.session_id
+        );
+        context
+            .continue_after_tool(
+                &tool_call.id,
+                cancelled_tool_result(),
+                "cancelled tool call",
+            )
+            .await;
+    }
+}
+
 pub async fn execute_tool_calls(
     session_repo: Arc<dyn SessionRepository>,
     active_sessions: Arc<RwLock<HashMap<String, AgentSession>>>,
@@ -433,6 +474,20 @@ pub async fn execute_tool_calls(
     tool_calls: Vec<ToolCall>,
     loop_prevention_short_circuits: HashMap<String, LoopPreventionShortCircuit>,
 ) {
+    let cancellation_token = {
+        let active = active_sessions.read().await;
+        match active.get(&session_id) {
+            Some(session) => session.cancellation_token.clone(),
+            None => {
+                log::warn!(
+                    "execute_tool_calls: session {} not found; skipping tool batch",
+                    session_id
+                );
+                return;
+            }
+        }
+    };
+
     let context = ToolExecutionContext {
         session_repo: &session_repo,
         active_sessions: &active_sessions,
@@ -441,32 +496,39 @@ pub async fn execute_tool_calls(
         session_id: &session_id,
     };
 
-    for ToolCall {
-        id: tool_call_id,
-        function,
-        ..
-    } in tool_calls
-    {
+    let mut index = 0;
+    while index < tool_calls.len() {
+        if session_cancel_requested(&active_sessions, &session_id, &cancellation_token).await {
+            inject_cancel_tombstones_for_remaining(&context, &tool_calls[index..]).await;
+            break;
+        }
+
+        let ToolCall {
+            id: tool_call_id,
+            function,
+            ..
+        } = &tool_calls[index];
         let ToolCallFunction {
             name: tool_name,
             arguments: args_str,
         } = function;
 
-        context.emit_tool_execution_started(&tool_name);
+        context.emit_tool_execution_started(tool_name);
 
-        if let Some(short_circuit) = loop_prevention_short_circuits.get(&tool_call_id) {
+        if let Some(short_circuit) = loop_prevention_short_circuits.get(tool_call_id) {
             let guidance = build_loop_prevention_guidance(short_circuit);
             context
                 .continue_after_tool(
-                    &tool_call_id,
+                    tool_call_id,
                     loop_prevention_tool_result(&guidance),
                     "loop prevention short-circuit",
                 )
                 .await;
+            index += 1;
             continue;
         }
 
-        let args = match inspect_tool_call_arguments(&args_str) {
+        let args = match inspect_tool_call_arguments(args_str) {
             Ok(map) => serde_json::Value::Object(map),
             Err((kind, parse_error)) => {
                 log::error!(
@@ -478,10 +540,10 @@ pub async fn execute_tool_calls(
                 let max_output_tokens = context.configured_max_output_tokens().await;
                 context
                     .continue_after_tool(
-                        &tool_call_id,
+                        tool_call_id,
                         args_parse_error_result(
-                            &tool_name,
-                            &args_str,
+                            tool_name,
+                            args_str,
                             kind,
                             &parse_error,
                             max_output_tokens,
@@ -489,12 +551,13 @@ pub async fn execute_tool_calls(
                         "failed tool parse",
                     )
                     .await;
+                index += 1;
                 continue;
             }
         };
 
         let policy_decision =
-            crate::agent::tool_approvals::evaluate_tool_execution_policy(&tool_name, &args).await;
+            crate::agent::tool_approvals::evaluate_tool_execution_policy(tool_name, &args).await;
 
         let unsafe_enabled = context.current_unsafe_mode().await;
         if let Some(blocked) = crate::agent::tool_approvals::blocked_execution_for_runtime(
@@ -503,11 +566,12 @@ pub async fn execute_tool_calls(
         ) {
             context
                 .continue_after_tool(
-                    &tool_call_id,
+                    tool_call_id,
                     error_result(blocked.message.clone()),
                     "policy-blocked tool execution",
                 )
                 .await;
+            index += 1;
             continue;
         }
 
@@ -524,9 +588,9 @@ pub async fn execute_tool_calls(
             };
             match context
                 .request_approval(
-                    &tool_call_id,
-                    &tool_name,
-                    &args_str,
+                    tool_call_id,
+                    tool_name,
+                    args_str,
                     approval_request,
                     approval_kind,
                 )
@@ -536,20 +600,36 @@ pub async fn execute_tool_calls(
                 ApprovalOutcome::Rejected => {
                     context
                         .continue_after_tool(
-                            &tool_call_id,
+                            tool_call_id,
                             error_result("User rejected the tool execution."),
                             "tool rejection",
                         )
                         .await;
-                    return;
+                    // User rejected this tool — cancel remaining calls in the batch too.
+                    inject_cancel_tombstones_for_remaining(&context, &tool_calls[index + 1..])
+                        .await;
+                    break;
                 }
-                ApprovalOutcome::ChannelClosed => continue,
+                ApprovalOutcome::ChannelClosed => {
+                    // Cancel/terminate dropped the approval waiter. Close this call
+                    // and let the cancel check at the top tombstone any remainder.
+                    context
+                        .continue_after_tool(
+                            tool_call_id,
+                            cancelled_tool_result(),
+                            "approval cancelled",
+                        )
+                        .await;
+                    index += 1;
+                    continue;
+                }
             }
         }
 
-        let result = context.execute_tool(&tool_name, args).await;
+        let result = context.execute_tool(tool_name, args).await;
         context
-            .continue_after_tool(&tool_call_id, result, "tool execution")
+            .continue_after_tool(tool_call_id, result, "tool execution")
             .await;
+        index += 1;
     }
 }

--- a/src-tauri/src/agent/llm/tool_execution.rs
+++ b/src-tauri/src/agent/llm/tool_execution.rs
@@ -496,6 +496,9 @@ pub async fn execute_tool_calls(
         session_id: &session_id,
     };
 
+    // Index-based loop (not `for tool_calls`) so a mid-batch cancel can
+    // tombstone `tool_calls[index..]` and break without consuming the iterator.
+    // Every continue/success path must bump `index` before the next check.
     let mut index = 0;
     while index < tool_calls.len() {
         if session_cancel_requested(&active_sessions, &session_id, &cancellation_token).await {

--- a/src-tauri/src/agent/workflow/cancel.rs
+++ b/src-tauri/src/agent/workflow/cancel.rs
@@ -16,14 +16,14 @@ pub enum CancelStrategy {
     /// Tool batch is in flight: cancel the token immediately and keep
     /// `cancel_pending` set so awaitAgent / tool loop can short-circuit, then
     /// pause at the message boundary once remaining tools are tombstoned.
-    CancelToolsThenPauseAtBoundary,
+    CancelToolsThenPause,
     /// No tool batch: pause the session immediately.
     StopImmediately,
 }
 
 pub fn classify_cancel_strategy(has_pending_execution: bool) -> CancelStrategy {
     if has_pending_execution {
-        CancelStrategy::CancelToolsThenPauseAtBoundary
+        CancelStrategy::CancelToolsThenPause
     } else {
         CancelStrategy::StopImmediately
     }
@@ -253,9 +253,8 @@ pub async fn cancel_workflow(
     )
     .await;
 
-    if classify_cancel_strategy(has_pending_execution)
-        == CancelStrategy::CancelToolsThenPauseAtBoundary
-    {
+    if classify_cancel_strategy(has_pending_execution) == CancelStrategy::CancelToolsThenPause {
+
         log::info!(
             "Cancel requested for session {} during tool batch — token cancelled; remaining tools will be tombstoned",
             session_id

--- a/src-tauri/src/agent/workflow/cancel.rs
+++ b/src-tauri/src/agent/workflow/cancel.rs
@@ -13,13 +13,17 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CancelStrategy {
-    DeferToMessageBoundary,
+    /// Tool batch is in flight: cancel the token immediately and keep
+    /// `cancel_pending` set so awaitAgent / tool loop can short-circuit, then
+    /// pause at the message boundary once remaining tools are tombstoned.
+    CancelToolsThenPauseAtBoundary,
+    /// No tool batch: pause the session immediately.
     StopImmediately,
 }
 
 pub fn classify_cancel_strategy(has_pending_execution: bool) -> CancelStrategy {
     if has_pending_execution {
-        CancelStrategy::DeferToMessageBoundary
+        CancelStrategy::CancelToolsThenPauseAtBoundary
     } else {
         CancelStrategy::StopImmediately
     }
@@ -27,6 +31,29 @@ pub fn classify_cancel_strategy(has_pending_execution: bool) -> CancelStrategy {
 
 pub fn should_consume_cancel_at_message_boundary(cancel_pending: bool) -> bool {
     cancel_pending
+}
+
+/// Drop every pending approval waiter so `request_approval` unblocks on cancel.
+async fn abort_pending_tool_approvals(
+    active_sessions: &Arc<RwLock<HashMap<String, AgentSession>>>,
+    session_id: &str,
+) {
+    let active = active_sessions.read().await;
+    let Some(session) = active.get(session_id) else {
+        return;
+    };
+    let mut approvals = session.pending_approvals.write().await;
+    if approvals.is_empty() {
+        return;
+    }
+    log::info!(
+        "Aborting {} pending tool approval(s) for cancelled session {}",
+        approvals.len(),
+        session_id
+    );
+    // Dropping senders yields ChannelClosed in execute_tool_calls, which injects
+    // cancel tombstones for the waiting tool call.
+    approvals.clear();
 }
 
 /// Cancel is a no-op when the session is already inactive — no workflow to stop.
@@ -169,9 +196,8 @@ pub async fn cancel_workflow(
 ) -> Result<(), String> {
     log::info!("Cancelling workflow for session: {}", session_id);
 
-    // Determine whether to stop immediately or defer to message boundary.
-    // If a tool-call batch is in progress, we only set cancel_pending and let
-    // continue_workflow_after_tool consume it after the full message completes.
+    // Determine whether tools are mid-batch (pause after tombstones) or idle
+    // (pause immediately). Cancellation is always signaled up front.
     let (has_pending_execution, current_status) = {
         let active = active_sessions.read().await;
         let session = active
@@ -203,30 +229,22 @@ pub async fn cancel_workflow(
         return Ok(());
     }
 
+    // Always signal cancel immediately — including mid tool-batch.
+    // Previously the "defer" path only set cancel_pending and left the token
+    // live, so execute_tool_calls kept running every remaining tool.
     {
         let active = active_sessions.read().await;
         if let Some(session) = active.get(&session_id) {
             session.cancel_pending.store(true, Ordering::SeqCst);
+            session.cancellation_token.cancel();
         }
     }
 
-    if classify_cancel_strategy(has_pending_execution) == CancelStrategy::DeferToMessageBoundary {
-        log::info!(
-            "Cancel requested for session {} (deferred to message boundary)",
-            session_id
-        );
-        // Waiting prompts stay in the durable FIFO queue so the user can
-        // cancel them individually or resume later.
-        // SP6: Wake any awaitAgent/pollProcess waiter that is suspended inside
-        // a tool call for THIS session. The deferred cancel only sets
-        // cancel_pending; without this notification the waiter would sleep up
-        // to 30 s before re-checking the flag.
-        crate::state::get_session_bus().notify_status_change(&session_id);
-        return Ok(());
-    }
+    abort_pending_tool_approvals(active_sessions, &session_id).await;
 
-    // No in-flight tool-call batch: stop immediately and leave the workflow paused
-    // so the user can explicitly resume from the current stack.
+    // SP6: wake awaitAgent/pollProcess waiters suspended in this session's tools.
+    crate::state::get_session_bus().notify_status_change(&session_id);
+
     cancel_frontend_completion_if_pending(
         active_sessions,
         app_handle,
@@ -235,6 +253,22 @@ pub async fn cancel_workflow(
     )
     .await;
 
+    if classify_cancel_strategy(has_pending_execution)
+        == CancelStrategy::CancelToolsThenPauseAtBoundary
+    {
+        log::info!(
+            "Cancel requested for session {} during tool batch — token cancelled; remaining tools will be tombstoned",
+            session_id
+        );
+        // Keep cancel_pending=true so awaitAgent short-circuits and
+        // continue_workflow_after_tool can pause at the message boundary after
+        // execute_tool_calls injects cancel tombstones for unfinished calls.
+        // Waiting prompts stay in the durable FIFO queue.
+        return Ok(());
+    }
+
+    // No in-flight tool-call batch: stop immediately and leave the workflow paused
+    // so the user can explicitly resume from the current stack.
     crate::agent::lifecycle::update_session_status(
         session_repo,
         active_sessions,
@@ -247,11 +281,8 @@ pub async fn cancel_workflow(
     let mut active = active_sessions.write().await;
     if let Some(session) = active.get_mut(&session_id) {
         session.cancel_pending.store(false, Ordering::SeqCst);
-        // Cancel the token (do NOT replace with a fresh one yet).
+        // Token already cancelled above; do NOT replace with a fresh one yet.
         // The cancelled state persists until start_workflow explicitly resets it.
-        // This prevents stale in-flight LLM responses carrying tool_calls from
-        // re-entering the workflow via the Idle+allow_idle_tool_entry path after cancel.
-        session.cancellation_token.cancel();
     }
     drop(active);
 

--- a/src-tauri/src/agent/workflow/cancel.rs
+++ b/src-tauri/src/agent/workflow/cancel.rs
@@ -254,7 +254,6 @@ pub async fn cancel_workflow(
     .await;
 
     if classify_cancel_strategy(has_pending_execution) == CancelStrategy::CancelToolsThenPause {
-
         log::info!(
             "Cancel requested for session {} during tool batch — token cancelled; remaining tools will be tombstoned",
             session_id

--- a/src-tauri/src/agent/workflow/tool.rs
+++ b/src-tauri/src/agent/workflow/tool.rs
@@ -88,8 +88,10 @@ pub async fn continue_workflow_after_tool(
             }
 
             // Message-boundary cancel handling:
-            // If cancel was requested while tools were running, consume it now
-            // after this message's full tool-call batch has completed.
+            // Cancel during a tool batch keeps cancel_pending=true and cancels the
+            // token immediately; remaining tools get cancel tombstones in
+            // execute_tool_calls. Once the batch is complete, consume the flag here
+            // and pause so we do not start another LLM turn.
             let should_stop_after_message = {
                 let sessions = active_sessions.read().await;
                 sessions

--- a/src-tauri/tests/integration/cancel_logic.rs
+++ b/src-tauri/tests/integration/cancel_logic.rs
@@ -20,9 +20,9 @@ use tokio_util::sync::CancellationToken;
 // -----------------------------------------------------------------------
 
 #[test]
-fn test_classify_cancel_strategy_defers_when_pending_execution_exists() {
+fn test_classify_cancel_strategy_keeps_boundary_pause_when_pending_execution_exists() {
     let strategy = classify_cancel_strategy(true);
-    assert_eq!(strategy, CancelStrategy::DeferToMessageBoundary);
+    assert_eq!(strategy, CancelStrategy::CancelToolsThenPauseAtBoundary);
 }
 
 #[test]
@@ -147,24 +147,31 @@ fn test_cancelled_token_clone_is_also_cancelled() {
 // cancel_pending AtomicBool
 // -----------------------------------------------------------------------
 
-/// DeferToBoundary path: cancel_pending is set to true by cancel_workflow
-/// and must remain true until continue_workflow_after_tool consumes it.
+/// Mid-tool-batch cancel: cancel_pending stays true (for awaitAgent) and the
+/// token is cancelled immediately so execute_tool_calls can break + tombstone.
 #[test]
-fn test_cancel_pending_transitions_for_defer_to_boundary() {
+fn test_cancel_pending_stays_set_during_tool_batch_cancel() {
     let cancel_pending = Arc::new(AtomicBool::new(false));
+    let token = CancellationToken::new();
 
-    // cancel_workflow: set the flag
+    // cancel_workflow during tool batch
     cancel_pending.store(true, Ordering::SeqCst);
-    assert!(cancel_pending.load(Ordering::SeqCst));
+    token.cancel();
 
-    // continue_workflow_after_tool: reads and consumes the flag
+    assert!(cancel_pending.load(Ordering::SeqCst));
+    assert!(
+        token.is_cancelled(),
+        "token must cancel immediately even while tools are still draining"
+    );
+
+    // continue_workflow_after_tool: reads and consumes the flag at message boundary
     let should_stop = cancel_pending.load(Ordering::SeqCst);
     assert!(should_stop);
 
     cancel_pending.store(false, Ordering::SeqCst);
     assert!(
         !cancel_pending.load(Ordering::SeqCst),
-        "cancel_pending must be cleared after consumption"
+        "cancel_pending must be cleared after message-boundary consumption"
     );
 }
 
@@ -188,17 +195,16 @@ fn test_cancel_pending_cleared_immediately_on_stop_immediately() {
 // discard_pending_events semantics (via PendingEventManager)
 // -----------------------------------------------------------------------
 
-/// Bug 4 regression: DeferToBoundary cancel must drain the pending queue
-/// immediately so no buffered user messages are processed after the agent
-/// stops, even though the current tool batch is still completing.
+/// Soft cancel preserves the durable waiting-prompt queue in production, but
+/// in-memory PendingEventManager drains used by hard-terminate paths must stay
+/// idempotent.
 #[test]
-fn test_pending_events_drained_on_cancel() {
+fn test_pending_events_drain_is_complete() {
     let mut manager = PendingEventManager::new();
     manager.add(PendingEvent::Message("msg1".into()));
     manager.add(PendingEvent::Message("msg2".into()));
     assert_eq!(manager.count(), 2);
 
-    // Simulates discard_pending_events: drain all messages
     let drained = manager.drain_messages();
 
     assert_eq!(drained.len(), 2, "both pending messages must be discarded");
@@ -214,11 +220,9 @@ fn test_pending_events_drained_on_cancel() {
 fn test_discard_pending_events_is_idempotent() {
     let mut manager = PendingEventManager::new();
 
-    // First discard (DeferToBoundary)
     let first = manager.drain_messages();
     assert!(first.is_empty());
 
-    // Second discard (continue_workflow_after_tool message-boundary handler)
     let second = manager.drain_messages();
     assert!(
         second.is_empty(),
@@ -252,8 +256,6 @@ fn test_stop_immediately_full_lifecycle() {
     assert_eq!(manager.count(), 0);
 
     // --- start_workflow ---
-    // Regression: old code blocked here because is_cancelled() was checked BEFORE reset.
-    // Now start_workflow does the reset unconditionally.
     let token = CancellationToken::new(); // reset
     cancel_pending.store(false, Ordering::SeqCst);
 
@@ -264,28 +266,29 @@ fn test_stop_immediately_full_lifecycle() {
     assert!(!cancel_pending.load(Ordering::SeqCst));
 }
 
-/// Full DeferToBoundary scenario:
-///   cancel_workflow → flag set, queue drained (tool batch still running)
-///   continue_workflow_after_tool → flag consumed, token reset, status→Idle
-///   start_workflow → token already fresh, workflow starts normally
+/// Full mid-tool-batch cancel scenario (#1638):
+///   cancel_workflow → flag set AND token cancelled (tools still may finish current call)
+///   execute_tool_calls → sees cancel, injects tombstones for remaining, breaks
+///   continue_workflow_after_tool → flag consumed, status→Paused
+///   start_workflow → token reset, workflow starts normally
 #[test]
-fn test_defer_to_boundary_full_lifecycle() {
+fn test_tool_batch_cancel_cancels_token_immediately() {
     let token = CancellationToken::new();
     let cancel_pending = Arc::new(AtomicBool::new(false));
-    let mut manager = PendingEventManager::new();
 
-    manager.add(PendingEvent::Message("pending-msg".into()));
-
-    // --- cancel_workflow (DeferToBoundary) ---
+    // --- cancel_workflow during tool batch ---
     cancel_pending.store(true, Ordering::SeqCst);
-    let _drained = manager.drain_messages(); // discard immediately
+    token.cancel();
 
     assert!(cancel_pending.load(Ordering::SeqCst));
-    assert_eq!(manager.count(), 0, "queue cleared before tool batch ends");
     assert!(
-        !token.is_cancelled(),
-        "token NOT cancelled in DeferToBoundary"
+        token.is_cancelled(),
+        "token MUST be cancelled immediately so execute_tool_calls can stop remaining tools"
     );
+
+    // --- execute_tool_calls cancel check ---
+    let should_tombstone_remaining = token.is_cancelled() || cancel_pending.load(Ordering::SeqCst);
+    assert!(should_tombstone_remaining);
 
     // --- continue_workflow_after_tool (message boundary) ---
     let should_stop = cancel_pending.load(Ordering::SeqCst);
@@ -300,6 +303,6 @@ fn test_defer_to_boundary_full_lifecycle() {
     // --- start_workflow (user sends new message) ---
     assert!(
         !token.is_cancelled(),
-        "workflow must be startable after deferred cancel"
+        "workflow must be startable after tool-batch cancel"
     );
 }

--- a/src-tauri/tests/integration/cancel_logic.rs
+++ b/src-tauri/tests/integration/cancel_logic.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 #[test]
 fn test_classify_cancel_strategy_keeps_boundary_pause_when_pending_execution_exists() {
     let strategy = classify_cancel_strategy(true);
-    assert_eq!(strategy, CancelStrategy::CancelToolsThenPauseAtBoundary);
+    assert_eq!(strategy, CancelStrategy::CancelToolsThenPause);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Cancel during an in-flight tool batch now cancels the session token immediately (previously only set `cancel_pending`).
- `execute_tool_calls` checks cancel each iteration and injects cancel tombstones for unfinished tool calls, then breaks.
- Abort pending approval waiters on cancel so approval-blocked tools unblock with a cancel result.
- Keep `cancel_pending` until the message boundary so `awaitAgent` still short-circuits; pause/WorkflowCompleted happens after the batch drains.

Fixes #1638

## Test plan
- [ ] `cargo test --test cancel_logic` via integration suite on Linux/macOS CI
- [ ] Manually: start a turn with multiple sequential tools, hit Cancel mid-batch — remaining tools show cancelled tombstones, no stuck spinners, no next LLM turn
- [ ] Manually: Cancel while a tool approval dialog is open — approval dismisses, tool shows cancelled, session pauses
- [ ] Manually: Cancel with no tools running — still pauses immediately as before