### PR TITLE
refactor(agent): split oversized AgentChatMessages scroll-follow test and hook into modular pieces (#1658)

### DIFF
--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -52,6 +52,7 @@
     "src/context/__tests__/agent-session-test-utils.tsx",
     "src/context/__tests__/llm-service-test-utils.tsx",
     "src/features/agent/components/__tests__/AgentChatMessages.compaction-setup.tsx",
+    "src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.harness.ts",
     "src/hooks/__tests__/helpers.ts",
     "src/test/setup.ts"
   ],

--- a/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.harness.ts
+++ b/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.harness.ts
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import type { Message } from '@/models/chat';
+import type { GroupedMessage } from '@/hooks/useMessageGrouping';
+import {
+  installMockResizeObserver,
+  resetAgentChatMessagesHarness,
+  type AgentChatMessagesTestHarness,
+} from './AgentChatMessages.compaction-setup';
+
+export function setupScrollFollowHarness() {
+  const {
+    virtuosoMock,
+    scrollToIndexMock,
+    sessionState,
+    chatState,
+    hasVirtuosoHandle,
+  } = vi.hoisted(() => ({
+    virtuosoMock: vi.fn(),
+    scrollToIndexMock: vi.fn(),
+    sessionState: {
+      session: { id: 'session-1', assistant: { name: 'Agent' } },
+    },
+    chatState: {
+      messages: [] as Message[],
+      workflowStatus: 'idle' as 'idle' | 'busy',
+    },
+    hasVirtuosoHandle: { current: true },
+  }));
+
+  const groupedMessagesMock: GroupedMessage[] = [];
+  const resizeObserverCallbacks = { current: [] as ResizeObserverCallback[] };
+
+  installMockResizeObserver(resizeObserverCallbacks);
+
+  const harness: AgentChatMessagesTestHarness = {
+    virtuosoMock,
+    scrollToIndexMock,
+    sessionState,
+    chatState,
+    hasVirtuosoHandle,
+  };
+
+  const resetHarness = () => {
+    resetAgentChatMessagesHarness({
+      harness,
+      groupedMessagesMock,
+      resizeObserverCallbacks,
+    });
+  };
+
+  return {
+    virtuosoMock,
+    scrollToIndexMock,
+    sessionState,
+    chatState,
+    hasVirtuosoHandle,
+    groupedMessagesMock,
+    resizeObserverCallbacks,
+    harness,
+    resetHarness,
+  };
+}

--- a/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.intent.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.intent.test.tsx
@@ -1,0 +1,446 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentChatMessages } from '../AgentChatMessages';
+import {
+  setScrollerMetrics,
+  makeStreamingGroupEntry,
+  makeStreamingMessage,
+} from './AgentChatMessages.compaction-setup';
+import { setupScrollFollowHarness } from './AgentChatMessages.scroll-follow.harness';
+
+const {
+  virtuosoMock,
+  scrollToIndexMock,
+  sessionState,
+  chatState,
+  hasVirtuosoHandle,
+  groupedMessagesMock,
+  resizeObserverCallbacks,
+  resetHarness,
+} = setupScrollFollowHarness();
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChat: () => ({
+    messages: chatState.messages,
+    pendingMessages: [],
+    pendingQueue: [],
+    error: undefined,
+    llmError: undefined,
+    retryMessage: vi.fn(),
+    workflowStatus: chatState.workflowStatus,
+  }),
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSession: () => ({
+    session: sessionState.session,
+    pendingApprovals: [],
+    respondToToolApproval: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/LLMServiceContext', () => ({
+  useLLMService: () => ({
+    getCompactedRange: () => ({
+      toId: 'tool-1',
+      summary: 'Compacted summary',
+    }),
+  }),
+}));
+
+vi.mock('@/features/agent/hooks/useAgentResourceAttachment', () => ({
+  useAgentResourceAttachment: () => ({ refetchSessionFiles: vi.fn() }),
+}));
+
+vi.mock('@/features/agent/hooks/useFileRefetcher', () => ({
+  useFileRefetcher: vi.fn(),
+}));
+
+vi.mock('@/hooks/useMessageGrouping', () => ({
+  useMessageGrouping: () => ({
+    groupedMessages: groupedMessagesMock.slice(),
+    toolResultsMap: new Map(),
+  }),
+}));
+
+vi.mock('../AgentMessageBubble', () => ({
+  AgentMessageBubble: () => <div>message bubble</div>,
+}));
+
+vi.mock('@/features/agent/components/shared', () => ({
+  AnalysisLoader: () => <div>analysis loader</div>,
+}));
+
+vi.mock('../shared/CompactEventDivider', () => ({
+  CompactEventDivider: ({ summary }: { summary?: string }) => (
+    <div>{summary ?? 'compact divider'}</div>
+  ),
+}));
+
+vi.mock('@/features/agent/components/PendingApprovalWidget', () => ({
+  PendingApprovalWidget: () => <div>pending approvals</div>,
+}));
+
+vi.mock('@/components/shared/ErrorBubble', () => ({
+  ErrorBubble: () => <div>error bubble</div>,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: React.forwardRef(function MockVirtuoso(props, ref) {
+    React.useImperativeHandle(
+      ref,
+      () =>
+        hasVirtuosoHandle.current
+          ? { scrollToIndex: scrollToIndexMock }
+          : (null as unknown as { scrollToIndex: typeof scrollToIndexMock }),
+      [ref, hasVirtuosoHandle.current],
+    );
+    return virtuosoMock(props);
+  }),
+}));
+
+beforeEach(() => {
+  resetHarness();
+});
+
+describe('AgentChatMessages – scroll intent detection', () => {
+  it('pauses bottom follow via near-top threshold with a sub-36px upward delta', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage()];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    performanceNowSpy.mockImplementation(() => currentTime);
+
+    try {
+      const { container } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+
+      currentTime = 50;
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 500,
+        clientHeight: 100,
+        scrollTop: 20,
+      });
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      currentTime = 300;
+      scroller!.scrollTop = 4;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it('pauses bottom follow after three explicit upward scrolls', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage()];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    performanceNowSpy.mockImplementation(() => currentTime);
+
+    try {
+      const { container } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 500,
+        clientHeight: 100,
+        scrollTop: 400,
+      });
+
+      currentTime = 300;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      scroller!.scrollTop = 388;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      scroller!.scrollTop = 376;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      scroller!.scrollTop = 364;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it('resets upward release accumulation after a downward self-scroll returns toward bottom', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    const scrollIntoView = vi.fn();
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage()];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    performanceNowSpy.mockImplementation(() => currentTime);
+
+    try {
+      const { container } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 500,
+        clientHeight: 100,
+        scrollTop: 400,
+      });
+
+      currentTime = 50;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      currentTime = 250;
+      scroller!.scrollTop = 388;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      currentTime = 260;
+      act(() => {
+        resizeObserverCallbacks.current.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
+      });
+
+      currentTime = 300;
+      scroller!.scrollTop = 400;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      currentTime = 500;
+      scroller!.scrollTop = 388;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      currentTime = 700;
+      scroller!.scrollTop = 376;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      currentTime = 900;
+      scroller!.scrollTop = 364;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('keeps bottom follow until three explicit upward scrolls leave the visual bottom', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage()];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    performanceNowSpy.mockImplementation(() => currentTime);
+
+    try {
+      const { container } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 500,
+        clientHeight: 100,
+        scrollTop: 400,
+      });
+
+      currentTime = 300;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      scroller!.scrollTop = 388;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      scroller!.scrollTop = 376;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+      scroller!.scrollTop = 364;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it('resumes bottom follow when the user manually returns to latest during busy streaming', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const performanceNowSpy = vi.spyOn(performance, 'now');
+    const scrollIntoView = vi.fn();
+    let currentTime = 0;
+
+    chatState.messages = [makeStreamingMessage()];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
+
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    performanceNowSpy.mockImplementation(() => currentTime);
+
+    try {
+      const { container } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+
+      expect(scroller).not.toBeNull();
+
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 500,
+        clientHeight: 100,
+        scrollTop: 400,
+      });
+
+      currentTime = 300;
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      scroller!.scrollTop = 360;
+
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      const scrollToLatestButton = screen.getByLabelText('Scroll to latest');
+      expect(scrollToLatestButton).toBeInTheDocument();
+
+      scrollIntoView.mockClear();
+      currentTime = 600;
+
+      act(() => {
+        scrollToLatestButton.click();
+      });
+
+      expect(scrollToIndexMock).toHaveBeenCalled();
+      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+    } finally {
+      performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+});

--- a/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.streaming.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.streaming.test.tsx
@@ -3,47 +3,25 @@ import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentChatMessages } from '../AgentChatMessages';
-import type { Message } from '@/models/chat';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
 import {
-  installMockResizeObserver,
-  resetAgentChatMessagesHarness,
   setScrollerMetrics,
   baseMessage,
   makeStreamingGroupEntry,
   makeStreamingMessage,
-  type AgentChatMessagesTestHarness,
 } from './AgentChatMessages.compaction-setup';
+import { setupScrollFollowHarness } from './AgentChatMessages.scroll-follow.harness';
 
