### PR TITLE
feat(skills): add create-pr skill with latest-dev base resolution

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: create-pr
+description: >-
+  Create a GitHub pull request with gh, target the correct base branch, push only
+  committed work, and bind related issues via Fixes/Closes keywords. Use when asked
+  to create a PR, open a pull request, push and open PR, link/bind/associate an
+  issue to a PR, add Fixes #N, or close issues on merge.
+---
+
+# Create PR and Bind Issues
+
+Open a reviewable PR from the current branch and attach the right GitHub issues so merge auto-closes them.
+
+## Preconditions
+
+- Only **committed** changes go into the PR. Leave uncommitted/WIP files out (or ask before committing).
+- Do **not** update git config, force-push, or skip hooks unless the user explicitly asks.
+- Prefer `gh` for all GitHub operations.
+
+## Resolve base branch
+
+**If the user names a base** (e.g. `dev/0.8.x`, `main`) → use that exactly.
+
+**If the user does not name a base** → use the **latest `dev/<version>`** branch on `origin` (semver; treat `.x` as the highest patch for that minor). Do **not** hardcode a version.
+
+```bash
+git fetch origin 'refs/heads/dev/*:refs/remotes/origin/dev/*'
+python .agents/skills/create-pr/scripts/resolve_dev_base.py
+# → e.g. dev/0.8.x
+```
+
+Use the printed name as `<base>` everywhere below (`git log`, `git diff`, `gh pr create --base`).
+
+## Workflow
+
+### 1. Inspect branch state (parallel)
+
+After resolving `<base>`:
+
+```bash
+git status
+git diff
+git rev-parse --abbrev-ref HEAD
+git status -sb
+git fetch origin <base>
+git log --oneline origin/<base>..HEAD
+git diff --stat origin/<base>...HEAD
+gh pr list --head <current-branch> --json number,title,url,state,baseRefName
+```
+
+### 2. Decide branch / PR shape
+
+| Situation | Action |
+| --------- | ------ |
+| Open PR already exists for this head | Update it (`gh pr edit`) or push; do not open a duplicate |
+| Head branch was merged earlier; new commits remain | New PR from same or cleaner branch is OK; confirm `origin/<base>..HEAD` is only the intended commits |
+| Mixed concerns on one branch | Prefer a clean branch from `origin/<base>` + cherry-pick (or ask) before opening |
+
+### 3. Push, then create
+
+```bash
+git push -u origin HEAD
+gh pr create --base <base> --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <1-3 bullets: why / user-visible effect>
+
+Fixes #<issue>
+
+## Test plan
+- [ ] <concrete checks>
+
+EOF
+)"
+```
+
+On Windows PowerShell, use a here-string for `--body` instead of bash HEREDOC:
+
+```powershell
+gh pr create --base $base --title "..." --body @"
+## Summary
+- ...
+
+Fixes #1234
+
+## Test plan
+- [ ] ...
+"@
+```
+
+Title/body style: match recent repo commits (`fix(scope): …`, `feat(scope): …`). Include issue number in title only if helpful; **always** put a closing keyword in the body (see below).
+
+Return the PR URL when done.
+
+### 4. Bind relevant issues
+
+Always attach issues the PR actually resolves or substantially addresses.
+
+1. Infer candidates from: user message, branch name (`fix/1641-…`), commit messages (`(#1641)`), and `gh issue list` / `gh issue view` when needed.
+2. Put closing keywords in the PR body (preferred) or add them via:
+
+```bash
+gh pr edit <number> --body "$(…updated body with Fixes #N…)"
+```
+
+3. Verify link: `gh pr view <number> --json body,closingIssuesReferences` (or check the issue sidebar on GitHub).
+
+Keyword details and multi-issue examples: [references/issue-linking.md](references/issue-linking.md).
+
+### 5. After create (optional)
+
+- If the user only asked to bind an existing PR: skip create; edit body / confirm closing references.
+- Do not push again unless new commits were added.
+
+## Quick checks before opening
+
+- [ ] Diff vs base matches the intended fix only
+- [ ] No secrets / generated noise unless intentional
+- [ ] At least one `Fixes` / `Closes` / `Resolves` line when an issue exists
+- [ ] Base is user-specified **or** latest `dev/<version>` from `resolve_dev_base.py`

