### PR TITLE
fix(workspace): strip PowerShell wrapper noise from stderr (#1641)

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/code_execution/mod.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/mod.rs
@@ -1,5 +1,6 @@
 pub mod interactive;
 pub mod normalization;
+pub mod powershell_stderr;
 pub mod process;
 pub mod shell;
 pub mod validation;

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/powershell_stderr.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/powershell_stderr.rs
@@ -1,0 +1,124 @@
+//! Sanitize PowerShell host chrome that leaks into captured stderr.
+//!
+//! Windows isolated shell runs commands via a temp `.ps1` wrapper. PowerShell may
+//! append ScriptStackTrace lines (`at <ScriptBlock>, …`) or NativeCommandError
+//! frames (`exe : message` + `At path.ps1` + CategoryInfo) even when the native
+//! command succeeded. Those frames confuse LLM tool consumers.
+
+/// Strip PowerShell wrapper / NativeCommandError chrome from stderr.
+///
+/// Keeps the underlying message (e.g. cargo progress) while removing:
+/// - `at <ScriptBlock>, …cmd_*.ps1` ScriptStackTrace lines
+/// - `At path.ps1:line char:` frames and `+` continuation / CategoryInfo blocks
+/// - `exe : message` wrappers when followed by an `At …` frame
+pub fn sanitize_powershell_stderr(stderr: &str) -> String {
+    let lines: Vec<&str> = stderr.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim_start();
+
+        if trimmed.starts_with("at <ScriptBlock>,") {
+            i += 1;
+            continue;
+        }
+
+        // NativeCommandError display: "cargo : Compiling …" followed by At/.ps1 frame
+        if let Some(message) = native_command_error_message(line) {
+            if i + 1 < lines.len() && lines[i + 1].trim_start().starts_with("At ") {
+                if !message.is_empty() {
+                    out.push(message);
+                }
+                i += 1; // move to At line
+                i = skip_powershell_error_frame(lines.as_slice(), i);
+                continue;
+            }
+        }
+
+        if trimmed.starts_with("At ") && looks_like_powershell_script_frame(trimmed) {
+            i = skip_powershell_error_frame(lines.as_slice(), i);
+            continue;
+        }
+
+        out.push(line.to_string());
+        i += 1;
+    }
+
+    let mut sanitized = out.join("\n");
+    if stderr.ends_with('\n') && !sanitized.is_empty() {
+        sanitized.push('\n');
+    }
+    sanitized
+}
+
+fn native_command_error_message(line: &str) -> Option<String> {
+    // "cmd : progress" / "cargo : Compiling foo" — require non-space token before " : "
+    let trimmed = line.trim_end();
+    let (left, right) = trimmed.split_once(" : ")?;
+    if left.is_empty() || left.chars().any(char::is_whitespace) {
+        return None;
+    }
+    // Avoid stripping normal prose that happens to contain " : "
+    if left.len() > 64 {
+        return None;
+    }
+    Some(right.trim().to_string())
+}
+
+fn looks_like_powershell_script_frame(trimmed_at_line: &str) -> bool {
+    trimmed_at_line.contains(".ps1:")
+        || trimmed_at_line.contains("<ScriptBlock>")
+        || trimmed_at_line.contains("<No file>")
+}
+
+fn skip_powershell_error_frame(lines: &[&str], mut i: usize) -> usize {
+    if i < lines.len() && lines[i].trim_start().starts_with("At ") {
+        i += 1;
+    }
+    while i < lines.len() {
+        let t = lines[i].trim_start();
+        if t.starts_with('+') {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_scriptblock_stack_trace() {
+        let raw = "Compiling libragent v0.8.36\n\
+                   at <ScriptBlock>, C:\\ws\\.libragent\\tmp\\cmd_abc_17.ps1: line 5\n\
+                   at <ScriptBlock>, <No file>: line 1\n";
+        let cleaned = sanitize_powershell_stderr(raw);
+        assert_eq!(cleaned, "Compiling libragent v0.8.36\n");
+        assert!(!cleaned.contains("ScriptBlock"));
+    }
+
+    #[test]
+    fn unwraps_native_command_error_frame() {
+        let raw = "cmd : progress message\n\
+                   At C:\\ws\\.libragent\\tmp\\cmd_abc_0.ps1:5 char:3\n\
+                   +   cmd /c \"echo progress 1>&2\"\n\
+                   +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\
+                       + CategoryInfo          : NotSpecified: (progress message:String) [], RemoteException\n\
+                       + FullyQualifiedErrorId : NativeCommandError\n";
+        let cleaned = sanitize_powershell_stderr(raw);
+        assert_eq!(cleaned.trim(), "progress message");
+        assert!(!cleaned.contains("CategoryInfo"));
+        assert!(!cleaned.contains("cmd_abc_0.ps1"));
+    }
+
+    #[test]
+    fn preserves_unrelated_stderr() {
+        let raw = "error: could not compile `foo`\n\nCaused by:\n  linker failed\n";
+        assert_eq!(sanitize_powershell_stderr(raw), raw);
+    }
+}

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/process.rs
@@ -65,7 +65,14 @@ pub async fn read_output_file(file_path: &PathBuf) -> Result<String, String> {
     let bytes = tokio::fs::read(file_path)
         .await
         .map_err(|e| format!("Failed to read output file '{}': {e}", file_path.display()))?;
-    Ok(strip_ansi_escapes(&decode_process_output(&bytes)))
+    let decoded = strip_ansi_escapes(&decode_process_output(&bytes));
+    // Only stderr captures accumulate PowerShell wrapper chrome.
+    if file_path.file_name().and_then(|n| n.to_str()) == Some("stderr") {
+        return Ok(super::powershell_stderr::sanitize_powershell_stderr(
+            &decoded,
+        ));
+    }
+    Ok(decoded)
 }
 
 /// Spawn process and stream stdout/stderr to files (common logic for sync/async)
@@ -301,7 +308,9 @@ pub async fn spawn_and_stream_to_files(
     let stdout_content = strip_ansi_escapes(&decode_process_output(&stdout_bytes));
 
     let stderr_bytes = tokio::fs::read(&stderr_path).await.unwrap_or_default();
-    let stderr_content = strip_ansi_escapes(&decode_process_output(&stderr_bytes));
+    let stderr_content = super::powershell_stderr::sanitize_powershell_stderr(&strip_ansi_escapes(
+        &decode_process_output(&stderr_bytes),
+    ));
 
     info!(
         "Process {} completed with exit code {:?}",

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -103,19 +103,34 @@ pub async fn create_basic_isolated_command(
     let seq = SCRIPT_COUNTER.fetch_add(1, Ordering::Relaxed);
     let script_path = tmp_dir.join(format!("cmd_{}_{}.ps1", config.session_id, seq));
 
-    // Plain readable script — no obfuscation, AV-friendly
-    // Set UTF-8 console encoding to prevent UnicodeEncodeError on cp949/other non-UTF8 locales
+    // Plain readable script — no obfuscation, AV-friendly.
+    //
+    // ErrorActionPreference must be Continue (not Stop):
+    // Under Stop, native stderr merged via `2>&1` becomes terminating ErrorRecords,
+    // aborting pipelines like `cargo … 2>&1 | Select-Object` mid-stream and routing
+    // into catch with fake failures.
+    //
+    // Exit code: prefer $LASTEXITCODE when set (including 0). Do not use bare `$?`
+    // alone after 2>&1 — NativeCommandError records set $? = false even on success.
+    // Catch writes Exception.Message only (never ScriptStackTrace) to avoid
+    // `at <ScriptBlock>, …cmd_*.ps1` noise in agent-visible stderr.
     let script_content = format!(
-        "$ErrorActionPreference = 'Stop'\n\
+        "$ErrorActionPreference = 'Continue'\n\
          [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'\n\
          [Console]::InputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n\
+         $__libr_exit = 0\n\
          try {{\n\
              {}\n\
+             if ($null -ne $LASTEXITCODE) {{\n\
+                 $__libr_exit = $LASTEXITCODE\n\
+             }} elseif (-not $?) {{\n\
+                 $__libr_exit = 1\n\
+             }}\n\
          }} catch {{\n\
              [Console]::Error.WriteLine($_.Exception.Message)\n\
-             [Console]::Error.WriteLine($_.ScriptStackTrace)\n\
-             exit 1\n\
-         }}\n",
+             $__libr_exit = 1\n\
+         }}\n\
+         exit $__libr_exit\n",
         full_command
     );
 
@@ -135,10 +150,14 @@ pub async fn create_basic_isolated_command(
         .ok_or_else(|| "Script path contains invalid UTF-8".to_string())?
         .to_string();
 
-    // Wrap with a cleanup script: run the target .ps1, then delete it regardless of outcome.
-    // This prevents accumulation of temp files in the workspace tmp/ directory.
+    // Run the target .ps1, capture its exit code, then delete it.
+    //
+    // IMPORTANT: Do not wrap `& script` in `try/finally` without re-exiting.
+    // `exit N` inside a script invoked via `&` sets $LASTEXITCODE but returns to
+    // the caller; an outer try/finally that ends normally made powershell.exe
+    // report exit 0 even after script failures (false success to the agent).
     let self_deleting_wrapper = format!(
-        "try {{ & '{}' }} finally {{ Remove-Item -LiteralPath '{}' -Force -ErrorAction SilentlyContinue }}",
+        "& '{}'; $__libr_code = $LASTEXITCODE; if ($null -eq $__libr_code) {{ $__libr_code = 0 }}; Remove-Item -LiteralPath '{}' -Force -ErrorAction SilentlyContinue; exit $__libr_code",
         script_path_str.replace("'", "''"),
         script_path_str.replace("'", "''")
     );
@@ -241,15 +260,22 @@ mod tests {
     /// Mirrors the script content format used by `create_basic_isolated_command`.
     fn build_script_content(full_command: &str) -> String {
         format!(
-            "$ErrorActionPreference = 'Stop'\n\
+            "$ErrorActionPreference = 'Continue'\n\
              [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'\n\
+             [Console]::InputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n\
+             $__libr_exit = 0\n\
              try {{\n\
                  {}\n\
+                 if ($null -ne $LASTEXITCODE) {{\n\
+                     $__libr_exit = $LASTEXITCODE\n\
+                 }} elseif (-not $?) {{\n\
+                     $__libr_exit = 1\n\
+                 }}\n\
              }} catch {{\n\
                  [Console]::Error.WriteLine($_.Exception.Message)\n\
-                 [Console]::Error.WriteLine($_.ScriptStackTrace)\n\
-                 exit 1\n\
-             }}\n",
+                 $__libr_exit = 1\n\
+             }}\n\
+             exit $__libr_exit\n",
             full_command
         )
     }
@@ -258,7 +284,7 @@ mod tests {
     fn build_cleanup_wrapper(script_path: &str) -> String {
         let escaped = script_path.replace("'", "''");
         format!(
-            "try {{ & '{}' }} finally {{ Remove-Item -LiteralPath '{}' -Force -ErrorAction SilentlyContinue }}",
+            "& '{}'; $__libr_code = $LASTEXITCODE; if ($null -eq $__libr_code) {{ $__libr_code = 0 }}; Remove-Item -LiteralPath '{}' -Force -ErrorAction SilentlyContinue; exit $__libr_code",
             escaped, escaped
         )
     }
@@ -267,13 +293,21 @@ mod tests {
 
     #[test]
     fn test_script_content_has_error_handling() {
-        // Script must stop on first error, report it to stderr, and exit non-zero.
+        // Script must capture exit codes, report terminating errors to stderr, and exit.
         let script = build_script_content("Remove-Item -Path 'C:\\test' -Recurse -Force");
-        assert!(script.contains("$ErrorActionPreference = 'Stop'"));
+        assert!(script.contains("$ErrorActionPreference = 'Continue'"));
         assert!(script.contains("try {"));
         assert!(script.contains("} catch {"));
         assert!(script.contains("[Console]::Error.WriteLine"));
-        assert!(script.contains("exit 1"));
+        assert!(script.contains("exit $__libr_exit"));
+        assert!(
+            !script.contains("ScriptStackTrace"),
+            "ScriptStackTrace produces at <ScriptBlock> noise in agent stderr"
+        );
+        assert!(
+            !script.contains("$ErrorActionPreference = 'Stop'"),
+            "Stop makes native 2>&1 stderr terminating and aborts pipelines"
+        );
     }
 
     #[test]
@@ -334,13 +368,16 @@ mod tests {
 
     #[test]
     fn test_cleanup_wrapper_calls_script_and_deletes() {
-        // Wrapper must invoke the script AND delete it in a finally block (runs on success/failure).
+        // Wrapper must invoke the script, preserve exit code, AND delete the temp file.
         let wrapper = build_cleanup_wrapper("C:\\workspace\\tmp\\cmd_abc_0.ps1");
         assert!(wrapper.contains("& 'C:\\workspace\\tmp\\cmd_abc_0.ps1'"));
         assert!(wrapper.contains("Remove-Item"));
         assert!(wrapper.contains("-LiteralPath"));
-        assert!(wrapper.contains("finally"));
-        assert!(wrapper.contains("-ErrorAction SilentlyContinue"));
+        assert!(wrapper.contains("exit $__libr_code"));
+        assert!(
+            !wrapper.contains("try {"),
+            "Outer try/finally without re-exit swallowed script exit codes"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/powershell_stderr_sanitize_tests.rs
+++ b/src-tauri/tests/powershell_stderr_sanitize_tests.rs
@@ -1,0 +1,33 @@
+//! Regression tests for PowerShell stderr chrome sanitization (#1641).
+
+use tauri_mcp_agent_lib::mcp::builtin::workspace::code_execution::powershell_stderr::sanitize_powershell_stderr;
+
+#[test]
+fn sanitize_strips_scriptblock_stack_trace_lines() {
+    let raw = "Compiling libragent v0.8.36\n\
+               at <ScriptBlock>, C:\\ws\\.libragent\\tmp\\cmd_abc_17.ps1: line 5\n\
+               at <ScriptBlock>, <No file>: line 1\n";
+    let cleaned = sanitize_powershell_stderr(raw);
+    assert_eq!(cleaned, "Compiling libragent v0.8.36\n");
+    assert!(!cleaned.contains("ScriptBlock"));
+}
+
+#[test]
+fn sanitize_unwraps_native_command_error_frames() {
+    let raw = "cmd : progress message\n\
+               At C:\\ws\\.libragent\\tmp\\cmd_abc_0.ps1:5 char:3\n\
+               +   cmd /c \"echo progress 1>&2\"\n\
+               +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\
+                   + CategoryInfo          : NotSpecified: (progress message:String) [], RemoteException\n\
+                   + FullyQualifiedErrorId : NativeCommandError\n";
+    let cleaned = sanitize_powershell_stderr(raw);
+    assert_eq!(cleaned.trim(), "progress message");
+    assert!(!cleaned.contains("CategoryInfo"));
+    assert!(!cleaned.contains("cmd_abc_0.ps1"));
+}
+
+#[test]
+fn sanitize_preserves_real_compiler_stderr() {
+    let raw = "error: could not compile `foo`\n\nCaused by:\n  linker failed\n";
+    assert_eq!(sanitize_powershell_stderr(raw), raw);
+}


### PR DESCRIPTION
## Summary
- Fix PowerShell wrapper treating native `2>&1` stderr as terminating errors (`Stop` → `Continue`) and leaking `at <ScriptBlock>, …cmd_*.ps1` stack traces into agent-visible stderr.
- Preserve real process exit codes through the temp-script cleanup wrapper (outer `try/finally` previously swallowed non-zero exits as success).
- Sanitize remaining wrapper chrome from stderr captures and add unit coverage.

Fixes #1641

## Test plan
- [ ] Run a PowerShell command that merges native stderr (`cargo … 2>&1 | Select-Object …`) and confirm no `at <ScriptBlock>` / `cmd_*.ps1` noise in the tool result.
- [ ] Confirm a failing native command still reports a non-zero exit code to the agent (not false success).
- [ ] `cargo test --tests powershell_stderr_sanitize_tests`
- [ ] Spot-check Windows workspace `runPowerShell` on a successful command still returns exit 0.