-// ---------------------------------------------------------------------------
-// Vitest hoisted shared state
-// ---------------------------------------------------------------------------
-
-const { virtuosoMock, scrollToIndexMock, sessionState, chatState, hasVirtuosoHandle } =
-  vi.hoisted(() => ({
-    virtuosoMock: vi.fn(),
-    scrollToIndexMock: vi.fn(),
-    sessionState: { session: { id: 'session-1', assistant: { name: 'Agent' } } },
-    chatState: { messages: [] as Message[], workflowStatus: 'idle' as 'idle' | 'busy' },
-    hasVirtuosoHandle: { current: true },
-  }));
-
-let groupedMessagesMock: GroupedMessage[] = [];
-const resizeObserverCallbacks = { current: [] as ResizeObserverCallback[] };
-
-installMockResizeObserver(resizeObserverCallbacks);
-
-// ---------------------------------------------------------------------------
-// Module mocks
-// ---------------------------------------------------------------------------
-
-const harness: AgentChatMessagesTestHarness = {
+const {
   virtuosoMock,
   scrollToIndexMock,
   sessionState,
   chatState,
   hasVirtuosoHandle,
-};
+  groupedMessagesMock,
+  resizeObserverCallbacks,
+  resetHarness,
+} = setupScrollFollowHarness();
 
 vi.mock('@/context/AgentChatContext', () => ({
   useAgentChat: () => ({
@@ -132,78 +110,11 @@ vi.mock('react-virtuoso', () => ({
   }),
 }));
 
-// ---------------------------------------------------------------------------
-// Per-test reset
-// ---------------------------------------------------------------------------
-
 beforeEach(() => {
-  resetAgentChatMessagesHarness({
-    harness,
-    groupedMessagesMock,
-    resizeObserverCallbacks,
-  });
+  resetHarness();
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describe('AgentChatMessages – scroll-follow intent detection', () => {
-  it('pauses bottom follow via near-top threshold with a sub-36px upward delta', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
-    const originalCancelAnimationFrame = global.cancelAnimationFrame;
-    const performanceNowSpy = vi.spyOn(performance, 'now');
-    let currentTime = 0;
-
-    chatState.messages = [makeStreamingMessage()];
-    chatState.workflowStatus = 'busy';
-    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    global.cancelAnimationFrame = vi.fn();
-    performanceNowSpy.mockImplementation(() => currentTime);
-
-    try {
-      const { container } = render(<AgentChatMessages />);
-      const scroller = container.querySelector(
-        '.agent-chat-scrollbar',
-      ) as HTMLDivElement | null;
-
-      expect(scroller).not.toBeNull();
-
-      // Still inside the force-snap ignore window: park just above the near-top
-      // threshold without pausing follow (self-scroll ignores upward intent).
-      currentTime = 50;
-      setScrollerMetrics(scroller!, {
-        scrollHeight: 500,
-        clientHeight: 100,
-        scrollTop: 20,
-      });
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      // Ignore window expired. 20 → 4 is only 16px upward (< 36px release
-      // distance), so only the near-top rule can pause follow.
-      currentTime = 300;
-      scroller!.scrollTop = 4;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
-    } finally {
-      performanceNowSpy.mockRestore();
-      global.requestAnimationFrame = originalRequestAnimationFrame;
-      global.cancelAnimationFrame = originalCancelAnimationFrame;
-    }
-  });
-
+describe('AgentChatMessages – streaming follow & prepend preservation', () => {
   it('keeps Non-Thinking stream height growth from yanking away from the top', () => {
     const originalRequestAnimationFrame = global.requestAnimationFrame;
     const originalCancelAnimationFrame = global.cancelAnimationFrame;
@@ -255,7 +166,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
       expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
       scrollToIndexMock.mockClear();
 
-      // Layout-neutral text growth must not schedule a reactive bottom snap.
       chatState.messages = [makeStreamingMessage('streaming output extended')];
       groupedMessagesMock.splice(
         0,
@@ -266,7 +176,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
 
       expect(scrollToIndexMock).not.toHaveBeenCalled();
 
-      // ResizeObserver follow must also stay suppressed while parked at top.
       act(() => {
         resizeObserverCallbacks.current.forEach((callback) =>
           callback([], {} as ResizeObserver),
@@ -280,70 +189,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
       global.requestAnimationFrame = originalRequestAnimationFrame;
       global.cancelAnimationFrame = originalCancelAnimationFrame;
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-    }
-  });
-
-  it('pauses bottom follow after three explicit upward scrolls', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
-    const originalCancelAnimationFrame = global.cancelAnimationFrame;
-    const performanceNowSpy = vi.spyOn(performance, 'now');
-    let currentTime = 0;
-
-    chatState.messages = [makeStreamingMessage()];
-    chatState.workflowStatus = 'busy';
-    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    global.cancelAnimationFrame = vi.fn();
-    performanceNowSpy.mockImplementation(() => currentTime);
-
-    try {
-      const { container } = render(<AgentChatMessages />);
-      const scroller = container.querySelector(
-        '.agent-chat-scrollbar',
-      ) as HTMLDivElement | null;
-
-      expect(scroller).not.toBeNull();
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      setScrollerMetrics(scroller!, {
-        scrollHeight: 500,
-        clientHeight: 100,
-        scrollTop: 400,
-      });
-
-      currentTime = 300;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      scroller!.scrollTop = 388;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      scroller!.scrollTop = 376;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      scroller!.scrollTop = 364;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
-    } finally {
-      performanceNowSpy.mockRestore();
-      global.requestAnimationFrame = originalRequestAnimationFrame;
-      global.cancelAnimationFrame = originalCancelAnimationFrame;
     }
   });
 
@@ -382,7 +227,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
         scrollTop: 400,
       });
 
-      // Force snaps (session-changed) open the ignore window; streaming follows must not.
       currentTime = 50;
       act(() => {
         scroller?.dispatchEvent(new Event('scroll'));
@@ -456,13 +300,11 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
         scrollTop: 400,
       });
 
-      // Expire the force-snap ignore window from session hydration.
       currentTime = 300;
       act(() => {
         scroller?.dispatchEvent(new Event('scroll'));
       });
 
-      // Growing text tokens are layout-neutral; follow continues via ResizeObserver.
       chatState.messages = [makeStreamingMessage('streaming output extended')];
       groupedMessagesMock.splice(
         0,
@@ -504,94 +346,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
       });
 
       expect(scrollToIndexMock).not.toHaveBeenCalled();
-    } finally {
-      performanceNowSpy.mockRestore();
-      global.requestAnimationFrame = originalRequestAnimationFrame;
-      global.cancelAnimationFrame = originalCancelAnimationFrame;
-      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-    }
-  });
-
-  it('resets upward release accumulation after a downward self-scroll returns toward bottom', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
-    const originalCancelAnimationFrame = global.cancelAnimationFrame;
-    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
-    const performanceNowSpy = vi.spyOn(performance, 'now');
-    const scrollIntoView = vi.fn();
-    let currentTime = 0;
-
-    chatState.messages = [makeStreamingMessage()];
-    chatState.workflowStatus = 'busy';
-    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    global.cancelAnimationFrame = vi.fn();
-    HTMLElement.prototype.scrollIntoView = scrollIntoView;
-    performanceNowSpy.mockImplementation(() => currentTime);
-
-    try {
-      const { container } = render(<AgentChatMessages />);
-      const scroller = container.querySelector(
-        '.agent-chat-scrollbar',
-      ) as HTMLDivElement | null;
-
-      expect(scroller).not.toBeNull();
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      setScrollerMetrics(scroller!, {
-        scrollHeight: 500,
-        clientHeight: 100,
-        scrollTop: 400,
-      });
-
-      currentTime = 50;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      currentTime = 250;
-      scroller!.scrollTop = 388;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      currentTime = 260;
-      act(() => {
-        resizeObserverCallbacks.current.forEach((callback) =>
-          callback([], {} as ResizeObserver),
-        );
-      });
-
-      currentTime = 300;
-      scroller!.scrollTop = 400;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      currentTime = 500;
-      scroller!.scrollTop = 388;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      currentTime = 700;
-      scroller!.scrollTop = 376;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      currentTime = 900;
-      scroller!.scrollTop = 364;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
     } finally {
       performanceNowSpy.mockRestore();
       global.requestAnimationFrame = originalRequestAnimationFrame;
@@ -802,134 +556,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
     }
   });
 
-  it('keeps bottom follow until three explicit upward scrolls leave the visual bottom', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
-    const originalCancelAnimationFrame = global.cancelAnimationFrame;
-    const performanceNowSpy = vi.spyOn(performance, 'now');
-    let currentTime = 0;
-
-    chatState.messages = [makeStreamingMessage()];
-    chatState.workflowStatus = 'busy';
-    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    global.cancelAnimationFrame = vi.fn();
-    performanceNowSpy.mockImplementation(() => currentTime);
-
-    try {
-      const { container } = render(<AgentChatMessages />);
-      const scroller = container.querySelector(
-        '.agent-chat-scrollbar',
-      ) as HTMLDivElement | null;
-
-      expect(scroller).not.toBeNull();
-
-      setScrollerMetrics(scroller!, {
-        scrollHeight: 500,
-        clientHeight: 100,
-        scrollTop: 400,
-      });
-
-      currentTime = 300;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      scroller!.scrollTop = 388;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      scroller!.scrollTop = 376;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-
-      scroller!.scrollTop = 364;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
-    } finally {
-      performanceNowSpy.mockRestore();
-      global.requestAnimationFrame = originalRequestAnimationFrame;
-      global.cancelAnimationFrame = originalCancelAnimationFrame;
-    }
-  });
-
-  it('resumes bottom follow when the user manually returns to latest during busy streaming', () => {
-    const originalRequestAnimationFrame = global.requestAnimationFrame;
-    const originalCancelAnimationFrame = global.cancelAnimationFrame;
-    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
-    const performanceNowSpy = vi.spyOn(performance, 'now');
-    const scrollIntoView = vi.fn();
-    let currentTime = 0;
-
-    chatState.messages = [makeStreamingMessage()];
-    chatState.workflowStatus = 'busy';
-    groupedMessagesMock.splice(0, groupedMessagesMock.length, makeStreamingGroupEntry());
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    global.cancelAnimationFrame = vi.fn();
-    HTMLElement.prototype.scrollIntoView = scrollIntoView;
-    performanceNowSpy.mockImplementation(() => currentTime);
-
-    try {
-      const { container } = render(<AgentChatMessages />);
-      const scroller = container.querySelector(
-        '.agent-chat-scrollbar',
-      ) as HTMLDivElement | null;
-
-      expect(scroller).not.toBeNull();
-
-      setScrollerMetrics(scroller!, {
-        scrollHeight: 500,
-        clientHeight: 100,
-        scrollTop: 400,
-      });
-
-      currentTime = 300;
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      scroller!.scrollTop = 360;
-
-      act(() => {
-        scroller?.dispatchEvent(new Event('scroll'));
-      });
-
-      const scrollToLatestButton = screen.getByLabelText('Scroll to latest');
-      expect(scrollToLatestButton).toBeInTheDocument();
-
-      scrollIntoView.mockClear();
-      currentTime = 600;
-
-      act(() => {
-        scrollToLatestButton.click();
-      });
-
-      expect(scrollToIndexMock).toHaveBeenCalled();
-      expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
-    } finally {
-      performanceNowSpy.mockRestore();
-      global.requestAnimationFrame = originalRequestAnimationFrame;
-      global.cancelAnimationFrame = originalCancelAnimationFrame;
-      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-    }
-  });
-
   it('does not yank to bottom with sentinel scroll when older messages prepend at the top', () => {
     const originalRequestAnimationFrame = global.requestAnimationFrame;
     const originalCancelAnimationFrame = global.cancelAnimationFrame;
@@ -962,7 +588,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
 
       expect(scroller).not.toBeNull();
 
-      // Two-step upward park (same pattern as other near-top tests).
       currentTime = 50;
       setScrollerMetrics(scroller!, {
         scrollHeight: 2_000,
@@ -1018,7 +643,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
       ];
       rerender(<AgentChatMessages />);
 
-      // Prepend pins the previous head before paint (Virtuoso remount flash).
       expect(scrollToIndexMock).toHaveBeenCalledWith(
         expect.objectContaining({
           align: 'start',
@@ -1038,7 +662,6 @@ describe('AgentChatMessages – scroll-follow intent detection', () => {
         );
       });
 
-      // Must not also yank to the footer sentinel / latest messages.
       expect(scrollToIndexMock).not.toHaveBeenCalled();
       expect(scrollIntoView).not.toHaveBeenCalled();
       expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useBottomAlignment.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useBottomAlignment.ts
@@ -1,0 +1,156 @@
+import { useCallback, useRef, type MutableRefObject } from 'react';
+import type { BottomAlignmentPhase } from '../../types';
+import { isBottomAlignmentActive } from '../../utils';
+
+export interface UseBottomAlignmentOptions {
+  isPreservingPrependPositionRef: MutableRefObject<boolean>;
+  logScrollState: (
+    event: string,
+    extra?: Record<string, boolean | number | string | undefined>,
+  ) => void;
+}
+
+export function useBottomAlignment({
+  isPreservingPrependPositionRef,
+  logScrollState,
+}: UseBottomAlignmentOptions) {
+  const bottomAlignmentPhaseRef = useRef<BottomAlignmentPhase>('idle');
+  const bottomAlignmentLayoutVersionRef = useRef(0);
+  const bottomAlignmentRequestedVersionRef = useRef(0);
+  const bottomAlignmentVerifyFrameRef = useRef<number | null>(null);
+
+  const clearBottomAlignmentVerifyFrame = useCallback(() => {
+    if (bottomAlignmentVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(bottomAlignmentVerifyFrameRef.current);
+      bottomAlignmentVerifyFrameRef.current = null;
+    }
+  }, []);
+
+  const setBottomAlignmentPhase = useCallback(
+    (phase: BottomAlignmentPhase, reason: string) => {
+      if (bottomAlignmentPhaseRef.current === phase) {
+        return;
+      }
+
+      bottomAlignmentPhaseRef.current = phase;
+      logScrollState('bottom-alignment:phase', {
+        reason,
+        phase,
+      });
+    },
+    [logScrollState],
+  );
+
+  const requestBottomAlignment = useCallback(
+    (reason: string) => {
+      clearBottomAlignmentVerifyFrame();
+      bottomAlignmentRequestedVersionRef.current =
+        bottomAlignmentLayoutVersionRef.current;
+      setBottomAlignmentPhase('requesting', reason);
+    },
+    [clearBottomAlignmentVerifyFrame, setBottomAlignmentPhase],
+  );
+
+  const abortBottomAlignment = useCallback(
+    (reason: string) => {
+      clearBottomAlignmentVerifyFrame();
+      setBottomAlignmentPhase('aborted', reason);
+    },
+    [clearBottomAlignmentVerifyFrame, setBottomAlignmentPhase],
+  );
+
+  const markBottomAlignmentLayoutChanged = useCallback(
+    (reason: string) => {
+      if (isPreservingPrependPositionRef.current) {
+        logScrollState('bottom-alignment:layout-change-skipped', {
+          reason,
+        });
+        return;
+      }
+
+      bottomAlignmentLayoutVersionRef.current += 1;
+      logScrollState('bottom-alignment:layout-change', {
+        reason,
+        layoutVersion: bottomAlignmentLayoutVersionRef.current,
+      });
+    },
+    [isPreservingPrependPositionRef, logScrollState],
+  );
+
+  const maybeCompleteBottomAlignment = useCallback(
+    (reason: string, visualBottom: boolean, virtuosoAtBottom: boolean) => {
+      if (bottomAlignmentPhaseRef.current !== 'verifying') {
+        return;
+      }
+
+      if (isPreservingPrependPositionRef.current) {
+        return;
+      }
+
+      if (!visualBottom || !virtuosoAtBottom) {
+        logScrollState('bottom-alignment:pending', {
+          reason,
+          visualBottom,
+          virtuosoAtBottom,
+        });
+        return;
+      }
+
+      const layoutVersion = bottomAlignmentLayoutVersionRef.current;
+      if (bottomAlignmentRequestedVersionRef.current !== layoutVersion) {
+        bottomAlignmentRequestedVersionRef.current = layoutVersion;
+        logScrollState('bottom-alignment:version-invalidated', {
+          reason,
+          layoutVersion,
+        });
+        bottomAlignmentVerifyFrameRef.current = requestAnimationFrame(() => {
+          bottomAlignmentVerifyFrameRef.current = null;
+          maybeCompleteBottomAlignment(
+            'version-invalidated',
+            visualBottom,
+            virtuosoAtBottom,
+          );
+        });
+        return;
+      }
+
+      clearBottomAlignmentVerifyFrame();
+      setBottomAlignmentPhase('aligned', reason);
+    },
+    [
+      clearBottomAlignmentVerifyFrame,
+      isPreservingPrependPositionRef,
+      logScrollState,
+      setBottomAlignmentPhase,
+    ],
+  );
+
+  const scheduleBottomAlignmentVerification = useCallback(
+    (reason: string, visualBottom: boolean, virtuosoAtBottom: boolean) => {
+      if (!isBottomAlignmentActive(bottomAlignmentPhaseRef.current)) {
+        return;
+      }
+
+      clearBottomAlignmentVerifyFrame();
+      bottomAlignmentVerifyFrameRef.current = requestAnimationFrame(() => {
+        bottomAlignmentVerifyFrameRef.current = null;
+        maybeCompleteBottomAlignment(reason, visualBottom, virtuosoAtBottom);
+      });
+    },
+    [clearBottomAlignmentVerifyFrame, maybeCompleteBottomAlignment],
+  );
+
+  return {
+    bottomAlignmentPhaseRef,
+    bottomAlignmentLayoutVersionRef,
+    bottomAlignmentRequestedVersionRef,
+    bottomAlignmentVerifyFrameRef,
+    clearBottomAlignmentVerifyFrame,
+    setBottomAlignmentPhase,
+    requestBottomAlignment,
+    abortBottomAlignment,
+    markBottomAlignmentLayoutChanged,
+    maybeCompleteBottomAlignment,
+    scheduleBottomAlignmentVerification,
+  };
+}

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useHydrationTracking.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useHydrationTracking.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, type MutableRefObject } from 'react';
+
+export interface UseHydrationTrackingOptions {
+  sessionId: string | undefined;
+  groupedMessagesLength: number;
+  isPinnedToBottomRef: MutableRefObject<boolean>;
+  isPreservingPrependPositionRef: MutableRefObject<boolean>;
+  prependStabilizeTimeoutRef: MutableRefObject<number | null>;
+  requestBottomAlignment: (reason: string) => void;
+  scheduleScrollToBottom: (reason: string) => void;
+  logScrollState: (
+    event: string,
+    extra?: Record<string, boolean | number | string | undefined>,
+  ) => void;
+}
+
+export function useHydrationTracking({
+  sessionId,
+  groupedMessagesLength,
+  isPinnedToBottomRef,
+  isPreservingPrependPositionRef,
+  prependStabilizeTimeoutRef,
+  requestBottomAlignment,
+  scheduleScrollToBottom,
+  logScrollState,
+}: UseHydrationTrackingOptions) {
+  const hasHydratedMessagesRef = useRef<{
+    sessionId: string | undefined;
+    hasMessages: boolean;
+  }>({
+    sessionId: undefined,
+    hasMessages: false,
+  });
+
+  useEffect(() => {
+    const trackedSessionId = hasHydratedMessagesRef.current.sessionId;
+
+    if (trackedSessionId !== sessionId) {
+      hasHydratedMessagesRef.current = {
+        sessionId: sessionId,
+        hasMessages: groupedMessagesLength > 0,
+      };
+      logScrollState('hydration:tracked-session-changed', {
+        hasMessages: groupedMessagesLength > 0,
+      });
+      return;
+    }
+
+    if (
+      !hasHydratedMessagesRef.current.hasMessages &&
+      groupedMessagesLength > 0 &&
+      isPinnedToBottomRef.current
+    ) {
+      isPreservingPrependPositionRef.current = false;
+      if (prependStabilizeTimeoutRef.current !== null) {
+        window.clearTimeout(prependStabilizeTimeoutRef.current);
+        prependStabilizeTimeoutRef.current = null;
+      }
+      requestBottomAlignment('hydrated-messages-arrived');
+      logScrollState('hydration:messages-arrived');
+      scheduleScrollToBottom('hydrated-messages-arrived');
+    }
+
+    if (groupedMessagesLength > 0) {
+      hasHydratedMessagesRef.current.hasMessages = true;
+    }
+  }, [
+    groupedMessagesLength,
+    isPinnedToBottomRef,
+    isPreservingPrependPositionRef,
+    logScrollState,
+    prependStabilizeTimeoutRef,
+    requestBottomAlignment,
+    scheduleScrollToBottom,
+    sessionId,
+  ]);
+
+  return {
+    hasHydratedMessagesRef,
+  };
+}

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/usePrependPreservation.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/usePrependPreservation.ts
@@ -1,0 +1,207 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from 'react';
+import type { VirtuosoHandle } from 'react-virtuoso';
+import type { GroupedMessage } from '@/hooks/useMessageGrouping';
+import { getLogger } from '@/lib/logger';
+import {
+  INITIAL_FIRST_ITEM_INDEX,
+  SELF_SCROLL_IGNORE_WINDOW_MS,
+} from '../../types';
+import {
+  findGroupedMessageIndexByBoundary,
+  getPrependedFirstItemIndex,
+} from '../../utils';
+
+const logger = getLogger('AgentChatMessages');
+
+export interface PreviousListState {
+  firstId: string | undefined;
+  lastId: string | undefined;
+  length: number;
+  sessionId: string | undefined;
+}
+
+export interface UsePrependPreservationOptions {
+  groupedMessages: GroupedMessage[];
+  sessionId: string | undefined;
+  virtuosoRef: MutableRefObject<VirtuosoHandle | null>;
+  selfScrollIgnoreUntilRef: MutableRefObject<number>;
+  logScrollState: (
+    event: string,
+    extra?: Record<string, boolean | number | string | undefined>,
+  ) => void;
+}
+
+export function usePrependPreservation({
+  groupedMessages,
+  sessionId,
+  virtuosoRef,
+  selfScrollIgnoreUntilRef,
+  logScrollState,
+}: UsePrependPreservationOptions) {
+  const isPreservingPrependPositionRef = useRef(false);
+  const prependStabilizeTimeoutRef = useRef<number | null>(null);
+
+  const [firstItemIndex, setFirstItemIndex] = useState(
+    INITIAL_FIRST_ITEM_INDEX,
+  );
+
+  const previousListStateRef = useRef<PreviousListState>({
+    firstId: undefined,
+    lastId: undefined,
+    length: 0,
+    sessionId: undefined,
+  });
+
+  const previousListState = previousListStateRef.current;
+  const hasMessages = groupedMessages.length > 0;
+  const currentFirstGroupedMessageId = hasMessages
+    ? groupedMessages[0]?.message.id
+    : undefined;
+  const currentLastGroupedMessageId = hasMessages
+    ? groupedMessages[groupedMessages.length - 1]?.message.id
+    : undefined;
+  const didSessionChangeForListState =
+    previousListState.sessionId !== sessionId;
+
+  const previousHeadIndexInCurrentList =
+    !didSessionChangeForListState &&
+    groupedMessages.length > previousListState.length &&
+    previousListState.lastId === currentLastGroupedMessageId
+      ? findGroupedMessageIndexByBoundary(
+          groupedMessages,
+          previousListState.firstId,
+        )
+      : -1;
+
+  const candidatePrependCount =
+    previousHeadIndexInCurrentList > 0 ? previousHeadIndexInCurrentList : 0;
+  const preservesPreviousVisibleHead = previousHeadIndexInCurrentList >= 0;
+  const prependCount = candidatePrependCount;
+
+  // Arm prepend preservation during render so same-frame ResizeObserver / reactive scroll
+  // cannot yank to bottom before the effect runs.
+  if (prependCount > 0) {
+    isPreservingPrependPositionRef.current = true;
+  }
+
+  const effectiveFirstItemIndex = didSessionChangeForListState
+    ? INITIAL_FIRST_ITEM_INDEX
+    : prependCount > 0
+      ? getPrependedFirstItemIndex(firstItemIndex, prependCount)
+      : firstItemIndex;
+
+  if (
+    import.meta.env.DEV &&
+    groupedMessages.length > previousListState.length &&
+    previousListState.lastId === currentLastGroupedMessageId &&
+    previousListState.firstId &&
+    !preservesPreviousVisibleHead
+  ) {
+    logger.warn('[scroll-debug] prepend-invariant-violated', {
+      sessionId: sessionId,
+      previousFirstId: previousListState.firstId,
+      previousLastId: previousListState.lastId,
+      currentFirstId: currentFirstGroupedMessageId,
+      currentLastId: currentLastGroupedMessageId,
+      candidatePrependCount,
+      currentCandidateAnchorId:
+        candidatePrependCount > 0
+          ? groupedMessages[candidatePrependCount]?.message.id
+          : undefined,
+      previousHeadIndexInCurrentList,
+      previousLength: previousListState.length,
+      currentLength: groupedMessages.length,
+    });
+  }
+
+  useLayoutEffect(() => {
+    if (prependCount <= 0) {
+      return;
+    }
+
+    const virtuoso = virtuosoRef.current;
+    if (!virtuoso) {
+      return;
+    }
+
+    const anchorVirtuosoIndex = effectiveFirstItemIndex + prependCount;
+    logScrollState('prepend-preservation:anchor-scroll', {
+      prependCount,
+      anchorVirtuosoIndex,
+      effectiveFirstItemIndex,
+    });
+    selfScrollIgnoreUntilRef.current =
+      performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
+    virtuoso.scrollToIndex({
+      index: anchorVirtuosoIndex,
+      align: 'start',
+      behavior: 'auto',
+    });
+  }, [
+    effectiveFirstItemIndex,
+    logScrollState,
+    prependCount,
+    selfScrollIgnoreUntilRef,
+    virtuosoRef,
+  ]);
+
+  useEffect(() => {
+    if (didSessionChangeForListState) {
+      logScrollState('listState:session-changed', {
+        previousSessionId: previousListState.sessionId,
+        nextSessionId: sessionId,
+        groupedMessageCount: groupedMessages.length,
+      });
+      setFirstItemIndex(INITIAL_FIRST_ITEM_INDEX);
+    } else if (prependCount > 0) {
+      isPreservingPrependPositionRef.current = true;
+      if (prependStabilizeTimeoutRef.current !== null) {
+        window.clearTimeout(prependStabilizeTimeoutRef.current);
+      }
+      prependStabilizeTimeoutRef.current = window.setTimeout(() => {
+        prependStabilizeTimeoutRef.current = null;
+        isPreservingPrependPositionRef.current = false;
+        logScrollState('prepend-preservation:settled', {
+          prependCount,
+        });
+      }, 250);
+      logScrollState('prepend-preservation:start', {
+        prependCount,
+      });
+      setFirstItemIndex(effectiveFirstItemIndex);
+    }
+
+    previousListStateRef.current = {
+      firstId: currentFirstGroupedMessageId,
+      lastId: currentLastGroupedMessageId,
+      length: groupedMessages.length,
+      sessionId: sessionId,
+    };
+  }, [
+    currentFirstGroupedMessageId,
+    currentLastGroupedMessageId,
+    didSessionChangeForListState,
+    effectiveFirstItemIndex,
+    groupedMessages.length,
+    logScrollState,
+    prependCount,
+    sessionId,
+  ]);
+
+  return {
+    firstItemIndex,
+    setFirstItemIndex,
+    effectiveFirstItemIndex,
+    prependCount,
+    didSessionChangeForListState,
+    isPreservingPrependPositionRef,
+    prependStabilizeTimeoutRef,
+    previousListStateRef,
+  };
+}

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollFollowState.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollFollowState.ts
@@ -1,0 +1,70 @@
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseScrollFollowStateOptions {
+  logScrollState: (
+    event: string,
+    extra?: Record<string, boolean | number | string | undefined>,
+  ) => void;
+}
+
+export function useScrollFollowState({
+  logScrollState,
+}: UseScrollFollowStateOptions) {
+  const [isPinned, setIsPinned] = useState(true);
+  const isPinnedToBottomRef = useRef(true);
+  const visualBottomRef = useRef(true);
+  const shouldFollowLatestRef = useRef(true);
+  const upwardReleaseDistanceRef = useRef(0);
+  const selfScrollIgnoreUntilRef = useRef(0);
+
+  const setEffectivePinnedState = useCallback((nextPinned: boolean) => {
+    isPinnedToBottomRef.current = nextPinned;
+    setIsPinned(nextPinned);
+  }, []);
+
+  const resumeBottomFollow = useCallback(
+    (reason: string) => {
+      upwardReleaseDistanceRef.current = 0;
+      if (shouldFollowLatestRef.current) {
+        return;
+      }
+
+      shouldFollowLatestRef.current = true;
+      setEffectivePinnedState(true);
+      logScrollState('bottom-follow:resume', {
+        reason,
+      });
+    },
+    [logScrollState, setEffectivePinnedState],
+  );
+
+  const pauseBottomFollow = useCallback(
+    (reason: string) => {
+      upwardReleaseDistanceRef.current = 0;
+      if (!shouldFollowLatestRef.current) {
+        return;
+      }
+
+      shouldFollowLatestRef.current = false;
+      setEffectivePinnedState(visualBottomRef.current);
+      logScrollState('bottom-follow:pause', {
+        reason,
+        visualBottom: visualBottomRef.current,
+      });
+    },
+    [logScrollState, setEffectivePinnedState],
+  );
+
+  return {
+    isPinned,
+    setIsPinned,
+    isPinnedToBottomRef,
+    visualBottomRef,
+    shouldFollowLatestRef,
+    upwardReleaseDistanceRef,
+    selfScrollIgnoreUntilRef,
+    setEffectivePinnedState,
+    resumeBottomFollow,
+    pauseBottomFollow,
+  };
+}

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollScheduler.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollScheduler.ts
@@ -1,0 +1,249 @@
+import { useCallback, useMemo, useRef, type MutableRefObject } from 'react';
+import type { VirtuosoHandle } from 'react-virtuoso';
+import {
+  NEAR_TOP_SCROLL_THRESHOLD,
+  SELF_SCROLL_IGNORE_WINDOW_MS,
+  type BottomAlignmentPhase,
+} from '../../types';
+import {
+  isBottomAlignmentActive,
+  scrollFooterSentinelIntoView,
+  scrollVirtuosoToBottom,
+} from '../../utils';
+
+export interface UseScrollSchedulerOptions {
+  virtuosoRef: MutableRefObject<VirtuosoHandle | null>;
+  footerEndRef: MutableRefObject<HTMLDivElement | null>;
+  groupedMessageCountRef: MutableRefObject<number>;
+  selfScrollIgnoreUntilRef: MutableRefObject<number>;
+  shouldFollowLatestRef: MutableRefObject<boolean>;
+  isPreservingPrependPositionRef: MutableRefObject<boolean>;
+  bottomAlignmentPhaseRef: MutableRefObject<BottomAlignmentPhase>;
+  bottomAlignmentLayoutVersionRef: MutableRefObject<number>;
+  bottomAlignmentRequestedVersionRef: MutableRefObject<number>;
+  visualBottomRef: MutableRefObject<boolean>;
+  scrollTopRef: MutableRefObject<number>;
+  setBottomAlignmentPhase: (
+    phase: BottomAlignmentPhase,
+    reason: string,
+  ) => void;
+  scheduleBottomAlignmentVerification: (
+    reason: string,
+    visualBottom: boolean,
+    virtuosoAtBottom: boolean,
+  ) => void;
+  logScrollState: (
+    event: string,
+    extra?: Record<string, boolean | number | string | undefined>,
+  ) => void;
+}
+
+export function useScrollScheduler({
+  virtuosoRef,
+  footerEndRef,
+  groupedMessageCountRef,
+  selfScrollIgnoreUntilRef,
+  shouldFollowLatestRef,
+  isPreservingPrependPositionRef,
+  bottomAlignmentPhaseRef,
+  bottomAlignmentLayoutVersionRef,
+  bottomAlignmentRequestedVersionRef,
+  visualBottomRef,
+  scrollTopRef,
+  setBottomAlignmentPhase,
+  scheduleBottomAlignmentVerification,
+  logScrollState,
+}: UseScrollSchedulerOptions) {
+  const autoScrollFrameRef = useRef<number | null>(null);
+
+  const forceBottomScrollReasons = useMemo(
+    () =>
+      new Set([
+        'manual-scroll-to-bottom',
+        'session-changed',
+        'hydrated-messages-arrived',
+      ]),
+    [],
+  );
+
+  const clearScheduledAutoScroll = useCallback(() => {
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+  }, []);
+
+  const executeScrollToBottom = useCallback(
+    (reason: string): boolean => {
+      const itemCount = groupedMessageCountRef.current;
+      if (forceBottomScrollReasons.has(reason)) {
+        selfScrollIgnoreUntilRef.current =
+          performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
+      }
+      logScrollState('executeScrollToBottom:start', {
+        itemCount,
+        reason,
+        shouldFollowLatest: shouldFollowLatestRef.current,
+      });
+
+      const scrolledWithVirtuoso = scrollVirtuosoToBottom(
+        virtuosoRef.current,
+        itemCount,
+      );
+
+      if (scrolledWithVirtuoso) {
+        logScrollState('executeScrollToBottom:virtuoso-scroll', {
+          itemCount,
+          reason,
+          scrolledWithVirtuoso: true,
+        });
+      }
+
+      if (footerEndRef.current) {
+        logScrollState('executeScrollToBottom:footer-sentinel-align', {
+          itemCount,
+          reason,
+          scrolledWithVirtuoso,
+        });
+        scrollFooterSentinelIntoView(footerEndRef.current);
+        return true;
+      }
+
+      if (scrolledWithVirtuoso) {
+        logScrollState('executeScrollToBottom:virtuoso-scroll-no-footer', {
+          itemCount,
+          reason,
+          scrolledWithVirtuoso: true,
+        });
+        return true;
+      }
+
+      logScrollState('executeScrollToBottom:unavailable', {
+        itemCount,
+        reason,
+        scrolledWithVirtuoso: false,
+      });
+      return false;
+    },
+    [
+      footerEndRef,
+      forceBottomScrollReasons,
+      groupedMessageCountRef,
+      logScrollState,
+      selfScrollIgnoreUntilRef,
+      shouldFollowLatestRef,
+      virtuosoRef,
+    ],
+  );
+
+  const scheduleScrollToBottom = useCallback(
+    (reason: string, virtuosoAtBottom: boolean = false) => {
+      const isForceReason = forceBottomScrollReasons.has(reason);
+      const isNearTop = scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
+      const shouldForce =
+        isForceReason || (shouldFollowLatestRef.current && !isNearTop);
+      const shouldSuppressForPrepend =
+        isPreservingPrependPositionRef.current && !isForceReason;
+
+      const shouldSuppressForUserScroll =
+        !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
+        !visualBottomRef.current &&
+        !shouldForce;
+
+      const shouldSuppressForNearTop =
+        isNearTop && !visualBottomRef.current && !isForceReason;
+
+      if (
+        shouldSuppressForPrepend ||
+        shouldSuppressForUserScroll ||
+        shouldSuppressForNearTop
+      ) {
+        clearScheduledAutoScroll();
+        logScrollState('scheduleScrollToBottom:suppressed', {
+          reason,
+          shouldSuppressForPrepend,
+          shouldSuppressForUserScroll,
+          shouldSuppressForNearTop,
+          shouldForce,
+        });
+        return;
+      }
+
+      logScrollState('scheduleScrollToBottom', {
+        reason,
+      });
+      clearScheduledAutoScroll();
+
+      autoScrollFrameRef.current = requestAnimationFrame(() => {
+        autoScrollFrameRef.current = null;
+        const isForceReasonOnFire = forceBottomScrollReasons.has(reason);
+        const isNearTopOnFire =
+          scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
+        const shouldForceOnFire =
+          isForceReasonOnFire ||
+          (shouldFollowLatestRef.current && !isNearTopOnFire);
+        const shouldSuppressForPrependOnFire =
+          isPreservingPrependPositionRef.current && !isForceReasonOnFire;
+        const shouldSuppressForUserScrollOnFire =
+          !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
+          !visualBottomRef.current &&
+          !shouldForceOnFire;
+        const shouldSuppressForNearTopOnFire =
+          isNearTopOnFire && !visualBottomRef.current && !isForceReasonOnFire;
+
+        if (
+          shouldSuppressForPrependOnFire ||
+          shouldSuppressForUserScrollOnFire ||
+          shouldSuppressForNearTopOnFire
+        ) {
+          logScrollState('scheduleScrollToBottom:frame-suppressed', {
+            reason,
+            isPreservingPrepend: isPreservingPrependPositionRef.current,
+            isNearTop: isNearTopOnFire,
+            shouldFollowLatest: shouldFollowLatestRef.current,
+            visualBottom: visualBottomRef.current,
+          });
+          return;
+        }
+
+        logScrollState('scheduleScrollToBottom:frame-fired', {
+          reason,
+        });
+        const didScroll = executeScrollToBottom(reason);
+        if (didScroll && bottomAlignmentPhaseRef.current === 'requesting') {
+          bottomAlignmentRequestedVersionRef.current =
+            bottomAlignmentLayoutVersionRef.current;
+          setBottomAlignmentPhase('verifying', `scroll-dispatched:${reason}`);
+          scheduleBottomAlignmentVerification(
+            `scroll-dispatched:${reason}`,
+            visualBottomRef.current,
+            virtuosoAtBottom,
+          );
+        }
+      });
+    },
+    [
+      bottomAlignmentLayoutVersionRef,
+      bottomAlignmentPhaseRef,
+      bottomAlignmentRequestedVersionRef,
+      clearScheduledAutoScroll,
+      executeScrollToBottom,
+      forceBottomScrollReasons,
+      isPreservingPrependPositionRef,
+      logScrollState,
+      scheduleBottomAlignmentVerification,
+      setBottomAlignmentPhase,
+      shouldFollowLatestRef,
+      scrollTopRef,
+      visualBottomRef,
+    ],
+  );
+
+  return {
+    autoScrollFrameRef,
+    forceBottomScrollReasons,
+    clearScheduledAutoScroll,
+    executeScrollToBottom,
+    scheduleScrollToBottom,
+  };
+}

--- a/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
@@ -1,37 +1,30 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { type VirtuosoHandle } from 'react-virtuoso';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { VirtuosoHandle } from 'react-virtuoso';
 import { getLogger } from '@/lib/logger';
-import { type GroupedMessage } from '@/hooks/useMessageGrouping';
-import { type Message } from '@/models/chat';
-import { type useAgentChat } from '@/context/AgentChatContext';
-import { type useAgentSession } from '@/context/AgentSessionContext';
+import type { GroupedMessage } from '@/hooks/useMessageGrouping';
+import type { Message } from '@/models/chat';
+import type { useAgentChat } from '@/context/AgentChatContext';
+import type { useAgentSession } from '@/context/AgentSessionContext';
 import {
   INITIAL_FIRST_ITEM_INDEX,
   BOTTOM_FOLLOW_RELEASE_SCROLL_DISTANCE,
   NEAR_TOP_SCROLL_THRESHOLD,
-  SELF_SCROLL_IGNORE_WINDOW_MS,
-  type BottomAlignmentPhase,
 } from '../types';
 import {
-  getPrependedFirstItemIndex,
   getInitialTopMostItemIndex,
   getVisualBottomThreshold,
   isPinnedToBottom,
   isBottomAlignmentActive,
-  scrollFooterSentinelIntoView,
-  scrollVirtuosoToBottom,
   getScrollContentElement,
-  findGroupedMessageIndexByBoundary,
   isLayoutNeutralLatestMessageUpdate,
   isThinkingOnlyLatestMessageUpdate,
 } from '../utils';
+
+import { usePrependPreservation } from './subhooks/usePrependPreservation';
+import { useBottomAlignment } from './subhooks/useBottomAlignment';
+import { useScrollFollowState } from './subhooks/useScrollFollowState';
+import { useScrollScheduler } from './subhooks/useScrollScheduler';
+import { useHydrationTracking } from './subhooks/useHydrationTracking';
 
 const logger = getLogger('AgentChatMessages');
 
@@ -57,105 +50,21 @@ export function useAgentChatScroll({
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
   const virtuosoAtBottomRef = useRef(false);
-  const visualBottomRef = useRef(true);
-  const isPinnedToBottomRef = useRef(true);
-  const shouldFollowLatestRef = useRef(true);
-  const bottomAlignmentPhaseRef = useRef<BottomAlignmentPhase>('idle');
-  const bottomAlignmentLayoutVersionRef = useRef(0);
-  const bottomAlignmentRequestedVersionRef = useRef(0);
-  const bottomAlignmentVerifyFrameRef = useRef<number | null>(null);
-  const prependStabilizeTimeoutRef = useRef<number | null>(null);
-  const isPreservingPrependPositionRef = useRef(false);
-  const autoScrollFrameRef = useRef<number | null>(null);
-  const selfScrollIgnoreUntilRef = useRef(0);
   const previousScrollTopRef = useRef<number | null>(null);
   const scrollTopRef = useRef(0);
-  const upwardReleaseDistanceRef = useRef(0);
   const groupedMessageCountRef = useRef(groupedMessages.length);
   const previousLatestMessageRef = useRef<Message | undefined>(latestMessage);
-  const hasHydratedMessagesRef = useRef<{
-    sessionId: string | undefined;
-    hasMessages: boolean;
-  }>({
-    sessionId: undefined,
-    hasMessages: false,
-  });
 
-  const [firstItemIndex, setFirstItemIndex] = useState(
-    INITIAL_FIRST_ITEM_INDEX,
-  );
-  const [isPinned, setIsPinned] = useState(true);
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(
     null,
   );
 
   const bottomThreshold = getVisualBottomThreshold();
-  const forceBottomScrollReasons = useMemo(
-    () =>
-      new Set([
-        'manual-scroll-to-bottom',
-        'session-changed',
-        'hydrated-messages-arrived',
-      ]),
-    [],
-  );
-
-  const previousListStateRef = useRef<{
-    firstId: string | undefined;
-    lastId: string | undefined;
-    length: number;
-    sessionId: string | undefined;
-  }>({
-    firstId: undefined,
-    lastId: undefined,
-    length: 0,
-    sessionId: undefined,
-  });
-
-  const previousListState = previousListStateRef.current;
-  const hasMessages = groupedMessages.length > 0;
-  const currentFirstGroupedMessageId = hasMessages
-    ? groupedMessages[0]?.message.id
-    : undefined;
-  const currentLastGroupedMessageId = hasMessages
-    ? groupedMessages[groupedMessages.length - 1]?.message.id
-    : undefined;
-  const didSessionChangeForListState =
-    previousListState.sessionId !== sessionId;
-
-  const previousHeadIndexInCurrentList =
-    !didSessionChangeForListState &&
-    groupedMessages.length > previousListState.length &&
-    previousListState.lastId === currentLastGroupedMessageId
-      ? findGroupedMessageIndexByBoundary(
-          groupedMessages,
-          previousListState.firstId,
-        )
-      : -1;
-
-  const candidatePrependCount =
-    previousHeadIndexInCurrentList > 0 ? previousHeadIndexInCurrentList : 0;
-  const preservesPreviousVisibleHead = previousHeadIndexInCurrentList >= 0;
-  const prependCount = candidatePrependCount;
-
-  // Arm prepend preservation during render (not only in useEffect) so
-  // same-frame ResizeObserver / totalListHeightChanged / reactive scroll
-  // cannot yank to bottom before the effect runs — that flash often looks
-  // like a brief user bubble appearing then vanishing after load-older.
-  if (prependCount > 0) {
-    isPreservingPrependPositionRef.current = true;
-  }
-
-  const effectiveFirstItemIndex = didSessionChangeForListState
-    ? INITIAL_FIRST_ITEM_INDEX
-    : prependCount > 0
-      ? getPrependedFirstItemIndex(firstItemIndex, prependCount)
-      : firstItemIndex;
 
   const scrollDebugStateRef = useRef({
     sessionId: sessionId,
-    firstItemIndex,
-    effectiveFirstItemIndex,
+    firstItemIndex: INITIAL_FIRST_ITEM_INDEX,
+    effectiveFirstItemIndex: INITIAL_FIRST_ITEM_INDEX,
   });
 
   const initialTopMostItemIndex = useMemo(() => {
@@ -163,38 +72,7 @@ export function useAgentChatScroll({
       INITIAL_FIRST_ITEM_INDEX,
       groupedMessages.length,
     );
-    // Calculate initial position once when the session changes.
   }, [sessionId]);
-
-  scrollDebugStateRef.current = {
-    sessionId: sessionId,
-    firstItemIndex,
-    effectiveFirstItemIndex,
-  };
-
-  if (
-    import.meta.env.DEV &&
-    groupedMessages.length > previousListState.length &&
-    previousListState.lastId === currentLastGroupedMessageId &&
-    previousListState.firstId &&
-    !preservesPreviousVisibleHead
-  ) {
-    logger.warn('[scroll-debug] prepend-invariant-violated', {
-      sessionId: sessionId,
-      previousFirstId: previousListState.firstId,
-      previousLastId: previousListState.lastId,
-      currentFirstId: currentFirstGroupedMessageId,
-      currentLastId: currentLastGroupedMessageId,
-      candidatePrependCount,
-      currentCandidateAnchorId:
-        candidatePrependCount > 0
-          ? groupedMessages[candidatePrependCount]?.message.id
-          : undefined,
-      previousHeadIndexInCurrentList,
-      previousLength: previousListState.length,
-      currentLength: groupedMessages.length,
-    });
-  }
 
   const logScrollState = useCallback(
     (
@@ -225,398 +103,88 @@ export function useAgentChatScroll({
     [scrollerElement],
   );
 
-  // Virtuoso can remount the *start* of `data` for a frame when prepending
-  // (react-virtuoso#663), which briefly paints older user bubbles then swaps
-  // back. Pin the previous head before paint so that frame never shows.
-  useLayoutEffect(() => {
-    if (prependCount <= 0) {
-      return;
-    }
+  // 1. Follow state management
+  const {
+    isPinned,
+    isPinnedToBottomRef,
+    visualBottomRef,
+    shouldFollowLatestRef,
+    upwardReleaseDistanceRef,
+    selfScrollIgnoreUntilRef,
+    setEffectivePinnedState,
+    resumeBottomFollow,
+    pauseBottomFollow,
+  } = useScrollFollowState({ logScrollState });
 
-    const virtuoso = virtuosoRef.current;
-    if (!virtuoso) {
-      return;
-    }
+  // 2. Prepend preservation management
+  const {
+    firstItemIndex,
+    effectiveFirstItemIndex,
+    prependCount,
+    isPreservingPrependPositionRef,
+    prependStabilizeTimeoutRef,
+  } = usePrependPreservation({
+    groupedMessages,
+    sessionId,
+    virtuosoRef,
+    selfScrollIgnoreUntilRef,
+    logScrollState,
+  });
 
-    // Old head sits at data index `prependCount` → virtuoso index below.
-    const anchorVirtuosoIndex = effectiveFirstItemIndex + prependCount;
-    logScrollState('prepend-preservation:anchor-scroll', {
-      prependCount,
-      anchorVirtuosoIndex,
-      effectiveFirstItemIndex,
-    });
-    selfScrollIgnoreUntilRef.current =
-      performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
-    virtuoso.scrollToIndex({
-      index: anchorVirtuosoIndex,
-      align: 'start',
-      behavior: 'auto',
-    });
-  }, [effectiveFirstItemIndex, logScrollState, prependCount]);
+  scrollDebugStateRef.current = {
+    sessionId,
+    firstItemIndex,
+    effectiveFirstItemIndex,
+  };
 
   groupedMessageCountRef.current = groupedMessages.length;
 
-  const setEffectivePinnedState = useCallback((nextPinned: boolean) => {
-    isPinnedToBottomRef.current = nextPinned;
-    setIsPinned(nextPinned);
-  }, []);
-
-  const clearBottomAlignmentVerifyFrame = useCallback(() => {
-    if (bottomAlignmentVerifyFrameRef.current !== null) {
-      cancelAnimationFrame(bottomAlignmentVerifyFrameRef.current);
-      bottomAlignmentVerifyFrameRef.current = null;
-    }
-  }, []);
-
-  const clearScheduledAutoScroll = useCallback(() => {
-    if (autoScrollFrameRef.current !== null) {
-      cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-  }, []);
-
-  const setBottomAlignmentPhase = useCallback(
-    (phase: BottomAlignmentPhase, reason: string) => {
-      if (bottomAlignmentPhaseRef.current === phase) {
-        return;
-      }
-
-      bottomAlignmentPhaseRef.current = phase;
-      logScrollState('bottom-alignment:phase', {
-        reason,
-        phase,
-      });
-    },
-    [logScrollState],
-  );
-
-  const requestBottomAlignment = useCallback(
-    (reason: string) => {
-      clearBottomAlignmentVerifyFrame();
-      bottomAlignmentRequestedVersionRef.current =
-        bottomAlignmentLayoutVersionRef.current;
-      setBottomAlignmentPhase('requesting', reason);
-    },
-    [clearBottomAlignmentVerifyFrame, setBottomAlignmentPhase],
-  );
-
-  const abortBottomAlignment = useCallback(
-    (reason: string) => {
-      clearBottomAlignmentVerifyFrame();
-      setBottomAlignmentPhase('aborted', reason);
-    },
-    [clearBottomAlignmentVerifyFrame, setBottomAlignmentPhase],
-  );
-
-  const markBottomAlignmentLayoutChanged = useCallback(
-    (reason: string) => {
-      if (isPreservingPrependPositionRef.current) {
-        logScrollState('bottom-alignment:layout-change-skipped', {
-          reason,
-        });
-        return;
-      }
-
-      bottomAlignmentLayoutVersionRef.current += 1;
-      logScrollState('bottom-alignment:layout-change', {
-        reason,
-        layoutVersion: bottomAlignmentLayoutVersionRef.current,
-      });
-    },
-    [logScrollState],
-  );
-
-  const maybeCompleteBottomAlignment = useCallback(
-    (reason: string) => {
-      if (bottomAlignmentPhaseRef.current !== 'verifying') {
-        return;
-      }
-
-      if (isPreservingPrependPositionRef.current) {
-        return;
-      }
-
-      if (!visualBottomRef.current || !virtuosoAtBottomRef.current) {
-        logScrollState('bottom-alignment:pending', {
-          reason,
-          visualBottom: visualBottomRef.current,
-          virtuosoAtBottom: virtuosoAtBottomRef.current,
-        });
-        return;
-      }
-
-      const layoutVersion = bottomAlignmentLayoutVersionRef.current;
-      if (bottomAlignmentRequestedVersionRef.current !== layoutVersion) {
-        bottomAlignmentRequestedVersionRef.current = layoutVersion;
-        logScrollState('bottom-alignment:version-invalidated', {
-          reason,
-          layoutVersion,
-        });
-        bottomAlignmentVerifyFrameRef.current = requestAnimationFrame(() => {
-          bottomAlignmentVerifyFrameRef.current = null;
-          maybeCompleteBottomAlignment('version-invalidated');
-        });
-        return;
-      }
-
-      clearBottomAlignmentVerifyFrame();
-      setBottomAlignmentPhase('aligned', reason);
-    },
-    [clearBottomAlignmentVerifyFrame, logScrollState, setBottomAlignmentPhase],
-  );
-
-  const scheduleBottomAlignmentVerification = useCallback(
-    (reason: string) => {
-      if (!isBottomAlignmentActive(bottomAlignmentPhaseRef.current)) {
-        return;
-      }
-
-      clearBottomAlignmentVerifyFrame();
-      bottomAlignmentVerifyFrameRef.current = requestAnimationFrame(() => {
-        bottomAlignmentVerifyFrameRef.current = null;
-        maybeCompleteBottomAlignment(reason);
-      });
-    },
-    [clearBottomAlignmentVerifyFrame, maybeCompleteBottomAlignment],
-  );
-
-  const resumeBottomFollow = useCallback(
-    (reason: string) => {
-      upwardReleaseDistanceRef.current = 0;
-      if (shouldFollowLatestRef.current) {
-        return;
-      }
-
-      shouldFollowLatestRef.current = true;
-      setEffectivePinnedState(true);
-      logScrollState('bottom-follow:resume', {
-        reason,
-      });
-    },
-    [logScrollState, setEffectivePinnedState],
-  );
-
-  const pauseBottomFollow = useCallback(
-    (reason: string) => {
-      upwardReleaseDistanceRef.current = 0;
-      if (!shouldFollowLatestRef.current) {
-        return;
-      }
-
-      shouldFollowLatestRef.current = false;
-      setEffectivePinnedState(visualBottomRef.current);
-      logScrollState('bottom-follow:pause', {
-        reason,
-        visualBottom: visualBottomRef.current,
-      });
-    },
-    [logScrollState, setEffectivePinnedState],
-  );
-
-  const executeScrollToBottom = useCallback(
-    (reason: string): boolean => {
-      const itemCount = groupedMessageCountRef.current;
-      // Only force/manual bottom snaps should suppress upward unpin detection.
-      // Streaming follow (reactive/resize/height) must not refresh this window,
-      // or Non-Thinking token streams permanently block scroll-to-top.
-      if (forceBottomScrollReasons.has(reason)) {
-        selfScrollIgnoreUntilRef.current =
-          performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
-      }
-      logScrollState('executeScrollToBottom:start', {
-        itemCount,
-        reason,
-        shouldFollowLatest: shouldFollowLatestRef.current,
-      });
-
-      const scrolledWithVirtuoso = scrollVirtuosoToBottom(
-        virtuosoRef.current,
-        itemCount,
-      );
-
-      if (scrolledWithVirtuoso) {
-        logScrollState('executeScrollToBottom:virtuoso-scroll', {
-          itemCount,
-          reason,
-          scrolledWithVirtuoso: true,
-        });
-      }
-
-      // Virtuoso scrollToIndex(LAST) only aligns the last *data* item. Footer
-      // (composer spacer + sentinel) sits after data items, so always finish
-      // with sentinel alignment or the last ~composer-overlap px stays hidden
-      // behind AgentChatInput (#1647).
-      if (footerEndRef.current) {
-        logScrollState('executeScrollToBottom:footer-sentinel-align', {
-          itemCount,
-          reason,
-          scrolledWithVirtuoso,
-        });
-        scrollFooterSentinelIntoView(footerEndRef.current);
-        return true;
-      }
-
-      // Footer sentinel missing (unmounted / not yet attached). Virtuoso-only
-      // scroll is the best we can do; log so the rare path is visible in debug.
-      if (scrolledWithVirtuoso) {
-        logScrollState('executeScrollToBottom:virtuoso-scroll-no-footer', {
-          itemCount,
-          reason,
-          scrolledWithVirtuoso: true,
-        });
-        return true;
-      }
-
-      logScrollState('executeScrollToBottom:unavailable', {
-        itemCount,
-        reason,
-        scrolledWithVirtuoso: false,
-      });
-      return false;
-    },
-    [forceBottomScrollReasons, logScrollState],
-  );
-
-  useEffect(() => {
-    if (didSessionChangeForListState) {
-      logScrollState('listState:session-changed', {
-        previousSessionId: previousListState.sessionId,
-        nextSessionId: sessionId,
-        groupedMessageCount: groupedMessages.length,
-      });
-      setFirstItemIndex(INITIAL_FIRST_ITEM_INDEX);
-    } else if (prependCount > 0) {
-      isPreservingPrependPositionRef.current = true;
-      if (prependStabilizeTimeoutRef.current !== null) {
-        window.clearTimeout(prependStabilizeTimeoutRef.current);
-      }
-      prependStabilizeTimeoutRef.current = window.setTimeout(() => {
-        prependStabilizeTimeoutRef.current = null;
-        isPreservingPrependPositionRef.current = false;
-        logScrollState('prepend-preservation:settled', {
-          prependCount,
-        });
-      }, 250);
-      logScrollState('prepend-preservation:start', {
-        prependCount,
-      });
-      setFirstItemIndex(effectiveFirstItemIndex);
-    }
-
-    previousListStateRef.current = {
-      firstId: currentFirstGroupedMessageId,
-      lastId: currentLastGroupedMessageId,
-      length: groupedMessages.length,
-      sessionId: sessionId,
-    };
-  }, [
-    currentFirstGroupedMessageId,
-    currentLastGroupedMessageId,
-    didSessionChangeForListState,
-    effectiveFirstItemIndex,
-    groupedMessages.length,
+  // 3. Bottom alignment state machine
+  const {
+    bottomAlignmentPhaseRef,
+    bottomAlignmentLayoutVersionRef,
+    bottomAlignmentRequestedVersionRef,
+    clearBottomAlignmentVerifyFrame,
+    setBottomAlignmentPhase,
+    requestBottomAlignment,
+    abortBottomAlignment,
+    markBottomAlignmentLayoutChanged,
+    scheduleBottomAlignmentVerification,
+  } = useBottomAlignment({
+    isPreservingPrependPositionRef,
     logScrollState,
-    prependCount,
-    sessionId,
-  ]);
+  });
 
-  const scheduleScrollToBottom = useCallback(
-    (reason: string) => {
-      const isForceReason = forceBottomScrollReasons.has(reason);
-      const isNearTop = scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
-      // Near-top history reading must win over sticky follow. Short sessions
-      // (especially Non-Thinking token streams) can reach scrollTop≈0 before
-      // the upward-release distance threshold fires.
-      const shouldForce =
-        isForceReason || (shouldFollowLatestRef.current && !isNearTop);
-      const shouldSuppressForPrepend =
-        isPreservingPrependPositionRef.current && !isForceReason;
-
-      const shouldSuppressForUserScroll =
-        !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
-        !visualBottomRef.current &&
-        !shouldForce;
-
-      const shouldSuppressForNearTop =
-        isNearTop && !visualBottomRef.current && !isForceReason;
-
-      if (
-        shouldSuppressForPrepend ||
-        shouldSuppressForUserScroll ||
-        shouldSuppressForNearTop
-      ) {
-        clearScheduledAutoScroll();
-        logScrollState('scheduleScrollToBottom:suppressed', {
-          reason,
-          shouldSuppressForPrepend,
-          shouldSuppressForUserScroll,
-          shouldSuppressForNearTop,
-          shouldForce,
-        });
-        return;
-      }
-
-      logScrollState('scheduleScrollToBottom', {
-        reason,
-      });
-      clearScheduledAutoScroll();
-
-      autoScrollFrameRef.current = requestAnimationFrame(() => {
-        autoScrollFrameRef.current = null;
-        // Re-check intent inside the frame — a schedule from before scroll-up /
-        // prepend must not run sentinel scrollIntoView and flash bottom content.
-        // Keep these rules identical to the schedule-time suppress checks above.
-        const isForceReasonOnFire = forceBottomScrollReasons.has(reason);
-        const isNearTopOnFire =
-          scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
-        const shouldForceOnFire =
-          isForceReasonOnFire ||
-          (shouldFollowLatestRef.current && !isNearTopOnFire);
-        const shouldSuppressForPrependOnFire =
-          isPreservingPrependPositionRef.current && !isForceReasonOnFire;
-        const shouldSuppressForUserScrollOnFire =
-          !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
-          !visualBottomRef.current &&
-          !shouldForceOnFire;
-        const shouldSuppressForNearTopOnFire =
-          isNearTopOnFire && !visualBottomRef.current && !isForceReasonOnFire;
-
-        if (
-          shouldSuppressForPrependOnFire ||
-          shouldSuppressForUserScrollOnFire ||
-          shouldSuppressForNearTopOnFire
-        ) {
-          logScrollState('scheduleScrollToBottom:frame-suppressed', {
-            reason,
-            isPreservingPrepend: isPreservingPrependPositionRef.current,
-            isNearTop: isNearTopOnFire,
-            shouldFollowLatest: shouldFollowLatestRef.current,
-            visualBottom: visualBottomRef.current,
-          });
-          return;
-        }
-
-        logScrollState('scheduleScrollToBottom:frame-fired', {
-          reason,
-        });
-        const didScroll = executeScrollToBottom(reason);
-        if (didScroll && bottomAlignmentPhaseRef.current === 'requesting') {
-          bottomAlignmentRequestedVersionRef.current =
-            bottomAlignmentLayoutVersionRef.current;
-          setBottomAlignmentPhase('verifying', `scroll-dispatched:${reason}`);
-          scheduleBottomAlignmentVerification(`scroll-dispatched:${reason}`);
-        }
-      });
-    },
-    [
-      clearScheduledAutoScroll,
-      executeScrollToBottom,
-      forceBottomScrollReasons,
-      logScrollState,
-      scheduleBottomAlignmentVerification,
+  // 4. Scroll scheduler logic
+  const { clearScheduledAutoScroll, scheduleScrollToBottom } =
+    useScrollScheduler({
+      virtuosoRef,
+      footerEndRef,
+      groupedMessageCountRef,
+      selfScrollIgnoreUntilRef,
+      shouldFollowLatestRef,
+      isPreservingPrependPositionRef,
+      bottomAlignmentPhaseRef,
+      bottomAlignmentLayoutVersionRef,
+      bottomAlignmentRequestedVersionRef,
+      visualBottomRef,
+      scrollTopRef,
       setBottomAlignmentPhase,
-    ],
-  );
+      scheduleBottomAlignmentVerification,
+      logScrollState,
+    });
+
+  // 5. Hydration tracking
+  const { hasHydratedMessagesRef } = useHydrationTracking({
+    sessionId,
+    groupedMessagesLength: groupedMessages.length,
+    isPinnedToBottomRef,
+    isPreservingPrependPositionRef,
+    prependStabilizeTimeoutRef,
+    requestBottomAlignment,
+    scheduleScrollToBottom,
+    logScrollState,
+  });
 
   const handleResizeObserverLayoutChange = useCallback(
     (reason: 'content-resize-observer' | 'scroller-resize-observer') => {
@@ -625,7 +193,11 @@ export function useAgentChatScroll({
       }
 
       markBottomAlignmentLayoutChanged(reason);
-      scheduleBottomAlignmentVerification(reason);
+      scheduleBottomAlignmentVerification(
+        reason,
+        visualBottomRef.current,
+        virtuosoAtBottomRef.current,
+      );
       if (
         !shouldFollowLatestRef.current &&
         !visualBottomRef.current &&
@@ -634,13 +206,17 @@ export function useAgentChatScroll({
         return;
       }
 
-      scheduleScrollToBottom(reason);
+      scheduleScrollToBottom(reason, virtuosoAtBottomRef.current);
     },
     [
+      isPreservingPrependPositionRef,
       markBottomAlignmentLayoutChanged,
+      bottomAlignmentPhaseRef,
       prependCount,
       scheduleBottomAlignmentVerification,
       scheduleScrollToBottom,
+      shouldFollowLatestRef,
+      visualBottomRef,
     ],
   );
 
@@ -651,10 +227,14 @@ export function useAgentChatScroll({
         atBottom,
       });
       if (atBottom) {
-        scheduleBottomAlignmentVerification('at-bottom-state-change');
+        scheduleBottomAlignmentVerification(
+          'at-bottom-state-change',
+          visualBottomRef.current,
+          atBottom,
+        );
       }
     },
-    [logScrollState, scheduleBottomAlignmentVerification],
+    [logScrollState, scheduleBottomAlignmentVerification, visualBottomRef],
   );
 
   const handleTotalListHeightChanged = useCallback(
@@ -678,7 +258,11 @@ export function useAgentChatScroll({
       }
 
       markBottomAlignmentLayoutChanged('total-list-height-changed');
-      scheduleBottomAlignmentVerification('total-list-height-changed');
+      scheduleBottomAlignmentVerification(
+        'total-list-height-changed',
+        visualBottomRef.current,
+        virtuosoAtBottomRef.current,
+      );
 
       if (
         !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
@@ -690,17 +274,25 @@ export function useAgentChatScroll({
         return;
       }
 
-      scheduleScrollToBottom('total-list-height-changed');
+      scheduleScrollToBottom(
+        'total-list-height-changed',
+        virtuosoAtBottomRef.current,
+      );
     },
     [
+      bottomAlignmentPhaseRef,
+      isPinnedToBottomRef,
+      isPreservingPrependPositionRef,
       logScrollState,
       markBottomAlignmentLayoutChanged,
       prependCount,
       scheduleBottomAlignmentVerification,
       scheduleScrollToBottom,
+      visualBottomRef,
     ],
   );
 
+  // Session change reset effect
   useEffect(() => {
     setBottomAlignmentPhase('idle', 'session-reset');
     clearBottomAlignmentVerifyFrame();
@@ -721,18 +313,26 @@ export function useAgentChatScroll({
     scrollTopRef.current = 0;
     logScrollState('sessionEffect:reset-bottom-alignment');
     requestBottomAlignment('session-changed');
-    scheduleScrollToBottom('session-changed');
+    scheduleScrollToBottom('session-changed', false);
   }, [
+    bottomAlignmentLayoutVersionRef,
+    bottomAlignmentRequestedVersionRef,
     clearBottomAlignmentVerifyFrame,
     clearScheduledAutoScroll,
+    isPreservingPrependPositionRef,
     logScrollState,
+    prependStabilizeTimeoutRef,
     requestBottomAlignment,
     scheduleScrollToBottom,
     sessionId,
-    setEffectivePinnedState,
     setBottomAlignmentPhase,
+    setEffectivePinnedState,
+    shouldFollowLatestRef,
+    upwardReleaseDistanceRef,
+    visualBottomRef,
   ]);
 
+  // Unmount cleanup
   useEffect(() => {
     return () => {
       clearScheduledAutoScroll();
@@ -742,8 +342,13 @@ export function useAgentChatScroll({
       }
       clearBottomAlignmentVerifyFrame();
     };
-  }, [clearBottomAlignmentVerifyFrame, clearScheduledAutoScroll]);
+  }, [
+    clearBottomAlignmentVerifyFrame,
+    clearScheduledAutoScroll,
+    prependStabilizeTimeoutRef,
+  ]);
 
+  // DOM scroll listener
   useEffect(() => {
     if (!scrollerElement) {
       return;
@@ -791,8 +396,6 @@ export function useAgentChatScroll({
           }
         }
 
-        // True list top is enough intent to stop follow even on a single
-        // short upward gesture (common when the older-messages Header is idle).
         if (
           shouldFollowLatestRef.current &&
           !isPreservingPrependPositionRef.current &&
@@ -811,7 +414,11 @@ export function useAgentChatScroll({
         clearScheduledAutoScroll();
       }
 
-      scheduleBottomAlignmentVerification('scroll:updatePinnedState');
+      scheduleBottomAlignmentVerification(
+        'scroll:updatePinnedState',
+        visualPinned,
+        virtuosoAtBottomRef.current,
+      );
 
       setEffectivePinnedState(visualPinned || shouldFollowLatestRef.current);
       logScrollState('scroll:updatePinnedState', {
@@ -823,6 +430,7 @@ export function useAgentChatScroll({
         upwardReleaseDistance: upwardReleaseDistanceRef.current,
       });
     };
+
     const handleScroll = () => {
       updatePinnedState();
     };
@@ -837,52 +445,17 @@ export function useAgentChatScroll({
     abortBottomAlignment,
     bottomThreshold,
     clearScheduledAutoScroll,
+    isPreservingPrependPositionRef,
     logScrollState,
     pauseBottomFollow,
     resumeBottomFollow,
     scheduleBottomAlignmentVerification,
     scrollerElement,
+    selfScrollIgnoreUntilRef,
     setEffectivePinnedState,
-  ]);
-
-  useEffect(() => {
-    const trackedSessionId = hasHydratedMessagesRef.current.sessionId;
-
-    if (trackedSessionId !== sessionId) {
-      hasHydratedMessagesRef.current = {
-        sessionId: sessionId,
-        hasMessages: groupedMessages.length > 0,
-      };
-      logScrollState('hydration:tracked-session-changed', {
-        hasMessages: groupedMessages.length > 0,
-      });
-      return;
-    }
-
-    if (
-      !hasHydratedMessagesRef.current.hasMessages &&
-      groupedMessages.length > 0 &&
-      isPinnedToBottomRef.current
-    ) {
-      isPreservingPrependPositionRef.current = false;
-      if (prependStabilizeTimeoutRef.current !== null) {
-        window.clearTimeout(prependStabilizeTimeoutRef.current);
-        prependStabilizeTimeoutRef.current = null;
-      }
-      requestBottomAlignment('hydrated-messages-arrived');
-      logScrollState('hydration:messages-arrived');
-      scheduleScrollToBottom('hydrated-messages-arrived');
-    }
-
-    if (groupedMessages.length > 0) {
-      hasHydratedMessagesRef.current.hasMessages = true;
-    }
-  }, [
-    groupedMessages.length,
-    logScrollState,
-    requestBottomAlignment,
-    scheduleScrollToBottom,
-    sessionId,
+    shouldFollowLatestRef,
+    upwardReleaseDistanceRef,
+    visualBottomRef,
   ]);
 
   const handleManualScrollToBottom = useCallback(() => {
@@ -892,15 +465,21 @@ export function useAgentChatScroll({
     resumeBottomFollow('manual-scroll-to-bottom');
     setEffectivePinnedState(true);
     logScrollState('scrollToBottom:manual');
-    scheduleScrollToBottom('manual-scroll-to-bottom');
+    scheduleScrollToBottom(
+      'manual-scroll-to-bottom',
+      virtuosoAtBottomRef.current,
+    );
   }, [
     logScrollState,
     requestBottomAlignment,
     resumeBottomFollow,
     scheduleScrollToBottom,
     setEffectivePinnedState,
+    upwardReleaseDistanceRef,
+    visualBottomRef,
   ]);
 
+  // Content ResizeObserver
   useEffect(() => {
     const content = getScrollContentElement(scrollerElement);
 
@@ -919,6 +498,7 @@ export function useAgentChatScroll({
     };
   }, [handleResizeObserverLayoutChange, scrollerElement]);
 
+  // Scroller ResizeObserver
   useEffect(() => {
     if (!scrollerElement || typeof ResizeObserver === 'undefined') {
       return;
@@ -935,14 +515,11 @@ export function useAgentChatScroll({
     };
   }, [handleResizeObserverLayoutChange, scrollerElement]);
 
+  // Reactive state change tracking
   useEffect(() => {
     const previousLatestMessage = previousLatestMessageRef.current;
     previousLatestMessageRef.current = latestMessage;
 
-    // Only re-arm follow when the viewport is actually at the visual bottom.
-    // Using alignment-active here re-enabled follow after the user scrolled up
-    // during session hydrate / bottom snap, which fought their scroll intent
-    // and caused stick-to-bottom yank/glitch on the next content resize.
     if (
       groupedMessages.length > 0 &&
       hasHydratedMessagesRef.current.hasMessages &&
@@ -977,7 +554,10 @@ export function useAgentChatScroll({
       return;
     }
 
-    scheduleScrollToBottom('reactive-state-change');
+    scheduleScrollToBottom(
+      'reactive-state-change',
+      virtuosoAtBottomRef.current,
+    );
   }, [
     latestMessage,
     workflowStatus,
@@ -985,10 +565,15 @@ export function useAgentChatScroll({
     agentError,
     agentLlmError,
     groupedMessages.length,
+    hasHydratedMessagesRef,
+    isPinnedToBottomRef,
+    isPreservingPrependPositionRef,
     logScrollState,
     prependCount,
     resumeBottomFollow,
     scheduleScrollToBottom,
+    shouldFollowLatestRef,
+    visualBottomRef,
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- Split monolithic 1,009-line hook (`useAgentChatScroll.ts`) into 5 dedicated sub-hooks (`usePrependPreservation`, `useBottomAlignment`, `useScrollFollowState`, `useScrollScheduler`, `useHydrationTracking`) while preserving public API contracts.
- Split oversized 1,053-line test suite (`AgentChatMessages.scroll-follow.test.tsx`) into modular test specs (`intent.test.tsx`, `streaming.test.tsx`) and a shared test harness (`scroll-follow.harness.ts`).

Fixes #1658

## Test Plan
- [x] Run `pnpm test:run AgentChatMessages` (all 36 component tests passed)
- [x] Run full validation pipeline `pnpm refactor:validate` (all 18 steps passed cleanly)