### PR TITLE
fix(env): recover Windows PATH from registry for isolated processes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4358,6 +4358,7 @@ dependencies = [
  "walkdir",
  "warp",
  "windows-sys 0.59.0",
+ "winreg 0.55.0",
  "zip 0.6.6",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,8 +74,12 @@ handlebars = "6.4"
 ammonia = "4.0"
 jsonschema = "0.49"
 
-# Windows-only: decode process output captured from stdio pipes using the system ANSI code page
-windows-sys = { version = "0.59", features = ["Win32_Globalization"] }
+# Windows-only: ANSI code-page decode for stdio; ExpandEnvironmentStrings for registry PATH
+windows-sys = { version = "0.59", features = ["Win32_Globalization", "Win32_System_Environment"] }
+
+[target.'cfg(windows)'.dependencies]
+# Read HKCU/HKLM Path so GUI-launched isolation recovers user tool dirs (cargo, uv, npm, …)
+winreg = "0.55"
 
 # File parsing dependencies
 docx-rs = "0.4"           # DOCX parsing

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,10 +77,6 @@ jsonschema = "0.49"
 # Windows-only: ANSI code-page decode for stdio; ExpandEnvironmentStrings for registry PATH
 windows-sys = { version = "0.59", features = ["Win32_Globalization", "Win32_System_Environment"] }
 
-[target.'cfg(windows)'.dependencies]
-# Read HKCU/HKLM Path so GUI-launched isolation recovers user tool dirs (cargo, uv, npm, …)
-winreg = "0.55"
-
 # File parsing dependencies
 docx-rs = "0.4"           # DOCX parsing
 calamine = { version = "0.36", features = ["dates"] }  # XLSX parsing
@@ -103,6 +99,10 @@ libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 tauri-plugin-mcp-bridge = "0.12.0"
 sqlite-vec = "0.1.9"
 fastembed = "5.15.0"
+
+[target.'cfg(windows)'.dependencies]
+# Read HKCU/HKLM Path so GUI-launched isolation recovers user tool dirs (cargo, uv, npm, …)
+winreg = "0.55"
 
 [features]
 default = ["workspace-str-replace"]

--- a/src-tauri/src/mcp/session_isolation/stdio_manager/lifecycle.rs
+++ b/src-tauri/src/mcp/session_isolation/stdio_manager/lifecycle.rs
@@ -226,6 +226,8 @@ fn log_spawn_path_diagnostics(server_name: &str, command: &str) {
         "Scripts",
         ".local\\bin",
         ".local/bin",
+        ".cargo\\bin",
+        ".cargo/bin",
     ];
     let matched_markers: Vec<&str> = markers
         .iter()

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -52,7 +52,8 @@ pub async fn create_basic_isolated_command(
     // Apply environment isolation: clear all inherited environment variables
     cmd.env_clear();
 
-    // Re-apply whitelisted essential system variables (PATH includes discovered Python/pip/pipx dirs)
+    // Re-apply whitelisted essential system variables.
+    // PATH is rebuilt via registry User/Machine Path + discovered tool dirs (see get_effective_path).
     for (k, v) in crate::utils::env::get_isolated_env() {
         cmd.env(k, v);
     }
@@ -70,7 +71,7 @@ pub async fn create_basic_isolated_command(
         cmd.env(key, value);
     }
 
-    info!("Windows environment configured: workspace isolated, PATH preserved (with discovered tool dirs)");
+    info!("Windows environment configured: workspace isolated, PATH rebuilt from registry + discovered tool dirs");
     let path_len = crate::utils::env::get_effective_path().len();
     let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "<not-set>".to_string());
     let comspec = std::env::var("COMSPEC").unwrap_or_else(|_| "<not-set>".to_string());

--- a/src-tauri/src/utils/env.rs
+++ b/src-tauri/src/utils/env.rs
@@ -115,8 +115,8 @@ fn merge_path_values(preferred: &OsStr, fallback: &OsStr) -> Option<OsString> {
     }
 }
 
