### PR TITLE
fix(windows): normalize leading-slash and file:// workspace paths

### DIFF
--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -122,13 +122,21 @@ impl SecurityValidator {
 
         tracing::debug!("Resolved path: '{:?}'", absolute_path);
 
-        if enforce_base_containment && !path_starts_with(&absolute_path, &self.base_dir) {
+        // Prefer a canonical path for the early containment check. On macOS, tempfile and
+        // file:// URLs often use `/var/folders/...` while `base_dir` is stored as the
+        // canonical `/private/var/folders/...` form after construction.
+        let early_containment_path = absolute_path
+            .canonicalize()
+            .unwrap_or_else(|_| absolute_path.clone());
+
+        if enforce_base_containment && !path_starts_with(&early_containment_path, &self.base_dir)
+        {
             return Err(SecurityError::PathTraversal(format!(
                 "Access denied: Path '{user_path}' is outside the allowed base directory"
             )));
         }
 
-        self.ensure_not_sensitive_path(&absolute_path, user_path)?;
+        self.ensure_not_sensitive_path(&early_containment_path, user_path)?;
 
         // SecurityValidator only validates paths. Directory creation is handled explicitly by callers.
 

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -129,8 +129,7 @@ impl SecurityValidator {
             .canonicalize()
             .unwrap_or_else(|_| absolute_path.clone());
 
-        if enforce_base_containment && !path_starts_with(&early_containment_path, &self.base_dir)
-        {
+        if enforce_base_containment && !path_starts_with(&early_containment_path, &self.base_dir) {
             return Err(SecurityError::PathTraversal(format!(
                 "Access denied: Path '{user_path}' is outside the allowed base directory"
             )));
@@ -307,7 +306,10 @@ pub fn normalize_user_path(user_path: &str) -> String {
 
     // Prefer proper file URL parsing so Unix `file:///home/...` keeps its leading `/`
     // and Windows `file:///C:/...` / `file://localhost/C:/...` resolve correctly.
-    if s.len() >= 7 && s.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://")) {
+    if s.len() >= 7
+        && s.get(..7)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
+    {
         if let Ok(parsed) = url::Url::parse(s) {
             if parsed.scheme().eq_ignore_ascii_case("file") {
                 if let Ok(path) = parsed.to_file_path() {

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -78,26 +78,23 @@ impl SecurityValidator {
             self.base_dir
         );
 
-        // Normalize both Unix ('/') and Windows ('\\') style separators to '/' for consistent, cross-platform behavior.
-        let normalized_path = user_path.replace(['\\', '/'], "/");
-        let clean_path = PathBuf::from(normalized_path).clean();
+        let prepared_path = normalize_user_path(user_path);
+        let clean_path = PathBuf::from(&prepared_path).clean();
 
-        let absolute_path = if clean_path.is_absolute() {
+        // Intentionally not cfg!(windows)-gated: a drive-letter path must not be joined under
+        // base_dir on Unix either (otherwise `C:/...` becomes a relative workspace path).
+        let is_win_drive = prepared_path.len() >= 2
+            && prepared_path.as_bytes()[0].is_ascii_alphabetic()
+            && prepared_path.as_bytes()[1] == b':';
+
+        let absolute_path = if clean_path.is_absolute() || is_win_drive {
             clean_path
-        } else if cfg!(windows)
-            && user_path.len() >= 2
-            && user_path.as_bytes()[0].is_ascii_alphabetic()
-            && user_path.as_bytes()[1] == b':'
-        {
-            PathBuf::from(user_path)
         } else {
             self.base_dir.join(clean_path)
         };
 
         // Block parent-directory traversal before any filesystem access.
-        let traversal_check_path = user_path.replace(['\\', '/'], "/");
-
-        if Path::new(&traversal_check_path)
+        if Path::new(&prepared_path)
             .components()
             .any(|component| matches!(component, Component::ParentDir))
         {
@@ -111,7 +108,7 @@ impl SecurityValidator {
         // extensions enabled, single components > 255 chars are always invalid.
         // Reject them early to avoid triggering OS error 123 deep in the stack.
         const MAX_COMPONENT_LEN: usize = 255;
-        for component in Path::new(&traversal_check_path).components() {
+        for component in Path::new(&prepared_path).components() {
             if let Component::Normal(name) = component {
                 if name.len() > MAX_COMPONENT_LEN {
                     return Err(SecurityError::InvalidPath(format!(
@@ -237,7 +234,8 @@ impl SecurityValidator {
             "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
             "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
         ];
-        let path_for_check = PathBuf::from(user_path.replace(['\\', '/'], "/"));
+        let prepared = normalize_user_path(user_path);
+        let path_for_check = PathBuf::from(&prepared);
         for component in path_for_check.components() {
             if let Component::Normal(name) = component {
                 // Windows strips trailing spaces and dots from path components before resolving
@@ -288,6 +286,61 @@ impl SecurityValidator {
         let normalized = Self::normalize_path_separators(path);
         normalized.split('/').next_back().map(|s| s.to_string())
     }
+}
+
+/// Normalize user-provided path string before security and traversal checks.
+///
+/// Handles:
+/// - `file://` URLs via proper URL→path conversion (preserves Unix absolute paths)
+/// - Leading slashes/backslashes before Windows drive letters (e.g. `/C:/path`, `\C:\path`)
+/// - MSYS2/Git Bash POSIX-style paths on Windows only (e.g. `/c/Users/path` → `c:/Users/path`)
+pub fn normalize_user_path(user_path: &str) -> String {
+    let s = user_path.trim();
+
+    // Prefer proper file URL parsing so Unix `file:///home/...` keeps its leading `/`
+    // and Windows `file:///C:/...` / `file://localhost/C:/...` resolve correctly.
+    if s.len() >= 7 && s.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://")) {
+        if let Ok(parsed) = url::Url::parse(s) {
+            if parsed.scheme().eq_ignore_ascii_case("file") {
+                if let Ok(path) = parsed.to_file_path() {
+                    let with_forward_slashes = path.to_string_lossy().replace('\\', "/");
+                    return normalize_os_path_string(&with_forward_slashes);
+                }
+            }
+        }
+    }
+
+    normalize_os_path_string(&s.replace('\\', "/"))
+}
+
+/// Apply OS-oriented path heuristics after separators are normalized to `/`.
+fn normalize_os_path_string(normalized: &str) -> String {
+    // Strip leading slashes when followed by a Windows drive letter
+    // (e.g. `/C:/foo`, `///C:/foo`, and backslash forms already converted to `/`).
+    let trimmed_leading = normalized.trim_start_matches('/');
+    if trimmed_leading.len() >= 2 {
+        let bytes = trimmed_leading.as_bytes();
+        if bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let is_sep_or_end = trimmed_leading.len() == 2 || bytes[2] == b'/' || bytes[2] == b'.';
+            if is_sep_or_end {
+                return trimmed_leading.to_string();
+            }
+        }
+    }
+
+    // MSYS2 / Git Bash POSIX-style paths are Windows-only. On Unix, `/c/...` is a
+    // legitimate absolute path under `/c` and must not be rewritten.
+    #[cfg(windows)]
+    if normalized.len() >= 3 {
+        let bytes = normalized.as_bytes();
+        if bytes[0] == b'/' && bytes[1].is_ascii_alphabetic() && bytes[2] == b'/' {
+            let drive = bytes[1] as char;
+            let rest = &normalized[3..];
+            return format!("{drive}:/{rest}");
+        }
+    }
+
+    normalized.to_string()
 }
 
 /// Helper to check if a path starts with a base path, safely handling Windows UNC prefixes and case-insensitivity.

--- a/src-tauri/tests/windows_path_validation_tests.rs
+++ b/src-tauri/tests/windows_path_validation_tests.rs
@@ -1,0 +1,172 @@
+use tauri_mcp_agent_lib::mcp::builtin::utils::{normalize_user_path, SecurityValidator};
+use tempfile::tempdir;
+
+#[test]
+fn test_normalize_user_path_relative_unchanged() {
+    assert_eq!(
+        normalize_user_path("src/mcp/builtin/utils.rs"),
+        "src/mcp/builtin/utils.rs"
+    );
+    assert_eq!(
+        normalize_user_path("./subdir/file.txt"),
+        "./subdir/file.txt"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn test_normalize_user_path_windows_formats() {
+    assert_eq!(
+        normalize_user_path("/C:/Users/example/project"),
+        "C:/Users/example/project"
+    );
+    assert_eq!(
+        normalize_user_path("\\C:\\Users\\example\\project"),
+        "C:/Users/example/project"
+    );
+    assert_eq!(
+        normalize_user_path("file:///C:/Users/example/project"),
+        "C:/Users/example/project"
+    );
+    assert_eq!(
+        normalize_user_path("file://localhost/C:/Users/example/project"),
+        "C:/Users/example/project"
+    );
+    assert_eq!(
+        normalize_user_path("/c/Users/example/project"),
+        "c:/Users/example/project"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_normalize_user_path_unix_file_url_and_msys_passthrough() {
+    assert_eq!(
+        normalize_user_path("file:///home/example/project/readme.md"),
+        "/home/example/project/readme.md"
+    );
+    // On Unix, `/c/...` is a real absolute path and must not be rewritten as a drive path.
+    assert_eq!(
+        normalize_user_path("/c/Users/example/project"),
+        "/c/Users/example/project"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn test_scoped_validator_windows_leading_slash() {
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());
+    let test_file = temp_dir.path().join("test.txt");
+    std::fs::write(&test_file, "hello").expect("write test file");
+
+    let raw_path = test_file.to_string_lossy();
+    let leading_slash_path = format!("/{}", raw_path.replace('\\', "/"));
+
+    let validated = validator
+        .validate_path_for_read(&leading_slash_path)
+        .expect("absolute path with leading slash within base_dir must succeed");
+    assert_eq!(
+        validated.canonicalize().unwrap(),
+        test_file.canonicalize().unwrap()
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn test_scoped_validator_rejects_outside_base_leading_slash_drive_path() {
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());
+
+    let outside = normalize_user_path("/C:/Windows/System32/drivers/etc/hosts");
+    let result = validator.validate_path_for_read(&outside);
+    assert!(
+        result.is_err(),
+        "path outside base_dir must be rejected, got: {result:?}"
+    );
+}
+
+#[test]
+fn test_scoped_validator_file_url_within_base() {
+    let temp_dir = tempdir().expect("temp dir");
+    let validator = SecurityValidator::new_scoped_with_base_dir(temp_dir.path().to_path_buf());
+    let test_file = temp_dir.path().join("test.txt");
+    std::fs::write(&test_file, "hello").expect("write test file");
+
+    let file_url = url::Url::from_file_path(&test_file)
+        .expect("file url")
+        .to_string();
+
+    let validated = validator
+        .validate_path_for_read(&file_url)
+        .expect("file:// URL within base_dir must succeed");
+    assert_eq!(
+        validated.canonicalize().unwrap(),
+        test_file.canonicalize().unwrap()
+    );
+}
+
+#[cfg(windows)]
+mod windows_workspace_glob {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tauri_mcp_agent_lib::mcp::builtin::workspace::WorkspaceServer;
+    use tauri_mcp_agent_lib::mcp::types::{MCPContent, MCPResult};
+    use tauri_mcp_agent_lib::session::SessionManager;
+
+    fn extract_text_content(result: &MCPResult) -> String {
+        result
+            .content
+            .as_ref()
+            .expect("text content expected")
+            .iter()
+            .filter_map(|content| match content {
+                MCPContent::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn build_workspace_server(base_dir: &std::path::Path, session_id: &str) -> WorkspaceServer {
+        let session_manager =
+            SessionManager::new_with_base_dir(base_dir.to_path_buf()).expect("session manager");
+        WorkspaceServer::new(session_id.to_string(), Arc::new(session_manager))
+    }
+
+    #[tokio::test]
+    async fn test_glob_files_handles_windows_absolute_path_with_leading_slash() {
+        let temp_dir = tempdir().expect("temp dir");
+        let session_id = "glob-files-leading-slash";
+        let server = build_workspace_server(temp_dir.path(), session_id);
+        let workspace_dir = server.get_workspace_dir(session_id);
+
+        std::fs::write(
+            workspace_dir.join("message_bubble.rs"),
+            "pub struct MessageBubble;",
+        )
+        .expect("write file");
+
+        let raw_workspace_path = workspace_dir.to_string_lossy();
+        let leading_slash_path = format!("/{}", raw_workspace_path.replace('\\', "/"));
+
+        let glob_result = server
+            .call_tool(
+                "globFiles",
+                json!({
+                    "path": leading_slash_path,
+                    "filePattern": "*message*bubble*",
+                }),
+                Some(session_id.to_string()),
+            )
+            .await
+            .expect("globFiles dispatch should succeed");
+
+        let glob_text = extract_text_content(&glob_result);
+        assert!(
+            glob_text.contains("message_bubble.rs"),
+            "Expected glob result to contain message_bubble.rs but got: {glob_text}"
+        );
+    }
+}

--- a/src-tauri/tests/windows_path_validation_tests.rs
+++ b/src-tauri/tests/windows_path_validation_tests.rs
@@ -93,6 +93,8 @@ fn test_scoped_validator_file_url_within_base() {
     let test_file = temp_dir.path().join("test.txt");
     std::fs::write(&test_file, "hello").expect("write test file");
 
+    // Use a non-canonical path in the file:// URL when the OS exposes one (macOS
+    // `/var` vs `/private/var`) so we cover the early containment canonicalize path.
     let file_url = url::Url::from_file_path(&test_file)
         .expect("file url")
         .to_string();


### PR DESCRIPTION
## Summary
- Normalize user-provided path strings in SecurityValidator to strip leading slashes before Windows drive letters (e.g. /C:/... -> C:/...), ile:// URI schemes, and MSYS2/Git Bash style POSIX paths (/c/... -> c:/...).
- Prevent path validation failures in workspace / globFiles and related builtin tools on Windows when absolute paths with leading slashes are provided.
- Add test coverage in windows_path_validation_tests.rs.

## Test plan
- [x] Run cargo test --test windows_path_validation_tests (all 3 tests pass)
- [x] Run pnpm refactor:validate (all 18 validation steps pass)