### PR TITLE
fix(ai): keep custom provider selection and restore last model

### DIFF
--- a/src/context/ModelProvider.tsx
+++ b/src/context/ModelProvider.tsx
@@ -13,8 +13,10 @@ import {
   AIServiceFactory,
   isCustomOpenAIProviderId,
   listCustomProviderPickerOptions,
+  resolveDefaultModelForProviderChange,
   resolveProviderRuntimeConfig,
 } from '../lib/ai-service';
+import { setLastSelectedModel } from '../lib/ai-service/last-selected-model-storage';
 import { shouldFetchDynamicModels } from '../lib/ai-service/model-fetch-policy';
 import {
   llmConfigManager,
@@ -66,11 +68,13 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
     value: {
       serviceConfigs,
       customProviders,
-      preferredModel: { model, provider },
+      preferredModel,
+      fallbackModel,
     },
     update,
     isLoading,
   } = useSettings();
+  const { model, provider } = preferredModel;
 
   const resolvedProvider = useMemo(
     () =>
@@ -269,39 +273,40 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const setProvider = useCallback(
     (newProvider: string) => {
-      if (isCustomOpenAIProviderId(newProvider)) {
-        const resolved = resolveProviderRuntimeConfig(newProvider, {
+      const defaultModel = resolveDefaultModelForProviderChange(
+        newProvider,
+        {
           serviceConfigs,
           customProviders,
-        });
-        const defaultModel = resolved.manualModels?.[0] ?? '';
-        update({
-          preferredModel: { provider: newProvider, model: defaultModel },
-        });
-        return;
-      }
-
-      const availableModels =
-        llmConfigManager.getModelsForProvider(
-          newProvider as AIServiceProvider,
-        ) || {};
-
-      if (Object.keys(availableModels).length === 0) {
+          preferredModel,
+          fallbackModel,
+        },
+        model,
+      );
+      if (!defaultModel) {
         logger.warn(`No available models for ${newProvider}`);
-        update({ preferredModel: { provider: newProvider, model: '' } });
-        return;
+      } else {
+        setLastSelectedModel(newProvider, defaultModel);
       }
-
-      const modelEntries = Object.entries(availableModels);
-      const newModel = modelEntries.length > 0 ? modelEntries[0][0] : '';
-
-      update({ preferredModel: { provider: newProvider, model: newModel } });
+      update({
+        preferredModel: { provider: newProvider, model: defaultModel },
+      });
     },
-    [update, serviceConfigs, customProviders],
+    [
+      update,
+      serviceConfigs,
+      customProviders,
+      preferredModel,
+      fallbackModel,
+      model,
+    ],
   );
 
   const setModel = useCallback(
     (newModel: string) => {
+      if (newModel) {
+        setLastSelectedModel(provider, newModel);
+      }
       update({ preferredModel: { provider, model: newModel } });
     },
     [provider, update],

--- a/src/context/ModelProvider.tsx
+++ b/src/context/ModelProvider.tsx
@@ -65,12 +65,7 @@ const ModelOptionsContext = createContext<ModelOptionsContextType | null>(null);
 
 export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
   const {
-    value: {
-      serviceConfigs,
-      customProviders,
-      preferredModel,
-      fallbackModel,
-    },
+    value: { serviceConfigs, customProviders, preferredModel, fallbackModel },
     update,
     isLoading,
   } = useSettings();
@@ -304,7 +299,7 @@ export const ModelOptionsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const setModel = useCallback(
     (newModel: string) => {
-      if (newModel) {
+      if (provider && newModel) {
         setLastSelectedModel(provider, newModel);
       }
       update({ preferredModel: { provider, model: newModel } });

--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -202,11 +202,11 @@ function DraftChatInner() {
               builtinServices={builtinServices}
               mcpServers={mcpServers}
               currentModel={
-                overrideModel || settings?.preferredModel?.model || 'gpt-4'
+                overrideModel ?? settings?.preferredModel?.model ?? 'gpt-4'
               }
               currentProvider={
-                overrideProvider ||
-                settings?.preferredModel?.provider ||
+                overrideProvider ??
+                settings?.preferredModel?.provider ??
                 'openai'
               }
               onConfigUpdate={(model, provider) => {

--- a/src/features/agent/components/AgentModelPicker.tsx
+++ b/src/features/agent/components/AgentModelPicker.tsx
@@ -15,12 +15,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { AIServiceProvider } from '@/lib/ai-service';
 import {
-  isCustomOpenAIProviderId,
   listCustomProviderPickerOptions,
-  resolveProviderRuntimeConfig,
+  resolveDefaultModelForProviderChange,
 } from '@/lib/ai-service/custom-providers';
+import { setLastSelectedModel } from '@/lib/ai-service/last-selected-model-storage';
+import type { CustomOpenAIProvider } from '@/lib/services/settings-service';
 import { llmConfigManager } from '@/lib/llm-config-manager';
 import { cn } from '@/lib/utils';
 import { useSettings } from '@/hooks/use-settings';
@@ -32,6 +32,11 @@ interface AgentModelPickerProps {
   className?: string;
   disabled?: boolean;
   onConfigUpdate?: (model: string, provider: string) => void;
+  /**
+   * Optional override for custom providers (e.g. settings form draft).
+   * Falls back to persisted settings when omitted.
+   */
+  customProviders?: CustomOpenAIProvider[];
 }
 
 const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
@@ -40,11 +45,18 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
   className,
   disabled = false,
   onConfigUpdate,
+  customProviders: customProvidersProp,
 }) => {
   const { t } = useTranslation('common');
   const {
-    value: { customProviders, serviceConfigs },
+    value: {
+      customProviders: settingsCustomProviders,
+      serviceConfigs,
+      preferredModel,
+      fallbackModel,
+    },
   } = useSettings();
+  const customProviders = customProvidersProp ?? settingsCustomProviders;
   const {
     availableModels,
     isRefreshing,
@@ -97,30 +109,44 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
 
   const handleProviderChange = useCallback(
     (newProvider: string) => {
-      let defaultModel = '';
+      // Radix can emit "" when clearing / syncing controlled values — ignore it
+      // so a custom:`id` selection is not immediately reverted.
+      if (!newProvider) {
+        return;
+      }
 
-      if (isCustomOpenAIProviderId(newProvider)) {
-        const resolved = resolveProviderRuntimeConfig(newProvider, {
+      const defaultModel = resolveDefaultModelForProviderChange(
+        newProvider,
+        {
           serviceConfigs,
           customProviders,
-        });
-        defaultModel = resolved.manualModels?.[0] ?? '';
-      } else {
-        const staticModels = llmConfigManager.getModelsForProvider(
-          newProvider as AIServiceProvider,
-        );
-        if (staticModels && Object.keys(staticModels).length > 0) {
-          defaultModel = Object.keys(staticModels)[0];
-        }
+          preferredModel,
+          fallbackModel,
+        },
+        currentModel,
+      );
+      if (defaultModel) {
+        setLastSelectedModel(newProvider, defaultModel);
       }
 
       onConfigUpdate?.(defaultModel, newProvider);
     },
-    [customProviders, onConfigUpdate, serviceConfigs],
+    [
+      currentModel,
+      customProviders,
+      fallbackModel,
+      onConfigUpdate,
+      preferredModel,
+      serviceConfigs,
+    ],
   );
 
   const handleModelChange = useCallback(
     (newModel: string) => {
+      if (!newModel || !currentProvider) {
+        return;
+      }
+      setLastSelectedModel(currentProvider, newModel);
       onConfigUpdate?.(newModel, currentProvider);
     },
     [currentProvider, onConfigUpdate],
@@ -160,7 +186,9 @@ const AgentModelPickerComponent: FC<AgentModelPickerProps> = ({
 
       {/* Model Selector */}
       <Select
-        value={currentModel}
+        // Empty string means "cleared" in Radix Select — use undefined so the
+        // placeholder shows without wiping sibling controlled selects.
+        value={currentModel || undefined}
         onValueChange={handleModelChange}
         disabled={disabled || isRefreshing || !currentProvider}
       >
@@ -243,7 +271,8 @@ export const AgentModelPicker = React.memo(
       prev.currentProvider === next.currentProvider &&
       prev.className === next.className &&
       prev.disabled === next.disabled &&
-      prev.onConfigUpdate === next.onConfigUpdate
+      prev.onConfigUpdate === next.onConfigUpdate &&
+      prev.customProviders === next.customProviders
     );
   },
 );

--- a/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
+++ b/src/features/agent/components/__tests__/AgentModelPicker.test.tsx
@@ -32,9 +32,57 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/components/ui/select', () => ({
-  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Select: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }) => (
+    <div data-testid="select" data-value={value ?? ''}>
+      <button
+        type="button"
+        data-testid="select-trigger"
+        onClick={() => undefined}
+      >
+        {value}
+      </button>
+      <div
+        data-testid="select-options"
+        data-on-change={onValueChange ? 'yes' : 'no'}
+      >
+        {children}
+      </div>
+      {onValueChange ? (
+        <button
+          type="button"
+          data-testid={`select-set-${value || 'empty'}`}
+          onClick={() => onValueChange('custom:local1')}
+        >
+          pick-custom
+        </button>
+      ) : null}
+      {onValueChange ? (
+        <button
+          type="button"
+          data-testid="select-emit-empty"
+          onClick={() => onValueChange('')}
+        >
+          emit-empty
+        </button>
+      ) : null}
+    </div>
+  ),
   SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: ReactNode;
+    value: string;
+  }) => <div data-value={value}>{children}</div>,
   SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SelectValue: ({ placeholder }: { placeholder?: string }) => (
     <span>{placeholder}</span>
@@ -118,5 +166,27 @@ describe('AgentModelPicker', () => {
         name: /refresh/i,
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it('clears foreign model ids when switching to a custom provider', () => {
+    const onConfigUpdate = vi.fn();
+
+    render(
+      <AgentModelPicker
+        currentModel="gpt-4o"
+        currentProvider="openai"
+        onConfigUpdate={onConfigUpdate}
+      />,
+    );
+
+    // First Select is the provider picker
+    const pickCustomButtons = screen.getAllByText('pick-custom');
+    fireEvent.click(pickCustomButtons[0]);
+
+    expect(onConfigUpdate).toHaveBeenCalledWith('', 'custom:local1');
+
+    onConfigUpdate.mockClear();
+    fireEvent.click(screen.getAllByTestId('select-emit-empty')[0]);
+    expect(onConfigUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/features/agent/hooks/useAgentDraftChat.ts
+++ b/src/features/agent/hooks/useAgentDraftChat.ts
@@ -400,9 +400,9 @@ export function useAgentDraftChat() {
         request: {
           sessionId: newSessionId,
           name: shortName,
-          model: overrideModel || settings?.preferredModel?.model || 'gpt-4',
+          model: overrideModel ?? settings?.preferredModel?.model ?? 'gpt-4',
           provider:
-            overrideProvider || settings?.preferredModel?.provider || 'openai',
+            overrideProvider ?? settings?.preferredModel?.provider ?? 'openai',
           agentConfig,
           isEphemeral: false,
           workspacePath: workspaceOverride || undefined,

--- a/src/features/settings/hooks/useSettingsPageController.ts
+++ b/src/features/settings/hooks/useSettingsPageController.ts
@@ -317,7 +317,13 @@ export function useSettingsPageController() {
 
   const handleFallbackModelChange = useCallback(
     (model: string, provider: string) => {
-      update('fallbackModel', model ? { provider, model } : undefined);
+      // Keep provider selection even when model is temporarily empty (e.g. user
+      // just switched to a custom OpenAI-compatible provider before models load).
+      if (!provider) {
+        update('fallbackModel', undefined);
+        return;
+      }
+      update('fallbackModel', { provider, model });
     },
     [update],
   );

--- a/src/features/settings/tabs/AIModelsTab.tsx
+++ b/src/features/settings/tabs/AIModelsTab.tsx
@@ -210,6 +210,7 @@ function AIModelsTabComponent({
           <AgentModelPicker
             currentModel={localPreferredModel.model}
             currentProvider={localPreferredModel.provider}
+            customProviders={providers}
             onConfigUpdate={onPreferredModelChange}
             className="w-full max-w-sm"
           />
@@ -224,6 +225,7 @@ function AIModelsTabComponent({
             currentProvider={
               localFallbackModel?.provider ?? localPreferredModel.provider
             }
+            customProviders={providers}
             onConfigUpdate={onFallbackModelChange}
             className="w-full max-w-sm"
           />

--- a/src/lib/ai-service/__tests__/custom-providers.test.ts
+++ b/src/lib/ai-service/__tests__/custom-providers.test.ts
@@ -4,9 +4,14 @@ import {
   createCustomOpenAIProvider,
   isCustomOpenAIProviderId,
   parseCustomProviderId,
+  resolveDefaultModelForProviderChange,
   resolveProviderRuntimeConfig,
   toCustomProviderId,
 } from '../custom-providers';
+import {
+  clearLastSelectedModel,
+  setLastSelectedModel,
+} from '../last-selected-model-storage';
 import type { Settings } from '@/lib/services/settings-service';
 import { DEFAULT_SETTING } from '@/lib/services/settings-service';
 
@@ -128,5 +133,69 @@ describe('custom provider helpers', () => {
     expect(isCustomOpenAIProviderId(null)).toBe(false);
     expect(isCustomOpenAIProviderId(undefined)).toBe(false);
     expect(isCustomOpenAIProviderId('custom:')).toBe(false);
+  });
+
+  it('resolves default model only from the target provider on switch', () => {
+    clearLastSelectedModel();
+    const settings = settingsWithCustom();
+
+    expect(
+      resolveDefaultModelForProviderChange(
+        'custom:abc123',
+        settings,
+        'gpt-4o',
+      ),
+    ).toBe('llama-3.1-70b');
+
+    expect(
+      resolveDefaultModelForProviderChange(
+        'custom:missing-id',
+        settingsWithCustom({ customProviders: [] }),
+        'gpt-4o',
+      ),
+    ).toBe('');
+
+    expect(
+      resolveDefaultModelForProviderChange(
+        'custom:abc123',
+        settings,
+        'llama-3.1-70b',
+      ),
+    ).toBe('llama-3.1-70b');
+  });
+
+  it('prefers the last configured model for a provider when still valid', () => {
+    clearLastSelectedModel();
+    setLastSelectedModel('custom:abc123', 'llama-3.1-70b');
+
+    expect(
+      resolveDefaultModelForProviderChange(
+        'custom:abc123',
+        settingsWithCustom({
+          customProviders: [
+            {
+              id: 'abc123',
+              name: 'Local vLLM',
+              baseUrl: 'http://192.168.1.10:8000/v1',
+              models: ['other-model', 'llama-3.1-70b'],
+            },
+          ],
+        }),
+        'gpt-4o',
+      ),
+    ).toBe('llama-3.1-70b');
+  });
+
+  it('ignores a stale last-selected model that is no longer valid', () => {
+    clearLastSelectedModel();
+    setLastSelectedModel('custom:abc123', 'retired-model');
+
+    expect(
+      resolveDefaultModelForProviderChange(
+        'custom:abc123',
+        settingsWithCustom(),
+        'gpt-4o',
+      ),
+    ).toBe('llama-3.1-70b');
   });
 });

--- a/src/lib/ai-service/__tests__/last-selected-model-storage.test.ts
+++ b/src/lib/ai-service/__tests__/last-selected-model-storage.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearLastSelectedModel,
+  getLastSelectedModel,
+  setLastSelectedModel,
+} from '../last-selected-model-storage';
+
+describe('last-selected-model-storage', () => {
+  beforeEach(() => {
+    clearLastSelectedModel();
+  });
+
+  afterEach(() => {
+    clearLastSelectedModel();
+  });
+
+  it('saves and retrieves the last selected model per provider', () => {
+    setLastSelectedModel('custom:nim', 'meta/llama-3.1-70b-instruct');
+    setLastSelectedModel('openai', 'gpt-4o');
+
+    expect(getLastSelectedModel('custom:nim')).toBe(
+      'meta/llama-3.1-70b-instruct',
+    );
+    expect(getLastSelectedModel('openai')).toBe('gpt-4o');
+  });
+
+  it('ignores empty model values', () => {
+    setLastSelectedModel('openai', '   ');
+    expect(getLastSelectedModel('openai')).toBeNull();
+  });
+
+  it('clears one provider without affecting others', () => {
+    setLastSelectedModel('openai', 'gpt-4o');
+    setLastSelectedModel('anthropic', 'claude-sonnet-4');
+
+    clearLastSelectedModel('openai');
+    expect(getLastSelectedModel('openai')).toBeNull();
+    expect(getLastSelectedModel('anthropic')).toBe('claude-sonnet-4');
+  });
+});

--- a/src/lib/ai-service/custom-providers.ts
+++ b/src/lib/ai-service/custom-providers.ts
@@ -5,6 +5,8 @@ import type {
   Settings,
 } from '@/lib/services/settings-service';
 import { AIServiceProvider, type AIServiceConfig } from './types';
+import { getLastSelectedModel } from './last-selected-model-storage';
+import { getStoredModelCache } from './model-cache-storage';
 import { llmConfigManager } from '@/lib/llm-config-manager';
 
 export const CUSTOM_PROVIDER_PREFIX = 'custom:';
@@ -178,6 +180,102 @@ export function resolveProviderRuntimeConfig(
     customModelId: cfg.customModelId,
     serviceConfig,
   };
+}
+
+function collectKnownModelIds(
+  providerId: string,
+  settings: Pick<Settings, 'serviceConfigs' | 'customProviders'>,
+): Set<string> {
+  const ids = new Set<string>();
+
+  if (isCustomOpenAIProviderId(providerId)) {
+    const resolved = resolveProviderRuntimeConfig(providerId, settings);
+    for (const modelId of resolved.manualModels ?? []) {
+      ids.add(modelId);
+    }
+  } else {
+    const staticModels =
+      llmConfigManager.getModelsForProvider(providerId as AIServiceProvider) ||
+      {};
+    for (const modelId of Object.keys(staticModels)) {
+      ids.add(modelId);
+    }
+  }
+
+  const cached = getStoredModelCache(providerId);
+  if (cached) {
+    for (const modelId of Object.keys(cached)) {
+      ids.add(modelId);
+    }
+  }
+
+  return ids;
+}
+
+function firstKnownModelId(known: Set<string>): string {
+  for (const modelId of known) {
+    return modelId;
+  }
+  return '';
+}
+
+function configuredModelCandidates(
+  providerId: string,
+  settings: Partial<
+    Pick<Settings, 'preferredModel' | 'fallbackModel'>
+  >,
+): string[] {
+  const candidates: string[] = [];
+  const lastSelected = getLastSelectedModel(providerId);
+  if (lastSelected) {
+    candidates.push(lastSelected);
+  }
+  if (
+    settings.preferredModel?.provider === providerId &&
+    settings.preferredModel.model
+  ) {
+    candidates.push(settings.preferredModel.model);
+  }
+  if (
+    settings.fallbackModel?.provider === providerId &&
+    settings.fallbackModel.model
+  ) {
+    candidates.push(settings.fallbackModel.model);
+  }
+  return candidates;
+}
+
+/**
+ * Picks a model id for `providerId` after a provider switch.
+ *
+ * Preference order:
+ * 1. Last configured model for that provider (local memory / settings)
+ * 2. Current model when it belongs to the target provider
+ * 3. First known manual/static/cached model
+ * 4. Empty string
+ *
+ * A remembered model is kept when it is still in the known catalog, or when
+ * the catalog is empty (custom endpoints before /v1/models returns).
+ */
+export function resolveDefaultModelForProviderChange(
+  providerId: string,
+  settings: Pick<Settings, 'serviceConfigs' | 'customProviders'> &
+    Partial<Pick<Settings, 'preferredModel' | 'fallbackModel'>>,
+  currentModel = '',
+): string {
+  const known = collectKnownModelIds(providerId, settings);
+
+  for (const candidate of configuredModelCandidates(providerId, settings)) {
+    if (known.size === 0 || known.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  if (currentModel && known.has(currentModel)) {
+    return currentModel;
+  }
+
+  return firstKnownModelId(known);
 }
 
 export function listCustomProviderPickerOptions(

--- a/src/lib/ai-service/custom-providers.ts
+++ b/src/lib/ai-service/custom-providers.ts
@@ -182,6 +182,13 @@ export function resolveProviderRuntimeConfig(
   };
 }
 
+/**
+ * Builds the known model catalog for a provider.
+ *
+ * Insertion order (and therefore `firstKnownModelId` fallback order):
+ * 1. manual models (custom providers) or static config models (builtins)
+ * 2. persisted dynamic `/v1/models` cache
+ */
 function collectKnownModelIds(
   providerId: string,
   settings: Pick<Settings, 'serviceConfigs' | 'customProviders'>,
@@ -213,6 +220,7 @@ function collectKnownModelIds(
 }
 
 function firstKnownModelId(known: Set<string>): string {
+  // Set iterates in insertion order — see collectKnownModelIds priority.
   for (const modelId of known) {
     return modelId;
   }
@@ -221,9 +229,7 @@ function firstKnownModelId(known: Set<string>): string {
 
 function configuredModelCandidates(
   providerId: string,
-  settings: Partial<
-    Pick<Settings, 'preferredModel' | 'fallbackModel'>
-  >,
+  settings: Partial<Pick<Settings, 'preferredModel' | 'fallbackModel'>>,
 ): string[] {
   const candidates: string[] = [];
   const lastSelected = getLastSelectedModel(providerId);

--- a/src/lib/ai-service/index.ts
+++ b/src/lib/ai-service/index.ts
@@ -35,6 +35,7 @@ export {
   normalizeCustomOpenAIProvider,
   normalizeCustomOpenAIProviders,
   resolveProviderRuntimeConfig,
+  resolveDefaultModelForProviderChange,
   listCustomProviderPickerOptions,
   findCustomOpenAIProvider,
 } from './custom-providers';

--- a/src/lib/ai-service/last-selected-model-storage.ts
+++ b/src/lib/ai-service/last-selected-model-storage.ts
@@ -1,3 +1,8 @@
+/**
+ * Storage key format: `libragent:models:last-selected:<providerId>`
+ * Uses localStorage with an in-memory Map cache for environments where
+ * Storage is unavailable (private mode / SSR).
+ */
 const STORAGE_PREFIX = 'libragent:models:last-selected:';
 
 const memoryCache = new Map<string, string>();

--- a/src/lib/ai-service/last-selected-model-storage.ts
+++ b/src/lib/ai-service/last-selected-model-storage.ts
@@ -1,0 +1,101 @@
+const STORAGE_PREFIX = 'libragent:models:last-selected:';
+
+const memoryCache = new Map<string, string>();
+
+function getLocalStorage(): Storage | null {
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      window.localStorage &&
+      typeof window.localStorage.setItem === 'function'
+    ) {
+      return window.localStorage;
+    }
+    if (
+      typeof localStorage !== 'undefined' &&
+      typeof localStorage.setItem === 'function'
+    ) {
+      return localStorage;
+    }
+  } catch {
+    // Ignore error
+  }
+  return null;
+}
+
+/**
+ * Returns the last model id the user configured for a provider, if any.
+ */
+export function getLastSelectedModel(provider: string): string | null {
+  if (!provider) {
+    return null;
+  }
+
+  try {
+    const storage = getLocalStorage();
+    if (storage) {
+      const raw = storage.getItem(`${STORAGE_PREFIX}${provider}`);
+      if (typeof raw === 'string' && raw.trim().length > 0) {
+        return raw;
+      }
+    }
+  } catch {
+    // Fall through to memory cache
+  }
+
+  const mem = memoryCache.get(provider);
+  return mem && mem.trim().length > 0 ? mem : null;
+}
+
+/**
+ * Remembers the model id last configured for a provider.
+ */
+export function setLastSelectedModel(provider: string, model: string): void {
+  if (!provider || !model.trim()) {
+    return;
+  }
+
+  const normalized = model.trim();
+  memoryCache.set(provider, normalized);
+
+  try {
+    const storage = getLocalStorage();
+    storage?.setItem(`${STORAGE_PREFIX}${provider}`, normalized);
+  } catch {
+    // Ignore quota / private-mode errors
+  }
+}
+
+/**
+ * Clears last-selected model memory for one provider or all providers.
+ */
+export function clearLastSelectedModel(provider?: string): void {
+  if (provider) {
+    memoryCache.delete(provider);
+  } else {
+    memoryCache.clear();
+  }
+
+  try {
+    const storage = getLocalStorage();
+    if (!storage) {
+      return;
+    }
+    if (provider) {
+      storage.removeItem(`${STORAGE_PREFIX}${provider}`);
+      return;
+    }
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (key && key.startsWith(STORAGE_PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      storage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage errors
+  }
+}


### PR DESCRIPTION
## Summary
- Prevent Radix Select empty-value clears from reverting custom OpenAI-compatible provider selections
- On provider switch, clear foreign model ids and restore the last configured valid model for that provider
- Wire settings draft `customProviders` into the model picker and fix empty-string `||` fallbacks in draft/settings flows

## Test plan
- [ ] Settings → AI Models: select a custom provider (e.g. NVIDIA NIM); confirm provider stays selected
- [ ] Switch OpenAI → custom → OpenAI; confirm each side restores its last valid model, not a foreign id
- [ ] Fallback LLM picker: switch to a custom provider with no models yet; provider selection should stick
- [ ] Draft chat model picker: same provider/model restore behavior
- [ ] `pnpm exec vitest run src/lib/ai-service/__tests__/custom-providers.test.ts src/lib/ai-service/__tests__/last-selected-model-storage.test.ts src/features/agent/components/__tests__/AgentModelPicker.test.tsx`

Related to #1631

Made with [Cursor](https://cursor.com)