--- a/.agents/skills/create-pr/references/issue-linking.md
+++ b/.agents/skills/create-pr/references/issue-linking.md
@@ -1,0 +1,50 @@
+# Issue linking keywords
+
+GitHub closes linked issues when the PR merges into the **default** branch of the repo, or when the closing reference is recognized for the PR's base (behavior can vary by repo settings). Prefer explicit keywords in the PR description.
+
+## Closing keywords (auto-close on merge)
+
+Use any of these followed by an issue number:
+
+- `Fixes #123`
+- `Closes #123`
+- `Resolves #123`
+- Same with `Fixed` / `Closed` / `Resolved` (past tense also works)
+
+Full form also works: `Fixes https://github.com/owner/repo/issues/123`
+
+## Non-closing references
+
+When the PR is related but should **not** close the issue:
+
+- `Related to #123`
+- `See also #123`
+- `Refs #123`
+
+## Multiple issues
+
+```markdown
+Fixes #1641
+Fixes #1638
+```
+
+Or one line: `Fixes #1641, fixes #1638`
+
+## Bind after PR exists
+
+```bash
+gh pr view <n> --json body -q .body
+# Edit body to include Fixes #N, then:
+gh pr edit <n> --body "…"
+```
+
+Do not rely on title-only `#123` for auto-close — put the keyword in the **body**.
+
+## Choosing the right issue
+
+| Signal | Use |
+| ------ | --- |
+| User says “for #1641” / “bind #1641” | That issue |
+| Branch `fix/1641-…` or commit `(#1641)` | Confirm with `gh issue view 1641` |
+| Several open bugs touched | Prefer one PR per issue when possible; otherwise list every closed issue |
+| Partial fix | `Related to #N` — do not `Fixes` |

--- a/.agents/skills/create-pr/scripts/resolve_dev_base.py
+++ b/.agents/skills/create-pr/scripts/resolve_dev_base.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Print the latest origin/dev/<version> branch name (e.g. dev/0.8.x)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+
+VERSION_RE = re.compile(
+    r"^origin/dev/(?P<maj>\d+)\.(?P<min>\d+)\.(?P<pat>\d+|x)$"
+)
+
+
+def version_key(remote_ref: str) -> tuple[int, int, int] | None:
+    match = VERSION_RE.match(remote_ref.strip())
+    if not match:
+        return None
+    patch = match.group("pat")
+    return (
+        int(match.group("maj")),
+        int(match.group("min")),
+        10**9 if patch == "x" else int(patch),
+    )
+
+
+def list_dev_remotes() -> list[str]:
+    result = subprocess.run(
+        ["git", "branch", "-r", "--list", "origin/dev/*"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    scored: list[tuple[tuple[int, int, int], str]] = []
+    for ref in list_dev_remotes():
+        key = version_key(ref)
+        if key is None:
+            continue
+        # Strip origin/ prefix for gh --base / human use
+        scored.append((key, ref.removeprefix("origin/")))
+
+    if not scored:
+        print("No origin/dev/<version> branches found. Fetch first.", file=sys.stderr)
+        return 1
+
+    scored.sort(key=lambda item: item[0])
+    print(scored[-1][1])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `create-pr` agent skill for opening GitHub PRs with `gh`, including push/inspect workflow and issue binding via Fixes/Closes.
- Default PR base to the latest `origin/dev/<version>` branch when the user does not name one (`resolve_dev_base.py`); honor an explicit base such as `dev/0.8.x`.

## Test plan
- [ ] `python .agents/skills/create-pr/scripts/resolve_dev_base.py` prints the newest `dev/*` (currently `dev/0.8.x`).
- [ ] Ask an agent to create a PR without naming a base and confirm it targets that latest `dev` branch.
- [ ] Ask an agent to create a PR `to `dev/0.8.x` and confirm the explicit base is used.

Made with [Cursor](https://cursor.com)