### PR TITLE
feat(agent): enhance spillover notice with line count guidance

### DIFF
--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -381,6 +381,15 @@ pub async fn tool_result_inline_limit_bytes() -> usize {
     }
 }
 
+/// How the inline spillover preview was produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreviewTruncateKind {
+    /// Cut at a newline boundary (complete lines only).
+    LineBoundary,
+    /// Hard byte cut (single giant line, or newline too close to the start).
+    HardByteCut,
+}
+
 /// Truncate `text` to at most `limit` bytes for inline preview.
 ///
 /// Normally we cut at the last newline boundary so we don't expose a partial
@@ -389,10 +398,11 @@ pub async fn tool_result_inline_limit_bytes() -> usize {
 /// almost-empty preview. In that case we fall back to a **hard byte cut** so
 /// the agent sees real content instead of nothing.
 ///
-/// Returns `(preview_slice, was_truncated)`.
-fn truncate_to_complete_lines(text: &str, limit: usize) -> (&str, bool) {
+/// Returns `(preview_slice, truncate_kind)`.
+fn truncate_to_complete_lines(text: &str, limit: usize) -> (&str, PreviewTruncateKind) {
     if text.len() <= limit {
-        return (text, false);
+        // Caller only truncates when over the inline limit; treat as line-safe.
+        return (text, PreviewTruncateKind::LineBoundary);
     }
 
     let mut boundary = limit.min(text.len());
@@ -408,42 +418,75 @@ fn truncate_to_complete_lines(text: &str, limit: usize) -> (&str, bool) {
     // byte cut so single-line payloads still show real content.
     let min_useful = (limit / 20).max(1);
     match truncated.rfind('\n') {
-        Some(pos) if pos >= min_useful => (&truncated[..pos], true),
+        Some(pos) if pos >= min_useful => (&truncated[..pos], PreviewTruncateKind::LineBoundary),
         // No newline, or newline is too close to the start → hard cut.
-        _ => (truncated, true),
+        _ => (truncated, PreviewTruncateKind::HardByteCut),
     }
-}
-
-fn count_preview_lines(text: &str) -> usize {
-    text.lines().count()
 }
 
 fn build_tool_result_spillover_notice(
     relative_path: &str,
     original_size_bytes: usize,
+    total_line_count: usize,
     preview_line_count: usize,
+    truncate_kind: PreviewTruncateKind,
 ) -> String {
+    let truncation_summary = match truncate_kind {
+        PreviewTruncateKind::LineBoundary if preview_line_count > 0 => format!(
+            "total {} lines / {} bytes (showing lines 1-{})",
+            total_line_count, original_size_bytes, preview_line_count
+        ),
+        PreviewTruncateKind::LineBoundary => format!(
+            "total {} lines / {} bytes",
+            total_line_count, original_size_bytes
+        ),
+        PreviewTruncateKind::HardByteCut => format!(
+            "total {} lines / {} bytes (byte preview; not line-aligned)",
+            total_line_count, original_size_bytes
+        ),
+    };
+
     let mut notice = format!(
-        "\n\n... [output truncated: total size {} bytes] ...\n\nFull output saved to workspace file: `{}`\nRead it in chunks with `readFile({{\"path\": \"{}\", \"offset\": 1, \"size\": 200}})`.\nDo not call `readFile({{\"path\": \"{}\"}})` on the saved file without `offset` and `size`; that will just truncate again.",
-        original_size_bytes, relative_path, relative_path, relative_path
+        "\n\n... [output truncated: {}] ...\n\nFull output saved to workspace file: `{}`\nRead it in chunks with `readFile({{\"path\": \"{}\", \"offset\": 1, \"size\": 200}})`.\nDo not call `readFile({{\"path\": \"{}\"}})` on the saved file without `offset` and `size`; that will just truncate again.",
+        truncation_summary, relative_path, relative_path, relative_path
     );
 
-    if preview_line_count > 0 {
-        let next_start_line = preview_line_count + 1;
-        notice.push_str(&format!(
-            "\nTo continue after the inline preview, call `readFile({{\"path\": \"{}\", \"offset\": {}, \"size\": 200}})`.",
-            relative_path, next_start_line
-        ));
-    } else {
-        // preview_line_count == 0 means the output was a single giant line and
-        // the preview is a hard byte cut (no newlines found within the limit).
-        // Guide the agent to read by byte offset rather than line offset.
-        notice.push_str(&format!(
-            "\nThe inline preview above is a raw byte cut (single-line output). \
- Read the full file by byte ranges: `readFile({{\"path\": \"{}\", \"offset\": 1, \"size\": 200}})` \
- and increment offset by size each time.",
-            relative_path
-        ));
+    match truncate_kind {
+        PreviewTruncateKind::LineBoundary
+            if preview_line_count > 0 && preview_line_count < total_line_count =>
+        {
+            let next_start_line = preview_line_count + 1;
+            notice.push_str(&format!(
+                "\nTo read remaining lines ({} to {}), call `readFile({{\"path\": \"{}\", \"offset\": {}, \"size\": 200}})`.",
+                next_start_line, total_line_count, relative_path, next_start_line
+            ));
+        }
+        PreviewTruncateKind::LineBoundary if preview_line_count > 0 => {
+            // All counted lines appeared in the preview (e.g. trailing partial
+            // content was excluded at a newline). Still give an explicit
+            // follow-up offset past the preview.
+            notice.push_str(&format!(
+                "\nTo continue after the inline preview, call `readFile({{\"path\": \"{}\", \"offset\": {}, \"size\": 200}})`.",
+                relative_path,
+                preview_line_count + 1
+            ));
+        }
+        PreviewTruncateKind::HardByteCut => {
+            // Preview is a raw byte cut — line offsets for the truncated
+            // region are unreliable. Have the agent re-read from line 1.
+            notice.push_str(&format!(
+                "\nThe inline preview above is a raw byte cut (not line-aligned). \
+ Read the saved file from the start in chunks: `readFile({{\"path\": \"{}\", \"offset\": 1, \"size\": 200}})` \
+ and increment offset by size each time (file has {} lines / {} bytes).",
+                relative_path, total_line_count, original_size_bytes
+            ));
+        }
+        PreviewTruncateKind::LineBoundary => {
+            notice.push_str(&format!(
+                "\nRead the full file in chunks: `readFile({{\"path\": \"{}\", \"offset\": 1, \"size\": 200}})`.",
+                relative_path
+            ));
+        }
     }
 
     notice
@@ -497,8 +540,10 @@ pub async fn spill_oversized_tool_result_messages(
                         text.len()
                     );
 
-                    let (preview, _) = truncate_to_complete_lines(&text, preview_limit_bytes);
-                    let preview_line_count = count_preview_lines(preview);
+                    let (preview, truncate_kind) =
+                        truncate_to_complete_lines(&text, preview_limit_bytes);
+                    let total_line_count = text.lines().count();
+                    let preview_line_count = preview.lines().count();
 
                     next_content.push(MCPContent::Text {
                         text: format!(
@@ -507,7 +552,9 @@ pub async fn spill_oversized_tool_result_messages(
                             build_tool_result_spillover_notice(
                                 &relative_path,
                                 text.len(),
-                                preview_line_count
+                                total_line_count,
+                                preview_line_count,
+                                truncate_kind,
                             )
                         ),
                         is_error,

--- a/src-tauri/tests/integration/tool_result_spillover_tests.rs
+++ b/src-tauri/tests/integration/tool_result_spillover_tests.rs
@@ -178,6 +178,14 @@ async fn spillover_pointer_is_what_gets_persisted_to_repository() {
         "rewritten message should contain a truncation notice"
     );
     assert!(
+        text.contains("total 1 lines /"),
+        "spillover notice should report total line count alongside byte size: {text}"
+    );
+    assert!(
+        text.contains("byte preview; not line-aligned"),
+        "space-separated single-line payloads should use hard byte-cut wording: {text}"
+    );
+    assert!(
         text.contains("readFile({\"path\":"),
         "spillover notice should tell the agent how to inspect the spillover file"
     );
@@ -186,8 +194,12 @@ async fn spillover_pointer_is_what_gets_persisted_to_repository() {
         "spillover notice should warn against rereading the saved file without a line range"
     );
     assert!(
-        text.contains("To continue after the inline preview"),
-        "spillover notice should give an explicit follow-up command after the preview"
+        text.contains("raw byte cut"),
+        "spillover notice should explain the preview is not line-aligned: {text}"
+    );
+    assert!(
+        text.contains("file has 1 lines /"),
+        "hard-cut notice should repeat total line count in the follow-up guidance: {text}"
     );
     assert!(
         text.contains(&original_text[..128]),
@@ -265,6 +277,10 @@ async fn tool_result_spillover_writes_large_tool_output_to_workspace_file() {
     assert!(text.contains(".libragent/tool-results/"));
     assert!(text.contains("readFile({\"path\":"));
     assert!(
+        text.contains("total 1 lines /"),
+        "spillover notice should include total line count: {text}"
+    );
+    assert!(
         text.contains(&original_text[..128]),
         "spillover output should preserve a visible preview"
     );
@@ -312,4 +328,83 @@ async fn tool_result_spillover_leaves_small_tool_output_inline() {
     };
 
     assert_eq!(text, original_text);
+}
+
+#[tokio::test]
+async fn tool_result_spillover_multiline_notice_includes_line_range_guidance() {
+    let session_id = format!("spillover-multiline-{}", uuid::Uuid::new_v4());
+    // Enough complete lines to exceed the default 16 KiB inline limit while
+    // remaining newline-aligned so truncation snaps to a line boundary.
+    let line = "abcdefghijklmnopqrstuvwxyz0123456789\n"; // 37 bytes
+    let line_count = (TOOL_RESULT_SPILLOVER_THRESHOLD_BYTES / line.len()) + 400;
+    let original_text = line.repeat(line_count);
+    let total_lines = original_text.lines().count();
+    assert!(
+        total_lines > 400,
+        "fixture should produce hundreds of lines for range guidance"
+    );
+    assert!(
+        original_text.len() > TOOL_RESULT_SPILLOVER_THRESHOLD_BYTES,
+        "fixture must exceed spillover threshold"
+    );
+
+    let processed = spill_oversized_tool_result_messages(
+        &session_id,
+        vec![make_tool_message(
+            &session_id,
+            "tool_call_multiline",
+            &original_text,
+        )],
+    )
+    .await
+    .expect("multiline spillover should succeed");
+
+    let message = &processed[0];
+    let MCPContent::Text { text, .. } = &message.content[0] else {
+        panic!("expected text content");
+    };
+
+    assert!(
+        text.contains(&format!("total {total_lines} lines /")),
+        "notice should report exact total line count: {text}"
+    );
+    assert!(
+        text.contains("showing lines 1-"),
+        "notice should report the inline preview line range: {text}"
+    );
+    assert!(
+        text.contains("To read remaining lines ("),
+        "notice should guide the agent through remaining line ranges: {text}"
+    );
+    assert!(
+        text.contains(&format!("to {total_lines})")),
+        "remaining-range guidance should end at the last line: {text}"
+    );
+    assert!(
+        text.contains(", \"offset\":") && text.contains(", \"size\": 200}"),
+        "remaining-range guidance should include an explicit readFile offset/size: {text}"
+    );
+    assert!(
+        !text.contains("byte preview; not line-aligned"),
+        "newline-aligned payloads should not use hard byte-cut wording: {text}"
+    );
+    assert!(
+        text.len() < TOOL_RESULT_SPILLOVER_THRESHOLD_BYTES,
+        "spillover preview should stay below the inline threshold"
+    );
+
+    let start = text.find('`').expect("path opening backtick") + 1;
+    let end = text[start..]
+        .find('`')
+        .map(|offset| start + offset)
+        .expect("path closing backtick");
+    let relative_path = &text[start..end];
+
+    let session_manager = get_session_manager().expect("session manager");
+    let workspace_dir = session_manager.get_session_workspace_dir_by_id(&session_id);
+    let spilled_file = workspace_dir.join(relative_path);
+    let spilled_text = fs::read_to_string(&spilled_file).expect("spilled file should exist");
+    assert_eq!(spilled_text, original_text);
+
+    let _ = fs::remove_dir_all(workspace_dir);
 }


### PR DESCRIPTION
## Summary
- Enrich tool-result spillover notices with total line count, byte size, and inline preview line ranges
- Differentiate follow-up `readFile` guidance for line-aligned vs hard byte-cut previews via `PreviewTruncateKind`
- Extend spillover integration tests for multiline range guidance and hard-cut wording

Closes #1644

## Test plan
- [ ] `cargo test --tests tool_result_spillover` on Linux/macOS (integration suite is `cfg(not(windows))`)
- [ ] Confirm oversized multiline tool output notice includes `total N lines / ... (showing lines 1-M)` and remaining-range `readFile` guidance
- [ ] Confirm single-line/hard-cut spillover notice includes `byte preview; not line-aligned` and re-read-from-start guidance
- [ ] Confirm spilled workspace file content still matches the original tool output

Made with [Cursor](https://cursor.com)