### PR TITLE
fix(agent-chat): stop scroll-up flash and footer overlap (#1647)

### DIFF
--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -234,8 +234,11 @@ export function AgentChatMessages() {
 
   const renderMessageGroup = useCallback(
     (_index: number, groupedMessage: GroupedMessage) => {
-      const isLatestMessage = groupedMessage.message.id === latestMessage?.id;
-      const followChatScroll = !isLatestMessage || isPinned;
+      // Only pin nested auto-scroll (thinking / resources) while the list itself
+      // is stick-to-bottom. The old `!isLatest || isPinned` kept followChatScroll
+      // true for every historical bubble, so load-older mounts could briefly
+      // yank a user bubble into view then release it.
+      const followChatScroll = isPinned;
       const isCompactBoundary = groupedMessageContainsBoundary(
         groupedMessage,
         compactedRange?.toId,
@@ -252,7 +255,10 @@ export function AgentChatMessages() {
 
       if (groupedMessage.type === 'tool_group') {
         return (
-          <div className="mb-6">
+          // Use padding (not margin) for inter-item gap — Virtuoso's size
+          // observer ignores vertical margins and mis-corrects scrollTop on
+          // upward scroll, flashing above-viewport bubbles into view.
+          <div className="pb-6">
             <AgentMessageBubble
               message={groupedMessage.message}
               assistantName={assistantName}
@@ -268,7 +274,7 @@ export function AgentChatMessages() {
 
       if (groupedMessage.type === 'tool_error_group') {
         return (
-          <div className="mb-6">
+          <div className="pb-6">
             <AgentMessageBubble
               message={groupedMessage.message}
               assistantName={assistantName}
@@ -283,8 +289,8 @@ export function AgentChatMessages() {
 
       if (groupedMessage.message.error) {
         return (
-          <div className="mb-6">
-            <div className="self-start my-2">
+          <div className="pb-6">
+            <div className="self-start py-2">
               <ErrorBubble
                 error={groupedMessage.message.error}
                 onRetry={retryMessage}
@@ -311,7 +317,7 @@ export function AgentChatMessages() {
       }
 
       return (
-        <div className="mb-6">
+        <div className="pb-6">
           <AgentMessageBubble
             message={msg}
             assistantName={assistantName}
@@ -326,7 +332,6 @@ export function AgentChatMessages() {
       compactedEvent,
       compactedRange?.toId,
       isPinned,
-      latestMessage?.id,
       retryMessage,
       toolResultsMap,
       workflowStatus,
@@ -352,6 +357,10 @@ export function AgentChatMessages() {
           atBottomThreshold={bottomThreshold}
           atBottomStateChange={handleVirtuosoAtBottomStateChange}
           followOutput={false}
+          // Chat starts at LAST via initialTopMostItemIndex. Without this,
+          // scrolling up into never-measured variable-height rows briefly
+          // paints those above-viewport bubbles then corrects (virtuoso#1096).
+          skipAnimationFrameInResizeObserver
           increaseViewportBy={{ top: 640, bottom: 960 }}
           startReached={handleReachTop}
           totalListHeightChanged={handleTotalListHeightChanged}

--- a/src/features/agent/components/__tests__/AgentChatMessages.bottom-alignment.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.bottom-alignment.test.tsx
@@ -166,7 +166,29 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      // #1647: Virtuoso LAST-item scroll does not include Footer spacer —
+      // sentinel must still align so content clears the composer.
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      restoreAnimationFrame();
+      restoreScrollIntoView();
+    }
+  });
+
+  it('aligns the footer sentinel even when Virtuoso scrollToIndex succeeds (#1647)', () => {
+    const scrollIntoView = vi.fn();
+    const restoreAnimationFrame = installImmediateAnimationFrameMock();
+    const restoreScrollIntoView = installScrollIntoViewMock(scrollIntoView);
+
+    try {
+      render(<AgentChatMessages />);
+
+      expect(scrollToIndexMock).toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'end',
+        inline: 'nearest',
+        behavior: 'auto',
+      });
     } finally {
       restoreAnimationFrame();
       restoreScrollIntoView();
@@ -216,7 +238,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       restoreAnimationFrame();
       restoreScrollIntoView();
@@ -247,7 +269,9 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock.mock.calls.length).toBe(2);
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
+
+      scrollIntoView.mockClear();
 
       act(() => {
         virtuosoProps.atBottomStateChange?.(true);
@@ -255,7 +279,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock.mock.calls.length).toBe(3);
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       restoreAnimationFrame();
       restoreScrollIntoView();
@@ -276,7 +300,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       rerender(<AgentChatMessages />);
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       restoreAnimationFrame();
       restoreScrollIntoView();
@@ -312,7 +336,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
       global.cancelAnimationFrame = originalCancelAnimationFrame;
@@ -489,7 +513,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       });
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
       global.cancelAnimationFrame = originalCancelAnimationFrame;
@@ -545,7 +569,7 @@ describe('AgentChatMessages – bottom alignment and retry', () => {
       rerender(<AgentChatMessages />);
 
       expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
     } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
       global.cancelAnimationFrame = originalCancelAnimationFrame;

--- a/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.test.tsx
@@ -929,4 +929,124 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     }
   });
+
+  it('does not yank to bottom with sentinel scroll when older messages prepend at the top', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    const scrollIntoView = vi.fn();
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage('visible head')];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(
+      0,
+      groupedMessagesMock.length,
+      makeStreamingGroupEntry('visible head'),
+    );
+
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    performanceNowSpy.mockImplementation(() => currentTime);
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      const { container, rerender } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+
+      // Two-step upward park (same pattern as other near-top tests).
+      currentTime = 50;
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 2_000,
+        clientHeight: 400,
+        scrollTop: 40,
+      });
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      currentTime = 300;
+      scroller!.scrollTop = 2;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+
+      scrollToIndexMock.mockClear();
+      scrollIntoView.mockClear();
+
+      groupedMessagesMock.splice(
+        0,
+        groupedMessagesMock.length,
+        {
+          type: 'single',
+          message: {
+            ...baseMessage,
+            id: 'older-user',
+            role: 'user',
+            content: [{ type: 'text', text: 'Older user message' }],
+          },
+          messages: [
+            {
+              ...baseMessage,
+              id: 'older-user',
+              role: 'user',
+              content: [{ type: 'text', text: 'Older user message' }],
+            },
+          ],
+          coveredMessageIds: ['older-user'],
+        } as GroupedMessage,
+        makeStreamingGroupEntry('visible head'),
+      );
+      chatState.messages = [
+        {
+          ...baseMessage,
+          id: 'older-user',
+          role: 'user',
+          content: [{ type: 'text', text: 'Older user message' }],
+        },
+        makeStreamingMessage('visible head'),
+      ];
+      rerender(<AgentChatMessages />);
+
+      // Prepend pins the previous head before paint (Virtuoso remount flash).
+      expect(scrollToIndexMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          align: 'start',
+          behavior: 'auto',
+        }),
+      );
+      scrollToIndexMock.mockClear();
+
+      const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
+        totalListHeightChanged?: (height: number) => void;
+      };
+
+      act(() => {
+        virtuosoProps.totalListHeightChanged?.(2_400);
+        resizeObserverCallbacks.current.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
+      });
+
+      // Must not also yank to the footer sentinel / latest messages.
+      expect(scrollToIndexMock).not.toHaveBeenCalled();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
 });

--- a/src/features/agent/components/__tests__/AgentChatMessages.virtuoso-config.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.virtuoso-config.test.tsx
@@ -601,10 +601,12 @@ describe('AgentChatMessages – Virtuoso list configuration', () => {
     const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
       atBottomThreshold: number;
       followOutput: false;
+      skipAnimationFrameInResizeObserver?: boolean;
     };
 
     expect(virtuosoProps.atBottomThreshold).toBe(getVisualBottomThreshold());
     expect(virtuosoProps.followOutput).toBe(false);
+    expect(virtuosoProps.skipAnimationFrameInResizeObserver).toBe(true);
     expect(getVisualBottomThreshold()).toBe(4);
   });
 

--- a/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { type VirtuosoHandle } from 'react-virtuoso';
 import { getLogger } from '@/lib/logger';
 import { type GroupedMessage } from '@/hooks/useMessageGrouping';
@@ -131,6 +138,14 @@ export function useAgentChatScroll({
   const preservesPreviousVisibleHead = previousHeadIndexInCurrentList >= 0;
   const prependCount = candidatePrependCount;
 
+  // Arm prepend preservation during render (not only in useEffect) so
+  // same-frame ResizeObserver / totalListHeightChanged / reactive scroll
+  // cannot yank to bottom before the effect runs — that flash often looks
+  // like a brief user bubble appearing then vanishing after load-older.
+  if (prependCount > 0) {
+    isPreservingPrependPositionRef.current = true;
+  }
+
   const effectiveFirstItemIndex = didSessionChangeForListState
     ? INITIAL_FIRST_ITEM_INDEX
     : prependCount > 0
@@ -209,6 +224,35 @@ export function useAgentChatScroll({
     },
     [scrollerElement],
   );
+
+  // Virtuoso can remount the *start* of `data` for a frame when prepending
+  // (react-virtuoso#663), which briefly paints older user bubbles then swaps
+  // back. Pin the previous head before paint so that frame never shows.
+  useLayoutEffect(() => {
+    if (prependCount <= 0) {
+      return;
+    }
+
+    const virtuoso = virtuosoRef.current;
+    if (!virtuoso) {
+      return;
+    }
+
+    // Old head sits at data index `prependCount` → virtuoso index below.
+    const anchorVirtuosoIndex = effectiveFirstItemIndex + prependCount;
+    logScrollState('prepend-preservation:anchor-scroll', {
+      prependCount,
+      anchorVirtuosoIndex,
+      effectiveFirstItemIndex,
+    });
+    selfScrollIgnoreUntilRef.current =
+      performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
+    virtuoso.scrollToIndex({
+      index: anchorVirtuosoIndex,
+      align: 'start',
+      behavior: 'auto',
+    });
+  }, [effectiveFirstItemIndex, logScrollState, prependCount]);
 
   groupedMessageCountRef.current = groupedMessages.length;
 
@@ -396,15 +440,30 @@ export function useAgentChatScroll({
           reason,
           scrolledWithVirtuoso: true,
         });
+      }
+
+      // Virtuoso scrollToIndex(LAST) only aligns the last *data* item. Footer
+      // (composer spacer + sentinel) sits after data items, so always finish
+      // with sentinel alignment or the last ~composer-overlap px stays hidden
+      // behind AgentChatInput (#1647).
+      if (footerEndRef.current) {
+        logScrollState('executeScrollToBottom:footer-sentinel-align', {
+          itemCount,
+          reason,
+          scrolledWithVirtuoso,
+        });
+        scrollFooterSentinelIntoView(footerEndRef.current);
         return true;
       }
 
-      if (footerEndRef.current) {
-        logScrollState('executeScrollToBottom:footer-sentinel-fallback', {
+      // Footer sentinel missing (unmounted / not yet attached). Virtuoso-only
+      // scroll is the best we can do; log so the rare path is visible in debug.
+      if (scrolledWithVirtuoso) {
+        logScrollState('executeScrollToBottom:virtuoso-scroll-no-footer', {
           itemCount,
           reason,
+          scrolledWithVirtuoso: true,
         });
-        scrollFooterSentinelIntoView(footerEndRef.current);
         return true;
       }
 
@@ -504,6 +563,39 @@ export function useAgentChatScroll({
 
       autoScrollFrameRef.current = requestAnimationFrame(() => {
         autoScrollFrameRef.current = null;
+        // Re-check intent inside the frame — a schedule from before scroll-up /
+        // prepend must not run sentinel scrollIntoView and flash bottom content.
+        // Keep these rules identical to the schedule-time suppress checks above.
+        const isForceReasonOnFire = forceBottomScrollReasons.has(reason);
+        const isNearTopOnFire =
+          scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
+        const shouldForceOnFire =
+          isForceReasonOnFire ||
+          (shouldFollowLatestRef.current && !isNearTopOnFire);
+        const shouldSuppressForPrependOnFire =
+          isPreservingPrependPositionRef.current && !isForceReasonOnFire;
+        const shouldSuppressForUserScrollOnFire =
+          !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
+          !visualBottomRef.current &&
+          !shouldForceOnFire;
+        const shouldSuppressForNearTopOnFire =
+          isNearTopOnFire && !visualBottomRef.current && !isForceReasonOnFire;
+
+        if (
+          shouldSuppressForPrependOnFire ||
+          shouldSuppressForUserScrollOnFire ||
+          shouldSuppressForNearTopOnFire
+        ) {
+          logScrollState('scheduleScrollToBottom:frame-suppressed', {
+            reason,
+            isPreservingPrepend: isPreservingPrependPositionRef.current,
+            isNearTop: isNearTopOnFire,
+            shouldFollowLatest: shouldFollowLatestRef.current,
+            visualBottom: visualBottomRef.current,
+          });
+          return;
+        }
+
         logScrollState('scheduleScrollToBottom:frame-fired', {
           reason,
         });
@@ -859,6 +951,14 @@ export function useAgentChatScroll({
       resumeBottomFollow('bottom-context-restored');
     }
 
+    if (prependCount > 0 || isPreservingPrependPositionRef.current) {
+      logScrollState('reactive-state-change:prepend-skip', {
+        prependCount,
+        messageId: latestMessage?.id,
+      });
+      return;
+    }
+
     if (!shouldFollowLatestRef.current && !isPinnedToBottomRef.current) {
       return;
     }
@@ -886,6 +986,7 @@ export function useAgentChatScroll({
     agentLlmError,
     groupedMessages.length,
     logScrollState,
+    prependCount,
     resumeBottomFollow,
     scheduleScrollToBottom,
   ]);


### PR DESCRIPTION
## Summary
- Always align the footer sentinel after Virtuoso bottom scrolls so the composer spacer stays in view and input no longer overlaps the last message
- Harden prepend / load-older guards (preserve position, skip reactive follow during prepend, remount `scrollToIndex` before paint)
- Enable `skipAnimationFrameInResizeObserver` and switch item gaps from `mb-6` to `pb-6` so upward scroll no longer flashes above-viewport bubbles

Fixes #1647

## Test plan
- [ ] Open a long agent chat and confirm the last message sits above the composer (no overlap)
- [ ] Scroll up through variable-height bubbles — no flash of above-viewport messages
- [ ] Load older messages (prepend) — scroll position stays stable, no yank to bottom
- [ ] Pin/follow at bottom while streaming — still sticks to latest
- [ ] `pnpm test:run` AgentChatMessages suites pass (bottom-alignment, scroll-follow, virtuoso-config)