### PR TITLE
fix(env): discover Cargo and CLI tool paths for Windows isolation

### DIFF
--- a/src-tauri/src/session_isolation/common.rs
+++ b/src-tauri/src/session_isolation/common.rs
@@ -65,8 +65,55 @@ pub fn get_restricted_path() -> String {
                     .to_string_lossy()
                     .to_string(),
             );
+            paths.push(
+                home_path
+                    .join(".bun")
+                    .join("bin")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+            paths.push(
+                home_path
+                    .join(".volta")
+                    .join("bin")
+                    .to_string_lossy()
+                    .to_string(),
+            );
         }
 
         paths.join(":")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_restricted_path_includes_cargo_bin_on_unix() {
+        if cfg!(windows) {
+            return;
+        }
+
+        let Ok(home) = std::env::var("HOME") else {
+            return;
+        };
+
+        let cargo_bin = PathBuf::from(home).join(".cargo").join("bin");
+        let restricted = get_restricted_path();
+        assert!(
+            restricted.contains(cargo_bin.to_string_lossy().as_ref()),
+            "Unix restricted PATH should include ~/.cargo/bin; got: {restricted}"
+        );
+        assert!(
+            restricted.contains(
+                PathBuf::from(&home)
+                    .join(".bun")
+                    .join("bin")
+                    .to_string_lossy()
+                    .as_ref()
+            ),
+            "Unix restricted PATH should include ~/.bun/bin"
+        );
     }
 }

--- a/src-tauri/src/session_isolation/platforms/windows.rs
+++ b/src-tauri/src/session_isolation/platforms/windows.rs
@@ -52,7 +52,8 @@ pub async fn create_basic_isolated_command(
     // Apply environment isolation: clear all inherited environment variables
     cmd.env_clear();
 
-    // Re-apply whitelisted essential system variables (PATH includes discovered Python/pip/pipx dirs)
+    // Re-apply whitelisted essential system variables
+    // (PATH includes discovered Python/Cargo/Node CLI tool dirs)
     for (k, v) in crate::utils::env::get_isolated_env() {
         cmd.env(k, v);
     }

--- a/src-tauri/src/utils/env.rs
+++ b/src-tauri/src/utils/env.rs
@@ -115,8 +115,8 @@ fn merge_path_values(preferred: &OsStr, fallback: &OsStr) -> Option<OsString> {
     }
 }
 
