### PR TITLE
feat(ai): support multiple custom OpenAI-compatible providers

### DIFF
--- a/src-tauri/src/agent/llm/completion/compaction/payload.rs
+++ b/src-tauri/src/agent/llm/completion/compaction/payload.rs
@@ -320,7 +320,8 @@ pub fn inspect_compaction_payload(messages: &[Message]) -> CompactionPayloadDiag
 }
 
 fn provider_requires_compaction_tool_chain_cleanup(provider_id: &str) -> bool {
-    ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
+    crate::agent::llm::request_layout::is_custom_openai_compatible_provider(provider_id)
+        || ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
 }
 
 pub fn fit_compaction_request_messages_to_limit(

--- a/src-tauri/src/agent/llm/context_selector.rs
+++ b/src-tauri/src/agent/llm/context_selector.rs
@@ -41,7 +41,8 @@ const CONTEXT_FIT_TRUNCATION_SCALES: [f64; 6] = [0.5, 0.35, 0.25, 0.15, 0.1, 0.0
 const MIN_CONTEXT_FIT_SIDE_CHARS: usize = 48;
 
 fn provider_requires_tool_chain_cleanup(provider_id: &str) -> bool {
-    ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
+    crate::agent::llm::request_layout::is_custom_openai_compatible_provider(provider_id)
+        || ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
 }
 
 fn resolve_calibration_ratio(
@@ -322,8 +323,7 @@ pub fn select_recent_messages_fifo(
     let start_idx = batched_messages.len().saturating_sub(max_messages);
     let selected = batched_messages[start_idx..].to_vec();
 
-    let adjusted = if ["anthropic", "gemini", "openai", "openrouter", "groq"].contains(&provider_id)
-    {
+    let adjusted = if provider_requires_tool_chain_cleanup(provider_id) {
         remove_incomplete_tool_chains(selected)
     } else {
         selected

--- a/src-tauri/src/agent/llm/request_layout.rs
+++ b/src-tauri/src/agent/llm/request_layout.rs
@@ -13,11 +13,19 @@ pub struct RequestLayout {
     pub messages: Vec<Message>,
 }
 
+/// OpenAI-compatible custom providers use the `custom:<id>` session provider id.
+pub fn is_custom_openai_compatible_provider(provider: &str) -> bool {
+    provider
+        .strip_prefix("custom:")
+        .is_some_and(|id| !id.is_empty())
+}
+
 pub fn provider_uses_synthetic_session_context(provider: &str) -> bool {
-    matches!(
-        provider,
-        "openai" | "openrouter" | "fireworks" | "anthropic" | "gemini" | "ollama"
-    )
+    is_custom_openai_compatible_provider(provider)
+        || matches!(
+            provider,
+            "openai" | "openrouter" | "fireworks" | "anthropic" | "gemini" | "ollama"
+        )
 }
 
 fn provider_uses_background_reference_wrapper(provider: &str) -> bool {
@@ -25,6 +33,9 @@ fn provider_uses_background_reference_wrapper(provider: &str) -> bool {
 }
 
 fn synthetic_session_context_id_prefix(provider: &str) -> &str {
+    if is_custom_openai_compatible_provider(provider) {
+        return "custom-openai-session-context";
+    }
     match provider {
         "openai" => "openai-session-context",
         "openrouter" => "openrouter-session-context",

--- a/src-tauri/tests/integration/request_layout_checkpoint_tests.rs
+++ b/src-tauri/tests/integration/request_layout_checkpoint_tests.rs
@@ -1,5 +1,6 @@
 use tauri_mcp_agent_lib::agent::llm::{
-    build_request_layout, select_last_submitted_input_message_id,
+    build_request_layout, is_custom_openai_compatible_provider,
+    provider_uses_synthetic_session_context, select_last_submitted_input_message_id,
 };
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
 use tauri_mcp_agent_lib::models::chat::{Message, MessageSource};
@@ -29,6 +30,35 @@ fn make_user_message(id: &str, source: Option<MessageSource>) -> Message {
         error: None,
         metadata: None,
     }
+}
+
+#[test]
+fn custom_openai_compatible_provider_uses_synthetic_session_context() {
+    assert!(is_custom_openai_compatible_provider("custom:local-vllm"));
+    assert!(!is_custom_openai_compatible_provider("custom:"));
+    assert!(!is_custom_openai_compatible_provider("openai"));
+    assert!(provider_uses_synthetic_session_context("custom:local-vllm"));
+
+    let layout = build_request_layout(
+        "custom:local-vllm",
+        "session-1",
+        Some("system".to_string()),
+        Some("background context".to_string()),
+        vec![make_user_message("real-user", Some(MessageSource::Ui))],
+    );
+
+    assert_eq!(layout.messages.len(), 2);
+    assert!(layout
+        .messages
+        .last()
+        .expect("custom provider should inject synthetic session context")
+        .is_request_layout_scaffolding_message());
+    assert!(layout
+        .messages
+        .last()
+        .expect("synthetic message")
+        .id
+        .starts_with("custom-openai-session-context-"));
 }
 
 #[test]

--- a/src/context/ModelProvider.tsx
+++ b/src/context/ModelProvider.tsx
@@ -8,7 +8,13 @@ import {
 } from 'react';
 import useSWR from 'swr';
 import { withTimeout } from '../lib/retry-utils';
-import { AIServiceProvider, AIServiceFactory } from '../lib/ai-service';
+import {
+  AIServiceProvider,
+  AIServiceFactory,
+  isCustomOpenAIProviderId,
+  listCustomProviderPickerOptions,
+  resolveProviderRuntimeConfig,
+} from '../lib/ai-service';
 import { shouldFetchDynamicModels } from '../lib/ai-service/model-fetch-policy';
 import {
   llmConfigManager,
@@ -37,11 +43,12 @@ const logger = getLogger('ModelProvider');
 
 interface ModelOptionsContextType {
   modelId: string;
-  provider: AIServiceProvider;
+  /** Builtin provider id or `custom:<id>`. */
+  provider: string;
   models: Record<string, ModelInfo>;
   providers: Array<ProviderInfo>;
   currentProviderInfo: ProviderInfo | null;
-  setProvider: (provider: AIServiceProvider) => void;
+  setProvider: (provider: string) => void;
   setModel: (modelId: string) => void;
   isLoading: boolean;
   apiKeys: Record<AIServiceProvider, string>;
@@ -58,20 +65,28 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
   const {
     value: {
       serviceConfigs,
+      customProviders,
       preferredModel: { model, provider },
     },
     update,
     isLoading,
   } = useSettings();
 
-  // 동적 모델 목록 상태 (provider별로 저장)
-  // const [isRefreshingModels, setIsRefreshingModels] = useState(false); // Removed, using SWR isValidating
+  const resolvedProvider = useMemo(
+    () =>
+      resolveProviderRuntimeConfig(provider, {
+        serviceConfigs,
+        customProviders,
+      }),
+    [provider, serviceConfigs, customProviders],
+  );
 
-  // Compute API keys from service configs for backward compatibility
+  // Builtin-provider API keys only. Custom (`custom:<id>`) keys are resolved via
+  // resolveProviderRuntimeConfig() — do not look up custom ids in this map.
   const apiKeys = useMemo(() => {
     return Object.entries(serviceConfigs).reduce(
-      (acc, [provider, config]) => {
-        acc[provider as AIServiceProvider] = config.apiKey || '';
+      (acc, [providerKey, config]) => {
+        acc[providerKey as AIServiceProvider] = config.apiKey || '';
         return acc;
       },
       {} as Record<AIServiceProvider, string>,
@@ -80,13 +95,13 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   // Generate stable cache key including baseUrl
   const swrCacheKey = useMemo(() => {
-    const config = serviceConfigs[provider] || {};
     if (
       !shouldFetchDynamicModels({
         provider,
-        apiKey: config.apiKey,
-        use3rdParty: config.use3rdParty,
-        customModelId: config.customModelId,
+        apiKey: resolvedProvider.apiKey,
+        baseUrl: resolvedProvider.baseUrl,
+        use3rdParty: resolvedProvider.use3rdParty,
+        customModelId: resolvedProvider.customModelId,
       })
     ) {
       return null;
@@ -95,41 +110,32 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
     return [
       'models',
       provider,
-      config.apiKey || '', // API key for cache invalidation
-      config.baseUrl || '', // Include baseUrl
-      config.use3rdParty ? 'use-3rd-party' : 'first-party',
-      config.customModelId || '',
+      resolvedProvider.apiKey || '',
+      resolvedProvider.baseUrl || '',
+      resolvedProvider.use3rdParty ? 'use-3rd-party' : 'first-party',
+      resolvedProvider.customModelId || '',
     ];
-  }, [provider, serviceConfigs]);
+  }, [provider, resolvedProvider]);
 
   // Fetcher for models — always delegates to service.listModels(), which each
   // provider implements. Static-only providers return llmConfigManager data;
   // dynamic providers (Ollama, OpenAI, OpenRouter, …) fetch from their APIs.
-  // The "supports dynamic" decision lives in the service, not here.
   const fetchDynamicModels = useCallback(
-    async ([, provider, apiKey]: [string, string, string]) => {
-      // Use a non-empty placeholder when no real key is configured so that
-      // validateApiKey() (which rejects only empty strings) doesn't throw.
-      // Services whose listModels() needs a real key will fail gracefully and
-      // return an empty array; the models useMemo below then falls back to
-      // the static config from llmConfigManager.
+    async ([, providerId, apiKey]: [string, string, string]) => {
       const effectiveApiKey = apiKey || 'no-api-key';
+      const resolved = resolveProviderRuntimeConfig(providerId, {
+        serviceConfigs,
+        customProviders,
+      });
 
       try {
-        // Get provider config including baseUrl
-        const providerConfig =
-          serviceConfigs[provider as AIServiceProvider] || {};
-
         const service = AIServiceFactory.getService(
-          provider as AIServiceProvider,
+          providerId,
           effectiveApiKey,
-          providerConfig,
+          resolved.serviceConfig,
         );
-        // Use 20-second timeout for model loading to prevent UI hangs
         const modelList = await withTimeout(service.listModels(), 20000);
 
-        // Convert ModelInfo[] into Record<string, ModelInfo>
-        // ⚡ Bolt: Replaced .reduce() with a single-pass loop to reduce per-element callback overhead.
         const modelsRecord = Object.create(null) as Record<string, ModelInfo>;
         for (const modelInfo of modelList) {
           const key = modelInfo.id || modelInfo.name;
@@ -137,20 +143,20 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
         }
 
         if (Object.keys(modelsRecord).length > 0) {
-          setStoredModelCache(provider, modelsRecord);
+          setStoredModelCache(providerId, modelsRecord);
         }
 
-        logger.info(`Fetched ${modelList.length} models from ${provider}`);
+        logger.info(`Fetched ${modelList.length} models from ${providerId}`);
         return modelsRecord;
       } catch (error) {
         logger.error('Failed to fetch models:', error);
-        const storedModels = getStoredModelCache(provider);
+        const storedModels = getStoredModelCache(providerId);
         const hasCachedModels = !!(
           storedModels && Object.keys(storedModels).length > 0
         );
         reportListModelsFallback({
-          provider,
-          baseUrl: serviceConfigs[provider as AIServiceProvider]?.baseUrl,
+          provider: providerId,
+          baseUrl: resolved.baseUrl,
           reason: 'api_error',
           error,
           hasCachedModels,
@@ -158,7 +164,7 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
         return storedModels || {};
       }
     },
-    [serviceConfigs],
+    [serviceConfigs, customProviders],
   );
 
   // SWR for dynamic models
@@ -173,41 +179,62 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
     dedupingInterval: 30000, // 30 seconds
   });
 
-  // 현재 프로바이더의 모델 목록 계산
+  // Prefer dynamic list, then persisted cache, then static config / manual models.
   const models = useMemo(() => {
-    const staticModels = llmConfigManager.getModelsForProvider(provider) || {};
+    const staticModels = isCustomOpenAIProviderId(provider)
+      ? {}
+      : llmConfigManager.getModelsForProvider(provider as AIServiceProvider) ||
+        {};
     const storedModels = getStoredModelCache(provider);
+    const manualModels = (resolvedProvider.manualModels ?? []).reduce<
+      Record<string, ModelInfo>
+    >((acc, modelId) => {
+      acc[modelId] = {
+        ...DEFAULT_MODEL_INFO,
+        id: modelId,
+        name: modelId,
+        contextWindow: 128000,
+        supportTools: true,
+        supportStreaming: true,
+        description: 'Custom OpenAI-compatible model',
+      };
+      return acc;
+    }, {});
 
-    // 동적 목록이 provider별로 있으면 우선 사용
     if (Object.keys(dynamicModels).length > 0) {
-      return dynamicModels;
+      return { ...manualModels, ...dynamicModels };
     }
 
-    // 이전에 성공한 영속 캐시 목록이 있으면 즉시 활용 (0ms)
+    if (Object.keys(manualModels).length > 0) {
+      return manualModels;
+    }
+
     if (storedModels && Object.keys(storedModels).length > 0) {
       return storedModels;
     }
 
     return staticModels;
-  }, [provider, dynamicModels]);
+  }, [provider, dynamicModels, resolvedProvider.manualModels]);
 
-  // 수동 모델 새로고침 함수 (새로고침 버튼용)
   const refreshModels = useCallback(async () => {
-    const config = serviceConfigs[provider] || {};
-    AIServiceFactory.invalidateService(provider, config.apiKey || '', config);
+    AIServiceFactory.invalidateService(
+      provider,
+      resolvedProvider.apiKey || '',
+      resolvedProvider.serviceConfig,
+    );
     await mutateModels(undefined, {
       revalidate: true,
     });
-  }, [mutateModels, provider, serviceConfigs]);
+  }, [mutateModels, provider, resolvedProvider]);
 
   const providerOptions = useMemo(() => {
     const providers = llmConfigManager.getProviders();
-
-    return Object.entries(providers).map(([key, value]) => ({
+    const builtin = Object.entries(providers).map(([key, value]) => ({
       label: value.name,
       value: key,
     }));
-  }, []);
+    return [...builtin, ...listCustomProviderPickerOptions(customProviders)];
+  }, [customProviders]);
 
   const modelOptions = useMemo(() => {
     logger.info('🎯 Current provider:', provider);
@@ -227,18 +254,40 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
   }, [models, model]);
 
   const currentProviderInfo = useMemo(() => {
+    if (isCustomOpenAIProviderId(provider)) {
+      return {
+        name: resolvedProvider.displayName,
+        apiKeyEnvVar: '',
+        baseUrl: resolvedProvider.baseUrl ?? '',
+        requiresApiKey: false,
+        models: {},
+      } satisfies ProviderInfo;
+    }
     const providers = llmConfigManager.getProviders();
     return providers[provider] || null;
-  }, [provider]);
+  }, [provider, resolvedProvider.baseUrl, resolvedProvider.displayName]);
 
   const setProvider = useCallback(
-    (newProvider: AIServiceProvider) => {
+    (newProvider: string) => {
+      if (isCustomOpenAIProviderId(newProvider)) {
+        const resolved = resolveProviderRuntimeConfig(newProvider, {
+          serviceConfigs,
+          customProviders,
+        });
+        const defaultModel = resolved.manualModels?.[0] ?? '';
+        update({
+          preferredModel: { provider: newProvider, model: defaultModel },
+        });
+        return;
+      }
+
       const availableModels =
-        llmConfigManager.getModelsForProvider(newProvider) || {};
+        llmConfigManager.getModelsForProvider(
+          newProvider as AIServiceProvider,
+        ) || {};
 
       if (Object.keys(availableModels).length === 0) {
         logger.warn(`No available models for ${newProvider}`);
-        // 모델이 없어도 프로바이더는 변경하고, 모델은 빈 문자열로 설정
         update({ preferredModel: { provider: newProvider, model: '' } });
         return;
       }
@@ -248,7 +297,7 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
 
       update({ preferredModel: { provider: newProvider, model: newModel } });
     },
-    [update],
+    [update, serviceConfigs, customProviders],
   );
 
   const setModel = useCallback(

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -12,6 +12,7 @@ import {
   settingsService,
   Settings,
   ServiceConfig,
+  CustomOpenAIProvider,
   AdvancedSettings,
   DisplaySettings,
   SystemSettings,
@@ -28,6 +29,7 @@ const logger = getLogger('SettingsContext');
 export type {
   Settings,
   ServiceConfig,
+  CustomOpenAIProvider,
   AdvancedSettings,
   DisplaySettings,
   SystemSettings,

--- a/src/context/llm/compact-listener.ts
+++ b/src/context/llm/compact-listener.ts
@@ -3,12 +3,12 @@ import {
   handleCompactResponse,
   getAgentCompactContext,
 } from '@/lib/backend/agent-commands';
-import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
+import {
+  AIServiceFactory,
+  resolveProviderRuntimeConfig,
+} from '@/lib/ai-service';
 import { summarizeCompactionRequestSizes } from '@/lib/ai-service/request-ingredients';
-import type {
-  AIContextCompactionService,
-  AIServiceConfig,
-} from '@/lib/ai-service/types';
+import type { AIContextCompactionService } from '@/lib/ai-service/types';
 import { normalizeRustMessage } from '@/lib/ai-service/utils';
 import { getLogger } from '@/lib/logger';
 import type { Settings } from '@/context/SettingsContext';
@@ -97,9 +97,10 @@ export async function setupCompactRequestListener({
         return;
       }
 
-      const provider = (parentRequest?.provider ??
-        settings.preferredModel.provider) as AIServiceProvider;
-      const apiKey = settings.serviceConfigs?.[provider]?.apiKey ?? '';
+      const provider =
+        parentRequest?.provider ?? settings.preferredModel.provider;
+      const resolved = resolveProviderRuntimeConfig(provider, settings);
+      const apiKey = resolved.apiKey ?? '';
       const model = parentRequest?.model ?? settings.preferredModel.model;
       const systemPrompt = buildCompactionRetrySystemPrompt(
         parentRequest?.systemPrompt,
@@ -108,9 +109,10 @@ export async function setupCompactRequestListener({
       const availableTools = retryWithoutTools
         ? undefined
         : parentRequest?.availableTools;
-      const providerConfig: AIServiceConfig =
-        settings.serviceConfigs?.[provider] ?? {};
-      const runtimeConfig = buildServiceRuntimeConfig(settings, providerConfig);
+      const runtimeConfig = buildServiceRuntimeConfig(
+        settings,
+        resolved.serviceConfig,
+      );
       const requestComposition = summarizeCompactionRequestSizes({
         messages,
         systemPrompt,

--- a/src/context/llm/useExecuteCompletion.ts
+++ b/src/context/llm/useExecuteCompletion.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
+import {
+  AIServiceFactory,
+  resolveProviderRuntimeConfig,
+} from '@/lib/ai-service';
 import { reportLLMStreamingIssue } from '@/lib/backend/agent-commands';
 import type {
   AIServiceConfig,
@@ -193,16 +196,18 @@ export function useExecuteCompletion({
       // Create service instance via factory using the provider/apiKey from this request.
       // Pass runtimeConfig (includes settings.advanced maxRetries/retryDelay) so withRetry
       // uses the user's settings instead of BaseAIService defaults.
-      const providerConfig =
-        settingsRef.current.serviceConfigs?.[provider as AIServiceProvider] ||
-        {};
+      const resolved = resolveProviderRuntimeConfig(
+        provider,
+        settingsRef.current,
+      );
       const runtimeConfig = buildServiceRuntimeConfig(
         settingsRef.current,
-        providerConfig,
+        resolved.serviceConfig,
       );
       const service = AIServiceFactory.getService(
-        provider as AIServiceProvider,
-        apiKey ?? '',
+        provider,
+        // Empty string from the event payload should fall back to settings.
+        apiKey || resolved.apiKey || '',
         runtimeConfig,
       );
       activeServicesRef.current.set(sessionId, service);

--- a/src/context/llm/useLLMListener.ts
+++ b/src/context/llm/useLLMListener.ts
@@ -8,7 +8,7 @@ import { listen } from '@tauri-apps/api/event';
 import { messageToRustMessage, type Message } from '@/models/chat';
 import type { MCPTool } from '@/lib/mcp';
 import type { Settings } from '@/context/SettingsContext';
-import type { AIServiceProvider } from '@/lib/ai-service';
+import { resolveProviderRuntimeConfig } from '@/lib/ai-service';
 import { normalizeRustMessage } from '@/lib/ai-service/utils';
 import { getLogger } from '@/lib/logger';
 import { sleep } from '@/lib/retry-utils';
@@ -123,8 +123,8 @@ export function useLLMListener({
 
           // Always get API key from Settings, ignore any apiKey from Rust backend
           const finalApiKey =
-            settingsRef.current.serviceConfigs?.[provider as AIServiceProvider]
-              ?.apiKey || '';
+            resolveProviderRuntimeConfig(provider, settingsRef.current)
+              .apiKey || '';
 
           logger.info('📥 Received LLM completion request from Rust', {
             sessionId,
@@ -263,9 +263,10 @@ export function useLLMListener({
               const fallbackModel = settingsRef.current.fallbackModel;
               if (fallbackModel) {
                 const fallbackApiKey =
-                  settingsRef.current.serviceConfigs?.[
-                    fallbackModel.provider as AIServiceProvider
-                  ]?.apiKey ?? '';
+                  resolveProviderRuntimeConfig(
+                    fallbackModel.provider,
+                    settingsRef.current,
+                  ).apiKey ?? '';
 
                 logger.warn(
                   `LLM Recovery: Primary model failed all retries, switching to fallback ${fallbackModel.provider}/${fallbackModel.model}`,

--- a/src/features/agent/components/AgentModelPicker.tsx
+++ b/src/features/agent/components/AgentModelPicker.tsx
@@ -16,8 +16,14 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { AIServiceProvider } from '@/lib/ai-service';
+import {
+  isCustomOpenAIProviderId,
+  listCustomProviderPickerOptions,
+  resolveProviderRuntimeConfig,
+} from '@/lib/ai-service/custom-providers';
 import { llmConfigManager } from '@/lib/llm-config-manager';
 import { cn } from '@/lib/utils';
+import { useSettings } from '@/hooks/use-settings';
 import { useAgentModels } from '../hooks/useAgentModels';
 
 interface AgentModelPickerProps {
@@ -37,6 +43,9 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
 }) => {
   const { t } = useTranslation('common');
   const {
+    value: { customProviders, serviceConfigs },
+  } = useSettings();
+  const {
     availableModels,
     isRefreshing,
     refreshModels,
@@ -53,15 +62,18 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
 
   const providerOptions = useMemo(() => {
     const providers = llmConfigManager.getProviders();
-    return Object.entries(providers).map(([key, value]) => ({
+    const builtin = Object.entries(providers).map(([key, value]) => ({
       label: value.name,
       value: key,
     }));
-  }, []);
+    return [...builtin, ...listCustomProviderPickerOptions(customProviders)];
+  }, [customProviders]);
 
   const showRefreshButton =
     Boolean(currentProvider) &&
-    (canRefresh || refreshBlockedReason === 'missing-api-key');
+    (canRefresh ||
+      refreshBlockedReason === 'missing-api-key' ||
+      refreshBlockedReason === 'missing-base-url');
 
   const refreshButtonLabel = useMemo(() => {
     if (canRefresh) {
@@ -74,23 +86,37 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
       });
     }
 
+    if (refreshBlockedReason === 'missing-base-url') {
+      return t('agent.modelPicker.refreshRequiresBaseUrl', {
+        defaultValue: 'Add a base URL to enable model refresh',
+      });
+    }
+
     return '';
   }, [canRefresh, refreshBlockedReason, t]);
 
   const handleProviderChange = useCallback(
     (newProvider: string) => {
-      // Default model selection logic
-      const staticModels = llmConfigManager.getModelsForProvider(
-        newProvider as AIServiceProvider,
-      );
       let defaultModel = '';
-      if (staticModels && Object.keys(staticModels).length > 0) {
-        defaultModel = Object.keys(staticModels)[0];
+
+      if (isCustomOpenAIProviderId(newProvider)) {
+        const resolved = resolveProviderRuntimeConfig(newProvider, {
+          serviceConfigs,
+          customProviders,
+        });
+        defaultModel = resolved.manualModels?.[0] ?? '';
+      } else {
+        const staticModels = llmConfigManager.getModelsForProvider(
+          newProvider as AIServiceProvider,
+        );
+        if (staticModels && Object.keys(staticModels).length > 0) {
+          defaultModel = Object.keys(staticModels)[0];
+        }
       }
 
       onConfigUpdate?.(defaultModel, newProvider);
     },
-    [onConfigUpdate],
+    [customProviders, onConfigUpdate, serviceConfigs],
   );
 
   const handleModelChange = useCallback(

--- a/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
+++ b/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
@@ -45,6 +45,21 @@ vi.mock('../../hooks/useAgentModels', () => ({
   useAgentModels: () => mockUseAgentModelsState,
 }));
 
+vi.mock('@/hooks/use-settings', () => ({
+  useSettings: () => ({
+    value: {
+      customProviders: [
+        {
+          id: 'local1',
+          name: 'Local vLLM',
+          baseUrl: 'http://127.0.0.1:8000/v1',
+        },
+      ],
+      serviceConfigs: {},
+    },
+  }),
+}));
+
 describe('AgentModelPicker', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/features/agent/hooks/__tests__/useAgentModels.test.tsx
+++ b/src/features/agent/hooks/__tests__/useAgentModels.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/hooks/use-settings', () => ({
   useSettings: () => ({
     value: {
       serviceConfigs: mockState.serviceConfigs,
+      customProviders: [],
     },
   }),
 }));
@@ -146,7 +147,12 @@ describe('useAgentModels', () => {
     expect(mockedFactory.invalidateService).toHaveBeenCalledWith(
       AIServiceProvider.OpenAI,
       'saved-key',
-      mockState.serviceConfigs[AIServiceProvider.OpenAI],
+      {
+        baseUrl: 'https://saved.example.com/v1',
+        use3rdParty: undefined,
+        customModelId: undefined,
+        safetySettings: undefined,
+      },
     );
   });
 });

--- a/src/features/agent/hooks/useAgentModels.ts
+++ b/src/features/agent/hooks/useAgentModels.ts
@@ -2,7 +2,12 @@ import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 
 import { useSettings } from '@/hooks/use-settings';
-import { AIServiceFactory, AIServiceProvider } from '@/lib/ai-service';
+import {
+  AIServiceFactory,
+  AIServiceProvider,
+  isCustomOpenAIProviderId,
+  resolveProviderRuntimeConfig,
+} from '@/lib/ai-service';
 import { getDynamicModelFetchPolicy } from '@/lib/ai-service/model-fetch-policy';
 import type { AIModelLookupService } from '@/lib/ai-service/types';
 import { llmConfigManager, ModelInfo } from '@/lib/llm-config-manager';
@@ -18,6 +23,25 @@ const logger = getLogger('useAgentModels');
 type DynamicModelMap = Record<string, ModelInfo>;
 type ModelSWRKey = readonly [string, string, string, string, string, string];
 
+function manualModelsToMap(modelIds: string[] | undefined): DynamicModelMap {
+  if (!modelIds || modelIds.length === 0) {
+    return {};
+  }
+  return modelIds.reduce<DynamicModelMap>((acc, modelId) => {
+    acc[modelId] = {
+      id: modelId,
+      name: modelId,
+      contextWindow: 128000,
+      supportReasoning: false,
+      supportTools: true,
+      supportStreaming: true,
+      cost: { input: 0, output: 0 },
+      description: 'Custom OpenAI-compatible model',
+    };
+    return acc;
+  }, {});
+}
+
 /**
  * Loads models for a provider using **persisted** settings only.
  * Draft/unsaved API edits must not change the SWR key — refresh happens
@@ -25,39 +49,36 @@ type ModelSWRKey = readonly [string, string, string, string, string, string];
  */
 export const useAgentModels = (provider?: string) => {
   const {
-    value: { serviceConfigs },
+    value: { serviceConfigs, customProviders },
   } = useSettings();
 
-  const providerConfig = useMemo(() => {
+  const resolved = useMemo(() => {
     if (!provider) {
-      return {};
+      return null;
     }
+    return resolveProviderRuntimeConfig(provider, {
+      serviceConfigs,
+      customProviders,
+    });
+  }, [provider, serviceConfigs, customProviders]);
 
-    return serviceConfigs[provider as AIServiceProvider] || {};
-  }, [provider, serviceConfigs]);
-
-  // Get API key and baseUrl for the selected provider
-  const apiKey = useMemo(() => {
-    return providerConfig.apiKey || '';
-  }, [providerConfig]);
-
-  const baseUrl = useMemo(() => {
-    return providerConfig.baseUrl || '';
-  }, [providerConfig]);
+  const apiKey = resolved?.apiKey ?? '';
+  const baseUrl = resolved?.baseUrl ?? '';
 
   const dynamicModelPolicy = useMemo(
     () =>
       getDynamicModelFetchPolicy({
         provider,
         apiKey,
-        use3rdParty: providerConfig.use3rdParty,
-        customModelId: providerConfig.customModelId,
+        baseUrl,
+        use3rdParty: resolved?.use3rdParty,
+        customModelId: resolved?.customModelId,
       }),
-    [apiKey, provider, providerConfig],
+    [apiKey, baseUrl, provider, resolved?.customModelId, resolved?.use3rdParty],
   );
 
   const swrKey = useMemo<ModelSWRKey | null>(() => {
-    if (!provider || !dynamicModelPolicy.canFetch) {
+    if (!provider || !dynamicModelPolicy.canFetch || !resolved) {
       return null;
     }
 
@@ -66,33 +87,25 @@ export const useAgentModels = (provider?: string) => {
       provider,
       apiKey,
       baseUrl,
-      providerConfig.use3rdParty ? 'use-3rd-party' : 'first-party',
-      providerConfig.customModelId || '',
+      resolved.use3rdParty ? 'use-3rd-party' : 'first-party',
+      resolved.customModelId || '',
     ] as const;
-  }, [
-    apiKey,
-    baseUrl,
-    dynamicModelPolicy.canFetch,
-    provider,
-    providerConfig.customModelId,
-    providerConfig.use3rdParty,
-  ]);
+  }, [apiKey, baseUrl, dynamicModelPolicy.canFetch, provider, resolved]);
 
-  // Fetcher for models — delegates entirely to service.listModels().
-  // Each provider's implementation decides static vs dynamic;
-  // no hardcoded allowlist needed here.
   const fetchDynamicModels = useCallback(
     async ([, p, key]: ModelSWRKey) => {
+      if (!resolved) {
+        return {};
+      }
+
       // Use a non-empty placeholder so validateApiKey() doesn't throw.
-      // Services that need a real key will fail gracefully in their API calls;
-      // services using public endpoints (OpenRouter) or no key (Ollama) work normally.
       const effectiveApiKey = key || 'no-api-key';
 
       try {
         const service: AIModelLookupService = AIServiceFactory.getService(
-          p as AIServiceProvider,
+          p,
           effectiveApiKey,
-          providerConfig,
+          resolved.serviceConfig,
         );
         const modelList = await withTimeout(service.listModels(), 20000);
 
@@ -118,7 +131,7 @@ export const useAgentModels = (provider?: string) => {
         );
         reportListModelsFallback({
           provider: p,
-          baseUrl: providerConfig.baseUrl,
+          baseUrl: resolved.baseUrl,
           reason: 'api_error',
           error,
           hasCachedModels,
@@ -126,7 +139,7 @@ export const useAgentModels = (provider?: string) => {
         return storedModels || {};
       }
     },
-    [providerConfig],
+    [resolved],
   );
 
   const {
@@ -140,14 +153,14 @@ export const useAgentModels = (provider?: string) => {
   });
 
   const refreshModels = useCallback(async () => {
-    if (!dynamicModelPolicy.canFetch) {
+    if (!dynamicModelPolicy.canFetch || !resolved || !provider) {
       return dynamicModels;
     }
 
     AIServiceFactory.invalidateService(
-      provider as AIServiceProvider,
+      provider,
       apiKey,
-      providerConfig,
+      resolved.serviceConfig,
     );
 
     return await mutateModels(undefined, {
@@ -159,22 +172,21 @@ export const useAgentModels = (provider?: string) => {
     dynamicModels,
     mutateModels,
     provider,
-    providerConfig,
+    resolved,
   ]);
 
-  // Combine static and dynamic models
   const availableModels = useMemo(() => {
-    if (!provider) return {};
+    if (!provider || !resolved) return {};
 
-    // If 3rd party is enabled for OpenAI, show only custom model ID
+    // Legacy openai 3rd-party single custom model id
     if (
       provider === AIServiceProvider.OpenAI &&
-      providerConfig.use3rdParty &&
-      providerConfig.customModelId
+      resolved.use3rdParty &&
+      resolved.customModelId
     ) {
       const customModel: ModelInfo = {
-        id: providerConfig.customModelId,
-        name: providerConfig.customModelId,
+        id: resolved.customModelId,
+        name: resolved.customModelId,
         contextWindow: 128000,
         supportReasoning: false,
         supportTools: true,
@@ -187,18 +199,23 @@ export const useAgentModels = (provider?: string) => {
       };
 
       return {
-        [providerConfig.customModelId]: customModel,
+        [resolved.customModelId]: customModel,
       };
     }
 
-    // Otherwise, show dynamic models, stored persistent models, or static fallback
-    const staticModels =
-      llmConfigManager.getModelsForProvider(provider as AIServiceProvider) ||
-      {};
+    const manualModels = manualModelsToMap(resolved.manualModels);
+    const staticModels = isCustomOpenAIProviderId(provider)
+      ? {}
+      : llmConfigManager.getModelsForProvider(provider as AIServiceProvider) ||
+        {};
     const storedModels = getStoredModelCache(provider);
 
     if (Object.keys(dynamicModels).length > 0) {
-      return dynamicModels;
+      return { ...manualModels, ...dynamicModels };
+    }
+
+    if (Object.keys(manualModels).length > 0) {
+      return manualModels;
     }
 
     if (storedModels && Object.keys(storedModels).length > 0) {
@@ -206,7 +223,7 @@ export const useAgentModels = (provider?: string) => {
     }
 
     return staticModels;
-  }, [provider, dynamicModels, providerConfig]);
+  }, [provider, dynamicModels, resolved]);
 
   return {
     availableModels,

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -38,6 +38,7 @@ const SettingsPage: FC = function SettingsPage() {
     dangerZoneProps,
     handleClose,
     handleContextStrategyChange,
+    handleCustomProvidersChange,
     handleDiscard,
     handleDiscardAndLeave,
     handleFallbackModelChange,
@@ -170,10 +171,12 @@ const SettingsPage: FC = function SettingsPage() {
             <TabsContent value="ai-models">
               <AIModelsTab
                 serviceConfigs={formState.serviceConfigs}
+                customProviders={formState.customProviders ?? []}
                 providerEntries={PROVIDER_ENTRIES}
                 localPreferredModel={formState.preferredModel}
                 localFallbackModel={formState.fallbackModel}
                 onPendingChange={handlePendingChange}
+                onCustomProvidersChange={handleCustomProvidersChange}
                 onPreferredModelChange={handlePreferredModelChange}
                 onFallbackModelChange={handleFallbackModelChange}
               />

--- a/src/features/settings/components/CustomProviderCard.tsx
+++ b/src/features/settings/components/CustomProviderCard.tsx
@@ -1,0 +1,193 @@
+import React, { useState } from 'react';
+import type { CustomOpenAIProvider } from '@/context/SettingsContext';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Button,
+  Textarea,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui';
+import { Eye, EyeOff, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { normalizeManualModels } from '@/lib/ai-service/custom-providers';
+
+export interface CustomProviderCardProps {
+  provider: CustomOpenAIProvider;
+  onChange: (id: string, patch: Partial<CustomOpenAIProvider>) => void;
+  onRemove: (id: string) => void;
+}
+
+function modelsToText(models: string[] | undefined): string {
+  return (models ?? []).join('\n');
+}
+
+function textToModels(text: string): string[] | undefined {
+  const parts = text
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return normalizeManualModels(parts);
+}
+
+function CustomProviderCardBase({
+  provider,
+  onChange,
+  onRemove,
+}: CustomProviderCardProps) {
+  const [showApiKey, setShowApiKey] = useState(false);
+  const { t } = useTranslation('common');
+
+  return (
+    <Card className="bg-background border shadow-sm min-w-0 w-full">
+      <CardHeader className="pb-4 flex flex-row items-start justify-between gap-2 space-y-0">
+        <div className="min-w-0 flex-1 space-y-2">
+          <CardTitle className="text-foreground text-base font-medium">
+            {t('settings.customProviders.cardTitle', 'Custom OpenAI Provider')}
+          </CardTitle>
+          <Input
+            type="text"
+            placeholder={t(
+              'settings.customProviders.namePlaceholder',
+              'e.g., Local-LMStudio, vLLM-Server-1',
+            )}
+            value={provider.name}
+            onChange={(e) => onChange(provider.id, { name: e.target.value })}
+            className="bg-background border text-foreground w-full"
+            aria-label={t('settings.customProviders.name', 'Display name')}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRemove(provider.id)}
+          aria-label={t(
+            'settings.customProviders.remove',
+            'Remove custom provider',
+          )}
+        >
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-3 min-w-0">
+        <div className="min-w-0">
+          <label className="block text-muted-foreground mb-2 text-sm font-medium">
+            {t('settings.provider.baseUrl', 'Base URL')}
+          </label>
+          <Input
+            type="url"
+            placeholder={t(
+              'settings.customProviders.baseUrlPlaceholder',
+              'http://192.168.1.100:8000/v1',
+            )}
+            value={provider.baseUrl}
+            onChange={(e) => onChange(provider.id, { baseUrl: e.target.value })}
+            className="bg-background border text-foreground w-full"
+          />
+        </div>
+
+        <div className="min-w-0">
+          <label className="block text-muted-foreground mb-2 text-sm font-medium">
+            {t('settings.provider.apiKey', 'API Key')}{' '}
+            <span className="font-normal">
+              ({t('settings.customProviders.optional', 'optional')})
+            </span>
+          </label>
+          <div className="relative">
+            <Input
+              type={showApiKey ? 'text' : 'password'}
+              placeholder={t(
+                'settings.customProviders.apiKeyPlaceholder',
+                'Leave empty for local servers',
+              )}
+              value={provider.apiKey || ''}
+              onChange={(e) =>
+                onChange(provider.id, { apiKey: e.target.value })
+              }
+              className="bg-background border text-foreground w-full pr-10"
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                  onClick={() => setShowApiKey((v) => !v)}
+                  aria-label={
+                    showApiKey
+                      ? t('settings.provider.hideApiKey', 'Hide API key')
+                      : t('settings.provider.showApiKey', 'Show API key')
+                  }
+                  aria-pressed={showApiKey}
+                >
+                  {showApiKey ? (
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Eye className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {showApiKey
+                  ? t('settings.provider.hideApiKey', 'Hide API key')
+                  : t('settings.provider.showApiKey', 'Show API key')}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+
+        <div className="min-w-0">
+          <label className="block text-muted-foreground mb-2 text-sm font-medium">
+            {t('settings.customProviders.models', 'Models')}{' '}
+            <span className="font-normal">
+              (
+              {t(
+                'settings.customProviders.modelsOptional',
+                'optional manual list',
+              )}
+              )
+            </span>
+          </label>
+          <Textarea
+            placeholder={t(
+              'settings.customProviders.modelsPlaceholder',
+              'One model ID per line (or comma-separated).\nLeave empty to use /v1/models.',
+            )}
+            value={modelsToText(provider.models)}
+            onChange={(e) =>
+              onChange(provider.id, { models: textToModels(e.target.value) })
+            }
+            className="bg-background border text-foreground w-full min-h-[72px]"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            {t(
+              'settings.customProviders.modelsDescription',
+              'Used when the endpoint cannot list models. Otherwise models are fetched from /v1/models after save.',
+            )}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const CustomProviderCard = React.memo(
+  CustomProviderCardBase,
+  (prev, next) => {
+    // Callbacks are intentionally omitted: parents recreate them when provider
+    // list identity changes, and field equality already gates useful skips.
+    return (
+      prev.provider.id === next.provider.id &&
+      prev.provider.name === next.provider.name &&
+      prev.provider.baseUrl === next.provider.baseUrl &&
+      (prev.provider.apiKey || '') === (next.provider.apiKey || '') &&
+      modelsToText(prev.provider.models) === modelsToText(next.provider.models)
+    );
+  },
+);

--- a/src/features/settings/hooks/__tests__/useSettingsForm.test.tsx
+++ b/src/features/settings/hooks/__tests__/useSettingsForm.test.tsx
@@ -279,9 +279,62 @@ describe('useSettingsForm', () => {
       result.current.updateExperimental('inlineAudioAttachment', false);
     });
 
-    expect(result.current.formState.experimental.inlineAudioAttachment).toBe(false);
+    expect(result.current.formState.experimental.inlineAudioAttachment).toBe(
+      false,
+    );
     expect(result.current.isDirty).toBe(true);
     expect(result.current.dirtyState.experimental).toBe(true);
+  });
+
+  it('should save custom providers and clear dirty state', async () => {
+    mockUpdateGlobal.mockImplementation(async (nextSettings) => {
+      currentGlobalSettings = cloneSettings(nextSettings);
+    });
+
+    const { result, rerender } = renderHook(() => useSettingsForm());
+
+    act(() => {
+      result.current.updateCustomProviders([
+        {
+          id: 'p1',
+          name: 'Local vLLM',
+          baseUrl: 'http://127.0.0.1:8000/v1',
+          apiKey: '',
+          models: [],
+        },
+      ]);
+    });
+
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtyState['ai-models']).toBe(true);
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    act(() => {
+      rerender();
+    });
+
+    expect(mockUpdateGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customProviders: [
+          {
+            id: 'p1',
+            name: 'Local vLLM',
+            baseUrl: 'http://127.0.0.1:8000/v1',
+          },
+        ],
+      }),
+    );
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.formState.customProviders).toEqual([
+      {
+        id: 'p1',
+        name: 'Local vLLM',
+        baseUrl: 'http://127.0.0.1:8000/v1',
+      },
+    ]);
   });
 });
 

--- a/src/features/settings/hooks/useSettingsForm.ts
+++ b/src/features/settings/hooks/useSettingsForm.ts
@@ -3,12 +3,14 @@ import { useSettings } from '@/hooks/use-settings';
 import { AIServiceProvider } from '@/lib/ai-service';
 import type {
   ServiceConfig,
+  CustomOpenAIProvider,
   AdvancedSettings,
   DisplaySettings,
   SystemSettings,
   Settings,
   ExperimentalSettings,
 } from '@/context/SettingsContext';
+import { normalizeCustomOpenAIProviders } from '@/lib/ai-service/custom-providers';
 import equal from 'fast-deep-equal';
 
 export type SettingsFormState = Settings;
@@ -38,6 +40,7 @@ function getEmptyDirtyState(): SettingsDirtyState {
 function getAiModelsComparableState(settings: SettingsFormState) {
   return {
     serviceConfigs: settings.serviceConfigs,
+    customProviders: normalizeCustomOpenAIProviders(settings.customProviders),
     preferredModel: settings.preferredModel,
     fallbackModel: settings.fallbackModel,
     agentHubUrl: settings.agentHubUrl,
@@ -192,6 +195,16 @@ export function useSettingsForm() {
     [updateFormStore],
   );
 
+  const updateCustomProviders = useCallback(
+    (customProviders: CustomOpenAIProvider[]) => {
+      updateFormStore((prev) => ({
+        ...prev,
+        customProviders: normalizeCustomOpenAIProviders(customProviders),
+      }));
+    },
+    [updateFormStore],
+  );
+
   const updateAdvanced = useCallback(
     <K extends keyof AdvancedSettings>(key: K, value: AdvancedSettings[K]) => {
       updateFormStore((prev) => ({
@@ -253,7 +266,16 @@ export function useSettingsForm() {
 
   const save = useCallback(async () => {
     if (!draftState) return;
-    await updateGlobal(draftState);
+    const sanitized: SettingsFormState = {
+      ...draftState,
+      customProviders: normalizeCustomOpenAIProviders(
+        draftState.customProviders,
+      ),
+    };
+    // Keep a canonical draft visible until persisted globals catch up.
+    // Normalization ensures equality clears dirty once reload finishes.
+    setDraftState(sanitized);
+    await updateGlobal(sanitized);
   }, [draftState, updateGlobal]);
 
   return {
@@ -261,6 +283,7 @@ export function useSettingsForm() {
     dirtyState: activeDirtyState,
     update,
     updateServiceConfig,
+    updateCustomProviders,
     updateAdvanced,
     updateDisplay,
     updateSystem,

--- a/src/features/settings/hooks/useSettingsPageController.ts
+++ b/src/features/settings/hooks/useSettingsPageController.ts
@@ -6,7 +6,11 @@ import { toast } from 'sonner';
 import { AIServiceProvider } from '@/lib/ai-service';
 import { useSettings } from '@/hooks/use-settings';
 import i18n from '@/lib/i18n';
-import type { ContextStrategy, ServiceConfig } from '@/context/SettingsContext';
+import type {
+  ContextStrategy,
+  CustomOpenAIProvider,
+  ServiceConfig,
+} from '@/context/SettingsContext';
 import { getLogger } from '@/lib/logger';
 import { dbUtils } from '@/lib/db/service';
 import { restartApp } from '@/lib/backend';
@@ -52,6 +56,7 @@ export function useSettingsPageController() {
     dirtyState,
     update,
     updateServiceConfig,
+    updateCustomProviders,
     updateAdvanced,
     updateDisplay,
     updateSystem,
@@ -303,7 +308,7 @@ export function useSettingsPageController() {
   const handlePreferredModelChange = useCallback(
     (model: string, provider: string) => {
       update('preferredModel', {
-        provider: provider as AIServiceProvider,
+        provider,
         model,
       });
     },
@@ -312,12 +317,16 @@ export function useSettingsPageController() {
 
   const handleFallbackModelChange = useCallback(
     (model: string, provider: string) => {
-      update(
-        'fallbackModel',
-        model ? { provider: provider as AIServiceProvider, model } : undefined,
-      );
+      update('fallbackModel', model ? { provider, model } : undefined);
     },
     [update],
+  );
+
+  const handleCustomProvidersChange = useCallback(
+    (providers: CustomOpenAIProvider[]) => {
+      updateCustomProviders(providers);
+    },
+    [updateCustomProviders],
   );
 
   const handleWindowSizeChange = useCallback(
@@ -418,6 +427,7 @@ export function useSettingsPageController() {
     formState,
     handleClose,
     handleContextStrategyChange,
+    handleCustomProvidersChange,
     handleDiscard,
     handleDiscardAndLeave,
     handleFallbackModelChange,

--- a/src/features/settings/tabs/AIModelsTab.tsx
+++ b/src/features/settings/tabs/AIModelsTab.tsx
@@ -1,33 +1,52 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
 import { AIServiceProvider } from '@/lib/ai-service';
-import { ServiceConfig } from '@/context/SettingsContext';
+import {
+  createCustomOpenAIProvider,
+  normalizeCustomOpenAIProvider,
+  toCustomProviderId,
+} from '@/lib/ai-service/custom-providers';
+import type {
+  ServiceConfig,
+  CustomOpenAIProvider,
+  ModelChoice,
+} from '@/lib/services/settings-service';
 import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker';
+import { Button } from '@/components/ui';
 import { ProviderCard } from '../components/ProviderCard';
+import { CustomProviderCard } from '../components/CustomProviderCard';
+
+const EMPTY_CUSTOM_PROVIDERS: CustomOpenAIProvider[] = [];
 
 interface AIModelsTabProps {
   serviceConfigs: Record<AIServiceProvider, ServiceConfig>;
+  customProviders: CustomOpenAIProvider[];
   providerEntries: AIServiceProvider[];
-  localPreferredModel: { provider: AIServiceProvider; model: string };
-  localFallbackModel?: { provider: AIServiceProvider; model: string } | null;
+  localPreferredModel: ModelChoice;
+  localFallbackModel?: ModelChoice | null;
   onPendingChange: (
     provider: AIServiceProvider,
     patch: Partial<ServiceConfig>,
   ) => void;
+  onCustomProvidersChange: (providers: CustomOpenAIProvider[]) => void;
   onPreferredModelChange: (model: string, provider: string) => void;
   onFallbackModelChange: (model: string, provider: string) => void;
 }
 
 function AIModelsTabComponent({
   serviceConfigs,
+  customProviders,
   providerEntries,
   localPreferredModel,
   localFallbackModel,
   onPendingChange,
+  onCustomProvidersChange,
   onPreferredModelChange,
   onFallbackModelChange,
 }: AIModelsTabProps) {
   const { t } = useTranslation('common');
+  const providers = customProviders ?? EMPTY_CUSTOM_PROVIDERS;
   const PROVIDER_META: Record<
     AIServiceProvider,
     { name: string; description: string }
@@ -124,6 +143,60 @@ function AIModelsTabComponent({
     },
   };
 
+  const handleAddCustomProvider = useCallback(() => {
+    const next = createCustomOpenAIProvider({
+      name: '',
+      baseUrl: '',
+    });
+    onCustomProvidersChange([...providers, next]);
+  }, [providers, onCustomProvidersChange]);
+
+  const handleCustomProviderChange = useCallback(
+    (id: string, patch: Partial<CustomOpenAIProvider>) => {
+      onCustomProvidersChange(
+        providers.map((entry) =>
+          entry.id === id
+            ? normalizeCustomOpenAIProvider({ ...entry, ...patch })
+            : entry,
+        ),
+      );
+    },
+    [providers, onCustomProvidersChange],
+  );
+
+  const handleRemoveCustomProvider = useCallback(
+    (id: string) => {
+      const providerId = toCustomProviderId(id);
+      const confirmed = window.confirm(
+        t(
+          'settings.customProviders.removeConfirm',
+          'Remove this custom provider? Sessions using it will need a new model selection.',
+        ),
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      onCustomProvidersChange(providers.filter((entry) => entry.id !== id));
+
+      if (localPreferredModel.provider === providerId) {
+        onPreferredModelChange('', AIServiceProvider.OpenAI);
+      }
+      if (localFallbackModel?.provider === providerId) {
+        onFallbackModelChange('', AIServiceProvider.OpenAI);
+      }
+    },
+    [
+      providers,
+      localFallbackModel?.provider,
+      localPreferredModel.provider,
+      onCustomProvidersChange,
+      onFallbackModelChange,
+      onPreferredModelChange,
+      t,
+    ],
+  );
+
   return (
     <div className="space-y-8">
       <div className="space-y-4">
@@ -186,6 +259,52 @@ function AIModelsTabComponent({
             );
           })}
         </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-medium text-foreground">
+              {t('settings.customProviders.title', 'Custom OpenAI Providers')}
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              {t(
+                'settings.customProviders.description',
+                'Register multiple OpenAI-compatible endpoints (vLLM, LM Studio, LocalAI, etc.) and select them in the model picker.',
+              )}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAddCustomProvider}
+            className="gap-1.5"
+          >
+            <Plus className="h-4 w-4" />
+            {t('settings.customProviders.add', 'Add Custom OpenAI Provider')}
+          </Button>
+        </div>
+
+        {providers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'settings.customProviders.empty',
+              'No custom providers yet. Add one to connect an extra OpenAI-compatible server.',
+            )}
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {providers.map((provider) => (
+              <CustomProviderCard
+                key={provider.id}
+                provider={provider}
+                onChange={handleCustomProviderChange}
+                onRemove={handleRemoveCustomProvider}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
+++ b/src/features/settings/tabs/__tests__/AIModelsTab.test.tsx
@@ -48,6 +48,17 @@ vi.mock('@/components/ui', () => ({
       onChange={onChange}
     />
   ),
+  Textarea: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+    placeholder?: string;
+  }) => (
+    <textarea value={value} placeholder={placeholder} onChange={onChange} />
+  ),
   Slider: () => <div data-testid="mock-slider" />,
   Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   CardHeader: ({ children }: { children: ReactNode }) => (
@@ -110,6 +121,7 @@ describe('AIModelsTab', () => {
     render(
       <AIModelsTab
         serviceConfigs={serviceConfigs}
+        customProviders={[]}
         providerEntries={[AIServiceProvider.OpenAI]}
         localPreferredModel={{
           provider: AIServiceProvider.OpenAI,
@@ -117,6 +129,7 @@ describe('AIModelsTab', () => {
         }}
         localFallbackModel={undefined}
         onPendingChange={vi.fn()}
+        onCustomProvidersChange={vi.fn()}
         onPreferredModelChange={vi.fn()}
         onFallbackModelChange={vi.fn()}
       />,
@@ -152,6 +165,7 @@ describe('AIModelsTab', () => {
     };
 
     const baseProps = {
+      customProviders: [],
       providerEntries: [AIServiceProvider.Ollama],
       localPreferredModel: {
         provider: AIServiceProvider.Ollama,
@@ -159,6 +173,7 @@ describe('AIModelsTab', () => {
       },
       localFallbackModel: undefined,
       onPendingChange,
+      onCustomProvidersChange: vi.fn(),
       onPreferredModelChange: vi.fn(),
       onFallbackModelChange: vi.fn(),
     };
@@ -192,5 +207,54 @@ describe('AIModelsTab', () => {
     );
 
     expect(screen.getByDisplayValue('http://remote-host:11434')).toBeVisible();
+  });
+
+  it('adds a custom OpenAI provider entry', () => {
+    const onCustomProvidersChange = vi.fn();
+    const serviceConfigs: Record<AIServiceProvider, ServiceConfig> = {
+      [AIServiceProvider.Groq]: {},
+      [AIServiceProvider.OpenAI]: {},
+      [AIServiceProvider.Anthropic]: {},
+      [AIServiceProvider.Gemini]: {},
+      [AIServiceProvider.Fireworks]: {},
+      [AIServiceProvider.Cerebras]: {},
+      [AIServiceProvider.Ollama]: {},
+      [AIServiceProvider.OpenRouter]: {},
+      [AIServiceProvider.Empty]: {},
+    };
+
+    render(
+      <AIModelsTab
+        serviceConfigs={serviceConfigs}
+        customProviders={[]}
+        providerEntries={[AIServiceProvider.OpenAI]}
+        localPreferredModel={{
+          provider: AIServiceProvider.OpenAI,
+          model: 'gpt-4o',
+        }}
+        localFallbackModel={undefined}
+        onPendingChange={vi.fn()}
+        onCustomProvidersChange={onCustomProvidersChange}
+        onPreferredModelChange={vi.fn()}
+        onFallbackModelChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Add Custom OpenAI Provider',
+      }),
+    );
+
+    expect(onCustomProvidersChange).toHaveBeenCalledTimes(1);
+    const nextProviders = onCustomProvidersChange.mock.calls[0][0];
+    expect(nextProviders).toHaveLength(1);
+    expect(nextProviders[0]).toEqual(
+      expect.objectContaining({
+        name: '',
+        baseUrl: '',
+        id: expect.any(String),
+      }),
+    );
   });
 });

--- a/src/lib/ai-service/__tests__/custom-providers.test.ts
+++ b/src/lib/ai-service/__tests__/custom-providers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { AIServiceProvider } from '../types';
+import {
+  createCustomOpenAIProvider,
+  isCustomOpenAIProviderId,
+  parseCustomProviderId,
+  resolveProviderRuntimeConfig,
+  toCustomProviderId,
+} from '../custom-providers';
+import type { Settings } from '@/lib/services/settings-service';
+import { DEFAULT_SETTING } from '@/lib/services/settings-service';
+
+function settingsWithCustom(
+  overrides: Partial<Settings> = {},
+): Pick<Settings, 'serviceConfigs' | 'customProviders'> {
+  return {
+    serviceConfigs: {
+      ...DEFAULT_SETTING.serviceConfigs,
+      [AIServiceProvider.OpenAI]: {
+        apiKey: 'sk-openai',
+        baseUrl: 'https://api.openai.com/v1',
+      },
+    },
+    customProviders: [
+      {
+        id: 'abc123',
+        name: 'Local vLLM',
+        baseUrl: 'http://192.168.1.10:8000/v1',
+        apiKey: 'local-key',
+        models: ['llama-3.1-70b'],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('custom provider helpers', () => {
+  it('detects and parses custom provider ids', () => {
+    expect(isCustomOpenAIProviderId('custom:abc123')).toBe(true);
+    expect(isCustomOpenAIProviderId('openai')).toBe(false);
+    expect(isCustomOpenAIProviderId('custom:')).toBe(false);
+    expect(parseCustomProviderId('custom:abc123')).toBe('abc123');
+    expect(toCustomProviderId('abc123')).toBe('custom:abc123');
+    expect(toCustomProviderId('custom:abc123')).toBe('custom:abc123');
+  });
+
+  it('creates a custom provider with a stable id and cleaned models', () => {
+    const created = createCustomOpenAIProvider({
+      id: 'fixed-id',
+      name: '  LM Studio  ',
+      baseUrl: ' http://localhost:1234/v1 ',
+      models: [' model-a ', '', 'model-b'],
+    });
+
+    expect(created).toEqual({
+      id: 'fixed-id',
+      name: 'LM Studio',
+      baseUrl: 'http://localhost:1234/v1',
+      models: ['model-a', 'model-b'],
+    });
+    expect(created).not.toHaveProperty('apiKey');
+  });
+
+  it('omits empty optional fields so JSON round-trips stay equal', () => {
+    const created = createCustomOpenAIProvider({
+      id: 'empty-optionals',
+      name: 'Local',
+      baseUrl: 'http://127.0.0.1:8000/v1',
+      apiKey: '   ',
+      models: [],
+    });
+
+    expect(created).toEqual({
+      id: 'empty-optionals',
+      name: 'Local',
+      baseUrl: 'http://127.0.0.1:8000/v1',
+    });
+    expect(JSON.parse(JSON.stringify(created))).toEqual(created);
+  });
+
+  it('resolves custom providers to OpenAI factory routing', () => {
+    const resolved = resolveProviderRuntimeConfig(
+      'custom:abc123',
+      settingsWithCustom(),
+    );
+
+    expect(resolved.factoryProvider).toBe(AIServiceProvider.OpenAI);
+    expect(resolved.apiKey).toBe('local-key');
+    expect(resolved.baseUrl).toBe('http://192.168.1.10:8000/v1');
+    expect(resolved.use3rdParty).toBe(true);
+    expect(resolved.displayName).toBe('Local vLLM');
+    expect(resolved.manualModels).toEqual(['llama-3.1-70b']);
+    expect(resolved.serviceConfig).toEqual({
+      baseUrl: 'http://192.168.1.10:8000/v1',
+      use3rdParty: true,
+    });
+  });
+
+  it('resolves builtin providers from serviceConfigs', () => {
+    const resolved = resolveProviderRuntimeConfig(
+      AIServiceProvider.OpenAI,
+      settingsWithCustom(),
+    );
+
+    expect(resolved.factoryProvider).toBe(AIServiceProvider.OpenAI);
+    expect(resolved.apiKey).toBe('sk-openai');
+    expect(resolved.baseUrl).toBe('https://api.openai.com/v1');
+    expect(resolved.use3rdParty).toBeUndefined();
+  });
+
+  it('falls back when a custom provider id is missing from settings', () => {
+    const providerId = 'custom:missing-id';
+    const resolved = resolveProviderRuntimeConfig(
+      providerId,
+      settingsWithCustom({ customProviders: [] }),
+    );
+
+    expect(resolved.factoryProvider).toBe(AIServiceProvider.OpenAI);
+    expect(resolved.providerId).toBe(providerId);
+    expect(resolved.displayName).toBe(providerId);
+    expect(resolved.apiKey).toBe('');
+    expect(resolved.baseUrl).toBeUndefined();
+    expect(resolved.use3rdParty).toBe(true);
+    expect(resolved.manualModels).toBeUndefined();
+  });
+
+  it('treats nullish provider ids as non-custom', () => {
+    expect(isCustomOpenAIProviderId(null)).toBe(false);
+    expect(isCustomOpenAIProviderId(undefined)).toBe(false);
+    expect(isCustomOpenAIProviderId('custom:')).toBe(false);
+  });
+});

--- a/src/lib/ai-service/__tests__/factory.test.ts
+++ b/src/lib/ai-service/__tests__/factory.test.ts
@@ -110,6 +110,29 @@ describe('AIServiceFactory', () => {
       expect(service).toBeInstanceOf(EmptyAIService);
     });
 
+    it('should create OpenAIService for custom OpenAI-compatible provider ids', () => {
+      AIServiceFactory.getService('custom:local-vllm', 'local-key', {
+        baseUrl: 'http://127.0.0.1:8000/v1',
+      });
+      expect(OpenAIService).toHaveBeenCalledWith('local-key', {
+        baseUrl: 'http://127.0.0.1:8000/v1',
+        use3rdParty: true,
+      });
+    });
+
+    it('should cache custom providers separately even with the same API key', () => {
+      const sharedKey = 'same-local-key';
+      const serviceA = AIServiceFactory.getService('custom:server-a', sharedKey, {
+        baseUrl: 'http://127.0.0.1:8000/v1',
+      });
+      const serviceB = AIServiceFactory.getService('custom:server-b', sharedKey, {
+        baseUrl: 'http://127.0.0.1:8001/v1',
+      });
+
+      expect(serviceA).not.toBe(serviceB);
+      expect(OpenAIService).toHaveBeenCalledTimes(2);
+    });
+
     it('should return EmptyAIService if service constructor throws an error', () => {
       // Force GroqService constructor to throw an error
       vi.mocked(GroqService).mockImplementationOnce(() => {

--- a/src/lib/ai-service/__tests__/model-fetch-policy.test.ts
+++ b/src/lib/ai-service/__tests__/model-fetch-policy.test.ts
@@ -96,4 +96,27 @@ describe('shouldFetchDynamicModels', () => {
       reason: 'allowed',
     });
   });
+
+  it('allows custom OpenAI-compatible providers with a base URL and no API key', () => {
+    expect(
+      shouldFetchDynamicModels({
+        provider: 'custom:local-vllm',
+        apiKey: '',
+        baseUrl: 'http://127.0.0.1:8000/v1',
+      }),
+    ).toBe(true);
+  });
+
+  it('requires a base URL for custom OpenAI-compatible providers', () => {
+    expect(
+      getDynamicModelFetchPolicy({
+        provider: 'custom:local-vllm',
+        apiKey: 'optional-key',
+        baseUrl: '',
+      }),
+    ).toEqual({
+      canFetch: false,
+      reason: 'missing-base-url',
+    });
+  });
 });

--- a/src/lib/ai-service/custom-providers.ts
+++ b/src/lib/ai-service/custom-providers.ts
@@ -1,0 +1,190 @@
+import { createId } from '@paralleldrive/cuid2';
+import type {
+  CustomOpenAIProvider,
+  ServiceConfig,
+  Settings,
+} from '@/lib/services/settings-service';
+import { AIServiceProvider, type AIServiceConfig } from './types';
+import { llmConfigManager } from '@/lib/llm-config-manager';
+
+export const CUSTOM_PROVIDER_PREFIX = 'custom:';
+
+export interface ResolvedProviderRuntimeConfig {
+  /** Value passed to AIServiceFactory (builtin enum or OpenAI for custom). */
+  factoryProvider: AIServiceProvider;
+  /** Session / settings provider id (builtin or `custom:<id>`). */
+  providerId: string;
+  displayName: string;
+  apiKey: string;
+  baseUrl?: string;
+  use3rdParty?: boolean;
+  customModelId?: string;
+  /** Manual model IDs for custom providers when /v1/models is unavailable. */
+  manualModels?: string[];
+  /** Config object suitable for AIServiceFactory.getService. */
+  serviceConfig: AIServiceConfig;
+}
+
+/**
+ * Returns true when `providerId` is a custom OpenAI-compatible provider
+ * (`custom:<non-empty-id>`).
+ *
+ * Nullish values are treated as non-custom (returns false) so call sites can
+ * pass optional provider strings without an extra guard.
+ */
+export function isCustomOpenAIProviderId(
+  providerId: string | undefined | null,
+): boolean {
+  return (
+    typeof providerId === 'string' &&
+    providerId.startsWith(CUSTOM_PROVIDER_PREFIX) &&
+    providerId.length > CUSTOM_PROVIDER_PREFIX.length
+  );
+}
+
+export function toCustomProviderId(id: string): string {
+  if (isCustomOpenAIProviderId(id)) {
+    return id;
+  }
+  return `${CUSTOM_PROVIDER_PREFIX}${id}`;
+}
+
+export function parseCustomProviderId(providerId: string): string | undefined {
+  if (!isCustomOpenAIProviderId(providerId)) {
+    return undefined;
+  }
+  return providerId.slice(CUSTOM_PROVIDER_PREFIX.length);
+}
+
+export function normalizeManualModels(
+  models: string[] | null | undefined,
+): string[] | undefined {
+  if (!models || models.length === 0) {
+    return undefined;
+  }
+  const cleaned = models.map((m) => m.trim()).filter((m) => m.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Canonicalize a custom provider for persistence / equality checks.
+ * Optional empty fields are omitted so JSON round-trips match in-memory form state.
+ */
+export function normalizeCustomOpenAIProvider(
+  provider: CustomOpenAIProvider,
+): CustomOpenAIProvider {
+  const apiKey = provider.apiKey?.trim();
+  const models = normalizeManualModels(provider.models);
+  const normalized: CustomOpenAIProvider = {
+    id: provider.id.trim(),
+    name: provider.name.trim(),
+    baseUrl: provider.baseUrl.trim(),
+  };
+  if (apiKey) {
+    normalized.apiKey = apiKey;
+  }
+  if (models) {
+    normalized.models = models;
+  }
+  return normalized;
+}
+
+export function normalizeCustomOpenAIProviders(
+  providers: CustomOpenAIProvider[] | null | undefined,
+): CustomOpenAIProvider[] {
+  if (!providers || providers.length === 0) {
+    return [];
+  }
+  return providers
+    .filter(
+      (provider) => typeof provider?.id === 'string' && provider.id.trim(),
+    )
+    .map(normalizeCustomOpenAIProvider);
+}
+
+export function createCustomOpenAIProvider(
+  partial: Omit<CustomOpenAIProvider, 'id'> & { id?: string },
+): CustomOpenAIProvider {
+  return normalizeCustomOpenAIProvider({
+    id: partial.id ?? createId(),
+    name: partial.name,
+    baseUrl: partial.baseUrl,
+    apiKey: partial.apiKey,
+    models: partial.models,
+  });
+}
+
+export function findCustomOpenAIProvider(
+  settings: Pick<Settings, 'customProviders'>,
+  providerId: string,
+): CustomOpenAIProvider | undefined {
+  const id = parseCustomProviderId(providerId);
+  if (!id) {
+    return undefined;
+  }
+  return (settings.customProviders ?? []).find((p) => p.id === id);
+}
+
+function builtinDisplayName(provider: AIServiceProvider): string {
+  return llmConfigManager.getProvider(provider)?.name ?? provider;
+}
+
+/**
+ * Resolves API credentials and factory routing for a builtin or custom provider id.
+ */
+export function resolveProviderRuntimeConfig(
+  providerId: string,
+  settings: Pick<Settings, 'serviceConfigs' | 'customProviders'>,
+): ResolvedProviderRuntimeConfig {
+  if (isCustomOpenAIProviderId(providerId)) {
+    const entry = findCustomOpenAIProvider(settings, providerId);
+    const apiKey = entry?.apiKey ?? '';
+    const baseUrl = entry?.baseUrl ?? '';
+    const serviceConfig: AIServiceConfig = {
+      baseUrl: baseUrl || undefined,
+      use3rdParty: true,
+    };
+
+    return {
+      factoryProvider: AIServiceProvider.OpenAI,
+      providerId,
+      displayName: entry?.name ?? providerId,
+      apiKey,
+      baseUrl: baseUrl || undefined,
+      use3rdParty: true,
+      manualModels: entry?.models,
+      serviceConfig,
+    };
+  }
+
+  const provider = providerId as AIServiceProvider;
+  const cfg: ServiceConfig = settings.serviceConfigs?.[provider] ?? {};
+  const serviceConfig: AIServiceConfig = {
+    baseUrl: cfg.baseUrl,
+    use3rdParty: cfg.use3rdParty,
+    customModelId: cfg.customModelId,
+    safetySettings: cfg.safetySettings,
+  };
+
+  return {
+    factoryProvider: Object.values(AIServiceProvider).includes(provider)
+      ? provider
+      : AIServiceProvider.Empty,
+    providerId,
+    displayName: builtinDisplayName(provider),
+    apiKey: cfg.apiKey ?? '',
+    baseUrl: cfg.baseUrl,
+    use3rdParty: cfg.use3rdParty,
+    customModelId: cfg.customModelId,
+    serviceConfig,
+  };
+}
+
+export function listCustomProviderPickerOptions(
+  customProviders: CustomOpenAIProvider[] | undefined,
+): Array<{ label: string; value: string }> {
+  return (customProviders ?? []).map((p) => ({
+    label: p.name || toCustomProviderId(p.id),
+    value: toCustomProviderId(p.id),
+  }));
+}

--- a/src/lib/ai-service/factory.ts
+++ b/src/lib/ai-service/factory.ts
@@ -11,6 +11,7 @@ import { OpenRouterService } from './openrouter';
 import { EmptyAIService } from './empty';
 import { LLMConfigManager } from '../llm-config-manager';
 import { registerAIServiceFactory } from './model-capabilities';
+import { isCustomOpenAIProviderId } from './custom-providers';
 
 const logger = getLogger('AIService');
 const configManager = new LLMConfigManager();
@@ -56,32 +57,56 @@ export class AIServiceFactory {
   private static instances: Map<string, ServiceInstance> = new Map();
   private static readonly INSTANCE_TTL = 1000 * 60 * 60; // 1 hour
 
+  private static resolveFactoryProvider(
+    provider: AIServiceProvider | string,
+  ): AIServiceProvider {
+    if (isCustomOpenAIProviderId(provider)) {
+      return AIServiceProvider.OpenAI;
+    }
+    if (
+      Object.values(AIServiceProvider).includes(provider as AIServiceProvider)
+    ) {
+      return provider as AIServiceProvider;
+    }
+    return AIServiceProvider.Empty;
+  }
+
   private static computeEffectiveApiKey(
-    provider: AIServiceProvider,
+    provider: AIServiceProvider | string,
     apiKey: string,
   ): string {
+    const factoryProvider = this.resolveFactoryProvider(provider);
+    // Custom OpenAI-compatible endpoints often run locally without a key.
+    if (isCustomOpenAIProviderId(provider)) {
+      return !apiKey || apiKey.trim().length === 0
+        ? `${provider}-local`
+        : apiKey;
+    }
+
     const providers = configManager.getProviders();
-    const providerInfo = providers[provider];
+    const providerInfo = providers[factoryProvider];
     const requiresApiKey = providerInfo?.requiresApiKey ?? true;
 
     return !requiresApiKey && (!apiKey || apiKey.trim().length === 0)
-      ? `${provider}-local`
+      ? `${factoryProvider}-local`
       : apiKey;
   }
 
   private static buildInstanceKey(
-    provider: AIServiceProvider,
+    provider: AIServiceProvider | string,
     apiKey: string,
     config?: AIServiceConfig,
   ): string {
     const effectiveApiKey = this.computeEffectiveApiKey(provider, apiKey);
+    // Keep custom provider ids in the cache key so distinct endpoints do not collide.
     return `${provider}:${effectiveApiKey}:${buildConfigCacheKey(config)}`;
   }
 
   static getCapabilityDelegate(
-    provider: AIServiceProvider,
+    provider: AIServiceProvider | string,
   ): CapabilityDelegate {
-    switch (provider) {
+    const factoryProvider = this.resolveFactoryProvider(provider);
+    switch (factoryProvider) {
       case AIServiceProvider.Groq:
         return {
           supportsTools: GroqService.supportsToolsForModel,
@@ -143,12 +168,21 @@ export class AIServiceFactory {
    *          Returns an `EmptyAIService` instance if the provider is unknown or creation fails.
    */
   static getService(
-    provider: AIServiceProvider,
+    provider: AIServiceProvider | string,
     apiKey: string,
     config?: AIServiceConfig,
   ): IAIService {
+    const factoryProvider = this.resolveFactoryProvider(provider);
+    const effectiveConfig: AIServiceConfig | undefined =
+      isCustomOpenAIProviderId(provider)
+        ? { ...config, use3rdParty: true }
+        : config;
     const effectiveApiKey = this.computeEffectiveApiKey(provider, apiKey);
-    const instanceKey = this.buildInstanceKey(provider, apiKey, config);
+    const instanceKey = this.buildInstanceKey(
+      provider,
+      apiKey,
+      effectiveConfig,
+    );
     const now = Date.now();
 
     // Clean up expired instances
@@ -167,30 +201,30 @@ export class AIServiceFactory {
 
     let service: IAIService;
     try {
-      switch (provider) {
+      switch (factoryProvider) {
         case AIServiceProvider.Groq:
-          service = new GroqService(effectiveApiKey, config);
+          service = new GroqService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.OpenAI:
-          service = new OpenAIService(effectiveApiKey, config);
+          service = new OpenAIService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.Anthropic:
-          service = new AnthropicService(effectiveApiKey, config);
+          service = new AnthropicService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.Gemini:
-          service = new GeminiService(effectiveApiKey, config);
+          service = new GeminiService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.Fireworks:
-          service = new FireworksService(effectiveApiKey, config);
+          service = new FireworksService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.Cerebras:
-          service = new CerebrasService(effectiveApiKey, config);
+          service = new CerebrasService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.Ollama:
-          service = new OllamaService(effectiveApiKey, config);
+          service = new OllamaService(effectiveApiKey, effectiveConfig);
           break;
         case AIServiceProvider.OpenRouter:
-          service = new OpenRouterService(effectiveApiKey, config);
+          service = new OpenRouterService(effectiveApiKey, effectiveConfig);
           break;
         default:
           logger.warn(
@@ -226,11 +260,19 @@ export class AIServiceFactory {
   }
 
   static invalidateService(
-    provider: AIServiceProvider,
+    provider: AIServiceProvider | string,
     apiKey: string,
     config?: AIServiceConfig,
   ): void {
-    const instanceKey = this.buildInstanceKey(provider, apiKey, config);
+    const effectiveConfig: AIServiceConfig | undefined =
+      isCustomOpenAIProviderId(provider)
+        ? { ...config, use3rdParty: true }
+        : config;
+    const instanceKey = this.buildInstanceKey(
+      provider,
+      apiKey,
+      effectiveConfig,
+    );
     const existing = this.instances.get(instanceKey);
     if (!existing) {
       return;

--- a/src/lib/ai-service/index.ts
+++ b/src/lib/ai-service/index.ts
@@ -24,3 +24,18 @@ export { OllamaService } from './ollama';
 
 // Re-export factory
 export { AIServiceFactory } from './factory';
+
+// Re-export custom OpenAI-compatible provider helpers
+export {
+  CUSTOM_PROVIDER_PREFIX,
+  isCustomOpenAIProviderId,
+  toCustomProviderId,
+  parseCustomProviderId,
+  createCustomOpenAIProvider,
+  normalizeCustomOpenAIProvider,
+  normalizeCustomOpenAIProviders,
+  resolveProviderRuntimeConfig,
+  listCustomProviderPickerOptions,
+  findCustomOpenAIProvider,
+} from './custom-providers';
+export type { ResolvedProviderRuntimeConfig } from './custom-providers';

--- a/src/lib/ai-service/model-capabilities.ts
+++ b/src/lib/ai-service/model-capabilities.ts
@@ -12,7 +12,7 @@ const logger = getLogger('ModelCapabilities');
  * This avoids a direct import and thus prevents circular dependencies.
  */
 interface FactoryInterface {
-  getCapabilityDelegate(provider: AIServiceProvider): ServiceInterface;
+  getCapabilityDelegate(provider: AIServiceProvider | string): ServiceInterface;
 }
 
 interface ServiceInterface {
@@ -252,7 +252,7 @@ export async function getContextWindow(
  */
 export function supportsTools(
   modelName: string,
-  provider: AIServiceProvider,
+  provider: AIServiceProvider | string,
 ): boolean {
   try {
     if (registeredFactory) {
@@ -263,6 +263,10 @@ export function supportsTools(
   } catch {
     // Fallback if factory or service logic fails
     const lowerName = modelName.toLowerCase();
+    if (typeof provider === 'string' && provider.startsWith('custom:')) {
+      // Custom OpenAI-compatible endpoints: assume tool support unless proven otherwise.
+      return true;
+    }
     if (provider === AIServiceProvider.OpenAI) {
       return (
         lowerName.includes('gpt-4') ||
@@ -283,7 +287,7 @@ export function supportsTools(
  */
 export function estimateContextWindow(
   modelName: string,
-  provider: AIServiceProvider,
+  provider: AIServiceProvider | string,
 ): number {
   try {
     if (registeredFactory) {
@@ -294,7 +298,12 @@ export function estimateContextWindow(
   } catch {
     // Basic heuristics if delegation fails
     if (provider === AIServiceProvider.Anthropic) return 200000;
-    if (provider === AIServiceProvider.OpenAI) return 128000;
+    if (
+      provider === AIServiceProvider.OpenAI ||
+      (typeof provider === 'string' && provider.startsWith('custom:'))
+    ) {
+      return 128000;
+    }
     return 4096;
   }
 }

--- a/src/lib/ai-service/model-fetch-policy.ts
+++ b/src/lib/ai-service/model-fetch-policy.ts
@@ -1,8 +1,10 @@
+import { isCustomOpenAIProviderId } from './custom-providers';
 import { AIServiceProvider } from './types';
 
 interface DynamicModelFetchPolicyArgs {
   provider?: string;
   apiKey?: string;
+  baseUrl?: string;
   use3rdParty?: boolean;
   customModelId?: string;
 }
@@ -10,6 +12,7 @@ interface DynamicModelFetchPolicyArgs {
 export type DynamicModelFetchPolicyReason =
   | 'missing-provider'
   | 'missing-api-key'
+  | 'missing-base-url'
   | 'custom-openai-model'
   | 'allowed';
 
@@ -21,6 +24,7 @@ export interface DynamicModelFetchPolicyDecision {
 export function getDynamicModelFetchPolicy({
   provider,
   apiKey,
+  baseUrl,
   use3rdParty,
   customModelId,
 }: DynamicModelFetchPolicyArgs): DynamicModelFetchPolicyDecision {
@@ -28,6 +32,21 @@ export function getDynamicModelFetchPolicy({
     return {
       canFetch: false,
       reason: 'missing-provider',
+    };
+  }
+
+  // Multi custom OpenAI-compatible providers: fetch /v1/models when baseUrl is set
+  // (API key optional for local servers).
+  if (isCustomOpenAIProviderId(provider)) {
+    if (!baseUrl?.trim()) {
+      return {
+        canFetch: false,
+        reason: 'missing-base-url',
+      };
+    }
+    return {
+      canFetch: true,
+      reason: 'allowed',
     };
   }
 
@@ -68,12 +87,14 @@ export function getDynamicModelFetchPolicy({
 export function shouldFetchDynamicModels({
   provider,
   apiKey,
+  baseUrl,
   use3rdParty,
   customModelId,
 }: DynamicModelFetchPolicyArgs): boolean {
   return getDynamicModelFetchPolicy({
     provider,
     apiKey,
+    baseUrl,
     use3rdParty,
     customModelId,
   }).canFetch;

--- a/src/lib/services/rust-settings-service.ts
+++ b/src/lib/services/rust-settings-service.ts
@@ -5,6 +5,7 @@ import {
   type ISettingsService,
   type Settings,
   type ServiceConfig,
+  type CustomOpenAIProvider,
   type ModelChoice,
   type AdvancedSettings,
   type DisplaySettings,
@@ -12,12 +13,14 @@ import {
   type ExperimentalSettings,
 } from './settings-service';
 import type { AIServiceProvider } from '@/lib/ai-service';
+import { normalizeCustomOpenAIProviders } from '@/lib/ai-service/custom-providers';
 
 const logger = getLogger('RustSettingsService');
 
 // Define specific types for each setting value
 type SettingValue =
   | Record<AIServiceProvider, ServiceConfig> // serviceConfigs
+  | CustomOpenAIProvider[] // customProviders
   | ModelChoice // preferredModel / fallbackModel
   | null // fallbackModel can be null (cleared)
   | number // windowSize, toolCallGroupVisibleCount
@@ -76,6 +79,31 @@ function isPartialAdvancedSettings(
   });
 }
 
+function isCustomOpenAIProviderArray(
+  val: unknown,
+): val is CustomOpenAIProvider[] {
+  if (!Array.isArray(val)) {
+    return false;
+  }
+  return val.every((entry) => {
+    if (typeof entry !== 'object' || entry === null) {
+      return false;
+    }
+    const obj = entry as Record<string, unknown>;
+    const apiKey = obj.apiKey;
+    const models = obj.models;
+    return (
+      typeof obj.id === 'string' &&
+      typeof obj.name === 'string' &&
+      typeof obj.baseUrl === 'string' &&
+      (apiKey === undefined || apiKey === null || typeof apiKey === 'string') &&
+      (models === undefined ||
+        models === null ||
+        (Array.isArray(models) && models.every((m) => typeof m === 'string')))
+    );
+  });
+}
+
 function mapDtosToSettings(dtos: SettingDto[]): Settings {
   const settingsMap = new Map<string, SettingValue>();
   dtos.forEach((dto) => {
@@ -109,6 +137,13 @@ function mapDtosToSettings(dtos: SettingDto[]): Settings {
       ...DEFAULT_SETTING.serviceConfigs,
       ...getTypedValue('serviceConfigs', DEFAULT_SETTING.serviceConfigs),
     },
+    customProviders: normalizeCustomOpenAIProviders(
+      getTypedValue(
+        'customProviders',
+        DEFAULT_SETTING.customProviders,
+        isCustomOpenAIProviderArray,
+      ),
+    ),
     preferredModel: getTypedValue(
       'preferredModel',
       DEFAULT_SETTING.preferredModel,
@@ -221,6 +256,12 @@ export class RustSettingsService implements ISettingsService {
           ...settings.serviceConfigs,
         };
         changes['serviceConfigs'] = newServiceConfigs;
+      }
+
+      if (settings.customProviders !== undefined) {
+        changes['customProviders'] = normalizeCustomOpenAIProviders(
+          settings.customProviders,
+        );
       }
 
       if (settings.preferredModel) {

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -18,8 +18,23 @@ export interface ServiceConfig {
   customModelId?: string;
 }
 
+/** User-defined OpenAI-compatible endpoint (vLLM, LM Studio, LocalAI, etc.). */
+export interface CustomOpenAIProvider {
+  /** Stable cuid used in session provider strings as `custom:<id>`. */
+  id: string;
+  /** Display name shown in Settings and the model picker. */
+  name: string;
+  /** OpenAI-compatible base URL (e.g. http://192.168.1.100:8000/v1). */
+  baseUrl: string;
+  /** Optional API key for authenticated endpoints. */
+  apiKey?: string;
+  /** Optional manual model IDs when /v1/models is unavailable. */
+  models?: string[];
+}
+
 export interface ModelChoice {
-  provider: AIServiceProvider;
+  /** Builtin AIServiceProvider id or `custom:<id>` for custom providers. */
+  provider: string;
   model: string;
 }
 
@@ -81,6 +96,8 @@ export interface ExperimentalSettings {
 
 export interface Settings {
   serviceConfigs: Record<AIServiceProvider, ServiceConfig>;
+  /** Additional OpenAI-compatible providers beyond the builtin openai slot. */
+  customProviders: CustomOpenAIProvider[];
   preferredModel: ModelChoice;
   fallbackModel?: ModelChoice;
   contextStrategy: ContextStrategy;
@@ -105,8 +122,9 @@ export const DEFAULT_SETTING: Settings = {
     },
     {} as Record<AIServiceProvider, ServiceConfig>,
   ),
+  customProviders: [],
   preferredModel: {
-    provider: (DEFAULT_MODEL?.providerId || 'openai') as AIServiceProvider,
+    provider: DEFAULT_MODEL?.providerId || 'openai',
     model: DEFAULT_MODEL?.modelId || '',
   },
   fallbackModel: undefined,


### PR DESCRIPTION
## Summary
- Add Settings CRUD for multiple custom OpenAI-compatible providers (`custom:<id>`) with base URL, optional API key, and manual model lists
- Route custom providers through OpenAIService and the model picker so vLLM / LM Studio / LocalAI endpoints work as first-class choices
- Treat `custom:*` as OpenAI-compatible in Rust request layout / context cleanup for correct prompt shaping

Fixes #1631

## Test plan
- [ ] Settings → AI Models: add two custom providers with different base URLs; verify both appear in AgentModelPicker
- [ ] Select a custom provider + manual model, run a chat turn against a local OpenAI-compatible server
- [ ] Save settings with empty optional apiKey/models and confirm the form does not stay dirty after reload
- [ ] Remove a custom provider that is currently preferred; preferred model resets to OpenAI
- [ ] `pnpm test:run` for custom-providers / factory / AIModelsTab / AgentModelPicker
- [ ] `pnpm refactor:validate` (or CI green on this PR)

Made with [Cursor](https://cursor.com)