### PR TITLE
fix(agent-chat): close UX gaps from chat interface audit (#1649)

### DIFF
--- a/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
@@ -138,6 +138,7 @@ export function ContentItemRenderer({
           content={textItem.text}
           components={markdownComponents}
           hideCopyButton={message?.role === 'tool'}
+          isStreaming={Boolean(message?.isStreaming)}
         />
       );
     }

--- a/src/features/agent/components/AgentMessageRenderer/components/MarkdownText.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/MarkdownText.tsx
@@ -5,6 +5,7 @@ import { useClipboard } from '@/hooks/useClipboard';
 import { getLogger } from '@/lib/logger';
 import { toast } from 'sonner';
 import { REMARK_PLUGINS, REHYPE_PLUGINS } from '../config/markdown';
+import { useStreamMarkdownPreprocess } from '../hooks/useStreamMarkdownPreprocess';
 
 const logger = getLogger('AgentMessageRenderer');
 
@@ -14,15 +15,19 @@ export const MarkdownText = memo(
     content,
     components,
     hideCopyButton,
+    isStreaming = false,
   }: {
     content: string;
     components: React.ComponentProps<typeof ReactMarkdown>['components'];
     hideCopyButton?: boolean;
+    isStreaming?: boolean;
   }) => {
     const { copied, copyToClipboard } = useClipboard();
+    const displayContent = useStreamMarkdownPreprocess(content, isStreaming);
 
     const handleCopy = useCallback(async () => {
       try {
+        // Always copy the original (un-preprocessed) content
         await copyToClipboard(content);
       } catch (err) {
         logger.error('Failed to copy text content', err);
@@ -50,7 +55,7 @@ export const MarkdownText = memo(
           rehypePlugins={REHYPE_PLUGINS}
           components={components}
         >
-          {content}
+          {displayContent}
         </ReactMarkdown>
       </div>
     );

--- a/src/features/agent/components/AgentMessageRenderer/hooks/useStreamMarkdownPreprocess.ts
+++ b/src/features/agent/components/AgentMessageRenderer/hooks/useStreamMarkdownPreprocess.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { preprocessStreamMarkdown } from '../utils/streamMarkdownPreprocess';
+
+/**
+ * During streaming, returns markdown with unclosed fences / markers closed
+ * so the renderer stays stable. When streaming ends, returns original content.
+ */
+export function useStreamMarkdownPreprocess(
+  content: string,
+  isStreaming: boolean,
+): string {
+  return useMemo(
+    () => preprocessStreamMarkdown(content, isStreaming),
+    [content, isStreaming],
+  );
+}

--- a/src/features/agent/components/AgentMessageRenderer/utils/__tests__/streamMarkdownPreprocess.test.ts
+++ b/src/features/agent/components/AgentMessageRenderer/utils/__tests__/streamMarkdownPreprocess.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { preprocessStreamMarkdown } from '../streamMarkdownPreprocess';
+
+describe('preprocessStreamMarkdown', () => {
+  it('returns content unchanged when not streaming', () => {
+    const content = '```ts\nconst x = 1';
+    expect(preprocessStreamMarkdown(content, false)).toBe(content);
+  });
+
+  it('closes an unclosed fenced code block while streaming', () => {
+    const content = '```ts\nconst x = 1;';
+    expect(preprocessStreamMarkdown(content, true)).toBe(
+      '```ts\nconst x = 1;\n```',
+    );
+  });
+
+  it('does not double-close a complete fence', () => {
+    const content = '```ts\nconst x = 1;\n```';
+    expect(preprocessStreamMarkdown(content, true)).toBe(content);
+  });
+
+  it('closes unclosed bold markers', () => {
+    expect(preprocessStreamMarkdown('hello **world', true)).toBe(
+      'hello **world**',
+    );
+  });
+
+  it('closes italic after completed bold without double-counting', () => {
+    expect(preprocessStreamMarkdown('**bold** and *italic', true)).toBe(
+      '**bold** and *italic*',
+    );
+  });
+
+  it('strips an incomplete trailing HTML tag', () => {
+    expect(preprocessStreamMarkdown('hello <div class="x', true)).toBe(
+      'hello ',
+    );
+  });
+
+  it('closes unpaired inline code outside fences', () => {
+    expect(preprocessStreamMarkdown('use `code', true)).toBe('use `code`');
+  });
+});

--- a/src/features/agent/components/AgentMessageRenderer/utils/streamMarkdownPreprocess.ts
+++ b/src/features/agent/components/AgentMessageRenderer/utils/streamMarkdownPreprocess.ts
@@ -1,0 +1,106 @@
+/**
+ * Close incomplete markdown constructs during streaming so ReactMarkdown
+ * does not produce broken layouts (unclosed fences, dangling emphasis, etc.).
+ * When streaming finishes, callers should pass the original content unchanged.
+ */
+
+const FENCE_RE = /(^|\n)(```|~~~)/g;
+const INCOMPLETE_HTML_TAG_RE = /<[A-Za-z][^>]*$/;
+
+function countUnescapedOccurrences(text: string, token: string): number {
+  let count = 0;
+  let index = 0;
+
+  while (index < text.length) {
+    const found = text.indexOf(token, index);
+    if (found === -1) {
+      break;
+    }
+    if (found > 0 && text[found - 1] === '\\') {
+      index = found + token.length;
+      continue;
+    }
+    count += 1;
+    index = found + token.length;
+  }
+
+  return count;
+}
+
+function isInsideOpenFence(content: string): boolean {
+  let open = false;
+  FENCE_RE.lastIndex = 0;
+  while (FENCE_RE.exec(content) !== null) {
+    open = !open;
+  }
+  return open;
+}
+
+function closeUnpairedMarker(content: string, marker: string): string {
+  if (countUnescapedOccurrences(content, marker) % 2 === 0) {
+    return content;
+  }
+  return `${content}${marker}`;
+}
+
+/**
+ * Count single-char emphasis markers that are not part of a double marker
+ * (e.g. `*` not consumed by `**`).
+ */
+function countSingleEmphasis(
+  content: string,
+  single: '*' | '_',
+  double: '**' | '__',
+): number {
+  const withoutDouble = content.split(double).join('');
+  return countUnescapedOccurrences(withoutDouble, single);
+}
+
+function closeSingleEmphasis(
+  content: string,
+  single: '*' | '_',
+  double: '**' | '__',
+): string {
+  if (countSingleEmphasis(content, single, double) % 2 === 0) {
+    return content;
+  }
+  return `${content}${single}`;
+}
+
+function stripIncompleteHtmlTag(content: string): string {
+  const match = content.match(INCOMPLETE_HTML_TAG_RE);
+  if (!match || match.index === undefined) {
+    return content;
+  }
+  return content.slice(0, match.index);
+}
+
+/**
+ * Returns display-safe markdown while `isStreaming` is true.
+ * Returns `content` unchanged when streaming has finished.
+ */
+export function preprocessStreamMarkdown(
+  content: string,
+  isStreaming: boolean,
+): string {
+  if (!isStreaming || content.length === 0) {
+    return content;
+  }
+
+  let result = content;
+
+  if (isInsideOpenFence(result)) {
+    result = `${result}\n\`\`\``;
+  } else {
+    // Close unpaired inline code only outside an open fence
+    result = closeUnpairedMarker(result, '`');
+  }
+
+  result = closeUnpairedMarker(result, '**');
+  result = closeUnpairedMarker(result, '__');
+  result = closeSingleEmphasis(result, '*', '**');
+  result = closeSingleEmphasis(result, '_', '__');
+  result = stripIncompleteHtmlTag(result);
+
+  return result;
+}

--- a/src/features/agent/components/AgentToolsModal.tsx
+++ b/src/features/agent/components/AgentToolsModal.tsx
@@ -76,13 +76,13 @@ export const AgentToolsModal: React.FC<AgentToolsModalProps> = ({
             </DialogDescription>
 
             <div className="flex flex-wrap gap-2">
-              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-[11px] text-muted-foreground">
+              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
                 {totalCount} {t('agent.toolsModal.title')}
               </div>
-              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-[11px] text-muted-foreground">
+              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
                 {builtinCount} {t('agent.toolsModal.badgeBuiltin')}
               </div>
-              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-[11px] text-muted-foreground">
+              <div className="rounded-full border border-border/50 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
                 {mcpCount} {t('agent.toolsModal.badgeMcp')}
               </div>
             </div>
@@ -159,11 +159,7 @@ export const AgentToolsModal: React.FC<AgentToolsModalProps> = ({
 
                             <Badge
                               variant="outline"
-                              className={
-                                isBuiltinTool(tool.name)
-                                  ? 'shrink-0 border-border/40 bg-background/80 text-[10px] uppercase tracking-wide text-muted-foreground'
-                                  : 'shrink-0 border-border/40 bg-background/80 text-[10px] uppercase tracking-wide text-muted-foreground'
-                              }
+                              className="shrink-0 border-border/40 bg-background/80 text-xs uppercase tracking-wide text-muted-foreground"
                               aria-hidden
                             >
                               {isBuiltinTool(tool.name)

--- a/src/features/agent/components/PendingApprovalWidget.tsx
+++ b/src/features/agent/components/PendingApprovalWidget.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Card,
   CardHeader,
@@ -29,6 +29,30 @@ interface PendingApprovalWidgetProps {
   onRespond: (toolCallId: string, approved: boolean) => Promise<void>;
 }
 
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable
+  );
+}
+
+/** Prefer hard approvals; otherwise use the first pending item. */
+function pickPriorityApproval(
+  approvals: PendingApproval[],
+): PendingApproval | undefined {
+  return (
+    approvals.find((approval) => approval.approvalKind === 'hard') ??
+    approvals[0]
+  );
+}
+
 export function PendingApprovalWidget({
   approvals,
   executionMode,
@@ -36,21 +60,84 @@ export function PendingApprovalWidget({
 }: PendingApprovalWidgetProps) {
   const { t } = useTranslation();
   const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const firstCardRef = useRef<HTMLDivElement | null>(null);
+  const submittingIdRef = useRef<string | null>(null);
+
+  submittingIdRef.current = submittingId;
+
+  const handleResponse = useCallback(
+    async (toolCallId: string, approved: boolean) => {
+      if (submittingIdRef.current !== null) {
+        return;
+      }
+      setSubmittingId(toolCallId);
+      try {
+        await onRespond(toolCallId, approved);
+      } finally {
+        setSubmittingId(null);
+      }
+    },
+    [onRespond],
+  );
+
+  const firstToolCallId = approvals[0]?.toolCallId;
+
+  useEffect(() => {
+    if (!firstToolCallId || !firstCardRef.current) {
+      return;
+    }
+
+    const active = document.activeElement;
+    // Don't steal focus from chat input or other interactive controls.
+    const canAutofocus =
+      !active ||
+      active === document.body ||
+      firstCardRef.current.contains(active);
+
+    if (canAutofocus) {
+      firstCardRef.current.focus();
+    }
+  }, [firstToolCallId]);
+
+  useEffect(() => {
+    if (!approvals || approvals.length === 0) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (submittingIdRef.current !== null) {
+        return;
+      }
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      const target = pickPriorityApproval(approvals);
+      if (!target) {
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        void handleResponse(target.toolCallId, true);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        void handleResponse(target.toolCallId, false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [approvals, handleResponse]);
 
   if (!approvals || approvals.length === 0) return null;
 
-  const handleResponse = async (toolCallId: string, approved: boolean) => {
-    setSubmittingId(toolCallId);
-    try {
-      await onRespond(toolCallId, approved);
-    } finally {
-      setSubmittingId(null);
-    }
-  };
-
   return (
     <div className="flex flex-col gap-4 w-full max-w-full">
-      {approvals.map((approval) => {
+      {approvals.map((approval, index) => {
         let argsParsed;
         try {
           argsParsed = JSON.parse(approval.arguments);
@@ -88,8 +175,8 @@ export function PendingApprovalWidget({
           ? t('agent.approval.hardBadge', 'Hard approval')
           : t('agent.approval.standardBadge', 'Standard approval');
 
-        return (
-          <Card key={approval.toolCallId} className={containerClass}>
+        const card = (
+          <Card className={containerClass}>
             <CardHeader className="pb-3 flex flex-row items-center gap-3">
               <div className={iconContainerClass}>
                 {isHardApproval ? (
@@ -105,15 +192,15 @@ export function PendingApprovalWidget({
                     variant="outline"
                     className={
                       isHardApproval
-                        ? 'text-[10px] border-destructive/30 bg-destructive/10 text-destructive'
-                        : 'text-[10px] bg-background/50'
+                        ? 'text-xs border-destructive/30 bg-destructive/10 text-destructive'
+                        : 'text-xs bg-background/50'
                     }
                   >
                     {approvalKindLabel}
                   </Badge>
                   <Badge
                     variant="outline"
-                    className="font-mono text-[10px] bg-background/50"
+                    className="font-mono text-xs bg-background/50"
                   >
                     {approval.toolName}
                   </Badge>
@@ -177,6 +264,21 @@ export function PendingApprovalWidget({
             </CardFooter>
           </Card>
         );
+
+        if (index === 0) {
+          return (
+            <div
+              key={approval.toolCallId}
+              ref={firstCardRef}
+              tabIndex={0}
+              className="outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-xl"
+            >
+              {card}
+            </div>
+          );
+        }
+
+        return <div key={approval.toolCallId}>{card}</div>;
       })}
     </div>
   );

--- a/src/features/agent/components/__tests__/PendingApprovalWidget.test.tsx
+++ b/src/features/agent/components/__tests__/PendingApprovalWidget.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, it, vi } from 'vitest';
 
 import { PendingApprovalWidget } from '../PendingApprovalWidget';
+import type { PendingApproval } from '@/context/AgentSessionContext';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -10,21 +11,31 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+const standardApproval: PendingApproval = {
+  toolCallId: 'call-standard',
+  toolName: 'readFile',
+  arguments: '{"path":"README.md"}',
+  approvalKind: 'standard',
+  requestId: 'req-standard',
+  description: 'Standard approval',
+  inputPreview: 'README.md',
+};
+
+const hardApproval: PendingApproval = {
+  toolCallId: 'call-hard',
+  toolName: 'runShell',
+  arguments: '{"command":"rm -rf /important"}',
+  approvalKind: 'hard',
+  requestId: 'req-hard',
+  description: 'Hard approval',
+  inputPreview: 'rm -rf /important',
+};
+
 describe('PendingApprovalWidget', () => {
   it('surfaces hard approvals distinctly when YOLO mode is enabled', () => {
     render(
       <PendingApprovalWidget
-        approvals={[
-          {
-            toolCallId: 'call-hard',
-            toolName: 'runShell',
-            arguments: '{"command":"rm -rf /important"}',
-            approvalKind: 'hard',
-            requestId: 'req-hard',
-            description: 'Hard approval',
-            inputPreview: 'rm -rf /important',
-          },
-        ]}
+        approvals={[hardApproval]}
         executionMode="yolo"
         onRespond={vi.fn().mockResolvedValue(undefined)}
       />,
@@ -40,5 +51,62 @@ describe('PendingApprovalWidget', () => {
     expect(
       screen.getByRole('button', { name: 'Approve high-risk action' }),
     ).toBeInTheDocument();
+  });
+
+  it('approves the priority approval on Enter', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <PendingApprovalWidget
+        approvals={[standardApproval, hardApproval]}
+        executionMode="normal"
+        onRespond={onRespond}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onRespond).toHaveBeenCalledWith('call-hard', true);
+    });
+  });
+
+  it('rejects the priority approval on Escape', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <PendingApprovalWidget
+        approvals={[standardApproval]}
+        executionMode="normal"
+        onRespond={onRespond}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(onRespond).toHaveBeenCalledWith('call-standard', false);
+    });
+  });
+
+  it('ignores Enter while typing in an input', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <>
+        <input aria-label="chat-input" />
+        <PendingApprovalWidget
+          approvals={[standardApproval]}
+          executionMode="normal"
+          onRespond={onRespond}
+        />
+      </>,
+    );
+
+    const input = screen.getByLabelText('chat-input');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRespond).not.toHaveBeenCalled();
   });
 });

--- a/src/features/agent/components/shared/ThinkingBubble.tsx
+++ b/src/features/agent/components/shared/ThinkingBubble.tsx
@@ -1,8 +1,10 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { LoadingIndicator } from './LoadingIndicator';
 
 const THINKING_BOTTOM_PIN_THRESHOLD_PX = 4;
+const COLLAPSED_PREVIEW_CHARS = 80;
 
 interface ThinkingBubbleProps {
   /** The thinking/reasoning content to display. Can be undefined during initial streaming. */
@@ -26,15 +28,29 @@ function isNearThinkingBottom(element: HTMLDivElement): boolean {
   return distanceFromBottom <= THINKING_BOTTOM_PIN_THRESHOLD_PX;
 }
 
+function getCollapsedPreview(
+  thinking: string | undefined,
+  fallback: string,
+): string {
+  if (thinking == null || thinking.length === 0) {
+    return fallback;
+  }
+  if (thinking.length <= COLLAPSED_PREVIEW_CHARS) {
+    return thinking;
+  }
+  return `${thinking.slice(0, COLLAPSED_PREVIEW_CHARS)}…`;
+}
+
 /**
  * ThinkingBubble - Reusable thinking/reasoning content display
  * Used in AgentMessageBubble and AgentToolCallGroup to show
  * extended thinking content from reasoning-capable models.
  *
  * Features:
- * - Displays "Thinking Process" label with timer
+ * - Collapsed by default with truncated preview
+ * - Expand/collapse toggle next to the "Thinking Process" label
  * - Shows loading animation when streaming
- * - Scrollable content area with max height
+ * - Scrollable content area with max height when expanded
  * - Keeps the internal scroll pinned to the latest streamed reasoning output
  * - Respects manual upward scroll inside the thinking panel
  * - Consistent styling across components
@@ -47,6 +63,7 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
   className = '',
 }) => {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const userReleasedAutoPinRef = useRef(false);
 
@@ -65,6 +82,7 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
 
   useEffect(() => {
     if (
+      !isExpanded ||
       !isStreaming ||
       !followChatScroll ||
       !scrollRef.current ||
@@ -74,10 +92,12 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
     }
 
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-  }, [thinking, followChatScroll, isStreaming]);
+  }, [thinking, followChatScroll, isStreaming, isExpanded]);
 
   // Format time as (XXs)
   const formattedTime = thinkingTime ? `(${thinkingTime.toFixed(1)}s)` : '';
+  const thinkingFallback = t('agent.bubble.thinking');
+  const preview = getCollapsedPreview(thinking, thinkingFallback);
 
   return (
     <div
@@ -85,21 +105,50 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
     >
       <div className="flex items-center gap-2 text-xs font-medium opacity-70">
         {isStreaming && <LoadingIndicator size="sm" />}
-        <span>
-          {formattedTime
-            ? t('agent.bubble.thinkingProcessWithTime', { time: formattedTime })
-            : t('agent.bubble.thinkingProcess')}
-        </span>
+        <button
+          type="button"
+          onClick={() => setIsExpanded((prev) => !prev)}
+          className="inline-flex items-center gap-1 rounded-sm hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          )}
+          <span>
+            {formattedTime
+              ? t('agent.bubble.thinkingProcessWithTime', {
+                  time: formattedTime,
+                })
+              : t('agent.bubble.thinkingProcess')}
+          </span>
+        </button>
       </div>
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
-      >
-        {thinking != null && thinking.length > 0
-          ? thinking
-          : t('agent.bubble.thinking')}
-      </div>
+      {isExpanded ? (
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="text-xs opacity-50 italic whitespace-pre-wrap max-h-32 overflow-y-auto"
+        >
+          {thinking != null && thinking.length > 0
+            ? thinking
+            : thinkingFallback}
+        </div>
+      ) : (
+        <div className="flex items-start gap-2">
+          <p className="flex-1 text-xs opacity-50 italic whitespace-pre-wrap line-clamp-2">
+            {preview}
+          </p>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(true)}
+            className="shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+          >
+            {t('agent.bubble.expandThinking', 'Expand')}
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
+++ b/src/features/agent/components/shared/__tests__/ThinkingBubble.test.tsx
@@ -1,7 +1,31 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { ThinkingBubble } from '../ThinkingBubble';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValueOrOptions?: string | { time?: string }) => {
+      if (key === 'agent.bubble.thinkingProcessWithTime') {
+        const options = defaultValueOrOptions as { time?: string } | undefined;
+        return `Thinking Process ${options?.time ?? ''}`.trim();
+      }
+      if (typeof defaultValueOrOptions === 'string') {
+        return defaultValueOrOptions;
+      }
+      const defaults: Record<string, string> = {
+        'agent.bubble.thinkingProcess': 'Thinking Process',
+        'agent.bubble.thinking': 'Thinking…',
+        'agent.bubble.expandThinking': 'Expand',
+      };
+      return defaults[key] ?? key;
+    },
+  }),
+}));
+
+function expandThinking() {
+  fireEvent.click(screen.getByRole('button', { name: /Thinking Process/i }));
+}
 
 function getScrollContainer(container: HTMLElement): HTMLDivElement {
   const scrollContainer = container.querySelector(
@@ -31,10 +55,31 @@ function mockScrollMetrics(
 }
 
 describe('ThinkingBubble', () => {
+  it('is collapsed by default and shows a truncated preview', () => {
+    const longThinking = 'a'.repeat(120);
+    render(<ThinkingBubble thinking={longThinking} isStreaming={false} />);
+
+    expect(screen.getByText(/a{80}…/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
+    expect(screen.queryByText(longThinking)).not.toBeInTheDocument();
+  });
+
+  it('expands to show full thinking content', () => {
+    const longThinking = 'a'.repeat(120);
+    render(<ThinkingBubble thinking={longThinking} isStreaming={false} />);
+
+    expandThinking();
+
+    expect(screen.getByText(longThinking)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument();
+  });
+
   it('keeps its internal scroll pinned to the bottom while streaming', () => {
     const { container, rerender } = render(
       <ThinkingBubble thinking="first line" isStreaming={true} />,
     );
+
+    expandThinking();
 
     const scrollContainer = getScrollContainer(container);
     mockScrollMetrics(scrollContainer, {
@@ -57,6 +102,8 @@ describe('ThinkingBubble', () => {
     const { container, rerender } = render(
       <ThinkingBubble thinking="first line" isStreaming={true} />,
     );
+
+    expandThinking();
 
     const scrollContainer = getScrollContainer(container);
     mockScrollMetrics(scrollContainer, {
@@ -82,6 +129,8 @@ describe('ThinkingBubble', () => {
     const { container, rerender } = render(
       <ThinkingBubble thinking="first line" isStreaming={true} />,
     );
+
+    expandThinking();
 
     const scrollContainer = getScrollContainer(container);
     mockScrollMetrics(scrollContainer, {
@@ -115,6 +164,8 @@ describe('ThinkingBubble', () => {
       />,
     );
 
+    expandThinking();
+
     const scrollContainer = getScrollContainer(container);
     mockScrollMetrics(scrollContainer, {
       scrollHeight: 240,
@@ -131,5 +182,22 @@ describe('ThinkingBubble', () => {
     );
 
     expect(scrollContainer.scrollTop).toBe(0);
+  });
+
+  it('does not auto-pin while collapsed even when streaming', () => {
+    const { container, rerender } = render(
+      <ThinkingBubble thinking="first line" isStreaming={true} />,
+    );
+
+    expect(container.querySelector('.overflow-y-auto')).toBeNull();
+
+    rerender(
+      <ThinkingBubble
+        thinking={'first line\nsecond line\nthird line'}
+        isStreaming={true}
+      />,
+    );
+
+    expect(container.querySelector('.overflow-y-auto')).toBeNull();
   });
 });

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -1052,7 +1052,8 @@
       "noContent": "Kein Inhalt",
       "thinkingProcess": "Denkprozess",
       "thinkingProcessWithTime": "Denkprozess {{time}}",
-      "thinking": "Denke..."
+      "thinking": "Denke...",
+      "expandThinking": "Erweitern"
     },
     "start": {
       "heroTitle": "Was möchten Sie heute tun?",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1107,7 +1107,8 @@
       "noContent": "No content",
       "thinkingProcess": "Thinking Process",
       "thinkingProcessWithTime": "Thinking Process {{time}}",
-      "thinking": "Thinking..."
+      "thinking": "Thinking...",
+      "expandThinking": "Expand"
     },
     "start": {
       "heroTitle": "What would you like to do today?",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1052,7 +1052,8 @@
       "noContent": "Sin contenido",
       "thinkingProcess": "Proceso de pensamiento",
       "thinkingProcessWithTime": "Proceso de pensamiento {{time}}",
-      "thinking": "Pensando..."
+      "thinking": "Pensando...",
+      "expandThinking": "Expandir"
     },
     "start": {
       "heroTitle": "¿Qué te gustaría hacer hoy?",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1052,7 +1052,8 @@
       "noContent": "Aucun contenu",
       "thinkingProcess": "Processus de réflexion",
       "thinkingProcessWithTime": "Processus de réflexion {{time}}",
-      "thinking": "Réflexion..."
+      "thinking": "Réflexion...",
+      "expandThinking": "Développer"
     },
     "start": {
       "heroTitle": "Que voulez-vous faire aujourd'hui ?",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -1026,7 +1026,8 @@
       "noContent": "内容なし",
       "thinkingProcess": "思考プロセス",
       "thinkingProcessWithTime": "思考プロセス {{time}}",
-      "thinking": "思考中..."
+      "thinking": "思考中...",
+      "expandThinking": "展開"
     },
     "chat": {
       "failedToStartPlaybookWorkflow": "プレイブックワークフローの開始に失敗しました",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -1107,7 +1107,8 @@
       "noContent": "내용 없음",
       "thinkingProcess": "생각 프로세스",
       "thinkingProcessWithTime": "생각 프로세스 {{time}}",
-      "thinking": "생각 중..."
+      "thinking": "생각 중...",
+      "expandThinking": "펼치기"
     },
     "start": {
       "heroTitle": "오늘 무엇을 하고 싶으신가요?",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -1052,7 +1052,8 @@
       "noContent": "Sem conteúdo",
       "thinkingProcess": "Processo de pensamento",
       "thinkingProcessWithTime": "Processo de pensamento {{time}}",
-      "thinking": "Pensando..."
+      "thinking": "Pensando...",
+      "expandThinking": "Expandir"
     },
     "start": {
       "heroTitle": "O que você gostaria de fazer hoje?",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -1052,7 +1052,8 @@
       "noContent": "无内容",
       "thinkingProcess": "思考过程",
       "thinkingProcessWithTime": "思考过程 {{time}}",
-      "thinking": "正在思考..."
+      "thinking": "正在思考...",
+      "expandThinking": "展开"
     },
     "start": {
       "heroTitle": "今天想做什么？",


### PR DESCRIPTION
## Summary
- Close incomplete markdown (fences, emphasis, trailing HTML) while streaming so message layout stays stable
- Add Enter/Esc shortcuts on pending approvals (hard-first), with typing-safe guards and non-stealing autofocus
- Collapse thinking traces by default with expand toggle; standardize badge typography to `text-xs`

Fixes #1649

## Test plan
- [x] Stream a long assistant reply with an unclosed `` `	s `` fence — no broken layout mid-stream; final content unchanged when stream ends
- [x] Trigger a tool approval: press Enter to approve, Esc to deny; shortcuts ignored while typing in chat input
- [x] Hard + standard approvals together — Enter/Esc targets the hard approval first
- [x] ThinkingBubble starts collapsed with truncated preview; Expand shows full scrollable content; auto-pin only when expanded during stream
- [x] Visual check: AgentToolsModal / PendingApprovalWidget badges use consistent `text-xs` sizing
- [x] `pnpm refactor:validate` (already green on this branch)

Made with [Cursor](https://cursor.com)