-// Discovered/shell paths are prepended so user-local tool dirs (e.g. Python Scripts)
-// win over WindowsApps shims. Host PATH entries still follow and remain reachable.
+// Discovered/shell paths are prepended so user-local tool dirs (e.g. Python Scripts,
+// Cargo bin, Node managers) win over WindowsApps shims. Host PATH entries still follow.
 fn merge_with_current_path(preferred: OsString, current_path: Option<OsString>) -> OsString {
     let merged = current_path
         .as_ref()

--- a/src-tauri/src/utils/windows_path_discovery.rs
+++ b/src-tauri/src/utils/windows_path_discovery.rs
@@ -2,9 +2,9 @@ use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-/// Cached PATH prefix discovered from common Python/pip/pipx install locations.
+/// Cached PATH prefix discovered from common user/dev tool install locations.
 /// GUI-launched Windows apps often inherit a stripped PATH that omits user-local
-/// tool directories where `jupyter`, `pip`, and pipx shims are installed.
+/// directories for Python/pip/pipx, Cargo/Rust, Node package managers, and similar CLIs.
 pub fn get_windows_discovered_path_os() -> Option<OsString> {
     static DISCOVERED: OnceLock<Option<OsString>> = OnceLock::new();
     DISCOVERED
@@ -91,24 +91,73 @@ fn discover_windows_tool_paths() -> Vec<PathBuf> {
         push_unique_dir(&mut paths, &python_root.join("Library").join("bin"));
     }
 
-    if let Ok(appdata) = std::env::var("APPDATA") {
-        collect_versioned_scripts_dirs(&PathBuf::from(appdata).join("Python"), &mut paths);
+    let user_profile = std::env::var_os("USERPROFILE").map(PathBuf::from);
+    let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
+    let localappdata = std::env::var_os("LOCALAPPDATA").map(PathBuf::from);
+    let program_files = std::env::var_os("ProgramFiles").map(PathBuf::from);
+
+    if let Some(ref appdata) = appdata {
+        collect_versioned_scripts_dirs(&appdata.join("Python"), &mut paths);
     }
 
-    if let Ok(localappdata) = std::env::var("LOCALAPPDATA") {
-        collect_versioned_scripts_dirs(
-            &PathBuf::from(localappdata).join("Programs").join("Python"),
-            &mut paths,
-        );
+    if let Some(ref localappdata) = localappdata {
+        collect_versioned_scripts_dirs(&localappdata.join("Programs").join("Python"), &mut paths);
     }
 
-    if let Ok(profile) = std::env::var("USERPROFILE") {
-        push_unique_dir(
-            &mut paths,
-            &PathBuf::from(profile).join(".local").join("bin"),
-        );
+    for dir in collect_windows_user_tool_dirs(
+        user_profile.as_deref(),
+        appdata.as_deref(),
+        localappdata.as_deref(),
+        program_files.as_deref(),
+    ) {
+        push_unique_dir(&mut paths, &dir);
     }
 
+    paths
+}
+
+/// Well-known Windows user/dev CLI install dirs (Cargo, Node managers, Scoop, etc.).
+/// Only existing directories are returned so isolated PATH stays lean.
+pub fn collect_windows_user_tool_dirs(
+    user_profile: Option<&Path>,
+    appdata: Option<&Path>,
+    localappdata: Option<&Path>,
+    program_files: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(profile) = user_profile {
+        candidates.push(profile.join(".local").join("bin"));
+        // rustup / cargo / many rustup-installed CLIs (often also hosts `uv`)
+        candidates.push(profile.join(".cargo").join("bin"));
+        candidates.push(profile.join(".bun").join("bin"));
+        candidates.push(profile.join(".volta").join("bin"));
+        candidates.push(profile.join("scoop").join("shims"));
+        // fnm default root may hold current Node shims depending on install mode
+        candidates.push(profile.join(".fnm"));
+    }
+
+    if let Some(appdata) = appdata {
+        candidates.push(appdata.join("npm"));
+        candidates.push(appdata.join("pnpm"));
+        candidates.push(appdata.join("fnm"));
+    }
+
+    if let Some(localappdata) = localappdata {
+        // Default PNPM_HOME on Windows
+        candidates.push(localappdata.join("pnpm"));
+        candidates.push(localappdata.join("Programs").join("nodejs"));
+        candidates.push(localappdata.join("fnm"));
+    }
+
+    if let Some(program_files) = program_files {
+        candidates.push(program_files.join("nodejs"));
+    }
+
+    let mut paths = Vec::new();
+    for candidate in candidates {
+        push_unique_dir(&mut paths, &candidate);
+    }
     paths
 }
 
@@ -208,5 +257,64 @@ mod tests {
         assert_eq!(found, Some(versioned));
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn test_collect_windows_user_tool_dirs_includes_cargo_and_cli_managers() {
+        let root = std::env::temp_dir().join("libragent_user_tool_dirs_test");
+        let _ = std::fs::remove_dir_all(&root);
+
+        let profile = root.join("profile");
+        let appdata = root.join("appdata");
+        let localappdata = root.join("localappdata");
+        let program_files = root.join("program_files");
+
+        let expected = [
+            profile.join(".cargo").join("bin"),
+            profile.join(".bun").join("bin"),
+            profile.join(".volta").join("bin"),
+            profile.join("scoop").join("shims"),
+            profile.join(".local").join("bin"),
+            appdata.join("npm"),
+            appdata.join("pnpm"),
+            localappdata.join("pnpm"),
+            localappdata.join("Programs").join("nodejs"),
+            program_files.join("nodejs"),
+        ];
+
+        for dir in &expected {
+            std::fs::create_dir_all(dir).expect("create tool dir");
+        }
+
+        // Missing dirs must be skipped
+        let missing_fnm = profile.join(".fnm");
+        assert!(!missing_fnm.exists());
+
+        let found = collect_windows_user_tool_dirs(
+            Some(&profile),
+            Some(&appdata),
+            Some(&localappdata),
+            Some(&program_files),
+        );
+
+        for dir in &expected {
+            assert!(
+                found.iter().any(|p| p == dir),
+                "expected {} in discovered tool dirs: {found:?}",
+                dir.display()
+            );
+        }
+        assert!(
+            found.iter().all(|p| p != &missing_fnm),
+            "non-existent dirs must not be added"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn test_collect_windows_user_tool_dirs_skips_missing_roots() {
+        let found = collect_windows_user_tool_dirs(None, None, None, None);
+        assert!(found.is_empty());
     }
 }

--- a/src-tauri/tests/integration/path_env_recovery_tests.rs
+++ b/src-tauri/tests/integration/path_env_recovery_tests.rs
@@ -41,3 +41,94 @@ fn test_effective_path_includes_discovered_python_scripts_when_present() {
         "effective PATH should prepend discovered Python Scripts directory"
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn test_effective_path_includes_cargo_bin_when_present() {
+    use std::path::PathBuf;
+
+    let Ok(profile) = std::env::var("USERPROFILE") else {
+        return;
+    };
+
+    let cargo_bin = PathBuf::from(profile).join(".cargo").join("bin");
+    if !cargo_bin.is_dir() {
+        return;
+    }
+
+    let effective_path = get_effective_path();
+    let cargo_bin_str = cargo_bin.to_string_lossy();
+    assert!(
+        effective_path.contains(cargo_bin_str.as_ref())
+            || effective_path.contains(&cargo_bin_str.replace('/', "\\")),
+        "effective PATH should include %USERPROFILE%\\.cargo\\bin when present; got: {effective_path}"
+    );
+
+    let isolated_path = get_isolated_env()
+        .into_iter()
+        .find_map(|(key, value)| (key.eq_ignore_ascii_case("PATH")).then_some(value))
+        .expect("isolated env should always include PATH");
+    assert!(
+        isolated_path.contains(cargo_bin_str.as_ref())
+            || isolated_path.contains(&cargo_bin_str.replace('/', "\\")),
+        "isolated PATH must preserve discovered Cargo bin dir"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn test_collect_windows_user_tool_dirs_includes_cargo_and_cli_managers() {
+    use std::path::PathBuf;
+    use tauri_mcp_agent_lib::utils::windows_path_discovery::collect_windows_user_tool_dirs;
+
+    let root = std::env::temp_dir().join("libragent_user_tool_dirs_itest");
+    let _ = std::fs::remove_dir_all(&root);
+
+    let profile = root.join("profile");
+    let appdata = root.join("appdata");
+    let localappdata = root.join("localappdata");
+    let program_files = root.join("program_files");
+
+    let expected = [
+        profile.join(".cargo").join("bin"),
+        profile.join(".bun").join("bin"),
+        profile.join(".volta").join("bin"),
+        profile.join("scoop").join("shims"),
+        profile.join(".local").join("bin"),
+        appdata.join("npm"),
+        appdata.join("pnpm"),
+        localappdata.join("pnpm"),
+        localappdata.join("Programs").join("nodejs"),
+        program_files.join("nodejs"),
+    ];
+
+    for dir in &expected {
+        std::fs::create_dir_all(dir).expect("create tool dir");
+    }
+
+    let found = collect_windows_user_tool_dirs(
+        Some(&profile),
+        Some(&appdata),
+        Some(&localappdata),
+        Some(&program_files),
+    );
+
+    for dir in &expected {
+        assert!(
+            found.iter().any(|p| p == dir),
+            "expected {} in discovered tool dirs: {found:?}",
+            dir.display()
+        );
+    }
+
+    let missing = PathBuf::from(&profile).join(".fnm");
+    assert!(
+        found.iter().all(|p| p != &missing),
+        "non-existent dirs must not be added"
+    );
+
+    let empty = collect_windows_user_tool_dirs(None, None, None, None);
+    assert!(empty.is_empty());
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary
- Explicitly rediscover `%USERPROFILE%\.cargo\bin` and common CLI manager dirs (pnpm, npm, fnm, bun, volta, scoop, Node.js) when rebuilding PATH after `env_clear()` on Windows.
- Align Unix restricted PATH with `~/.bun/bin` and `~/.volta/bin` (Cargo/local already present).
- Add integration coverage for Cargo bin presence and the user-tool directory collector.

## Context
Closes the checklist gap in #1674 that registry PATH recovery alone (`#1681`) does not cover: well-known tool directories that may be missing from the host/registry PATH but still exist on disk.

Fixes #1674

## Test plan
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --test integration_tests path_env_recovery`
- [ ] On a Windows machine with Rust installed: run `workspace__runPowerShell` / `workspace__runShell` with `cargo --version` and confirm it resolves
- [ ] Confirm no regression for Python / uv path discovery (existing tests still pass)