-// Discovered/shell paths are prepended so user-local tool dirs (e.g. Python Scripts)
-// win over WindowsApps shims. Host PATH entries still follow and remain reachable.
+// Discovered/shell/registry paths are prepended so user-local tool dirs (e.g. Python Scripts,
+// cargo/uv from HKCU Path) win over WindowsApps shims. Host PATH entries still follow.
 fn merge_with_current_path(preferred: OsString, current_path: Option<OsString>) -> OsString {
     let merged = current_path
         .as_ref()
@@ -143,14 +143,44 @@ pub fn get_effective_path_os() -> OsString {
 
     #[cfg(windows)]
     {
-        if let Some(discovered) =
-            crate::utils::windows_path_discovery::get_windows_discovered_path_os()
-        {
-            return merge_with_current_path(discovered, current_path);
-        }
+        compose_windows_effective_path(
+            crate::utils::windows_path_discovery::get_windows_discovered_path_os(),
+            crate::utils::windows_registry_path::get_windows_registry_path_os(),
+            current_path,
+        )
     }
 
-    current_path.unwrap_or_else(|| OsString::from(default_path()))
+    // Non-Windows without a successful Unix shell probe: keep process PATH (or defaults).
+    #[cfg(not(windows))]
+    {
+        current_path.unwrap_or_else(|| OsString::from(default_path()))
+    }
+}
+
+/// Build the Windows effective PATH used by isolated child processes.
+///
+/// Order (first wins for duplicates):
+/// 1. Discovered tool dirs (Python Scripts ahead of WindowsApps shims)
+/// 2. Registry Machine+User Path (GUI-stripped process PATH recovery)
+/// 3. Current process PATH
+/// 4. Hard-coded system default if everything is empty
+#[cfg(windows)]
+pub fn compose_windows_effective_path(
+    discovered: Option<OsString>,
+    registry: Option<OsString>,
+    current_path: Option<OsString>,
+) -> OsString {
+    let mut base = current_path;
+
+    if let Some(registry_path) = registry {
+        base = Some(merge_with_current_path(registry_path, base));
+    }
+
+    if let Some(discovered_path) = discovered {
+        return merge_with_current_path(discovered_path, base);
+    }
+
+    base.unwrap_or_else(|| OsString::from(default_path()))
 }
 
 pub fn get_effective_path() -> String {

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -10,6 +10,8 @@ pub mod sqlite;
 pub mod terminal;
 #[cfg(windows)]
 pub mod windows_path_discovery;
+#[cfg(windows)]
+pub mod windows_registry_path;
 
 /// Safely truncates a string to a maximum number of characters.
 /// If truncated, adds an ellipsis (...) to the end.

--- a/src-tauri/src/utils/windows_registry_path.rs
+++ b/src-tauri/src/utils/windows_registry_path.rs
@@ -1,0 +1,105 @@
+//! Recover the full Windows PATH from the registry.
+//!
+//! GUI-launched processes (Explorer, Start menu, some installers) often inherit a
+//! stripped process PATH that omits user-local tool directories still present in
+//! `HKCU\Environment\Path`. Isolated child processes clear the host env and rebuild
+//! PATH via [`crate::utils::env::get_effective_path`]; without a registry probe those
+//! directories are permanently lost (unlike Unix, where a login-shell PATH probe runs).
+//!
+//! Construction order matches Windows: Machine Path, then User Path.
+
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::sync::OnceLock;
+
+use windows_sys::Win32::System::Environment::ExpandEnvironmentStringsW;
+use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_EXPAND_SZ, REG_SZ};
+use winreg::RegKey;
+
+const MACHINE_ENV_SUBKEY: &str = r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+const USER_ENV_SUBKEY: &str = r"Environment";
+
+/// Cached Machine+User PATH from the Windows registry (expanded).
+pub fn get_windows_registry_path_os() -> Option<OsString> {
+    static CACHED: OnceLock<Option<OsString>> = OnceLock::new();
+    CACHED.get_or_init(read_windows_registry_path).clone()
+}
+
+fn read_windows_registry_path() -> Option<OsString> {
+    let machine = read_registry_path_value(HKEY_LOCAL_MACHINE, MACHINE_ENV_SUBKEY);
+    let user = read_registry_path_value(HKEY_CURRENT_USER, USER_ENV_SUBKEY);
+
+    match (machine, user) {
+        (Some(machine_path), Some(user_path)) => {
+            merge_path_os(machine_path.as_os_str(), user_path.as_os_str())
+        }
+        (Some(machine_path), None) => Some(machine_path),
+        (None, Some(user_path)) => Some(user_path),
+        (None, None) => None,
+    }
+}
+
+fn read_registry_path_value(hive: winreg::HKEY, subkey: &str) -> Option<OsString> {
+    let root = RegKey::predef(hive);
+    let key = root.open_subkey(subkey).ok()?;
+    let raw = key.get_raw_value("Path").ok()?;
+    let stored = raw.to_string();
+    if stored.trim().is_empty() {
+        return None;
+    }
+
+    match raw.vtype {
+        REG_EXPAND_SZ => expand_environment_strings(&stored),
+        REG_SZ => Some(OsString::from(stored)),
+        _ => Some(OsString::from(stored)),
+    }
+}
+
+fn expand_environment_strings(input: &str) -> Option<OsString> {
+    let wide: Vec<u16> = OsStr::new(input)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // First call queries required length (chars including NUL).
+    // SAFETY: `wide` is a valid NUL-terminated UTF-16 buffer owned by this stack frame.
+    // Passing a null destination with nSize=0 is the documented size-query pattern for
+    // ExpandEnvironmentStringsW; the API does not write through a null lpDst in that case.
+    let required = unsafe { ExpandEnvironmentStringsW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if required == 0 {
+        return Some(OsString::from(input));
+    }
+
+    let mut buffer = vec![0u16; required as usize];
+    // SAFETY: `wide` remains a valid NUL-terminated source; `buffer` has exactly `required`
+    // UTF-16 slots as reported by the size-query call above. ExpandEnvironmentStringsW is
+    // safe to call concurrently for distinct buffers.
+    let written =
+        unsafe { ExpandEnvironmentStringsW(wide.as_ptr(), buffer.as_mut_ptr(), required) };
+    if written == 0 || written > required {
+        return Some(OsString::from(input));
+    }
+
+    // written includes the terminating NUL.
+    let len = (written as usize).saturating_sub(1);
+    Some(OsString::from_wide(&buffer[..len]))
+}
+
+fn merge_path_os(first: &OsStr, second: &OsStr) -> Option<OsString> {
+    let mut merged = Vec::new();
+
+    for source in [first, second] {
+        for path in std::env::split_paths(source) {
+            if path.as_os_str().is_empty() || merged.iter().any(|existing| existing == &path) {
+                continue;
+            }
+            merged.push(path);
+        }
+    }
+
+    if merged.is_empty() {
+        None
+    } else {
+        std::env::join_paths(merged).ok()
+    }
+}

--- a/src-tauri/tests/integration/path_env_recovery_tests.rs
+++ b/src-tauri/tests/integration/path_env_recovery_tests.rs
@@ -20,24 +20,5 @@ fn test_isolated_env_uses_effective_path() {
     assert_eq!(isolated_path, effective_path);
 }
 
-#[cfg(windows)]
-#[test]
-fn test_effective_path_includes_discovered_python_scripts_when_present() {
-    use tauri_mcp_agent_lib::utils::windows_path_discovery::find_python_install_root;
-
-    let Some(python_root) = find_python_install_root() else {
-        return;
-    };
-
-    let scripts_dir = python_root.join("Scripts");
-    if !scripts_dir.is_dir() {
-        return;
-    }
-
-    let effective_path = get_effective_path();
-    assert!(
-        effective_path.contains(&scripts_dir.to_string_lossy().replace('/', "\\"))
-            || effective_path.contains(scripts_dir.to_string_lossy().as_ref()),
-        "effective PATH should prepend discovered Python Scripts directory"
-    );
-}
+// Windows registry PATH recovery lives in `windows_path_env_recovery_tests.rs`
+// because this consolidated integration binary is `cfg(not(windows))`.

--- a/src-tauri/tests/windows_path_env_recovery_tests.rs
+++ b/src-tauri/tests/windows_path_env_recovery_tests.rs
@@ -1,0 +1,149 @@
+//! Windows PATH recovery for isolated processes.
+//!
+//! Kept as a standalone test binary: `tests/integration_tests.rs` is
+//! `#![cfg(not(windows))]` due to WebView link crashes on Windows.
+
+#![cfg(windows)]
+
+use std::ffi::{OsStr, OsString};
+use tauri_mcp_agent_lib::utils::env::{
+    compose_windows_effective_path, get_effective_path, get_isolated_env,
+};
+use tauri_mcp_agent_lib::utils::windows_path_discovery::find_python_install_root;
+use tauri_mcp_agent_lib::utils::windows_registry_path::get_windows_registry_path_os;
+
+#[test]
+fn test_effective_path_is_not_empty() {
+    let effective_path = get_effective_path();
+    assert!(
+        !effective_path.trim().is_empty(),
+        "effective PATH should never be empty"
+    );
+}
+
+#[test]
+fn test_isolated_env_uses_effective_path() {
+    let effective_path = get_effective_path();
+    let isolated_path = get_isolated_env()
+        .into_iter()
+        .find_map(|(key, value)| (key == "PATH").then_some(value))
+        .expect("isolated env should always include PATH");
+
+    assert_eq!(isolated_path, effective_path);
+}
+
+#[test]
+fn test_effective_path_includes_discovered_python_scripts_when_present() {
+    let Some(python_root) = find_python_install_root() else {
+        return;
+    };
+
+    let scripts_dir = python_root.join("Scripts");
+    if !scripts_dir.is_dir() {
+        return;
+    }
+
+    let effective_path = get_effective_path();
+    assert!(
+        effective_path.contains(&scripts_dir.to_string_lossy().replace('/', "\\"))
+            || effective_path.contains(scripts_dir.to_string_lossy().as_ref()),
+        "effective PATH should prepend discovered Python Scripts directory"
+    );
+}
+
+#[test]
+fn test_registry_path_is_readable_and_non_empty() {
+    let registry =
+        get_windows_registry_path_os().expect("Windows registry Path should be readable");
+    assert!(
+        !registry.is_empty(),
+        "registry Machine+User Path should not be empty"
+    );
+}
+
+#[test]
+fn test_compose_recovers_registry_dirs_missing_from_stripped_process_path() {
+    let registry =
+        get_windows_registry_path_os().expect("Windows registry Path should be readable");
+
+    // Simulate Explorer/GUI-launched PATH that omits user tool directories.
+    let stripped = OsString::from(r"C:\Windows\System32;C:\Windows");
+    let effective = compose_windows_effective_path(None, Some(registry.clone()), Some(stripped));
+
+    let effective_dirs: Vec<_> = std::env::split_paths(&effective).collect();
+    for dir in std::env::split_paths(&registry) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        assert!(
+            effective_dirs.iter().any(|existing| existing == &dir),
+            "stripped process PATH recovery should keep registry entry: {}",
+            dir.display()
+        );
+    }
+}
+
+#[test]
+fn test_compose_keeps_discovered_dirs_ahead_of_registry() {
+    let discovered = OsString::from(r"C:\Discovered\Python\Scripts");
+    let registry = OsString::from(r"C:\Windows\System32;C:\Users\test\.cargo\bin");
+    let current = OsString::from(r"C:\Windows");
+
+    let effective = compose_windows_effective_path(Some(discovered), Some(registry), Some(current));
+    let parts: Vec<_> = std::env::split_paths(&effective)
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(
+        parts.first().map(String::as_str),
+        Some(r"C:\Discovered\Python\Scripts")
+    );
+    assert!(parts.iter().any(|p| p == r"C:\Users\test\.cargo\bin"));
+    assert!(parts.iter().any(|p| p == r"C:\Windows\System32"));
+}
+
+#[test]
+fn test_effective_path_includes_cargo_bin_when_present_on_user_path() {
+    let Some(home) = std::env::var_os("USERPROFILE") else {
+        return;
+    };
+    let cargo_bin = std::path::PathBuf::from(home).join(".cargo").join("bin");
+    if !cargo_bin.is_dir() {
+        return;
+    }
+
+    let registry = match get_windows_registry_path_os() {
+        Some(path) => path,
+        None => return,
+    };
+
+    let cargo_in_registry = std::env::split_paths(&registry).any(|dir| dir == cargo_bin);
+    if !cargo_in_registry {
+        // Installed but not on User PATH — registry recovery cannot invent it.
+        return;
+    }
+
+    let effective = get_effective_path();
+    let cargo_text = cargo_bin.to_string_lossy();
+    assert!(
+        effective
+            .to_ascii_lowercase()
+            .contains(&cargo_text.to_ascii_lowercase().replace('/', "\\"))
+            || effective
+                .to_ascii_lowercase()
+                .contains(&cargo_text.to_ascii_lowercase()),
+        "effective PATH should include registry .cargo\\bin when present: {cargo_text}"
+    );
+}
+
+#[test]
+fn test_compose_prefers_registry_over_empty_process_path() {
+    let registry = OsString::from(r"C:\Users\test\.cargo\bin");
+    let effective = compose_windows_effective_path(None, Some(registry), None);
+    let parts: Vec<_> = std::env::split_paths(&effective).collect();
+    assert_eq!(parts.len(), 1);
+    assert_eq!(
+        parts[0].as_os_str(),
+        OsStr::new(r"C:\Users\test\.cargo\bin")
+    );
+}


### PR DESCRIPTION
## Summary
- Rebuild isolated Windows PATH from HKLM + HKCU registry Path (Unix shell-probe equivalent) so GUI-launched apps keep user tool dirs after `env_clear()`.
- Keep discovered tool dirs (e.g. Python Scripts) prepended ahead of registry/process PATH for WindowsApps shim priority.
- Add Windows-safe PATH recovery tests (consolidated integration binary is `cfg(not(windows))`).

Fixes #1674

## Test plan
- [ ] `cargo test --test windows_path_env_recovery_tests --manifest-path src-tauri/Cargo.toml`
- [ ] `cargo clippy --lib --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [ ] Launch LibrAgent from Explorer (not a terminal), run `cargo --version` / `uv --version` via workspace shell and confirm they resolve when present on User PATH

Made with [Cursor](https://cursor.com)