### PR TITLE
feat(agent): enrich checkSession with identity metadata (#1639)

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -355,10 +355,18 @@ pub struct CheckSessionEnrichment {
 }
 
 fn optional_nonempty(value: Option<&str>) -> Option<String> {
-    value
-        .map(str::trim)
-        .filter(|text| !text.is_empty())
-        .map(str::to_string)
+    value.and_then(sanitize_check_session_metadata_field)
+}
+
+/// Keep Metadata fields on a single line so crafted values cannot break the fence layout.
+fn sanitize_check_session_metadata_field(value: &str) -> Option<String> {
+    let without_breaks: String = value.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+    let trimmed = without_breaks.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Build enrichment fields from session metadata (assistant name resolved separately).
@@ -441,37 +449,29 @@ pub fn format_check_session_context_text(enrichment: &CheckSessionEnrichment) ->
     }
 }
 
-fn inject_check_session_context_text(text: &str, context: &str) -> String {
-    const FOLLOW_UPS: &str = "💡 Suggested Follow-ups:";
-    if let Some(index) = text.find(FOLLOW_UPS) {
-        let (before, after) = text.split_at(index);
-        format!("{}{}\n\n{}", before.trim_end(), context, after)
-    } else {
-        format!("{}\n\n{}", text.trim_end(), context)
-    }
-}
-
-/// Attach enrichment fields onto an existing `checkSession` MCP result (structured + text).
-pub fn enrich_check_session_result(
-    mut result: MCPResult,
+/// Insert Metadata markdown into the checkSession body **before** SuccessHint wraps it.
+///
+/// Placement (so long Result bodies / tool-result truncation keep identity visible):
+/// status line → Metadata → `Result:` / `Last known output:` → optional Follow-ups.
+pub fn append_check_session_context_to_message(
+    message: &str,
     enrichment: &CheckSessionEnrichment,
-) -> MCPResult {
-    if let Some(Value::Object(ref mut data)) = result.structured_content {
-        apply_check_session_enrichment(data, enrichment);
-    }
+) -> String {
+    let Some(context) = format_check_session_context_text(enrichment) else {
+        return message.to_string();
+    };
 
-    if let Some(context) = format_check_session_context_text(enrichment) {
-        if let Some(content_items) = result.content.as_mut() {
-            for item in content_items.iter_mut() {
-                if let MCPContent::Text { text, .. } = item {
-                    *text = inject_check_session_context_text(text, &context);
-                    break;
-                }
-            }
+    // Prefer Metadata before large child bodies — truncation keeps the head of the text.
+    const BODY_MARKERS: &[&str] = &["\n\nResult:\n", "\n\nLast known output:\n"];
+    for marker in BODY_MARKERS {
+        if let Some(index) = message.find(marker) {
+            let before = message[..index].trim_end();
+            let after = &message[index..];
+            return format!("{}\n\n{}{}", before, context, after);
         }
     }
 
-    result
+    format!("{}\n\n{}", message.trim_end(), context)
 }
 
 /// Resolve assistant display name and build enrichment for a delegated session.
@@ -506,14 +506,18 @@ pub fn build_paused_check_session_result_from_messages(
     session_id: &str,
     turn_count: usize,
     messages_value: &[Value],
+    enrichment: Option<&CheckSessionEnrichment>,
 ) -> MCPResult {
     let latest_output = latest_session_output(messages_value);
     let recovery_reason =
         "Wake the paused child session so it can continue from the last stable step.";
-    let message = format!(
+    let mut message = format!(
         "Session {} is paused and will not make progress on its own.\n\nLast known output:\n{}\n\nRecovery: send a follow-up message with messageToSession(...) to restart the child workflow.",
         session_id, latest_output
     );
+    if let Some(enrichment) = enrichment {
+        message = append_check_session_context_to_message(&message, enrichment);
+    }
     let next_actions = vec![
         recovery_action_for_session(session_id, "paused", recovery_reason),
         json!({
@@ -546,6 +550,9 @@ pub fn build_paused_check_session_result_from_messages(
     );
     response_data.insert("abnormalTermination".to_string(), Value::Bool(false));
     response_data.insert("result".to_string(), Value::String(latest_output));
+    if let Some(enrichment) = enrichment {
+        apply_check_session_enrichment(&mut response_data, enrichment);
+    }
 
     hint.to_mcp_result_with_data(Some(Value::Object(response_data)))
 }
@@ -555,6 +562,7 @@ pub fn build_terminal_check_session_result_from_messages(
     status: &str,
     turn_count: usize,
     messages_value: &[Value],
+    enrichment: Option<&CheckSessionEnrichment>,
 ) -> MCPResult {
     let assistant_text = latest_session_output(messages_value);
     let normalized_status = status.to_ascii_lowercase();
@@ -589,7 +597,7 @@ pub fn build_terminal_check_session_result_from_messages(
             }
         })]
     };
-    let message = if is_abnormal {
+    let mut message = if is_abnormal {
         format!(
             "Session {} ended abnormally ({}).\n\nLast known output:\n{}\n\nRecovery: this child session will not continue on its own. Use messageToSession(...) to retry from the last stable step.",
             session_id, status, assistant_text
@@ -605,6 +613,9 @@ pub fn build_terminal_check_session_result_from_messages(
             session_id, status, assistant_text, session_id
         )
     };
+    if let Some(enrichment) = enrichment {
+        message = append_check_session_context_to_message(&message, enrichment);
+    }
     let hint = SuccessHint::new(message.clone(), vec![]);
     let mut response_data = build_agent_session_tool_data(
         "checkSession",
@@ -636,6 +647,9 @@ pub fn build_terminal_check_session_result_from_messages(
     }
     // Always include hasMoreDetail hint so UI can show a "view more" action
     response_data.insert("hasMoreDetail".to_string(), Value::Bool(true));
+    if let Some(enrichment) = enrichment {
+        apply_check_session_enrichment(&mut response_data, enrichment);
+    }
 
     hint.to_mcp_result_with_data(Some(Value::Object(response_data)))
 }
@@ -644,6 +658,7 @@ async fn build_terminal_check_session_result(
     session_id: &str,
     status: &str,
     turn_count: usize,
+    enrichment: &CheckSessionEnrichment,
 ) -> Result<MCPResult, String> {
     let messages_value =
         fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
@@ -653,12 +668,14 @@ async fn build_terminal_check_session_result(
         status,
         turn_count,
         &messages_value,
+        Some(enrichment),
     ))
 }
 
 async fn build_paused_check_session_result(
     session_id: &str,
     turn_count: usize,
+    enrichment: &CheckSessionEnrichment,
 ) -> Result<MCPResult, String> {
     let messages_value =
         fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
@@ -667,6 +684,7 @@ async fn build_paused_check_session_result(
         session_id,
         turn_count,
         &messages_value,
+        Some(enrichment),
     ))
 }
 mod check_session;

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -339,6 +339,169 @@ fn recovery_action_for_session(session_id: &str, status: &str, reason: &str) -> 
     })
 }
 
+/// Session context fields attached to every successful `checkSession` response.
+///
+/// Session `name` / task title is intentionally omitted: it often reflects a past
+/// request and can mislead a parent agent about the child's current work.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CheckSessionEnrichment {
+    pub assistant_id: Option<String>,
+    pub assistant_name: Option<String>,
+    pub workspace_path: Option<String>,
+    /// Present in structured content only; omitted from the text Metadata block
+    /// (low routing signal, adds noise for the parent agent).
+    pub created_at: Option<i64>,
+    pub org_id: Option<String>,
+}
+
+fn optional_nonempty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
+}
+
+/// Build enrichment fields from session metadata (assistant name resolved separately).
+pub fn check_session_enrichment_from_metadata(
+    meta: &SessionMetadata,
+    assistant_name: Option<String>,
+) -> CheckSessionEnrichment {
+    let workspace_path = optional_nonempty(meta.workspace_override.as_deref())
+        .or_else(|| optional_nonempty(meta.docker_host_workspace_path.as_deref()));
+
+    CheckSessionEnrichment {
+        assistant_id: optional_nonempty(meta.assistant_id.as_deref()),
+        assistant_name: optional_nonempty(assistant_name.as_deref()),
+        workspace_path,
+        created_at: Some(meta.created_at),
+        org_id: optional_nonempty(meta.org_id.as_deref()),
+    }
+}
+
+/// Insert `checkSession` context metadata into structured response data (camelCase keys).
+pub fn apply_check_session_enrichment(
+    data: &mut serde_json::Map<String, Value>,
+    enrichment: &CheckSessionEnrichment,
+) {
+    if let Some(assistant_id) = enrichment.assistant_id.as_ref() {
+        data.insert(
+            "assistantId".to_string(),
+            Value::String(assistant_id.clone()),
+        );
+    }
+    if let Some(assistant_name) = enrichment.assistant_name.as_ref() {
+        data.insert(
+            "assistantName".to_string(),
+            Value::String(assistant_name.clone()),
+        );
+    }
+    if let Some(workspace_path) = enrichment.workspace_path.as_ref() {
+        data.insert(
+            "workspacePath".to_string(),
+            Value::String(workspace_path.clone()),
+        );
+    }
+    if let Some(created_at) = enrichment.created_at {
+        data.insert("createdAt".to_string(), json!(created_at));
+    }
+    if let Some(org_id) = enrichment.org_id.as_ref() {
+        data.insert("orgId".to_string(), Value::String(org_id.clone()));
+    }
+}
+
+/// Format a fenced identity/routing block for agent-visible text content.
+///
+/// Omits `createdAt` (kept in structured data only) and never includes session name.
+pub fn format_check_session_context_text(enrichment: &CheckSessionEnrichment) -> Option<String> {
+    let mut lines = Vec::new();
+
+    match (
+        enrichment.assistant_name.as_deref(),
+        enrichment.assistant_id.as_deref(),
+    ) {
+        (Some(name), Some(id)) => lines.push(format!("assistant: {} ({})", name, id)),
+        (Some(name), None) => lines.push(format!("assistant: {}", name)),
+        (None, Some(id)) => lines.push(format!("assistantId: {}", id)),
+        (None, None) => {}
+    }
+    if let Some(workspace_path) = enrichment.workspace_path.as_ref() {
+        lines.push(format!("workspace: {}", workspace_path));
+    }
+    if let Some(org_id) = enrichment.org_id.as_ref() {
+        lines.push(format!("orgId: {}", org_id));
+    }
+
+    if lines.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "---\n[Metadata — identity/routing only; not the child session's answer]\n{}",
+            lines.join("\n")
+        ))
+    }
+}
+
+fn inject_check_session_context_text(text: &str, context: &str) -> String {
+    const FOLLOW_UPS: &str = "💡 Suggested Follow-ups:";
+    if let Some(index) = text.find(FOLLOW_UPS) {
+        let (before, after) = text.split_at(index);
+        format!("{}{}\n\n{}", before.trim_end(), context, after)
+    } else {
+        format!("{}\n\n{}", text.trim_end(), context)
+    }
+}
+
+/// Attach enrichment fields onto an existing `checkSession` MCP result (structured + text).
+pub fn enrich_check_session_result(
+    mut result: MCPResult,
+    enrichment: &CheckSessionEnrichment,
+) -> MCPResult {
+    if let Some(Value::Object(ref mut data)) = result.structured_content {
+        apply_check_session_enrichment(data, enrichment);
+    }
+
+    if let Some(context) = format_check_session_context_text(enrichment) {
+        if let Some(content_items) = result.content.as_mut() {
+            for item in content_items.iter_mut() {
+                if let MCPContent::Text { text, .. } = item {
+                    *text = inject_check_session_context_text(text, &context);
+                    break;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Resolve assistant display name and build enrichment for a delegated session.
+pub async fn resolve_check_session_enrichment(meta: &SessionMetadata) -> CheckSessionEnrichment {
+    use crate::repositories::AssistantRepository;
+
+    let assistant_name = match optional_nonempty(meta.assistant_id.as_deref()) {
+        Some(assistant_id) => {
+            match crate::state::get_assistant_repository()
+                .get_assistant(&assistant_id)
+                .await
+            {
+                Ok(Some(assistant)) => Some(assistant.name),
+                Ok(None) => None,
+                Err(error) => {
+                    log::warn!(
+                        "checkSession: failed to resolve assistantName for {}: {}",
+                        assistant_id,
+                        error
+                    );
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+
+    check_session_enrichment_from_metadata(meta, assistant_name)
+}
+
 pub fn build_paused_check_session_result_from_messages(
     session_id: &str,
     turn_count: usize,

--- a/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
@@ -10,9 +10,9 @@ use crate::mcp::types::MCPResult;
 
 use super::super::AgentServer;
 use super::{
+    append_check_session_context_to_message, apply_check_session_enrichment,
     build_paused_check_session_result, build_terminal_check_session_result,
-    enrich_check_session_result, load_accessible_delegated_session,
-    resolve_check_session_enrichment,
+    load_accessible_delegated_session, resolve_check_session_enrichment,
 };
 
 /// checkSession handler (from awaitAgent / getAgentStatus)
@@ -44,10 +44,8 @@ pub async fn check_session(
     let current_turn_count = count_session_turns(&session_id).await;
 
     if current_status == "paused" {
-        return Ok(enrich_check_session_result(
-            build_paused_check_session_result(&session_id, current_turn_count).await?,
-            &enrichment,
-        ));
+        return build_paused_check_session_result(&session_id, current_turn_count, &enrichment)
+            .await;
     }
 
     if wait {
@@ -106,47 +104,42 @@ pub async fn check_session(
         let status = extract_session_status(&session_data);
         let turn_count = count_session_turns(&session_id).await;
         if status == "paused" {
-            return Ok(enrich_check_session_result(
-                build_paused_check_session_result(&session_id, turn_count).await?,
-                &enrichment,
-            ));
+            return build_paused_check_session_result(&session_id, turn_count, &enrichment).await;
         }
-        return Ok(enrich_check_session_result(
-            build_terminal_check_session_result(&session_id, &status, turn_count).await?,
-            &enrichment,
-        ));
+        return build_terminal_check_session_result(&session_id, &status, turn_count, &enrichment)
+            .await;
     }
 
     let status = current_status;
     let turn_count = current_turn_count;
 
     if is_terminal_status(&status) {
-        return Ok(enrich_check_session_result(
-            build_terminal_check_session_result(&session_id, &status, turn_count).await?,
-            &enrichment,
-        ));
+        return build_terminal_check_session_result(&session_id, &status, turn_count, &enrichment)
+            .await;
     }
 
     let next_steps = vec![format!(
         "Use checkSession(\"{}\", wait=true) to wait for completion.",
         session_id
     )];
-    let message = format!(
-        "Session {} is currently {} (Turns elapsed: {}).",
-        session_id, status, turn_count
+    let message = append_check_session_context_to_message(
+        &format!(
+            "Session {} is currently {} (Turns elapsed: {}).",
+            session_id, status, turn_count
+        ),
+        &enrichment,
     );
     let hint = SuccessHint::new(message.clone(), next_steps);
+    let mut response_data = build_agent_session_tool_data(
+        "checkSession",
+        &session_id,
+        &message,
+        &status,
+        "pending",
+        turn_count,
+        check_session_next_actions(&session_id),
+    );
+    apply_check_session_enrichment(&mut response_data, &enrichment);
 
-    Ok(enrich_check_session_result(
-        hint.to_mcp_result_with_data(Some(Value::Object(build_agent_session_tool_data(
-            "checkSession",
-            &session_id,
-            &message,
-            &status,
-            "pending",
-            turn_count,
-            check_session_next_actions(&session_id),
-        )))),
-        &enrichment,
-    ))
+    Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
 }

--- a/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
@@ -11,7 +11,8 @@ use crate::mcp::types::MCPResult;
 use super::super::AgentServer;
 use super::{
     build_paused_check_session_result, build_terminal_check_session_result,
-    load_accessible_delegated_session,
+    enrich_check_session_result, load_accessible_delegated_session,
+    resolve_check_session_enrichment,
 };
 
 /// checkSession handler (from awaitAgent / getAgentStatus)
@@ -38,11 +39,15 @@ pub async fn check_session(
         Ok(session) => session,
         Err(result) => return Ok(result),
     };
+    let enrichment = resolve_check_session_enrichment(&current_session_meta).await;
     let current_status = format!("{:?}", current_session_meta.status).to_lowercase();
     let current_turn_count = count_session_turns(&session_id).await;
 
     if current_status == "paused" {
-        return build_paused_check_session_result(&session_id, current_turn_count).await;
+        return Ok(enrich_check_session_result(
+            build_paused_check_session_result(&session_id, current_turn_count).await?,
+            &enrichment,
+        ));
     }
 
     if wait {
@@ -101,16 +106,25 @@ pub async fn check_session(
         let status = extract_session_status(&session_data);
         let turn_count = count_session_turns(&session_id).await;
         if status == "paused" {
-            return build_paused_check_session_result(&session_id, turn_count).await;
+            return Ok(enrich_check_session_result(
+                build_paused_check_session_result(&session_id, turn_count).await?,
+                &enrichment,
+            ));
         }
-        return build_terminal_check_session_result(&session_id, &status, turn_count).await;
+        return Ok(enrich_check_session_result(
+            build_terminal_check_session_result(&session_id, &status, turn_count).await?,
+            &enrichment,
+        ));
     }
 
     let status = current_status;
     let turn_count = current_turn_count;
 
     if is_terminal_status(&status) {
-        return build_terminal_check_session_result(&session_id, &status, turn_count).await;
+        return Ok(enrich_check_session_result(
+            build_terminal_check_session_result(&session_id, &status, turn_count).await?,
+            &enrichment,
+        ));
     }
 
     let next_steps = vec![format!(
@@ -123,7 +137,7 @@ pub async fn check_session(
     );
     let hint = SuccessHint::new(message.clone(), next_steps);
 
-    Ok(
+    Ok(enrich_check_session_result(
         hint.to_mcp_result_with_data(Some(Value::Object(build_agent_session_tool_data(
             "checkSession",
             &session_id,
@@ -133,5 +147,6 @@ pub async fn check_session(
             turn_count,
             check_session_next_actions(&session_id),
         )))),
-    )
+        &enrichment,
+    ))
 }

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -364,7 +364,7 @@ fn check_session_tool() -> MCPTool {
             &["Session ID from agent__startSession or agent__listAgents(type='sessions')."],
             &[
                 "Call with wait=false for a snapshot or wait=true to block until terminal state.",
-                "After the child status/result, a fenced Metadata block adds identity/routing only (assistant, workspace) — not the child's answer. Session title/name is omitted.",
+                "After the status line (before Result), a fenced Metadata block adds identity/routing only (assistant, workspace) — not the child's answer. Session title/name is omitted.",
                 "Paused or error sessions need recovery via agent__messageToSession.",
             ],
             &[

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -364,6 +364,7 @@ fn check_session_tool() -> MCPTool {
             &["Session ID from agent__startSession or agent__listAgents(type='sessions')."],
             &[
                 "Call with wait=false for a snapshot or wait=true to block until terminal state.",
+                "After the child status/result, a fenced Metadata block adds identity/routing only (assistant, workspace) — not the child's answer. Session title/name is omitted.",
                 "Paused or error sessions need recovery via agent__messageToSession.",
             ],
             &[

--- a/src-tauri/tests/check_session_enrichment_tests.rs
+++ b/src-tauri/tests/check_session_enrichment_tests.rs
@@ -4,10 +4,11 @@
 use serde_json::json;
 use tauri_mcp_agent_lib::execution_mode::ExecutionMode;
 use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::{
-    apply_check_session_enrichment, build_terminal_check_session_result_from_messages,
-    check_session_enrichment_from_metadata, enrich_check_session_result,
+    append_check_session_context_to_message, apply_check_session_enrichment,
+    build_terminal_check_session_result_from_messages, check_session_enrichment_from_metadata,
     format_check_session_context_text,
 };
+use tauri_mcp_agent_lib::mcp::builtin::error_guidance::SuccessHint;
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
 use tauri_mcp_agent_lib::models::workspace_isolation::WorkspaceIsolationMode;
 use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
@@ -82,7 +83,7 @@ fn check_session_enrichment_omits_name_and_mirrors_fenced_context_into_text() {
     assert!(!context.contains("createdAt"));
     assert!(!context.contains("Draft release notes"));
 
-    let mut result = build_terminal_check_session_result_from_messages(
+    let result = build_terminal_check_session_result_from_messages(
         "child-1",
         "idle",
         1,
@@ -90,8 +91,8 @@ fn check_session_enrichment_omits_name_and_mirrors_fenced_context_into_text() {
             "role": "assistant",
             "content": [{"type": "text", "text": "done"}]
         })],
+        Some(&enrichment),
     );
-    result = enrich_check_session_result(result, &enrichment);
 
     let structured = result
         .structured_content
@@ -119,11 +120,15 @@ fn check_session_enrichment_omits_name_and_mirrors_fenced_context_into_text() {
     let text = extract_text(&result);
     assert!(text.contains("Session child-1 is terminal (idle)."));
     assert!(text.contains("Result:\ndone"));
-    let result_idx = text.find("Result:").expect("Result section expected");
+    let status_idx = text
+        .find("Session child-1 is terminal (idle).")
+        .expect("status line expected");
     let meta_idx = text
         .find(METADATA_FENCE_HEADER)
         .expect("metadata fence expected");
-    assert!(result_idx < meta_idx);
+    let result_idx = text.find("Result:").expect("Result section expected");
+    assert!(status_idx < meta_idx);
+    assert!(meta_idx < result_idx);
     assert!(text.contains("assistant: Researcher (asst-1)"));
     assert!(text.contains("workspace: /shared/workspace"));
     assert!(!text.contains("createdAt"));
@@ -145,17 +150,40 @@ fn check_session_enrichment_omits_name_and_mirrors_fenced_context_into_text() {
 }
 
 #[test]
-fn check_session_metadata_block_is_inserted_before_follow_ups() {
-    use tauri_mcp_agent_lib::mcp::types::MCPResult;
+fn check_session_metadata_fields_collapse_newlines() {
+    let mut meta = sample_meta();
+    meta.assistant_id = Some("asst\n-1".to_string());
+    meta.org_id = Some("org\r\n9".to_string());
+    meta.workspace_override = Some("/shared/\nworkspace".to_string());
 
     let enrichment =
+        check_session_enrichment_from_metadata(&meta, Some("Researcher\nName".to_string()));
+
+    assert_eq!(enrichment.assistant_id.as_deref(), Some("asst-1"));
+    assert_eq!(enrichment.assistant_name.as_deref(), Some("ResearcherName"));
+    assert_eq!(
+        enrichment.workspace_path.as_deref(),
+        Some("/shared/workspace")
+    );
+    assert_eq!(enrichment.org_id.as_deref(), Some("org9"));
+
+    let context = format_check_session_context_text(&enrichment).expect("context text");
+    assert!(!context.contains('\r'));
+    assert_eq!(context.matches('\n').count(), 4); // --- + header + 3 field lines
+    assert!(context.contains("assistant: ResearcherName (asst-1)"));
+    assert!(context.contains("workspace: /shared/workspace"));
+    assert!(context.contains("orgId: org9"));
+}
+
+#[test]
+fn check_session_metadata_block_is_before_follow_ups_from_success_hint() {
+    let enrichment =
         check_session_enrichment_from_metadata(&sample_meta(), Some("Researcher".to_string()));
-    let result = enrich_check_session_result(
-        MCPResult::success(
-            "✓ Session child-1 is currently busy (Turns elapsed: 2).\n\n💡 Suggested Follow-ups:\n- wait",
-        ),
+    let message = append_check_session_context_to_message(
+        "Session child-1 is currently busy (Turns elapsed: 2).",
         &enrichment,
     );
+    let result = SuccessHint::new(message, vec!["wait".to_string()]).to_mcp_result();
     let text = extract_text(&result);
     let meta_idx = text
         .find(METADATA_FENCE_HEADER)
@@ -164,4 +192,33 @@ fn check_session_metadata_block_is_inserted_before_follow_ups() {
         .find("💡 Suggested Follow-ups:")
         .expect("follow-ups expected");
     assert!(meta_idx < follow_up_idx);
+}
+
+#[test]
+fn check_session_metadata_stays_before_result_that_quotes_follow_ups_marker() {
+    let enrichment =
+        check_session_enrichment_from_metadata(&sample_meta(), Some("Researcher".to_string()));
+    // Child answers can quote the Follow-ups marker (e.g. code reviews). Metadata is
+    // inserted before Result, so quotes in the body cannot steal placement.
+    let body = "\
+Session child-1 is terminal (idle).\n\n\
+Result:\n\
+Review notes that mention inserting before the\n\n\
+💡 Suggested Follow-ups:\" marker in inject_check_session_context_text.\n\n\
+More analysis after the quoted marker.";
+    let message = append_check_session_context_to_message(body, &enrichment);
+    let result = SuccessHint::new(message, vec![]).to_mcp_result();
+    let text = extract_text(&result);
+
+    let meta_idx = text
+        .find(METADATA_FENCE_HEADER)
+        .expect("metadata fence expected");
+    let result_idx = text.find("Result:").expect("Result section");
+    let quoted_idx = text
+        .find("quoted marker")
+        .expect("quoted prose after fake marker");
+
+    assert!(meta_idx < result_idx);
+    assert!(result_idx < quoted_idx);
+    assert!(text.contains("orgId: org-9"));
 }

--- a/src-tauri/tests/check_session_enrichment_tests.rs
+++ b/src-tauri/tests/check_session_enrichment_tests.rs
@@ -1,0 +1,167 @@
+//! Windows-safe unit tests for checkSession response metadata enrichment (#1639).
+//! (Not behind cfg(not(windows)) — no Tauri WebView link.)
+
+use serde_json::json;
+use tauri_mcp_agent_lib::execution_mode::ExecutionMode;
+use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::{
+    apply_check_session_enrichment, build_terminal_check_session_result_from_messages,
+    check_session_enrichment_from_metadata, enrich_check_session_result,
+    format_check_session_context_text,
+};
+use tauri_mcp_agent_lib::mcp::types::MCPContent;
+use tauri_mcp_agent_lib::models::workspace_isolation::WorkspaceIsolationMode;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+
+const METADATA_FENCE_HEADER: &str =
+    "[Metadata — identity/routing only; not the child session's answer]";
+
+fn sample_meta() -> SessionMetadata {
+    SessionMetadata {
+        id: "child-1".to_string(),
+        name: Some("  Draft release notes  ".to_string()),
+        status: SessionStatus::Busy,
+        model: "gpt-test".to_string(),
+        provider: "openai".to_string(),
+        assistant_id: Some("asst-1".to_string()),
+        parent_session_id: Some("parent-1".to_string()),
+        lineage_id: Some("lineage-1".to_string()),
+        depth: Some(1),
+        max_depth: None,
+        max_fanout: None,
+        org_id: Some("org-9".to_string()),
+        org_name: Some("Team".to_string()),
+        org_root_session_id: Some("root-1".to_string()),
+        created_at: 1_700_000_000,
+        updated_at: 1_700_000_100,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        execution_mode: ExecutionMode::Normal,
+        workspace_override: Some("/shared/workspace".to_string()),
+        workspace_isolation: WorkspaceIsolationMode::Host,
+        docker_config: None,
+        docker_container_name: None,
+        docker_host_workspace_path: Some("/docker/host/path".to_string()),
+    }
+}
+
+fn extract_text(result: &tauri_mcp_agent_lib::mcp::types::MCPResult) -> String {
+    result
+        .content
+        .as_ref()
+        .expect("text content expected")
+        .iter()
+        .filter_map(|content| match content {
+            MCPContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn check_session_enrichment_omits_name_and_mirrors_fenced_context_into_text() {
+    let meta = sample_meta();
+    let enrichment = check_session_enrichment_from_metadata(&meta, Some("Researcher".to_string()));
+
+    assert_eq!(enrichment.assistant_id.as_deref(), Some("asst-1"));
+    assert_eq!(enrichment.assistant_name.as_deref(), Some("Researcher"));
+    assert_eq!(
+        enrichment.workspace_path.as_deref(),
+        Some("/shared/workspace")
+    );
+
+    let context = format_check_session_context_text(&enrichment).expect("context text");
+    assert!(context.starts_with("---\n"));
+    assert!(context.contains(METADATA_FENCE_HEADER));
+    assert!(context.contains("assistant: Researcher (asst-1)"));
+    assert!(context.contains("workspace: /shared/workspace"));
+    assert!(context.contains("orgId: org-9"));
+    assert!(!context.contains("createdAt"));
+    assert!(!context.contains("Draft release notes"));
+
+    let mut result = build_terminal_check_session_result_from_messages(
+        "child-1",
+        "idle",
+        1,
+        &[json!({
+            "role": "assistant",
+            "content": [{"type": "text", "text": "done"}]
+        })],
+    );
+    result = enrich_check_session_result(result, &enrichment);
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+    assert!(structured.get("name").is_none());
+    assert!(structured.get("task").is_none());
+    assert_eq!(
+        structured
+            .get("assistantName")
+            .and_then(|value| value.as_str()),
+        Some("Researcher")
+    );
+    assert_eq!(
+        structured
+            .get("workspacePath")
+            .and_then(|value| value.as_str()),
+        Some("/shared/workspace")
+    );
+    assert_eq!(
+        structured.get("createdAt").and_then(|value| value.as_i64()),
+        Some(1_700_000_000)
+    );
+
+    let text = extract_text(&result);
+    assert!(text.contains("Session child-1 is terminal (idle)."));
+    assert!(text.contains("Result:\ndone"));
+    let result_idx = text.find("Result:").expect("Result section expected");
+    let meta_idx = text
+        .find(METADATA_FENCE_HEADER)
+        .expect("metadata fence expected");
+    assert!(result_idx < meta_idx);
+    assert!(text.contains("assistant: Researcher (asst-1)"));
+    assert!(text.contains("workspace: /shared/workspace"));
+    assert!(!text.contains("createdAt"));
+    assert!(!text.contains("Draft release notes"));
+
+    let docker_only = SessionMetadata {
+        workspace_override: None,
+        ..meta
+    };
+    let docker_enrichment = check_session_enrichment_from_metadata(&docker_only, None);
+    let mut map = serde_json::Map::new();
+    apply_check_session_enrichment(&mut map, &docker_enrichment);
+    assert_eq!(
+        map.get("workspacePath").and_then(|value| value.as_str()),
+        Some("/docker/host/path")
+    );
+    assert!(map.get("assistantName").is_none());
+    assert!(map.get("name").is_none());
+}
+
+#[test]
+fn check_session_metadata_block_is_inserted_before_follow_ups() {
+    use tauri_mcp_agent_lib::mcp::types::MCPResult;
+
+    let enrichment =
+        check_session_enrichment_from_metadata(&sample_meta(), Some("Researcher".to_string()));
+    let result = enrich_check_session_result(
+        MCPResult::success(
+            "✓ Session child-1 is currently busy (Turns elapsed: 2).\n\n💡 Suggested Follow-ups:\n- wait",
+        ),
+        &enrichment,
+    );
+    let text = extract_text(&result);
+    let meta_idx = text
+        .find(METADATA_FENCE_HEADER)
+        .expect("metadata fence expected");
+    let follow_up_idx = text
+        .find("💡 Suggested Follow-ups:")
+        .expect("follow-ups expected");
+    assert!(meta_idx < follow_up_idx);
+}

--- a/src-tauri/tests/integration/check_session_terminal_result_tests.rs
+++ b/src-tauri/tests/integration/check_session_terminal_result_tests.rs
@@ -34,6 +34,7 @@ fn terminal_check_session_result_includes_final_answer_without_waiting() {
                 }
             ]
         })],
+        None,
     );
 
     let text = extract_text(&result);
@@ -112,6 +113,7 @@ fn terminal_check_session_result_uses_last_text_block_in_assistant_content() {
                 {"type": "text", "text": "All subtasks completed successfully."}
             ]
         })],
+        None,
     );
 
     let structured = result
@@ -146,6 +148,7 @@ fn terminal_check_session_result_falls_back_to_tool_text_when_assistant_has_no_t
                 "content": []
             }),
         ],
+        None,
     );
 
     let text = extract_text(&result);
@@ -177,6 +180,7 @@ fn terminal_error_check_session_result_marks_session_as_recoverable() {
                 }
             ]
         })],
+        None,
     );
 
     let text = extract_text(&result);
@@ -221,6 +225,7 @@ fn paused_check_session_result_includes_recovery_guidance() {
                 }
             ]
         })],
+        None,
     );
 
     let text = extract_text(&result);


### PR DESCRIPTION
## Summary
- Enrich `checkSession` with identity/routing metadata (`assistantId`/`assistantName`, `workspacePath`, `orgId`, `createdAt`) in structured content and a fenced text Metadata block
- Omit session `name`/`task` so parents are not misled by stale spawn-time labels
- Compose Metadata into the message **before** SuccessHint, placed after the status line and **before** `Result:` / `Last known output:` so long-result truncation still keeps identity visible
- Sanitize `\n`/`\r` out of metadata fields so crafted values cannot break the fence layout

## Test plan
- [ ] `cargo test --test check_session_enrichment_tests`
- [ ] Busy `checkSession`: Metadata appears before Follow-ups; no session name
- [ ] Terminal with a long Result: Metadata remains visible above Result (not lost to truncation)
- [ ] Result text that quotes `💡 Suggested Follow-ups:` does not misplace Metadata
- [ ] Structured content includes `assistantName`/`workspacePath` and omits `name`/`task`

Closes #1639