### PR TITLE
fix(agent): side-panel shell polish and checkSession storage-id guard

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -613,6 +613,11 @@ pub async fn resolve_check_session_enrichment(meta: &SessionMetadata) -> CheckSe
     check_session_enrichment_from_metadata(meta, assistant_name)
 }
 
+/// Build a paused checkSession MCP result from pre-fetched messages.
+///
+/// `session_id` must be the opaque storage key (`SessionMetadata.id`). It is
+/// only used to derive the agent-facing display token — never pass
+/// `display_session_id(...)` here if you also feed messages fetched by that id.
 pub fn build_paused_check_session_result_from_messages(
     session_id: &str,
     turn_count: usize,
@@ -669,6 +674,12 @@ pub fn build_paused_check_session_result_from_messages(
     hint.to_mcp_result_with_data(Some(Value::Object(response_data)))
 }
 
+/// Build a terminal checkSession MCP result from pre-fetched messages.
+///
+/// `session_id` must be the opaque storage key (`SessionMetadata.id`). It is
+/// only used to derive the agent-facing display token — messages must already
+/// have been loaded via `fetch_session_messages_for_result` with a
+/// `StorageSessionId`.
 pub fn build_terminal_check_session_result_from_messages(
     session_id: &str,
     status: &str,
@@ -768,16 +779,18 @@ pub fn build_terminal_check_session_result_from_messages(
 }
 
 async fn build_terminal_check_session_result(
-    session_id: &str,
+    storage_session_id: &crate::utils::session_id::StorageSessionId,
     status: &str,
     turn_count: usize,
     enrichment: &CheckSessionEnrichment,
 ) -> Result<MCPResult, String> {
+    // Message fetch requires the opaque storage key, never display_session_id().
     let messages_value =
-        fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
+        fetch_session_messages_for_result(storage_session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT)
+            .await?;
 
     Ok(build_terminal_check_session_result_from_messages(
-        session_id,
+        storage_session_id.as_str(),
         status,
         turn_count,
         &messages_value,
@@ -786,15 +799,17 @@ async fn build_terminal_check_session_result(
 }
 
 async fn build_paused_check_session_result(
-    session_id: &str,
+    storage_session_id: &crate::utils::session_id::StorageSessionId,
     turn_count: usize,
     enrichment: &CheckSessionEnrichment,
 ) -> Result<MCPResult, String> {
+    // Message fetch requires the opaque storage key, never display_session_id().
     let messages_value =
-        fetch_session_messages_for_result(session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT).await?;
+        fetch_session_messages_for_result(storage_session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT)
+            .await?;
 
     Ok(build_paused_check_session_result_from_messages(
-        session_id,
+        storage_session_id.as_str(),
         turn_count,
         &messages_value,
         Some(enrichment),

--- a/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/check_session.rs
@@ -40,14 +40,22 @@ pub async fn check_session(
         Err(result) => return Ok(result),
     };
     let session_id = current_session_meta.id.clone();
+    let storage_session_id =
+        crate::utils::session_id::StorageSessionId::from_resolved(session_id.clone());
     let display_id = crate::utils::session_id::display_session_id(&session_id);
     let enrichment = resolve_check_session_enrichment(&current_session_meta).await;
     let current_status = format!("{:?}", current_session_meta.status).to_lowercase();
     let current_turn_count = count_session_turns(&session_id).await;
 
     if current_status == "paused" {
-        return build_paused_check_session_result(&display_id, current_turn_count, &enrichment)
-            .await;
+        // Must pass storage session id — builders fetch messages by opaque key.
+        // display_id is only for agent-facing copy inside those builders.
+        return build_paused_check_session_result(
+            &storage_session_id,
+            current_turn_count,
+            &enrichment,
+        )
+        .await;
     }
 
     if wait {
@@ -106,18 +114,29 @@ pub async fn check_session(
         let status = extract_session_status(&session_data);
         let turn_count = count_session_turns(&session_id).await;
         if status == "paused" {
-            return build_paused_check_session_result(&display_id, turn_count, &enrichment).await;
+            return build_paused_check_session_result(&storage_session_id, turn_count, &enrichment)
+                .await;
         }
-        return build_terminal_check_session_result(&display_id, &status, turn_count, &enrichment)
-            .await;
+        return build_terminal_check_session_result(
+            &storage_session_id,
+            &status,
+            turn_count,
+            &enrichment,
+        )
+        .await;
     }
 
     let status = current_status;
     let turn_count = current_turn_count;
 
     if is_terminal_status(&status) {
-        return build_terminal_check_session_result(&display_id, &status, turn_count, &enrichment)
-            .await;
+        return build_terminal_check_session_result(
+            &storage_session_id,
+            &status,
+            turn_count,
+            &enrichment,
+        )
+        .await;
     }
 
     let next_steps = vec![format!(

--- a/src-tauri/src/mcp/builtin/agent/utils.rs
+++ b/src-tauri/src/mcp/builtin/agent/utils.rs
@@ -1,6 +1,6 @@
 use crate::agent::AgentSessionManager;
 use crate::mcp::types::{MCPContent, MCPResult};
-use crate::repositories::{MessageRepository, SessionMetadata};
+use crate::repositories::{MessageRepository, SessionMetadata, SessionRepository};
 use serde_json::{json, Value};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -46,6 +46,8 @@ pub fn latest_assistant_message_text(
     messages: &[Value],
     max_chars: Option<usize>,
 ) -> Option<(String, String)> {
+    let mut first_assistant_id: Option<String> = None;
+
     for message in messages {
         let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
         if role != "assistant" {
@@ -58,36 +60,43 @@ pub fn latest_assistant_message_text(
             .unwrap_or("unknown")
             .to_string();
 
-        let content = match message.get("content").and_then(|v| v.as_array()) {
-            Some(content) => content,
-            None => continue,
-        };
+        if first_assistant_id.is_none() {
+            first_assistant_id = Some(message_id.clone());
+        }
 
-        for item in content.iter().rev() {
-            let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
-            if item_type != "text" {
-                continue;
-            }
-
-            if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                let text = text.trim();
-                if !text.is_empty() {
-                    let output = match max_chars {
-                        Some(limit) if limit > 0 => truncate_text(text, limit),
-                        _ => text.to_string(),
-                    };
-                    return Some((message_id, output));
-                }
+        if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
+            let text = text.trim();
+            if !text.is_empty() {
+                let output = match max_chars {
+                    Some(limit) if limit > 0 => truncate_text(text, limit),
+                    _ => text.to_string(),
+                };
+                return Some((message_id, output));
             }
         }
 
-        return Some((
-            message_id,
-            "[assistant message has no text content]".to_string(),
-        ));
+        if let Some(content) = message.get("content").and_then(|v| v.as_array()) {
+            for item in content.iter().rev() {
+                let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if item_type != "text" {
+                    continue;
+                }
+
+                if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                    let text = text.trim();
+                    if !text.is_empty() {
+                        let output = match max_chars {
+                            Some(limit) if limit > 0 => truncate_text(text, limit),
+                            _ => text.to_string(),
+                        };
+                        return Some((message_id, output));
+                    }
+                }
+            }
+        }
     }
 
-    None
+    first_assistant_id.map(|id| (id, "[assistant message has no text content]".to_string()))
 }
 
 pub fn latest_tool_message_text(messages: &[Value]) -> Option<String> {
@@ -261,10 +270,33 @@ pub(crate) fn select_preferred_session_messages(
     db_messages
 }
 
+/// Fetch newest-first messages for checkSession result assembly.
+///
+/// Requires [`StorageSessionId`] so `display_session_id(...)` cannot be passed
+/// by accident. When the session repository is initialized, also rejects ids
+/// that are not an exact `sessions.id` row (legacy display-token footgun).
 pub async fn fetch_session_messages_for_result(
-    session_id: &str,
+    storage_session_id: &crate::utils::session_id::StorageSessionId,
     limit: u64,
 ) -> Result<Vec<Value>, String> {
+    let session_id = storage_session_id.as_str();
+
+    if let Some(session_repo) = crate::state::try_get_session_repository() {
+        let exists = session_repo
+            .get_session(session_id)
+            .await
+            .map_err(|e| format!("Failed to verify session id for message lookup: {e}"))?
+            .is_some();
+        if !exists {
+            return Err(format!(
+                "BUG: session message lookup used unknown id '{session_id}'. \
+                 Pass StorageSessionId::from_resolved(SessionMetadata.id), never \
+                 display_session_id() — display tokens yield empty history and false \
+                 \"No final answer yet.\""
+            ));
+        }
+    }
+
     let repo = crate::state::get_message_repository();
     let messages = repo
         .get_messages_by_session(session_id, limit)
@@ -605,5 +637,25 @@ mod tests {
         let selected = select_preferred_session_messages(db_messages, Some(cached_messages));
 
         assert_eq!(latest_session_output(&selected), "authoritative answer");
+    }
+
+    #[test]
+    fn latest_assistant_message_text_scans_past_empty_tool_call_turns() {
+        // Message #2 (latest): tool call turn with no text content
+        let latest_empty_asst = json!({
+            "id": "asst-2",
+            "role": "assistant",
+            "content": [],
+            "tool_calls": [{"id": "call-1", "function": {"name": "agent__checkSession"}}]
+        });
+        // Message #1 (earlier): contains the real final answer text
+        let earlier_asst = assistant_json("asst-1", "Consensus delegation review completed successfully.");
+
+        let messages = vec![latest_empty_asst, earlier_asst];
+
+        let (msg_id, output) = latest_assistant_message_text(&messages, None).unwrap();
+        assert_eq!(msg_id, "asst-1");
+        assert_eq!(output, "Consensus delegation review completed successfully.");
+        assert_eq!(latest_session_output(&messages), "Consensus delegation review completed successfully.");
     }
 }

--- a/src-tauri/src/mcp/builtin/agent/utils.rs
+++ b/src-tauri/src/mcp/builtin/agent/utils.rs
@@ -124,7 +124,95 @@ pub fn latest_tool_message_text(messages: &[Value]) -> Option<String> {
     None
 }
 
+/// Whether a tool-message content item is the `ui__reportResult` resource sibling
+/// (paired with a text summary item in the same `content` array).
+fn content_item_is_report_result_resource(item: &Value) -> bool {
+    if item.get("type").and_then(|v| v.as_str()) != Some("resource") {
+        return false;
+    }
+
+    let tool_name = item
+        .get("serviceInfo")
+        .and_then(|info| info.get("toolName"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if tool_name == "reportResult" {
+        return true;
+    }
+
+    item.get("resource")
+        .and_then(|resource| resource.get("uri"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|uri| uri.starts_with("ui://result/"))
+}
+
+/// Extract the user-facing body from a `ui__reportResult` tool summary.
+///
+/// The tool wraps the deliverable as:
+/// `...Result:\n{body}\n\nSTOP: Do not call any more tools...`
+fn extract_report_result_body_from_summary(summary: &str) -> Option<String> {
+    const RESULT_MARKER: &str = "Result:\n";
+    const STOP_MARKER: &str = "\n\nSTOP:";
+
+    let start = summary.find(RESULT_MARKER)? + RESULT_MARKER.len();
+    let rest = &summary[start..];
+    let body = match rest.find(STOP_MARKER) {
+        Some(end) => &rest[..end],
+        None => rest,
+    };
+    let body = body.trim();
+    if body.is_empty() {
+        None
+    } else {
+        Some(body.to_string())
+    }
+}
+
+/// Newest `ui__reportResult` deliverable body, if any (messages are newest-first).
+///
+/// Parent `checkSession` / blocking `messageToSession` must prefer this over
+/// earlier assistant chatter when a child finished via reportResult.
+pub fn latest_report_result_body(messages: &[Value]) -> Option<String> {
+    for message in messages {
+        let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role != "tool" {
+            continue;
+        }
+
+        let Some(content) = message.get("content").and_then(|v| v.as_array()) else {
+            continue;
+        };
+
+        // Identify via the resource sibling, then read the paired text summary.
+        if !content.iter().any(content_item_is_report_result_resource) {
+            continue;
+        }
+
+        for item in content {
+            if item.get("type").and_then(|v| v.as_str()) != Some("text") {
+                continue;
+            }
+            let Some(text) = item.get("text").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if let Some(body) = extract_report_result_body_from_summary(text) {
+                return Some(body);
+            }
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
 pub fn latest_session_output(messages: &[Value]) -> String {
+    // Explicit UI final deliverable wins over earlier assistant narration.
+    if let Some(report_body) = latest_report_result_body(messages) {
+        return report_body;
+    }
+
     let (_, mut assistant_text) = latest_assistant_message_text(messages, None)
         .unwrap_or(("none".to_string(), "No final answer yet.".to_string()));
 
@@ -649,13 +737,105 @@ mod tests {
             "tool_calls": [{"id": "call-1", "function": {"name": "agent__checkSession"}}]
         });
         // Message #1 (earlier): contains the real final answer text
-        let earlier_asst = assistant_json("asst-1", "Consensus delegation review completed successfully.");
+        let earlier_asst = assistant_json(
+            "asst-1",
+            "Consensus delegation review completed successfully.",
+        );
 
         let messages = vec![latest_empty_asst, earlier_asst];
 
         let (msg_id, output) = latest_assistant_message_text(&messages, None).unwrap();
         assert_eq!(msg_id, "asst-1");
-        assert_eq!(output, "Consensus delegation review completed successfully.");
-        assert_eq!(latest_session_output(&messages), "Consensus delegation review completed successfully.");
+        assert_eq!(
+            output,
+            "Consensus delegation review completed successfully."
+        );
+        assert_eq!(
+            latest_session_output(&messages),
+            "Consensus delegation review completed successfully."
+        );
+    }
+
+    #[test]
+    fn latest_session_output_prefers_report_result_over_earlier_assistant_text() {
+        // Mirrors production: child called ui__reportResult, then parent checkSession
+        // used to return older assistant narration instead of the report body.
+        let report_tool = json!({
+            "id": "tool-report",
+            "role": "tool",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Final result reported (status=success).\nTitle: Result\nResult:\n## Verdict: approve-with-caveats\n## Confidence: high\n\nSTOP: Do not call any more tools. The task outcome is already delivered. End your turn now with at most a one-sentence confirmation."
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "ui://result/abc-123",
+                        "mimeType": "text/html",
+                        "text": "<html></html>"
+                    },
+                    "serviceInfo": {
+                        "serverName": "ui",
+                        "toolName": "reportResult",
+                        "backendType": "BuiltInRust"
+                    }
+                }
+            ]
+        });
+        let empty_asst = json!({
+            "id": "asst-report-call",
+            "role": "assistant",
+            "content": [],
+            "tool_calls": [{"id": "call-report", "function": {"name": "ui__reportResult"}}]
+        });
+        let earlier_asst = assistant_json(
+            "asst-progress",
+            "The persist_terminal test passes in isolation — continuing the review.",
+        );
+
+        let messages = vec![report_tool, empty_asst, earlier_asst];
+
+        assert_eq!(
+            latest_session_output(&messages),
+            "## Verdict: approve-with-caveats\n## Confidence: high"
+        );
+    }
+
+    #[test]
+    fn latest_session_output_falls_back_to_report_result_text_without_markers() {
+        // When the summary format drifts (no Result:/STOP markers), still prefer
+        // the reportResult tool text over earlier assistant narration.
+        let report_tool = json!({
+            "id": "tool-report-plain",
+            "role": "tool",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Deliverable without wrapper markers: approve-with-caveats"
+                },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "ui://result/plain-1",
+                        "mimeType": "text/html",
+                        "text": "<html></html>"
+                    },
+                    "serviceInfo": {
+                        "serverName": "ui",
+                        "toolName": "reportResult",
+                        "backendType": "BuiltInRust"
+                    }
+                }
+            ]
+        });
+        let earlier_asst = assistant_json("asst-old", "Earlier assistant chatter should lose.");
+
+        let messages = vec![report_tool, earlier_asst];
+
+        assert_eq!(
+            latest_session_output(&messages),
+            "Deliverable without wrapper markers: approve-with-caveats"
+        );
     }
 }

--- a/src-tauri/src/utils/session_id.rs
+++ b/src-tauri/src/utils/session_id.rs
@@ -13,6 +13,16 @@
 //! - **Resolution order**: exact stored-id match first; otherwise display alias / short
 //!   token among a caller-provided candidate set (MCP tools scope this to the caller's
 //!   **delegated descendants**). Zero matches → missing; multiple → ambiguous.
+//!
+//! # Hard rule (do not regress)
+//!
+//! DB / cache message lookups, turn counts, and wait loops must use
+//! [`StorageSessionId`] (`SessionMetadata.id` after resolve). Never pass
+//! [`display_session_id`] output into those APIs — for legacy `session-…` rows the
+//! display token is a **different string** and yields empty history → false
+//! "No final answer yet." (#1689 footgun).
+
+use std::fmt;
 
 /// Length of the unique short token used in display aliases.
 pub const SESSION_ID_SHORT_LEN: usize = 10;
@@ -20,6 +30,42 @@ pub const SESSION_ID_SHORT_LEN: usize = 10;
 /// Historical / optional prefix still accepted on input (`session-{short}`).
 /// Display output no longer includes this prefix.
 pub const SESSION_ID_DISPLAY_PREFIX: &str = "session-";
+
+/// Opaque storage session key — the value stored as `sessions.id` /
+/// `SessionMetadata.id` after resolution.
+///
+/// Construct only via [`StorageSessionId::from_resolved`]. Message fetches and
+/// other DB lookups take this type so `display_session_id(...)` (`String`) cannot
+/// be passed by accident at compile time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StorageSessionId(String);
+
+impl StorageSessionId {
+    /// Wrap an already-resolved storage key (`SessionMetadata.id`).
+    ///
+    /// Do **not** pass [`display_session_id`] output here unless the session's
+    /// storage key is itself the short token (modern spawn ids).
+    pub fn from_resolved(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for StorageSessionId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for StorageSessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// Outcome of resolving an agent-supplied session reference against candidates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,4 +143,34 @@ pub fn resolve_session_id_among<'a>(
         [] => SessionIdResolve::Missing,
         many => SessionIdResolve::Ambiguous(many.len()),
     }
+}
+
+/// Pure guard for the display-token-as-storage-key footgun.
+///
+/// Returns `Err` when `lookup_id` is not an exact candidate storage id but *is*
+/// a display alias of one — the #1689/`checkSession` empty-history failure mode.
+pub fn reject_display_token_used_as_storage_key(
+    lookup_id: &str,
+    known_storage_ids: &[&str],
+) -> Result<(), String> {
+    if known_storage_ids.iter().any(|id| *id == lookup_id) {
+        return Ok(());
+    }
+
+    let aliased: Vec<&str> = known_storage_ids
+        .iter()
+        .copied()
+        .filter(|id| session_id_matches_ref(id, lookup_id))
+        .collect();
+
+    if aliased.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "BUG: session message/status lookup used display token '{lookup_id}' instead of storage id '{}'. \
+         Pass SessionMetadata.id / StorageSessionId::from_resolved(...), never display_session_id(). \
+         Display-token lookups return empty history and false \"No final answer yet.\"",
+        aliased.join(", ")
+    ))
 }

--- a/src-tauri/src/utils/session_id.rs
+++ b/src-tauri/src/utils/session_id.rs
@@ -153,7 +153,7 @@ pub fn reject_display_token_used_as_storage_key(
     lookup_id: &str,
     known_storage_ids: &[&str],
 ) -> Result<(), String> {
-    if known_storage_ids.iter().any(|id| *id == lookup_id) {
+    if known_storage_ids.contains(&lookup_id) {
         return Ok(());
     }
 

--- a/src-tauri/tests/integration/check_session_terminal_result_tests.rs
+++ b/src-tauri/tests/integration/check_session_terminal_result_tests.rs
@@ -166,6 +166,67 @@ fn terminal_check_session_result_falls_back_to_tool_text_when_assistant_has_no_t
 }
 
 #[test]
+fn terminal_check_session_result_prefers_ui_report_result_body() {
+    let result = build_terminal_check_session_result_from_messages(
+        "session-terminal-report-result",
+        "idle",
+        5,
+        &[
+            json!({
+                "role": "tool",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Final result reported (status=success).\nTitle: Result\nResult:\n## Verdict: approve-with-caveats\n## Confidence: high\n\nSTOP: Do not call any more tools. The task outcome is already delivered."
+                    },
+                    {
+                        "type": "resource",
+                        "resource": {
+                            "uri": "ui://result/review-1",
+                            "mimeType": "text/html",
+                            "text": "<html></html>"
+                        },
+                        "serviceInfo": {
+                            "serverName": "ui",
+                            "toolName": "reportResult",
+                            "backendType": "BuiltInRust"
+                        }
+                    }
+                ]
+            }),
+            json!({
+                "role": "assistant",
+                "content": [],
+                "tool_calls": [{"id": "call-1", "function": {"name": "ui__reportResult"}}]
+            }),
+            json!({
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "The persist_terminal test passes in isolation — continuing the review."
+                    }
+                ]
+            }),
+        ],
+        None,
+    );
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+
+    assert_eq!(
+        structured.get("result").and_then(|value| value.as_str()),
+        Some("## Verdict: approve-with-caveats\n## Confidence: high")
+    );
+    let text = extract_text(&result);
+    assert!(text.contains("approve-with-caveats"));
+    assert!(!text.contains("persist_terminal test passes"));
+}
+
+#[test]
 fn terminal_error_check_session_result_marks_session_as_recoverable() {
     let result = build_terminal_check_session_result_from_messages(
         "session-error-123",

--- a/src-tauri/tests/integration/workflow_settlement_durability_tests.rs
+++ b/src-tauri/tests/integration/workflow_settlement_durability_tests.rs
@@ -33,6 +33,7 @@ use tauri_mcp_agent_lib::repositories::{
     MessageRepository, SessionMetadata, SessionRepository, SessionStatus, SqliteMessageRepository,
     SqliteSessionRepository, SqliteSettingsRepository,
 };
+use tauri_mcp_agent_lib::utils::session_id::StorageSessionId;
 use tauri_mcp_agent_lib::{init_concurrency_gate, init_session_bus, set_settings_repository};
 use tokio::sync::{Mutex as AsyncMutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -333,9 +334,12 @@ async fn persist_terminal_assistant_sync_makes_cache_only_message_durable_before
     .await
     .expect("persist succeeds");
 
-    let messages_for_check_session = fetch_session_messages_for_result(&harness.session_id, 50)
-        .await
-        .expect("checkSession message fetch");
+    let messages_for_check_session = fetch_session_messages_for_result(
+        &StorageSessionId::from_resolved(harness.session_id.clone()),
+        50,
+    )
+    .await
+    .expect("checkSession message fetch");
     assert_eq!(
         latest_session_output(&messages_for_check_session),
         "All subtasks completed."
@@ -377,9 +381,12 @@ async fn settle_session_and_go_idle_persists_terminal_message_and_sets_idle() {
         )
     }));
 
-    let messages_for_check_session = fetch_session_messages_for_result(&harness.session_id, 50)
-        .await
-        .expect("checkSession message fetch");
+    let messages_for_check_session = fetch_session_messages_for_result(
+        &StorageSessionId::from_resolved(harness.session_id.clone()),
+        50,
+    )
+    .await
+    .expect("checkSession message fetch");
     assert_eq!(
         latest_session_output(&messages_for_check_session),
         "Workflow finished cleanly."

--- a/src-tauri/tests/session_id_display_tests.rs
+++ b/src-tauri/tests/session_id_display_tests.rs
@@ -10,8 +10,8 @@ use tauri_mcp_agent_lib::repositories::{
 };
 use tauri_mcp_agent_lib::services::agent_service::spawn::generate_spawn_session_id;
 use tauri_mcp_agent_lib::utils::session_id::{
-    display_session_id, resolve_session_id_among, session_id_matches_ref, session_id_short_token,
-    SessionIdResolve,
+    display_session_id, reject_display_token_used_as_storage_key, resolve_session_id_among,
+    session_id_matches_ref, session_id_short_token, SessionIdResolve, StorageSessionId,
 };
 
 fn sample_session(id: &str, name: &str, status: SessionStatus) -> SessionMetadata {
@@ -172,4 +172,41 @@ fn http_style_resolve_among_all_candidates_accepts_short_token() {
         resolve_session_id_among(candidates, "abcdef1234"),
         SessionIdResolve::Unique("abcdef1234")
     );
+}
+
+/// Regression: #1689 checkSession passed `display_session_id` into message fetch.
+/// Legacy storage keys have a different string than their display token — using
+/// the display token as a DB key returns empty history → "No final answer yet."
+#[test]
+fn reject_display_token_as_storage_key_for_legacy_session() {
+    let storage = "session-376d7c7c-aaaa-bbbb-cccc-dddddddd5ed777";
+    let display = display_session_id(storage);
+    assert_ne!(
+        storage, display,
+        "legacy ids must differ from display tokens (otherwise this test is vacuous)"
+    );
+    assert_eq!(display.len(), 10);
+
+    let err = reject_display_token_used_as_storage_key(&display, &[storage])
+        .expect_err("display token must not be accepted as storage key");
+    assert!(
+        err.contains("display token"),
+        "error should name the footgun: {err}"
+    );
+    assert!(
+        err.contains(storage),
+        "error should point at the real storage id: {err}"
+    );
+
+    reject_display_token_used_as_storage_key(storage, &[storage])
+        .expect("exact storage id must be accepted");
+
+    // Modern spawn ids: display == storage, so display_session_id is fine for lookup.
+    let modern = "a1b2c3d4e5";
+    assert_eq!(display_session_id(modern), modern);
+    reject_display_token_used_as_storage_key(modern, &[modern]).expect("modern id ok");
+
+    // StorageSessionId is the typed wrapper callers must use for message fetch.
+    let typed = StorageSessionId::from_resolved(storage);
+    assert_eq!(typed.as_str(), storage);
 }

--- a/src/features/agent/components/AgentChatHeader.tsx
+++ b/src/features/agent/components/AgentChatHeader.tsx
@@ -8,7 +8,7 @@ import {
   useAgentSessionListActions,
   useAgentSessionListState,
 } from '@/context/AgentSessionListContext';
-import { useAgentPanels } from '@/context/AgentPanelsContext';
+import { AGENT_PANEL_IDS, useAgentPanels } from '@/context/AgentPanelsContext';
 import { useAgentChat } from '@/context/AgentChatContext';
 import { SessionFilesPopover } from '@/components/shared/SessionFilesPopover';
 import { Button } from '@/components/ui/button';
@@ -17,7 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { FolderOpen, Copy, Loader2, Terminal, ListChecks } from 'lucide-react';
+import { Copy, Loader2, PanelRight } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { useClipboard } from '@/hooks/useClipboard';
@@ -38,12 +38,9 @@ export function AgentChatHeader({
   const { renameSession } = useAgentSessionActions();
   const { toggleBookmark } = useAgentSessionListActions();
   const { sessions, notificationSessions } = useAgentSessionListState();
-  const { isPanelOpen, togglePanel, hasPanelAttention } = useAgentPanels();
-  const showWorkspacePanel = isPanelOpen('workspace');
-  const showPlanningPanel = isPanelOpen('planning');
-  const showProcessesPanel = isPanelOpen('processes');
-  const processesAttention = hasPanelAttention('processes');
-  const planningAttention = hasPanelAttention('planning');
+  const { isShellOpen, toggleShell, hasPanelAttention } = useAgentPanels();
+  const shellOpen = isShellOpen();
+  const shellAttention = AGENT_PANEL_IDS.some((id) => hasPanelAttention(id));
   const { messages } = useAgentChat();
   const [isCopying, setIsCopying] = useState(false);
   const [bookmarkOverride, setBookmarkOverride] = useState<
@@ -152,90 +149,28 @@ export function AgentChatHeader({
                 variant="ghost"
                 size="sm"
                 onClick={() => {
-                  togglePanel('workspace');
-                }}
-                aria-label={t('agent.header.toggleWorkspaceAria')}
-                aria-controls="agent-workspace-panel"
-                aria-expanded={showWorkspacePanel}
-                className="h-6 px-2"
-              >
-                <FolderOpen
-                  className={`h-4 w-4 ${showWorkspacePanel ? 'text-primary' : ''}`}
-                />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {t('agent.header.toggleWorkspaceTooltip')}
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  togglePanel('processes');
+                  toggleShell();
                 }}
                 aria-label={
-                  processesAttention
+                  shellAttention
                     ? t(
-                        'agent.header.toggleProcessesHasUpdatesAria',
-                        'Toggle Background Processes Panel (has updates)',
+                        'agent.header.toggleShellHasUpdatesAria',
+                        'Toggle agent panels (has updates)',
                       )
-                    : t(
-                        'agent.header.toggleProcessesAria',
-                        'Toggle Background Processes Panel',
-                      )
+                    : t('agent.header.toggleShellAria', 'Toggle agent panels')
                 }
-                aria-controls="agent-processes-panel"
-                aria-expanded={showProcessesPanel}
+                aria-controls="agent-side-panel-shell"
+                aria-expanded={shellOpen}
                 className="relative h-6 px-2"
               >
-                <Terminal
-                  className={`h-4 w-4 ${showProcessesPanel ? 'text-primary' : ''}`}
+                <PanelRight
+                  className={`h-4 w-4 ${shellOpen ? 'text-primary' : ''}`}
                 />
-                <PanelAttentionDot visible={processesAttention} />
+                <PanelAttentionDot visible={shellAttention} />
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              {t(
-                'agent.header.toggleProcessesTooltip',
-                'Toggle Background Processes Panel',
-              )}
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  togglePanel('planning');
-                }}
-                aria-label={
-                  planningAttention
-                    ? t(
-                        'agent.header.togglePlanningHasUpdatesAria',
-                        'Toggle AI Planning Panel (has updates)',
-                      )
-                    : t('agent.header.togglePlanningAria')
-                }
-                aria-controls="agent-planning-panel"
-                aria-expanded={showPlanningPanel}
-                className="relative h-6 px-2"
-              >
-                <ListChecks
-                  className={`h-4 w-4 ${showPlanningPanel ? 'text-primary' : ''}`}
-                />
-                <PanelAttentionDot visible={planningAttention} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {t('agent.header.togglePlanningTooltip')}
+              {t('agent.header.toggleShellTooltip', 'Toggle agent panels')}
             </TooltipContent>
           </Tooltip>
 

--- a/src/features/agent/components/AgentPlanningUpdates.tsx
+++ b/src/features/agent/components/AgentPlanningUpdates.tsx
@@ -21,15 +21,45 @@ const logger = getLogger('AgentPlanningUpdates');
 
 const PLANNING_TOAST_ID_PREFIX = 'agent-planning-update';
 
+/** Treat missing / empty plan snapshots as equivalent across context reloads. */
+function normalizePlanning(
+  state: PlanningState | undefined,
+): PlanningState | null {
+  if (!state) {
+    return null;
+  }
+  if ((state.goal == null || state.goal === '') && state.todos.length === 0) {
+    return null;
+  }
+  return state;
+}
+
+function normalizeScratchpad(
+  state: ScratchpadState | undefined,
+): ScratchpadState | null {
+  if (!state) {
+    return null;
+  }
+  if (state.items.length === 0 && state.count === 0) {
+    return null;
+  }
+  return state;
+}
+
 export function AgentPlanningUpdates() {
   const { t } = useTranslation();
   const { session } = useAgentSessionState();
   const { showPlanningPanel } = useAgentPlanning();
-  const { markPanelAttention } = useAgentPanels();
+  const { markPanelAttention, clearPanelAttention } = useAgentPanels();
   const { serviceContexts, updateServiceContexts } = useAgentChat();
   const previousPlanningRef = useRef<PlanningState | undefined>(undefined);
   const previousScratchpadRef = useRef<ScratchpadState | undefined>(undefined);
-  const hasHydratedRef = useRef(false);
+  const trackedSessionIdRef = useRef<string | undefined>(undefined);
+  /**
+   * After a session switch, the next real planning/scratchpad delta is usually
+   * the async service-context reload — absorb it instead of notifying.
+   */
+  const absorbNextDeltaRef = useRef(false);
 
   const planningState = useMemo(
     () => parsePlanningState(serviceContexts.planning?.structuredState),
@@ -39,14 +69,6 @@ export function AgentPlanningUpdates() {
     () => parseScratchpadState(serviceContexts.scratchpad?.structuredState),
     [serviceContexts.scratchpad?.structuredState],
   );
-
-  useEffect(() => {
-    if (!session?.id) {
-      hasHydratedRef.current = false;
-      previousPlanningRef.current = undefined;
-      previousScratchpadRef.current = undefined;
-    }
-  }, [session?.id]);
 
   const triggerCallback = useCallback(() => {
     updateServiceContexts().catch((error: unknown) => {
@@ -86,44 +108,70 @@ export function AgentPlanningUpdates() {
   useAgentMessageTrigger(triggerCallback, triggerOptions);
 
   useEffect(() => {
-    if (!session?.id) {
+    const sessionId = session?.id;
+
+    if (!sessionId) {
+      trackedSessionIdRef.current = undefined;
+      previousPlanningRef.current = undefined;
+      previousScratchpadRef.current = undefined;
+      absorbNextDeltaRef.current = false;
+      clearPanelAttention('planning');
       return;
     }
 
-    if (!hasHydratedRef.current) {
+    // Session switch (or first mount): adopt current snapshot as baseline and
+    // drop leftover attention from the previous session.
+    if (trackedSessionIdRef.current !== sessionId) {
+      trackedSessionIdRef.current = sessionId;
       previousPlanningRef.current = planningState;
       previousScratchpadRef.current = scratchpadState;
-      hasHydratedRef.current = true;
+      absorbNextDeltaRef.current = true;
+      clearPanelAttention('planning');
       return;
     }
 
-    const planningChanged = !equal(previousPlanningRef.current, planningState);
+    const planningChanged = !equal(
+      normalizePlanning(previousPlanningRef.current),
+      normalizePlanning(planningState),
+    );
     const scratchpadChanged = !equal(
-      previousScratchpadRef.current,
-      scratchpadState,
+      normalizeScratchpad(previousScratchpadRef.current),
+      normalizeScratchpad(scratchpadState),
     );
 
-    if ((planningChanged || scratchpadChanged) && !showPlanningPanel) {
-      // Notification-dot on the header toggle — do not auto-open the panel.
+    if (!planningChanged && !scratchpadChanged) {
+      // Empty→empty after switch: nothing to absorb; arm real updates.
+      absorbNextDeltaRef.current = false;
+      return;
+    }
+
+    const previousTodos = previousPlanningRef.current?.todos;
+    previousPlanningRef.current = planningState;
+    previousScratchpadRef.current = scratchpadState;
+
+    if (absorbNextDeltaRef.current) {
+      absorbNextDeltaRef.current = false;
+      return;
+    }
+
+    if (!showPlanningPanel) {
       markPanelAttention('planning');
       toast(t('agent.planning.title'), {
-        id: `${PLANNING_TOAST_ID_PREFIX}-${session.id}`,
+        id: `${PLANNING_TOAST_ID_PREFIX}-${sessionId}`,
         duration: 5000,
         description: (
           <PlanningToastSummary
             goal={planningState?.goal ?? null}
             todos={planningState?.todos ?? []}
-            previousTodos={previousPlanningRef.current?.todos}
+            previousTodos={previousTodos}
             scratchpad={scratchpadState}
             scratchpadChanged={scratchpadChanged}
           />
         ),
       });
     }
-
-    previousPlanningRef.current = planningState;
-    previousScratchpadRef.current = scratchpadState;
   }, [
+    clearPanelAttention,
     markPanelAttention,
     planningState,
     scratchpadState,

--- a/src/features/agent/components/AgentProcessAttentionUpdates.tsx
+++ b/src/features/agent/components/AgentProcessAttentionUpdates.tsx
@@ -23,7 +23,8 @@ const logger = getLogger('AgentProcessAttentionUpdates');
 
 export function AgentProcessAttentionUpdates() {
   const { session } = useAgentSessionState();
-  const { isPanelOpen, markPanelAttention } = useAgentPanels();
+  const { isPanelOpen, markPanelAttention, clearPanelAttention } =
+    useAgentPanels();
   const { agentCallBuiltinTool } = useRustBackend();
   const panelOpen = isPanelOpen('processes');
 
@@ -33,13 +34,14 @@ export function AgentProcessAttentionUpdates() {
   const panelOpenRef = useRef(panelOpen);
   panelOpenRef.current = panelOpen;
 
+  // Reset baseline on every session change so a different process list is not
+  // treated as an in-session update, and drop leftover attention dots.
   useEffect(() => {
-    if (!session?.id) {
-      hasHydratedRef.current = false;
-      fingerprintRef.current = '';
-      setHasActive(false);
-    }
-  }, [session?.id]);
+    hasHydratedRef.current = false;
+    fingerprintRef.current = '';
+    setHasActive(false);
+    clearPanelAttention('processes');
+  }, [clearPanelAttention, session?.id]);
 
   // While the processes tab is active the user sees updates live — clear the
   // baseline so leaving the tab does not immediately re-mark viewed changes.

--- a/src/features/agent/components/AgentSidePanelShell.tsx
+++ b/src/features/agent/components/AgentSidePanelShell.tsx
@@ -1,11 +1,17 @@
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import {
   useAgentPanels,
   type AgentPanelId,
 } from '@/context/AgentPanelsContext';
 import { cn } from '@/lib/utils';
-import { FolderOpen, ListChecks, Terminal } from 'lucide-react';
+import { FolderOpen, ListChecks, Terminal, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AgentPlanningPanel } from './AgentPlanningPanel';
 import { AgentProcessPanel } from './AgentProcessPanel';
@@ -21,14 +27,21 @@ const TAB_ORDER: AgentPanelId[] = ['workspace', 'processes', 'planning'];
 
 /**
  * Single right-side shell hosting Files / Processes / Planning as tabs.
+ * Tabs switch content only; use the header shell toggle or the close control
+ * to dismiss the shell.
  */
 export function AgentSidePanelShell({
   isVisible = true,
   variant = 'rail',
 }: AgentSidePanelShellProps) {
   const { t } = useTranslation();
-  const { activeTab, setActiveTab, hasPanelAttention, isPanelOpen } =
-    useAgentPanels();
+  const {
+    activeTab,
+    setActiveTab,
+    hasPanelAttention,
+    isPanelOpen,
+    closeShell,
+  } = useAgentPanels();
 
   return (
     <Card
@@ -51,8 +64,8 @@ export function AgentSidePanelShell({
         }}
         className="flex min-h-0 flex-1 flex-col gap-0"
       >
-        <div className="shrink-0 border-b border-border/40 px-3 py-2">
-          <TabsList className="grid h-9 w-full grid-cols-3">
+        <div className="flex shrink-0 items-center gap-1 border-b border-border/40 px-2 py-2">
+          <TabsList className="grid h-9 min-w-0 flex-1 grid-cols-3">
             {TAB_ORDER.map((tabId) => {
               const attention = hasPanelAttention(tabId);
               const label =
@@ -89,6 +102,24 @@ export function AgentSidePanelShell({
               );
             })}
           </TabsList>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+                onClick={() => {
+                  closeShell();
+                }}
+                aria-label={t('agent.panels.closeAria', 'Close agent panels')}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('agent.panels.close', 'Close')}</TooltipContent>
+          </Tooltip>
         </div>
 
         {TAB_ORDER.map((tabId) => (

--- a/src/features/agent/components/__tests__/AgentChatHeader.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatHeader.test.tsx
@@ -7,8 +7,11 @@ import { AgentChatHeader } from '../AgentChatHeader';
 const mockRenameSession = vi.fn();
 const mockToggleBookmark = vi.fn();
 const mockCopyToClipboard = vi.fn();
-const mockTogglePanel = vi.fn();
-const mockHasPanelAttention = vi.fn((/* eslint-disable @typescript-eslint/no-unused-vars */ _id: string) => false);
+const mockToggleShell = vi.fn();
+const mockHasPanelAttention = vi.fn(
+  (/* eslint-disable @typescript-eslint/no-unused-vars */ _id: string) => false,
+);
+let shellOpen = false;
 
 vi.mock('@/context/AgentSessionContext', () => ({
   useAgentSessionState: () => ({
@@ -61,19 +64,31 @@ vi.mock('@/context/AgentSessionListContext', () => ({
   }),
 }));
 
-vi.mock('@/context/AgentPanelsContext', () => ({
-  useAgentPanels: () => ({
-    isPanelOpen: () => false,
-    openPanel: vi.fn(),
-    closePanel: vi.fn(),
-    togglePanel: mockTogglePanel,
-    closeAllPanels: vi.fn(),
-    getLastClosedAt: () => 0,
-    hasPanelAttention: mockHasPanelAttention,
-    markPanelAttention: vi.fn(),
-    clearPanelAttention: vi.fn(),
-  }),
-}));
+vi.mock('@/context/AgentPanelsContext', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/context/AgentPanelsContext')
+  >('@/context/AgentPanelsContext');
+  return {
+    ...actual,
+    useAgentPanels: () => ({
+      isShellOpen: () => shellOpen,
+      openShell: vi.fn(),
+      closeShell: vi.fn(),
+      toggleShell: mockToggleShell,
+      activeTab: 'workspace',
+      setActiveTab: vi.fn(),
+      isPanelOpen: () => false,
+      openPanel: vi.fn(),
+      closePanel: vi.fn(),
+      togglePanel: vi.fn(),
+      closeAllPanels: vi.fn(),
+      getLastClosedAt: () => 0,
+      hasPanelAttention: mockHasPanelAttention,
+      markPanelAttention: vi.fn(),
+      clearPanelAttention: vi.fn(),
+    }),
+  };
+});
 
 vi.mock('@/context/AgentChatContext', () => ({
   useAgentChat: () => ({
@@ -128,20 +143,11 @@ vi.mock('react-i18next', () => ({
       if (key === 'agent.header.copyAria') {
         return 'Copy conversation';
       }
-      if (key === 'agent.header.toggleWorkspaceAria') {
-        return 'Toggle workspace';
+      if (key === 'agent.header.toggleShellAria') {
+        return 'Toggle agent panels';
       }
-      if (key === 'agent.header.toggleProcessesAria') {
-        return 'Toggle processes';
-      }
-      if (key === 'agent.header.toggleProcessesHasUpdatesAria') {
-        return 'Toggle processes (has updates)';
-      }
-      if (key === 'agent.header.togglePlanningAria') {
-        return 'Toggle planning';
-      }
-      if (key === 'agent.header.togglePlanningHasUpdatesAria') {
-        return 'Toggle planning (has updates)';
+      if (key === 'agent.header.toggleShellHasUpdatesAria') {
+        return 'Toggle agent panels (has updates)';
       }
       if (key === 'agent.header.defaultAssistant') {
         return 'Agent';
@@ -163,6 +169,7 @@ global.ResizeObserver = class ResizeObserver {
 describe('AgentChatHeader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    shellOpen = false;
     mockHasPanelAttention.mockReturnValue(false);
   });
 
@@ -189,15 +196,17 @@ describe('AgentChatHeader', () => {
     ).toBeTruthy();
   });
 
-  it('toggles the processes panel from the header control', () => {
+  it('toggles the agent panel shell from the header control', () => {
     render(<AgentChatHeader />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Toggle processes' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle agent panels' }),
+    );
 
-    expect(mockTogglePanel).toHaveBeenCalledWith('processes');
+    expect(mockToggleShell).toHaveBeenCalledTimes(1);
   });
 
-  it('shows an attention dot on the processes toggle when marked', () => {
+  it('shows an attention dot on the shell toggle when any tab is marked', () => {
     mockHasPanelAttention.mockImplementation(
       (id: string) => id === 'processes',
     );
@@ -207,7 +216,7 @@ describe('AgentChatHeader', () => {
     expect(screen.getByTestId('panel-attention-dot')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: 'Toggle processes (has updates)',
+        name: 'Toggle agent panels (has updates)',
       }),
     ).toBeInTheDocument();
   });

--- a/src/features/agent/components/__tests__/AgentPlanningUpdates.test.tsx
+++ b/src/features/agent/components/__tests__/AgentPlanningUpdates.test.tsx
@@ -1,0 +1,144 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServiceContext } from '@/models/service-context';
+import { AgentPlanningUpdates } from '../AgentPlanningUpdates';
+
+const mockMarkPanelAttention = vi.fn();
+const mockClearPanelAttention = vi.fn();
+const mockUpdateServiceContexts = vi.fn();
+const mockToast = vi.fn();
+
+const mocks = vi.hoisted(() => ({
+  sessionId: 'session-a' as string | undefined,
+  showPlanningPanel: false,
+  serviceContexts: {} as Record<string, ServiceContext>,
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: mocks.sessionId ? { id: mocks.sessionId } : undefined,
+  }),
+}));
+
+vi.mock('@/context/AgentPlanningContext', () => ({
+  useAgentPlanning: () => ({
+    showPlanningPanel: mocks.showPlanningPanel,
+  }),
+}));
+
+vi.mock('@/context/AgentPanelsContext', () => ({
+  useAgentPanels: () => ({
+    markPanelAttention: mockMarkPanelAttention,
+    clearPanelAttention: mockClearPanelAttention,
+  }),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChat: () => ({
+    serviceContexts: mocks.serviceContexts,
+    updateServiceContexts: mockUpdateServiceContexts,
+  }),
+}));
+
+vi.mock('@/hooks/use-agent-message-trigger', () => ({
+  useAgentMessageTrigger: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function planningContext(
+  goal: string | null,
+  todos: Array<{ id: number; title: string; checked: boolean }> = [],
+): ServiceContext {
+  return {
+    contextPrompt: '',
+    structuredState: {
+      goal,
+      todos,
+    },
+  };
+}
+
+describe('AgentPlanningUpdates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sessionId = 'session-a';
+    mocks.showPlanningPanel = false;
+    mocks.serviceContexts = {
+      planning: planningContext('Ship it', [
+        { id: 1, title: 'Task', checked: false },
+      ]),
+    };
+  });
+
+  it('clears attention and does not re-mark when switching to an empty plan session', () => {
+    const { rerender } = render(<AgentPlanningUpdates />);
+
+    expect(mockClearPanelAttention).toHaveBeenCalledWith('planning');
+    mockClearPanelAttention.mockClear();
+    mockMarkPanelAttention.mockClear();
+
+    mocks.sessionId = 'session-b';
+    mocks.serviceContexts = {};
+    rerender(<AgentPlanningUpdates />);
+
+    expect(mockClearPanelAttention).toHaveBeenCalledWith('planning');
+    expect(mockMarkPanelAttention).not.toHaveBeenCalled();
+
+    // Post-switch context reload settles on an empty plan.
+    mocks.serviceContexts = {
+      planning: planningContext(null, []),
+    };
+    rerender(<AgentPlanningUpdates />);
+
+    expect(mockMarkPanelAttention).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('absorbs the first post-switch plan reload without marking attention', () => {
+    const { rerender } = render(<AgentPlanningUpdates />);
+    mockClearPanelAttention.mockClear();
+    mockMarkPanelAttention.mockClear();
+
+    mocks.sessionId = 'session-b';
+    mocks.serviceContexts = {};
+    rerender(<AgentPlanningUpdates />);
+
+    mocks.serviceContexts = {
+      planning: planningContext('Existing goal', [
+        { id: 1, title: 'Existing', checked: false },
+      ]),
+    };
+    rerender(<AgentPlanningUpdates />);
+
+    expect(mockMarkPanelAttention).not.toHaveBeenCalled();
+
+    // A later in-session update should still notify.
+    mocks.serviceContexts = {
+      planning: planningContext('Existing goal', [
+        { id: 1, title: 'Existing', checked: true },
+      ]),
+    };
+    rerender(<AgentPlanningUpdates />);
+
+    expect(mockMarkPanelAttention).toHaveBeenCalledWith('planning');
+  });
+});

--- a/src/features/agent/components/__tests__/AgentProcessAttentionUpdates.test.tsx
+++ b/src/features/agent/components/__tests__/AgentProcessAttentionUpdates.test.tsx
@@ -5,6 +5,7 @@ import { AgentProcessAttentionUpdates } from '../AgentProcessAttentionUpdates';
 
 const mockAgentCallBuiltinTool = vi.fn();
 const mockMarkPanelAttention = vi.fn();
+const mockClearPanelAttention = vi.fn();
 let panelOpen = false;
 
 vi.mock('@/hooks/use-rust-backend', () => ({
@@ -23,6 +24,7 @@ vi.mock('@/context/AgentPanelsContext', () => ({
   useAgentPanels: () => ({
     isPanelOpen: (id: string) => id === 'processes' && panelOpen,
     markPanelAttention: mockMarkPanelAttention,
+    clearPanelAttention: mockClearPanelAttention,
   }),
 }));
 

--- a/src/features/agent/components/__tests__/AgentSidePanelShell.test.tsx
+++ b/src/features/agent/components/__tests__/AgentSidePanelShell.test.tsx
@@ -181,4 +181,35 @@ describe('AgentSidePanelShell', () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId('panel-attention-dot')).toBeInTheDocument();
   });
+
+  it('closes the shell from the explicit close control', () => {
+    function ShellState({ children }: { children: ReactNode }) {
+      const { openPanel, isShellOpen } = useAgentPanels();
+      return (
+        <div>
+          <button type="button" onClick={() => openPanel('workspace')}>
+            open
+          </button>
+          <span data-testid="shell-open">{String(isShellOpen())}</span>
+          {children}
+        </div>
+      );
+    }
+
+    render(
+      <AgentPanelsProvider>
+        <ShellState>
+          <AgentSidePanelShell isVisible />
+        </ShellState>
+      </AgentPanelsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'open' }));
+    expect(screen.getByTestId('shell-open')).toHaveTextContent('true');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Close agent panels' }),
+    );
+    expect(screen.getByTestId('shell-open')).toHaveTextContent('false');
+  });
 });

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -920,6 +920,9 @@
       "copyTooltip": "Copy conversation as Markdown",
       "toggleWorkspaceAria": "Toggle Workspace Files Panel",
       "toggleWorkspaceTooltip": "Toggle Workspace Files Panel",
+      "toggleShellAria": "Toggle agent panels",
+      "toggleShellTooltip": "Toggle agent panels",
+      "toggleShellHasUpdatesAria": "Toggle agent panels (has updates)",
       "toggleProcessesAria": "Toggle Background Processes Panel",
       "toggleProcessesTooltip": "Toggle Background Processes Panel",
       "toggleProcessesHasUpdatesAria": "Toggle Background Processes Panel (has updates)",
@@ -1091,7 +1094,9 @@
     },
     "panels": {
       "shellTitle": "Agent panels",
-      "tabHasUpdatesAria": "{{tab}} (has updates)"
+      "tabHasUpdatesAria": "{{tab}} (has updates)",
+      "close": "Close",
+      "closeAria": "Close agent panels"
     },
     "planning": {
       "title": "AI Planning",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -920,6 +920,9 @@
       "copyTooltip": "대화 내용을 마크다운으로 복사",
       "toggleWorkspaceAria": "워크스페이스 파일 패널 전환",
       "toggleWorkspaceTooltip": "워크스페이스 파일 패널 전환",
+      "toggleShellAria": "에이전트 패널 전환",
+      "toggleShellTooltip": "에이전트 패널 전환",
+      "toggleShellHasUpdatesAria": "에이전트 패널 전환 (업데이트 있음)",
       "toggleProcessesAria": "백그라운드 프로세스 패널 전환",
       "toggleProcessesTooltip": "백그라운드 프로세스 패널 전환",
       "toggleProcessesHasUpdatesAria": "백그라운드 프로세스 패널 전환 (업데이트 있음)",
@@ -1091,7 +1094,9 @@
     },
     "panels": {
       "shellTitle": "에이전트 패널",
-      "tabHasUpdatesAria": "{{tab}} (업데이트 있음)"
+      "tabHasUpdatesAria": "{{tab}} (업데이트 있음)",
+      "close": "닫기",
+      "closeAria": "에이전트 패널 닫기"
     },
     "planning": {
       "title": "AI 계획",


### PR DESCRIPTION
## Summary
- Unify Files/Processes/Planning into a right tabbed shell with a single header toggle, explicit close, and aggregate attention.
- Reset planning/process attention correctly on session switch.
- Harden `checkSession` so message fetch uses `StorageSessionId` (never display tokens), preventing false **No final answer yet** after #1689.

Related to #1689
Related to #1694

## Test plan
- [ ] Open agent chat: one shell toggle opens the tabbed side panel; X closes it; tab clicks only switch tabs
- [ ] Switch sessions with/without plans: attention dots do not stick from the previous session
- [ ] `cargo test --test session_id_display_tests`
- [ ] Child session with a real final answer: `checkSession` returns that text (not "No final answer yet")


Made with [Cursor](https://cursor.com)