### PR TITLE
feat(sidebar): expand Recent Sessions with infinite scroll and tree (#1652)

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Bot,
@@ -13,8 +13,12 @@ import {
   Circle,
   Clock,
   Database,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
 } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
+import { toast } from 'sonner';
 import {
   Sidebar,
   SidebarContent,
@@ -29,10 +33,18 @@ import {
   useSidebar,
 } from '../ui/sidebar';
 import { Badge } from '../ui/badge';
-import { useAgentSessionListState } from '@/context/AgentSessionListContext';
+import {
+  useAgentSessionListActions,
+  useAgentSessionListState,
+} from '@/context/AgentSessionListContext';
 import { useUpdateContext } from '@/context/UpdateContext';
-import { buildChildrenMap } from '@/lib/session-utils';
+import { useInfiniteScroll } from '@/features/agent/components/use-session-scroll';
+import { useKnownDirectChildCounts } from '@/features/agent/components/use-known-direct-child-counts';
+import { getLogger } from '@/lib/logger';
 import { cn } from '@/lib/utils';
+import { buildSidebarSessionRows } from './sidebar-recent-sessions';
+
+const logger = getLogger('AppSidebar');
 
 /** Maps session status to a semantically meaningful dot */
 function StatusDot({ status }: { status: string }) {
@@ -78,76 +90,68 @@ export default function AppSidebar() {
   const { status: updateStatus } = useUpdateContext();
   const hasUpdate = updateStatus === 'available';
 
-  const { sessions, hasMoreSessions } = useAgentSessionListState();
+  const { sessions, hasMoreSessions, isLoadingMoreSessions } =
+    useAgentSessionListState();
+  const { loadMoreSessions } = useAgentSessionListActions();
+
+  const recentSessionsRootRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const knownDirectChildCountByParentId = useKnownDirectChildCounts(
+    sessions,
+    hasMoreSessions,
+  );
+
   const bookmarkedCount = useMemo(
     () => sessions.filter((session) => session.isBookmarked === true).length,
     [sessions],
   );
 
-  /** Show up to 5 recent sessions with lightweight hierarchy cues. */
-  const recentSessions = useMemo(() => {
-    const statusPriority: Record<string, number> = {
-      busy: 1,
-      idle: 2,
-      paused: 3,
-      error: 4,
-    };
-    const sortByPriority = (
-      a: (typeof sessions)[number],
-      b: (typeof sessions)[number],
-    ) => {
-      const statusDiff =
-        (statusPriority[a.status] ?? 9) - (statusPriority[b.status] ?? 9);
-      if (statusDiff !== 0) return statusDiff;
-      return (
-        (b.updatedAt ?? b.createdAt).getTime() -
-        (a.updatedAt ?? a.createdAt).getTime()
+  const recentSessions = useMemo(
+    () =>
+      buildSidebarSessionRows(
+        sessions,
+        expandedSessionIds,
+        knownDirectChildCountByParentId,
+      ),
+    [sessions, expandedSessionIds, knownDirectChildCountByParentId],
+  );
+
+  const handleLoadMore = useCallback(() => {
+    void loadMoreSessions().catch((error) => {
+      logger.error('Failed to load more sessions', error);
+      toast.error(
+        t(
+          'sessionHistory.toasts.loadMoreFailed',
+          'Failed to load more sessions',
+        ),
       );
-    };
-
-    const sortedSessions = [...sessions].sort(sortByPriority);
-    const sessionById = new Map(
-      sortedSessions.map((session) => [session.id, session]),
-    );
-    const childrenByParent = buildChildrenMap(sortedSessions);
-    const rows: Array<{
-      session: (typeof sessions)[number];
-      nestingLevel: number;
-    }> = [];
-    const visited = new Set<string>();
-
-    const pushSession = (
-      session: (typeof sessions)[number],
-      nestingLevel: number,
-    ) => {
-      if (visited.has(session.id) || rows.length >= 5) {
-        return;
-      }
-
-      visited.add(session.id);
-      rows.push({ session, nestingLevel });
-
-      const children = childrenByParent.get(session.id) || [];
-      children.forEach((child) => {
-        pushSession(child, Math.min(nestingLevel + 1, 2));
-      });
-    };
-
-    sortedSessions
-      .filter(
-        (session) =>
-          !session.parentSessionId || !sessionById.has(session.parentSessionId),
-      )
-      .forEach((root) => {
-        pushSession(root, 0);
-      });
-
-    sortedSessions.forEach((session) => {
-      pushSession(session, session.parentSessionId ? 1 : 0);
     });
+  }, [loadMoreSessions, t]);
 
-    return rows;
-  }, [sessions]);
+  const handleToggleExpand = useCallback((sessionId: string) => {
+    setExpandedSessionIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(sessionId)) {
+        next.delete(sessionId);
+      } else {
+        next.add(sessionId);
+      }
+      return next;
+    });
+  }, []);
+
+  useInfiniteScroll({
+    rootRef: recentSessionsRootRef,
+    loadMoreSentinelRef,
+    hasMoreSessions,
+    isLoadingMoreSessions,
+    onLoadMore: handleLoadMore,
+    displayRowsLength: recentSessions.length,
+  });
 
   return (
     <Sidebar className="backdrop-blur-sm border-r shadow-xl" collapsible="icon">
@@ -175,9 +179,9 @@ export default function AppSidebar() {
         </div>
       </SidebarHeader>
 
-      <SidebarContent className={`flex-1 overflow-y-auto terminal-scrollbar`}>
+      <SidebarContent className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {/* Main Section */}
-        <SidebarGroup>
+        <SidebarGroup className="shrink-0">
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
@@ -244,7 +248,7 @@ export default function AppSidebar() {
         </SidebarGroup>
 
         {/* Library Section */}
-        <SidebarGroup>
+        <SidebarGroup className="shrink-0">
           <SidebarGroupLabel className="text-sm font-semibold uppercase tracking-wide mb-2">
             {t('sidebar.library')}
           </SidebarGroupLabel>
@@ -342,53 +346,102 @@ export default function AppSidebar() {
         </SidebarGroup>
 
         {/* Recent Sessions – only visible when sidebar is expanded */}
-        {!isCollapsed && recentSessions.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel className="text-sm font-semibold uppercase tracking-wide mb-2">
+        {!isCollapsed && sessions.length > 0 && (
+          <SidebarGroup className="flex min-h-0 flex-1 flex-col">
+            <SidebarGroupLabel className="mb-2 shrink-0 text-sm font-semibold uppercase tracking-wide">
               {t('sidebar.recentSessions')}
             </SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {recentSessions.map(({ session, nestingLevel }) => (
-                  <SidebarMenuItem key={session.id}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={location.pathname === `/agent/${session.id}`}
-                      tooltip={
-                        session.name ||
-                        `${t('sidebar.session')} ${session.id.slice(0, 8)}`
-                      }
-                    >
-                      <Link
-                        to={`/agent/${session.id}`}
-                        className={cn(
-                          'flex w-full items-center gap-2',
-                          nestingLevel > 0 && 'text-muted-foreground',
-                        )}
-                        style={{ paddingLeft: `${nestingLevel * 12}px` }}
-                      >
-                        <StatusDot status={session.status} />
-                        {nestingLevel > 0 && (
-                          <span
-                            className="text-[10px] shrink-0"
-                            aria-hidden="true"
+            <div className="min-h-0 flex-1 overflow-y-auto terminal-scrollbar">
+              {/*
+                rootRef must be a descendant of the overflow container —
+                useInfiniteScroll's findScrollParent starts at parentElement.
+              */}
+              <div ref={recentSessionsRootRef}>
+                <SidebarMenu>
+                  {recentSessions.map(
+                    ({
+                      session,
+                      nestingLevel,
+                      hasExpandableChildren,
+                      isExpanded,
+                    }) => (
+                      <SidebarMenuItem key={session.id}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={
+                            location.pathname === `/agent/${session.id}`
+                          }
+                          tooltip={
+                            session.name ||
+                            `${t('sidebar.session')} ${session.id.slice(0, 8)}`
+                          }
+                        >
+                          <Link
+                            to={`/agent/${session.id}`}
+                            className={cn(
+                              'flex w-full items-center gap-2',
+                              nestingLevel > 0 && 'text-muted-foreground',
+                            )}
+                            style={{
+                              paddingLeft: `${nestingLevel * 12}px`,
+                            }}
                           >
-                            ↳
-                          </span>
-                        )}
-                        <span className="truncate text-xs">
-                          {session.name ||
-                            `${t('sidebar.session')} ${session.id.slice(0, 8)}`}
-                        </span>
-                        {session.isBookmarked && (
-                          <BookmarkCheck className="h-3.5 w-3.5 shrink-0 text-warning" />
-                        )}
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
+                            {hasExpandableChildren ? (
+                              <button
+                                type="button"
+                                className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+                                aria-expanded={isExpanded}
+                                aria-label={
+                                  isExpanded
+                                    ? t(
+                                        'sidebar.collapseSession',
+                                        'Collapse session children',
+                                      )
+                                    : t(
+                                        'sidebar.expandSession',
+                                        'Expand session children',
+                                      )
+                                }
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  handleToggleExpand(session.id);
+                                }}
+                              >
+                                {isExpanded ? (
+                                  <ChevronDown className="h-3.5 w-3.5" />
+                                ) : (
+                                  <ChevronRight className="h-3.5 w-3.5" />
+                                )}
+                              </button>
+                            ) : (
+                              <span className="inline-block h-4 w-4 shrink-0" />
+                            )}
+                            <StatusDot status={session.status} />
+                            <span className="truncate text-xs">
+                              {session.name ||
+                                `${t('sidebar.session')} ${session.id.slice(0, 8)}`}
+                            </span>
+                            {session.isBookmarked && (
+                              <BookmarkCheck className="h-3.5 w-3.5 shrink-0 text-warning" />
+                            )}
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ),
+                  )}
+                </SidebarMenu>
+                <div ref={loadMoreSentinelRef} className="h-px w-full" />
+                {isLoadingMoreSessions && (
+                  <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    <span>
+                      {t('sessionHistory.loadingMore', 'Loading more...')}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
           </SidebarGroup>
         )}
       </SidebarContent>

--- a/src/components/layout/__tests__/sidebar-recent-sessions.test.ts
+++ b/src/components/layout/__tests__/sidebar-recent-sessions.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSession } from '@/models/agent';
+import { buildSidebarSessionRows } from '../sidebar-recent-sessions';
+
+function createSession(
+  id: string,
+  overrides: Partial<AgentSession> = {},
+): AgentSession {
+  return {
+    id,
+    name: id,
+    status: 'idle',
+    model: 'test-model',
+    provider: 'test-provider',
+    createdAt: new Date('2026-03-20T00:00:00Z'),
+    updatedAt: new Date('2026-03-20T00:00:00Z'),
+    executionMode: 'normal',
+    ...overrides,
+  };
+}
+
+describe('buildSidebarSessionRows', () => {
+  it('returns all roots with no hard cap', () => {
+    const sessions = Array.from({ length: 8 }, (_, index) =>
+      createSession(`root-${index}`, {
+        updatedAt: new Date(`2026-03-2${index}T00:00:00Z`),
+      }),
+    );
+
+    const rows = buildSidebarSessionRows(sessions, new Set());
+
+    expect(rows).toHaveLength(8);
+    expect(rows.every((row) => row.nestingLevel === 0)).toBe(true);
+  });
+
+  it('hides children until parent is expanded', () => {
+    const sessions = [
+      createSession('parent'),
+      createSession('child', { parentSessionId: 'parent' }),
+    ];
+
+    const collapsed = buildSidebarSessionRows(sessions, new Set());
+    expect(collapsed.map((row) => row.session.id)).toEqual(['parent']);
+    expect(collapsed[0]?.hasExpandableChildren).toBe(true);
+    expect(collapsed[0]?.isExpanded).toBe(false);
+
+    const expanded = buildSidebarSessionRows(sessions, new Set(['parent']));
+    expect(expanded.map((row) => row.session.id)).toEqual(['parent', 'child']);
+    expect(expanded[0]?.isExpanded).toBe(true);
+    expect(expanded[1]?.nestingLevel).toBe(1);
+  });
+
+  it('treats sessions with missing parents as roots', () => {
+    const sessions = [
+      createSession('orphan', { parentSessionId: 'missing-parent' }),
+      createSession('root'),
+    ];
+
+    const rows = buildSidebarSessionRows(sessions, new Set());
+    expect(rows.map((row) => row.session.id)).toEqual(['orphan', 'root']);
+    expect(rows.every((row) => row.nestingLevel === 0)).toBe(true);
+  });
+
+  it('sorts busy sessions before idle, then by recency', () => {
+    const sessions = [
+      createSession('idle-new', {
+        status: 'idle',
+        updatedAt: new Date('2026-03-22T00:00:00Z'),
+      }),
+      createSession('busy-old', {
+        status: 'busy',
+        updatedAt: new Date('2026-03-20T00:00:00Z'),
+      }),
+      createSession('busy-new', {
+        status: 'busy',
+        updatedAt: new Date('2026-03-21T00:00:00Z'),
+      }),
+    ];
+
+    const rows = buildSidebarSessionRows(sessions, new Set());
+    expect(rows.map((row) => row.session.id)).toEqual([
+      'busy-new',
+      'busy-old',
+      'idle-new',
+    ]);
+  });
+
+  it('marks expandable when only known direct child count is present', () => {
+    const sessions = [createSession('parent')];
+    const knownCounts = new Map([['parent', 2]]);
+
+    const rows = buildSidebarSessionRows(sessions, new Set(), knownCounts);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.hasExpandableChildren).toBe(true);
+    expect(rows[0]?.isExpanded).toBe(false);
+  });
+});

--- a/src/components/layout/sidebar-recent-sessions.ts
+++ b/src/components/layout/sidebar-recent-sessions.ts
@@ -1,0 +1,90 @@
+import type { AgentSession } from '@/models/agent';
+import { buildChildrenMap } from '@/lib/session-utils';
+
+const STATUS_PRIORITY: Record<string, number> = {
+  busy: 1,
+  idle: 2,
+  paused: 3,
+  error: 4,
+};
+
+export interface SidebarSessionRow {
+  session: AgentSession;
+  nestingLevel: number;
+  hasExpandableChildren: boolean;
+  isExpanded: boolean;
+}
+
+function compareSessionsBySidebarPriority(
+  a: AgentSession,
+  b: AgentSession,
+): number {
+  const statusDiff =
+    (STATUS_PRIORITY[a.status] ?? 9) - (STATUS_PRIORITY[b.status] ?? 9);
+  if (statusDiff !== 0) {
+    return statusDiff;
+  }
+  return (
+    (b.updatedAt ?? b.createdAt).getTime() -
+    (a.updatedAt ?? a.createdAt).getTime()
+  );
+}
+
+/**
+ * Builds visible Recent Sessions rows for the app sidebar.
+ * Roots are sorted by status priority then recency. Children appear only when
+ * their parent id is in `expandedSessionIds`.
+ */
+export function buildSidebarSessionRows(
+  sessions: AgentSession[],
+  expandedSessionIds: Set<string>,
+  knownDirectChildCountByParentId: Map<string, number> = new Map(),
+): SidebarSessionRow[] {
+  const sortedSessions = [...sessions].sort(compareSessionsBySidebarPriority);
+  const sessionById = new Map(
+    sortedSessions.map((session) => [session.id, session]),
+  );
+  const childrenByParent = buildChildrenMap(sortedSessions);
+
+  for (const children of childrenByParent.values()) {
+    children.sort(compareSessionsBySidebarPriority);
+  }
+
+  const roots = sortedSessions.filter(
+    (session) =>
+      !session.parentSessionId || !sessionById.has(session.parentSessionId),
+  );
+
+  const rows: SidebarSessionRow[] = [];
+
+  const walk = (session: AgentSession, nestingLevel: number) => {
+    const loadedChildren = childrenByParent.get(session.id) ?? [];
+    const knownDirectChildCount =
+      knownDirectChildCountByParentId.get(session.id) ?? 0;
+    const hasExpandableChildren =
+      loadedChildren.length > 0 || knownDirectChildCount > 0;
+    const isExpanded =
+      hasExpandableChildren && expandedSessionIds.has(session.id);
+
+    rows.push({
+      session,
+      nestingLevel,
+      hasExpandableChildren,
+      isExpanded,
+    });
+
+    if (!isExpanded) {
+      return;
+    }
+
+    loadedChildren.forEach((child) => {
+      walk(child, nestingLevel + 1);
+    });
+  };
+
+  roots.forEach((root) => {
+    walk(root, 0);
+  });
+
+  return rows;
+}


### PR DESCRIPTION
## Summary
- Remove the 5-item Recent Sessions hardcap and give the section a nested scroll region so Main/Library stay fixed while sessions scroll.
- Add infinite pagination via `loadMoreSessions` + `useInfiniteScroll`, and expand/collapse for parent sessions with compact navigate-only rows (no SessionCard variant).
- Extract `buildSidebarSessionRows` into a testable helper with unit coverage.

Closes #1652

## Test plan
- [ ] Expanded sidebar: Recent Sessions fills remaining height; Main/Library do not scroll away
- [ ] Scroll to bottom loads more sessions; loading indicator appears
- [ ] Parent with children shows chevron; expand/collapse works without navigating
- [ ] Busy sessions still sort above idle/paused of similar age
- [ ] Icon-collapsed sidebar: Recent Sessions remains hidden
- [ ] `/history` SessionHistoryPanel behavior unchanged
- [ ] `pnpm refactor:validate` passes

Made with [Cursor](https://cursor.com)