### PR TITLE
refactor(mcp): harden create_proxy mutex hygiene (#1676)

### DIFF
--- a/src-tauri/src/agent/lifecycle/creation.rs
+++ b/src-tauri/src/agent/lifecycle/creation.rs
@@ -219,27 +219,12 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
     // SSOT: MCP activation is session → assistant → mcpServerIds (not create-request payload).
     let (tool_ids, mcp_server_ids) = crate::agent::resolve_session_mcp_bindings(&session).await?;
 
-    // Create proxy for this session
-    proxy_manager
-        .create_proxy(
-            session_id.clone(),
-            tool_ids,
-            mcp_server_ids,
-            Some(app_handle.clone()),
-        )
-        .await?;
-
-    log::info!(
-        "Created MCP proxy for session: {} with builtin tools",
-        session_id
-    );
-
     // Load compact context if exists (SP17)
     let compact_context_record =
         crate::agent::lifecycle::load_compact_context_record(&session_id, "session creation")
             .await?;
 
-    // Add to active sessions with cancellation token and empty cache
+    // Activate session in memory first so create can return without waiting on MCP.
     let mut active = active_sessions.write().await;
     if let Some(existing_session) = active.get_mut(&session_id) {
         log::info!(
@@ -260,6 +245,17 @@ pub async fn create_session(params: CreateSessionParams) -> Result<SessionMetada
             AgentSession::new(session.clone(), context_registry, compact_context_record),
         );
     }
+    drop(active);
+
+    // MCP proxy creation must not block session create — same soft-wait model as resume/open.
+    crate::agent::lifecycle::spawn_create_proxy_for_session(
+        Arc::clone(&proxy_manager),
+        app_handle.clone(),
+        session_id.clone(),
+        tool_ids,
+        mcp_server_ids,
+    )
+    .await;
 
     log::info!("Created agent session: {}", session_id);
 

--- a/src-tauri/src/agent/lifecycle/management.rs
+++ b/src-tauri/src/agent/lifecycle/management.rs
@@ -83,26 +83,11 @@ pub async fn resume_session(
     // SSOT: MCP activation is session → assistant → mcpServerIds.
     let (tool_ids, mcp_server_ids) = crate::agent::resolve_session_mcp_bindings(&session).await?;
 
-    // Create proxy for this session (tool discovery runs asynchronously in background)
-    proxy_manager
-        .create_proxy(
-            session_id.to_string(),
-            tool_ids,
-            mcp_server_ids,
-            Some(app_handle.clone()),
-        )
-        .await?;
-
-    log::info!(
-        "Created MCP proxy for resumed session: {} with builtin tools",
-        session_id
-    );
-
     // Load compact context if exists (SP17)
     let compact_context_record =
         crate::agent::lifecycle::load_compact_context_record(session_id, "session resume").await?;
 
-    // Add to active sessions with cancellation token and empty cache
+    // Activate session in memory first so open/resume can return without waiting on MCP.
     let mut active = active_sessions.write().await;
     if let Some(existing_session) = active.get_mut(session_id) {
         log::info!(
@@ -135,6 +120,18 @@ pub async fn resume_session(
             ),
         );
     }
+    drop(active);
+
+    // MCP proxy creation (incl. HTTP startup) must not block session UI.
+    // Workflow soft-waits via ensure_proxy_ready; discovery surfaces via runtime-state events.
+    crate::agent::lifecycle::spawn_create_proxy_for_session(
+        Arc::clone(proxy_manager),
+        app_handle.clone(),
+        session_id.to_string(),
+        tool_ids,
+        mcp_server_ids,
+    )
+    .await;
 
     log::info!("Resumed agent session: {}", session_id);
     Ok(session)

--- a/src-tauri/src/agent/lifecycle/mod.rs
+++ b/src-tauri/src/agent/lifecycle/mod.rs
@@ -3,6 +3,7 @@ pub mod compact_context;
 pub mod creation;
 pub mod deletion;
 pub mod management;
+pub mod proxy_bootstrap;
 pub mod queries;
 pub mod recovery;
 
@@ -11,5 +12,6 @@ pub use compact_context::*;
 pub use creation::*;
 pub use deletion::*;
 pub use management::*;
+pub use proxy_bootstrap::*;
 pub use queries::*;
 pub use recovery::*;

--- a/src-tauri/src/agent/lifecycle/proxy_bootstrap.rs
+++ b/src-tauri/src/agent/lifecycle/proxy_bootstrap.rs
@@ -1,0 +1,67 @@
+use crate::agent::runtime_state::SessionRuntimeState;
+use crate::mcp::MCPServiceProxyManager;
+use std::sync::Arc;
+use tauri::AppHandle;
+
+/// Kick off MCP proxy creation without blocking session open/create.
+///
+/// Session UI must return as soon as metadata is active. External MCP HTTP/stdio
+/// work continues in the background; workflows soft-wait via `ensure_proxy_ready`.
+pub async fn spawn_create_proxy_for_session(
+    proxy_manager: Arc<MCPServiceProxyManager>,
+    app_handle: AppHandle,
+    session_id: String,
+    tool_ids: Vec<String>,
+    mcp_server_ids: Vec<String>,
+) {
+    // Surface an immediate hydrating state when no proxy is published yet so the
+    // open response is not stuck on NotStarted while create_proxy is still queued.
+    if proxy_manager.get_proxy(&session_id).await.is_none() {
+        let current = proxy_manager.get_runtime_state(&session_id).await;
+        if matches!(
+            current.phase,
+            crate::agent::runtime_state::SessionRuntimePhase::NotStarted
+        ) {
+            let _ = proxy_manager
+                .set_runtime_state(
+                    &session_id,
+                    SessionRuntimeState::hydrating(),
+                    Some(&app_handle),
+                )
+                .await;
+        }
+    }
+
+    tokio::spawn(async move {
+        match proxy_manager
+            .create_proxy(
+                session_id.clone(),
+                tool_ids,
+                mcp_server_ids,
+                Some(app_handle.clone()),
+            )
+            .await
+        {
+            Ok(_) => {
+                log::info!(
+                    "Background MCP proxy creation finished for session: {}",
+                    session_id
+                );
+            }
+            Err(error) => {
+                log::error!(
+                    "Background MCP proxy creation failed for session {}: {}",
+                    session_id,
+                    error
+                );
+                let _ = proxy_manager
+                    .set_runtime_state(
+                        &session_id,
+                        SessionRuntimeState::failed(error),
+                        Some(&app_handle),
+                    )
+                    .await;
+            }
+        }
+    });
+}

--- a/src-tauri/src/agent/runtime_state.rs
+++ b/src-tauri/src/agent/runtime_state.rs
@@ -157,6 +157,19 @@ impl SessionRuntimeState {
         }
     }
 
+    pub fn failed(error: String) -> Self {
+        Self {
+            phase: SessionRuntimePhase::Failed,
+            initialization: SessionRuntimeInitializationState {
+                current_step: Some("Session initialization failed".to_string()),
+                result: SessionRuntimeInitResult::Failed,
+                error: Some(error),
+                docker: None,
+            },
+            ..Self::default()
+        }
+    }
+
     pub fn configured_initializing(servers: Vec<SessionRuntimeServerState>) -> Self {
         Self {
             sequence: 0,

--- a/src-tauri/src/mcp/service_proxy_manager/creation.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/creation.rs
@@ -228,13 +228,10 @@ impl MCPServiceProxyManager {
         app_handle: Option<AppHandle>,
     ) -> Result<Arc<MCPServiceProxy>, String> {
         let total_start = Instant::now();
-        let session_guard = {
-            let mut guards = self.creation_guards.lock().await;
-            guards
-                .entry(session_id.clone())
-                .or_insert_with(|| Arc::new(Mutex::new(())))
-                .clone()
-        };
+        // Per-session tokio Mutex intentionally held across HTTP startup and publish.
+        // This is single-flight for the same session_id, not a std::Mutex / worker-thread
+        // hazard. Different sessions do not share this lock.
+        let session_guard = self.session_creation_guard(&session_id).await;
         let _session_lock = session_guard.lock().await;
 
         let config_load_start = Instant::now();
@@ -501,6 +498,7 @@ impl MCPServiceProxyManager {
         }
 
         if loaded.has_external_servers() {
+            // Kick off discovery under the lock so destroy cannot race between insert and spawn.
             spawn_background_tool_loading(
                 self,
                 BackgroundDiscoveryPlan {
@@ -528,6 +526,9 @@ impl MCPServiceProxyManager {
                 runtime_state_emits += 1;
             }
         }
+
+        // End single-flight: publish and discovery/builtin_ready kickoff are visible.
+        drop(_session_lock);
 
         log_create_proxy_metrics(&CreateProxyMetrics {
             session_id: &session_id,

--- a/src-tauri/src/mcp/service_proxy_manager/lazy_proxy.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/lazy_proxy.rs
@@ -5,7 +5,6 @@ use super::MCPServiceProxyManager;
 use crate::agent::runtime_state::SessionRuntimeState;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 impl MCPServiceProxyManager {
     /// Ensure a session has a proxy that matches its persisted agent configuration.
@@ -53,14 +52,10 @@ impl MCPServiceProxyManager {
             return Ok(existing);
         }
 
-        let session_guard = {
-            let mut guards = self.creation_guards.lock().await;
-            guards
-                .entry(session_id.to_string())
-                .or_insert_with(|| Arc::new(Mutex::new(())))
-                .clone()
-        };
-        let _lock = session_guard.lock().await;
+        // Per-session tokio Mutex intentionally held across publish + builtin_ready.
+        // Same single-flight lock as create_proxy / destroy_proxy; not a worker-thread hazard.
+        let session_guard = self.session_creation_guard(session_id).await;
+        let _session_lock = session_guard.lock().await;
 
         if let Some(existing) = self.get_proxy(session_id).await {
             return Ok(existing);
@@ -117,6 +112,8 @@ impl MCPServiceProxyManager {
             .insert(session_id.to_string(), empty_http);
         self.set_runtime_state(session_id, SessionRuntimeState::builtin_ready(), None)
             .await;
+
+        drop(_session_lock);
 
         log::info!(
             "Lazily initialised builtin-only proxy for idle session {} with tools: {:?}",

--- a/src-tauri/src/mcp/service_proxy_manager/management.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/management.rs
@@ -10,6 +10,7 @@ use crate::agent::runtime_state::SessionRuntimeState;
 use crate::mcp::builtin::service_id::BuiltinServiceId;
 use std::sync::Arc;
 use tauri::AppHandle;
+use tokio::sync::Mutex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProxyReadinessState {
@@ -82,7 +83,7 @@ impl MCPServiceProxyManager {
         resolve_startup_timeout_seconds(&self.config).await
     }
 
-    pub(super) async fn set_runtime_state(
+    pub(crate) async fn set_runtime_state(
         &self,
         session_id: &str,
         runtime_state: SessionRuntimeState,
@@ -120,14 +121,32 @@ impl MCPServiceProxyManager {
         self.proxies.read().await.get(session_id).cloned()
     }
 
+    /// Per-session creation mutex used by create / ensure_builtin / destroy.
+    ///
+    /// The outer `creation_guards` map lock is held only long enough to insert or look up
+    /// the per-session `Arc<Mutex<()>>`. Callers hold the returned mutex across publish
+    /// (and, for create, across HTTP startup) for single-flight semantics.
+    pub(super) async fn session_creation_guard(&self, session_id: &str) -> Arc<Mutex<()>> {
+        let mut guards = self.creation_guards.lock().await;
+        guards
+            .entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     /// Destroy a proxy and cleanup its resources
     ///
     /// This should be called when an agent session terminates to free resources.
     /// Builtin tool instances are automatically dropped when the proxy is removed.
+    /// Serialized with in-flight `create_proxy` / `ensure_builtin_proxy` via the
+    /// per-session creation lock.
     ///
     /// # Arguments
     /// * `session_id` - The session identifier
     pub async fn destroy_proxy(&self, session_id: &str) {
+        let session_guard = self.session_creation_guard(session_id).await;
+        let _session_lock = session_guard.lock().await;
+
         // 1. Remove builtin proxy
         let proxy_removed = self.proxies.write().await.remove(session_id).is_some();
 
@@ -143,7 +162,8 @@ impl MCPServiceProxyManager {
         // 4. Remove HTTP session manager (HTTP connections are shared, just remove the manager)
         self.session_http_managers.write().await.remove(session_id);
 
-        // 5. Remove per-session creation guard (allows future re-creation of same session_id)
+        // 5. Remove per-session creation guard while still holding `_session_lock`
+        //    so waiters cannot observe a missing guard mid-teardown.
         self.creation_guards.lock().await.remove(session_id);
 
         if proxy_removed {

--- a/src-tauri/src/mcp/service_proxy_manager/mod.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/mod.rs
@@ -67,9 +67,10 @@ pub struct MCPServiceProxyManager {
     /// external servers are considered immediately ready (no entry).
     proxy_readiness: Arc<RwLock<HashMap<String, ProxyReadinessEntry>>>,
 
-    /// Per-session creation lock to prevent duplicate proxy creation under concurrent calls.
-    /// Two concurrent `create_proxy` calls for the same session_id will serialize here;
-    /// the second caller blocks until the first finishes and then hits the idempotency re-check.
+    /// Per-session creation lock shared by `create_proxy`, `ensure_builtin_proxy`, and
+    /// `destroy_proxy`. Concurrent creates for the same session_id serialize here (single-flight
+    /// across HTTP startup and publish); destroy waits for in-flight create/publish before
+    /// tearing down. Different sessions use independent inner mutexes.
     creation_guards: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 
     /// Structured runtime state snapshots owned by Rust and pushed to the frontend.

--- a/src-tauri/src/mcp/service_proxy_manager/test_helpers.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/test_helpers.rs
@@ -28,4 +28,25 @@ impl MCPServiceProxyManager {
     pub(crate) async fn readiness_entry_count(&self) -> usize {
         self.proxy_readiness.read().await.len()
     }
+
+    /// Whether a session still has a stdio manager entry (test probe for destroy hygiene).
+    pub(crate) async fn has_stdio_manager_for_test(&self, session_id: &str) -> bool {
+        self.session_stdio_managers
+            .read()
+            .await
+            .contains_key(session_id)
+    }
+
+    /// Whether a session still has an HTTP manager entry (test probe for destroy hygiene).
+    pub(crate) async fn has_http_manager_for_test(&self, session_id: &str) -> bool {
+        self.session_http_managers
+            .read()
+            .await
+            .contains_key(session_id)
+    }
+
+    /// Whether a per-session creation guard remains registered.
+    pub(crate) async fn has_creation_guard_for_test(&self, session_id: &str) -> bool {
+        self.creation_guards.lock().await.contains_key(session_id)
+    }
 }

--- a/src-tauri/src/mcp/service_proxy_manager/tests.rs
+++ b/src-tauri/src/mcp/service_proxy_manager/tests.rs
@@ -930,3 +930,151 @@ async fn test_builtin_only_proxy_flag_and_upgrade() {
         "Fully configured proxy must NOT be marked as is_builtin_only"
     );
 }
+
+/// Concurrent create_proxy for the same session must single-flight to one Arc.
+#[tokio::test]
+async fn test_concurrent_create_proxy_same_session_single_flight() {
+    let harness = create_test_harness().await;
+    let manager = Arc::clone(&harness.manager);
+    let session_id = "concurrent-create-same-session";
+
+    insert_test_session(&manager, session_id).await;
+
+    let manager_a = Arc::clone(&manager);
+    let manager_b = Arc::clone(&manager);
+    let session_a = session_id.to_string();
+    let session_b = session_id.to_string();
+
+    let (result_a, result_b) = tokio::join!(
+        manager_a.create_proxy(session_a, vec!["playbook".to_string()], vec![], None),
+        manager_b.create_proxy(session_b, vec!["playbook".to_string()], vec![], None),
+    );
+
+    let proxy_a = result_a.expect("first create_proxy must succeed");
+    let proxy_b = result_b.expect("second create_proxy must succeed");
+    assert!(
+        Arc::ptr_eq(&proxy_a, &proxy_b),
+        "concurrent create_proxy must return the same proxy Arc"
+    );
+    assert!(
+        Arc::ptr_eq(
+            &proxy_a,
+            &manager.get_proxy(session_id).await.expect("proxy present")
+        ),
+        "map must hold the single published proxy"
+    );
+}
+
+/// ensure_builtin_proxy and create_proxy on the same session must serialize;
+/// final proxy must be the full (non-builtin-only) create path.
+#[tokio::test]
+async fn test_ensure_builtin_and_create_proxy_serialize() {
+    let harness = create_test_harness().await;
+    let manager = Arc::clone(&harness.manager);
+    let session_id = "ensure-builtin-create-serialize";
+
+    insert_test_session(&manager, session_id).await;
+
+    let manager_a = Arc::clone(&manager);
+    let manager_b = Arc::clone(&manager);
+    let session_owned = session_id.to_string();
+
+    let (ensure_result, create_result) = tokio::join!(
+        manager_a.ensure_builtin_proxy(session_id),
+        manager_b.create_proxy(session_owned, vec!["playbook".to_string()], vec![], None),
+    );
+
+    let ensure_proxy = ensure_result.expect("ensure_builtin_proxy must succeed");
+    let create_proxy = create_result.expect("create_proxy must succeed");
+    let final_proxy = manager
+        .get_proxy(session_id)
+        .await
+        .expect("proxy must exist after both settle");
+
+    assert!(
+        !final_proxy.is_builtin_only(),
+        "final proxy must match full create_proxy upgrade path"
+    );
+    assert!(
+        Arc::ptr_eq(&final_proxy, &create_proxy),
+        "map proxy must be the create_proxy result after serialization"
+    );
+    // ensure may have observed the pre-upgrade lazy proxy or the final one.
+    assert!(
+        Arc::ptr_eq(&ensure_proxy, &final_proxy) || ensure_proxy.is_builtin_only(),
+        "ensure_builtin must return either the final proxy or a prior builtin-only Arc"
+    );
+}
+
+/// Overlapping create_proxy and destroy_proxy must settle without panic or dangling managers.
+#[tokio::test]
+async fn test_create_proxy_overlapping_destroy_proxy() {
+    let harness = create_test_harness().await;
+    let manager = Arc::clone(&harness.manager);
+    let session_id = "create-destroy-overlap";
+
+    insert_test_session(&manager, session_id).await;
+
+    // Warm path: establish a proxy first so destroy has work, then overlap recreate+destroy.
+    manager
+        .create_proxy(
+            session_id.to_string(),
+            vec!["playbook".to_string()],
+            vec![],
+            None,
+        )
+        .await
+        .expect("initial create must succeed");
+
+    let manager_create = Arc::clone(&manager);
+    let manager_destroy = Arc::clone(&manager);
+    let session_owned = session_id.to_string();
+
+    let (create_result, ()) = tokio::join!(
+        manager_create.create_proxy(session_owned, vec!["playbook".to_string()], vec![], None),
+        manager_destroy.destroy_proxy(session_id),
+    );
+
+    // create may Ok (ran after destroy) or Ok (ran before / reused then destroyed).
+    let _ = create_result;
+
+    let proxy = manager.get_proxy(session_id).await;
+    let has_stdio = manager.has_stdio_manager_for_test(session_id).await;
+    let has_http = manager.has_http_manager_for_test(session_id).await;
+    let has_guard = manager.has_creation_guard_for_test(session_id).await;
+
+    match proxy {
+        None => {
+            assert!(
+                !has_stdio && !has_http,
+                "destroyed session must not leave dangling managers"
+            );
+            assert!(
+                !has_guard,
+                "destroy must remove creation guard when no proxy remains"
+            );
+        }
+        Some(p) => {
+            // Only valid if create started after destroy finished and re-published.
+            assert!(
+                has_stdio && has_http,
+                "live proxy must have matching managers"
+            );
+            assert!(
+                !p.is_builtin_only(),
+                "post-destroy recreate must be a full proxy"
+            );
+            assert!(
+                has_guard,
+                "active session after recreate may retain creation guard"
+            );
+        }
+    }
+
+    // Second destroy must clean any surviving create-after-destroy proxy.
+    manager.destroy_proxy(session_id).await;
+    assert!(manager.get_proxy(session_id).await.is_none());
+    assert!(!manager.has_stdio_manager_for_test(session_id).await);
+    assert!(!manager.has_http_manager_for_test(session_id).await);
+    assert!(!manager.has_creation_guard_for_test(session_id).await);
+}

--- a/src-tauri/src/session_isolation/common.rs
+++ b/src-tauri/src/session_isolation/common.rs
@@ -99,7 +99,7 @@ mod tests {
             return;
         };
 
-        let cargo_bin = PathBuf::from(home).join(".cargo").join("bin");
+        let cargo_bin = PathBuf::from(&home).join(".cargo").join("bin");
         let restricted = get_restricted_path();
         assert!(
             restricted.contains(cargo_bin.to_string_lossy().as_ref()),

--- a/src/context/__tests__/AgentSessionContext.test.tsx
+++ b/src/context/__tests__/AgentSessionContext.test.tsx
@@ -355,7 +355,7 @@ describe('AgentSessionContext (Local)', () => {
         expect(result.current.runtimeState.phase).toBe('degraded');
     });
 
-    it('sets isProxyReady to false when proxy.ready is false during initialization', async () => {
+    it('keeps isSessionLoading false during MCP initialization so chat can render', async () => {
         openAgentSessionMock.mockResolvedValue(
             createOpenSessionResponse(TEST_SESSION_ID, {
                 runtimeState: createReadyRuntimeState({
@@ -369,11 +369,11 @@ describe('AgentSessionContext (Local)', () => {
             wrapper: defaultWrapper,
         });
 
-        // During initialization phase, isSessionLoading should be true
         await waitFor(() => {
-            expect(result.current.isSessionLoading).toBe(true);
+            expect(result.current.runtimeState.phase).toBe('initializing');
         });
 
+        expect(result.current.isSessionLoading).toBe(false);
         expect(result.current.isProxyReady).toBe(false);
     });
 

--- a/src/context/agent-session/useAgentSessionState.ts
+++ b/src/context/agent-session/useAgentSessionState.ts
@@ -185,10 +185,10 @@ export function useAgentSessionState() {
     state: {
       session,
       messages,
+      // MCP `initializing` is not session loading — show the chat once open returns;
+      // proxy readiness / discovery toasts gate send and MCP progress separately.
       isSessionLoading:
-        runtimeState.phase === 'hydrating' ||
-        runtimeState.phase === 'initializing' ||
-        session?.status === 'provisioning',
+        runtimeState.phase === 'hydrating' || session?.status === 'provisioning',
       isProxyReady,
       isLoadingOlderMessages,
       hasOlderMessages,

--- a/src/features/agent/__tests__/AgentChatView.test.tsx
+++ b/src/features/agent/__tests__/AgentChatView.test.tsx
@@ -302,7 +302,7 @@ describe('AgentChatView', () => {
   it('shows discovery loading toast during proxy initialization', () => {
     mocks.agentSessionState = createSessionState({
       session: createMockSession(),
-      isSessionLoading: true,
+      isSessionLoading: false,
       isProxyReady: false,
       runtimeState: {
         ...createBaseRuntimeState(),


### PR DESCRIPTION
## Summary
- Resolve #1676 by documenting and hardening the intentional per-session `create_proxy` mutex: keep the creation guard held across HTTP awaits (unlock-before-HTTP rejected as racy), share `session_creation_guard()` with `destroy_proxy`, drop the lock explicitly after publish, and add concurrency tests.
- Unrelated UX in the same change set: spawn MCP proxy bootstrap after session activation so chat messages can render while MCP finalize continues in the background; `isSessionLoading` no longer treats `initializing` as a blocking spinner.
- Ready / `ensure_proxy_ready` contract unchanged — session *ready* still waits on MCP finalize; only early *display* is decoupled.

Fixes #1676

## Test plan
- [ ] `cargo check -p libragent`
- [ ] Open an existing session with slow MCP: messages appear before MCP hydrate finishes
- [ ] Create a new session: chat UI usable while proxy bootstrap runs
- [ ] Concurrent create/destroy for the same session id does not race (proxy present or cleanly absent)
- [ ] Failed proxy bootstrap surfaces `SessionRuntimeState::failed` without leaving a stuck hydrating spinner

Made with [Cursor](https://cursor.com)