### PR TITLE
fix(attachments): persist session files across app restart

### DIFF
--- a/src-tauri/src/mcp/builtin/attachments/storage.rs
+++ b/src-tauri/src/mcp/builtin/attachments/storage.rs
@@ -296,6 +296,55 @@ impl AttachmentsStorage {
             .collect()
     }
 
+    /// Load content and chunk rows for a session into the in-memory cache.
+    ///
+    /// Called when an existing store is discovered in SQLite so that
+    /// memory-only readers (`list_content`, `read_content`, etc.) see
+    /// persisted attachments after process restart.
+    async fn hydrate_session_cache(&mut self, session_id: &str) -> Result<(), String> {
+        let Some(db) = &self.db else {
+            return Ok(());
+        };
+
+        let content_models = content::Entity::find()
+            .filter(content::Column::SessionId.eq(session_id))
+            .all(db)
+            .await
+            .map_err(|e| format!("Failed to hydrate attachment contents: {e}"))?;
+
+        if content_models.is_empty() {
+            return Ok(());
+        }
+
+        let content_ids: Vec<String> = content_models.iter().map(|m| m.id.clone()).collect();
+
+        let chunk_models = chunk::Entity::find()
+            .filter(chunk::Column::ContentId.is_in(content_ids))
+            .order_by_asc(chunk::Column::ChunkIndex)
+            .all(db)
+            .await
+            .map_err(|e| format!("Failed to hydrate attachment chunks: {e}"))?;
+
+        let mut chunks_by_content: HashMap<String, Vec<AttachmentChunk>> = HashMap::new();
+        for model in chunk_models {
+            let chunk = AttachmentChunk::from(model);
+            chunks_by_content
+                .entry(chunk.content_id.clone())
+                .or_default()
+                .push(chunk);
+        }
+
+        for model in content_models {
+            let item = AttachmentItem::from(model);
+            let content_id = item.id.clone();
+            let chunks = chunks_by_content.remove(&content_id).unwrap_or_default();
+            self.contents.insert(content_id.clone(), item);
+            self.chunks.insert(content_id, chunks);
+        }
+
+        Ok(())
+    }
+
     /// Get or create an attachment store for the given session ID
     pub async fn get_or_create_store(
         &mut self,
@@ -309,18 +358,21 @@ impl AttachmentsStorage {
         }
 
         // If using database, check if store exists
-        if let Some(db) = &self.db {
-            let result = StoreEntity::find_by_id(session_id.clone())
+        let existing_store = if let Some(db) = &self.db {
+            StoreEntity::find_by_id(session_id.clone())
                 .one(db)
                 .await
-                .map_err(|e| format!("Failed to check store existence: {e}"))?;
+                .map_err(|e| format!("Failed to check store existence: {e}"))?
+        } else {
+            None
+        };
 
-            if let Some(model) = result {
-                // Store exists in database, convert and add to memory cache
-                let store = AttachmentStore::from(model);
-                self.stores.insert(session_id.clone(), store.clone());
-                return Ok(store);
-            }
+        if let Some(model) = existing_store {
+            // Store exists in database — cache store + hydrate contents/chunks
+            let store = AttachmentStore::from(model);
+            self.stores.insert(session_id.clone(), store.clone());
+            self.hydrate_session_cache(&session_id).await?;
+            return Ok(store);
         }
 
         // Store doesn't exist, create new one

--- a/src-tauri/src/mcp/builtin/attachments/test_functional.rs
+++ b/src-tauri/src/mcp/builtin/attachments/test_functional.rs
@@ -135,4 +135,172 @@ mod tests {
 
         assert_eq!(list_result[0].src_url, src_url);
     }
+
+    #[tokio::test]
+    async fn test_attachments_persist_across_storage_restart() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_restart.db");
+        std::fs::File::create(&db_path).unwrap();
+
+        let url = crate::utils::sqlite::format_sqlite_url(&db_path.to_string_lossy());
+        crate::lifecycle::database::register_sqlite_vec();
+
+        let session_id = "restart_session".to_string();
+        let content_body = "Persisted across restart.\nLine two.";
+        let content_id;
+
+        // Phase 1: write with a DB-backed store, then drop it (simulates app exit)
+        {
+            let db = sea_orm::Database::connect(&url)
+                .await
+                .expect("Failed to connect to database");
+            use migration::{Migrator, MigratorTrait};
+            Migrator::up(&db, None)
+                .await
+                .expect("Failed to run migrations");
+
+            let mut storage = AttachmentsStorage::new_with_db(db)
+                .await
+                .expect("Failed to init storage");
+
+            storage
+                .create_store(session_id.clone(), None, None)
+                .await
+                .expect("Failed to create store");
+
+            let item = storage
+                .add_content(AddContentInput {
+                    session_id: &session_id,
+                    filename: "persisted.txt",
+                    mime_type: "text/plain",
+                    size: content_body.len(),
+                    content: content_body,
+                    chunks: vec![content_body.to_string()],
+                    src_url: None,
+                })
+                .await
+                .expect("Failed to add content");
+            content_id = item.id;
+        }
+
+        // Phase 2: reconnect with empty in-memory cache (simulates app relaunch)
+        {
+            let db = sea_orm::Database::connect(&url)
+                .await
+                .expect("Failed to reconnect to database");
+
+            let mut storage = AttachmentsStorage::new_with_db(db)
+                .await
+                .expect("Failed to re-init storage");
+
+            storage
+                .get_or_create_store(session_id.clone(), None, None)
+                .await
+                .expect("Failed to load existing store");
+
+            let (listed, total) = storage
+                .list_content(&session_id, 0, 10)
+                .await
+                .expect("Failed to list after restart");
+            assert_eq!(total, 1);
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].id, content_id);
+            assert_eq!(listed[0].filename, "persisted.txt");
+
+            let read = storage
+                .read_content(&content_id, 1, None)
+                .await
+                .expect("Failed to read after restart");
+            assert!(read.contains("Persisted across restart"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_or_create_store_creates_when_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_missing_store.db");
+        std::fs::File::create(&db_path).unwrap();
+
+        let url = crate::utils::sqlite::format_sqlite_url(&db_path.to_string_lossy());
+        crate::lifecycle::database::register_sqlite_vec();
+
+        let db = sea_orm::Database::connect(&url)
+            .await
+            .expect("Failed to connect to database");
+        use migration::{Migrator, MigratorTrait};
+        Migrator::up(&db, None)
+            .await
+            .expect("Failed to run migrations");
+
+        let mut storage = AttachmentsStorage::new_with_db(db)
+            .await
+            .expect("Failed to init storage");
+
+        let session_id = "brand_new_session".to_string();
+        let store = storage
+            .get_or_create_store(session_id.clone(), None, None)
+            .await
+            .expect("Failed to create store for missing session");
+
+        assert_eq!(store.session_id, session_id);
+
+        let (listed, total) = storage
+            .list_content(&session_id, 0, 10)
+            .await
+            .expect("Failed to list empty store");
+        assert_eq!(total, 0);
+        assert!(listed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_empty_store_hydrates_with_no_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_empty_store.db");
+        std::fs::File::create(&db_path).unwrap();
+
+        let url = crate::utils::sqlite::format_sqlite_url(&db_path.to_string_lossy());
+        crate::lifecycle::database::register_sqlite_vec();
+        let session_id = "empty_session".to_string();
+
+        {
+            let db = sea_orm::Database::connect(&url)
+                .await
+                .expect("Failed to connect to database");
+            use migration::{Migrator, MigratorTrait};
+            Migrator::up(&db, None)
+                .await
+                .expect("Failed to run migrations");
+
+            let mut storage = AttachmentsStorage::new_with_db(db)
+                .await
+                .expect("Failed to init storage");
+
+            storage
+                .create_store(session_id.clone(), None, None)
+                .await
+                .expect("Failed to create empty store");
+        }
+
+        {
+            let db = sea_orm::Database::connect(&url)
+                .await
+                .expect("Failed to reconnect to database");
+
+            let mut storage = AttachmentsStorage::new_with_db(db)
+                .await
+                .expect("Failed to re-init storage");
+
+            storage
+                .get_or_create_store(session_id.clone(), None, None)
+                .await
+                .expect("Failed to hydrate empty store");
+
+            let (listed, total) = storage
+                .list_content(&session_id, 0, 10)
+                .await
+                .expect("Failed to list after empty hydrate");
+            assert_eq!(total, 0);
+            assert!(listed.is_empty());
+        }
+    }
 }

--- a/src-tauri/src/mcp/service_proxy/factory.rs
+++ b/src-tauri/src/mcp/service_proxy/factory.rs
@@ -108,7 +108,12 @@ pub(crate) async fn create_builtin_server(
             )))
         }
         BuiltinServiceId::Attachments => Ok(Some(Box::new(
-            crate::mcp::builtin::attachments::AttachmentsServer::new(_session_id, _session_manager),
+            crate::mcp::builtin::attachments::AttachmentsServer::new_with_db(
+                _session_id,
+                _session_manager,
+                (*_db).clone(),
+            )
+            .await?,
         ))),
         BuiltinServiceId::Ui => Ok(Some(Box::new(crate::mcp::builtin::ui::UiServer::new()))),
         BuiltinServiceId::Browser => {

--- a/src/components/shared/SessionFilesPopover.tsx
+++ b/src/components/shared/SessionFilesPopover.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Folder, FolderOpen, FileText } from 'lucide-react';
+import { Paperclip, FolderOpen, FileText } from 'lucide-react';
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -11,6 +12,9 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@/components/ui';
 import { useAgentResourceAttachment } from '@/features/agent/hooks/useAgentResourceAttachment';
 import { getLogger } from '@/lib/logger';
@@ -45,86 +49,89 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
     return sessionFiles.filter((file) => file.sessionId === sessionId);
   }, [sessionFiles, sessionId]);
 
-  const handleFileClick = useCallback(async (file: AttachmentReference) => {
-    setSelectedFile(file);
-    setIsLoadingContent(true);
+  const handleFileClick = useCallback(
+    async (file: AttachmentReference) => {
+      setSelectedFile(file);
+      setIsLoadingContent(true);
 
-    try {
-      let content = file.preview || '';
+      try {
+        let content = file.preview || '';
 
-      if (!content || content.length < 100) {
-        logger.debug('Loading full file content via builtin tool', {
-          sessionId: file.sessionId,
-          contentId: file.contentId,
-          filename: file.filename,
-        });
-
-        const result = await agentCallBuiltinTool(
-          file.sessionId,
-          'attachments__readAttachment',
-          {
+        if (!content || content.length < 100) {
+          logger.debug('Loading full file content via builtin tool', {
             sessionId: file.sessionId,
             contentId: file.contentId,
-            lineRange: { fromLine: 1 },
-          },
-        );
+            filename: file.filename,
+          });
 
-        // Parse the result
-        // The result from agentCallBuiltinTool is strict MCPResult
-        if (result && typeof result === 'object' && 'content' in result) {
-          // Check for structuredContent first (Agent V2 pattern)
-          // But built-in tools often return TextContent or EmbeddedResource
-          const textContent = Array.isArray(result.content)
-            ? result.content.find((c) => c.type === 'text')?.text
-            : undefined;
+          const result = await agentCallBuiltinTool(
+            file.sessionId,
+            'attachments__readAttachment',
+            {
+              sessionId: file.sessionId,
+              contentId: file.contentId,
+              lineRange: { fromLine: 1 },
+            },
+          );
 
-          if (textContent) {
-            content = textContent;
-          } else if ('structuredContent' in result) {
-            // Some tools might still use this custom field?
-            // Checking types.rs/MCPResult, it has content: Vec<MCPContent>
-            // So structuredContent might be deprecated or non-standard.
-            // However, let's keep the logic aligned with what the legacy tool did if possible.
-            // Legacy tool seemed to handle a custom 'structuredContent' field in result.
-            // Let's assume the Rust tool returns standard MCP content now.
-            content = 'File content format not supported for display.';
+          // Parse the result
+          // The result from agentCallBuiltinTool is strict MCPResult
+          if (result && typeof result === 'object' && 'content' in result) {
+            // Check for structuredContent first (Agent V2 pattern)
+            // But built-in tools often return TextContent or EmbeddedResource
+            const textContent = Array.isArray(result.content)
+              ? result.content.find((c) => c.type === 'text')?.text
+              : undefined;
+
+            if (textContent) {
+              content = textContent;
+            } else if ('structuredContent' in result) {
+              // Some tools might still use this custom field?
+              // Checking types.rs/MCPResult, it has content: Vec<MCPContent>
+              // So structuredContent might be deprecated or non-standard.
+              // However, let's keep the logic aligned with what the legacy tool did if possible.
+              // Legacy tool seemed to handle a custom 'structuredContent' field in result.
+              // Let's assume the Rust tool returns standard MCP content now.
+              content = 'File content format not supported for display.';
+            } else {
+              content = 'File content not available.';
+            }
           } else {
-            content = 'File content not availble.';
+            content = 'File content not available';
           }
-        } else {
-          content = 'File content not available';
+
+          // Refined logic based on expected Rust output for read
+          // The Rust `read_content` returns a TextContent block with the file data.
+          // Or if it was structured, it might return a JSON string in text.
+          if (
+            result &&
+            Array.isArray(result.content) &&
+            result.content.length > 0
+          ) {
+            const item = result.content[0];
+            if (item.type === 'text') {
+              content = item.text;
+            }
+          }
         }
 
-        // Refined logic based on expected Rust output for read
-        // The Rust `read_content` returns a TextContent block with the file data.
-        // Or if it was structured, it might return a JSON string in text.
-        if (
-          result &&
-          Array.isArray(result.content) &&
-          result.content.length > 0
-        ) {
-          const item = result.content[0];
-          if (item.type === 'text') {
-            content = item.text;
-          }
-        }
+        setFileContent(content);
+        logger.debug('Successfully loaded file content', {
+          filename: file.filename,
+          contentLength: content.length,
+        });
+      } catch (error) {
+        logger.error('Failed to load file content:', {
+          filename: file.filename,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        setFileContent(t('sessionFiles.readError', 'Error reading file.'));
+      } finally {
+        setIsLoadingContent(false);
       }
-
-      setFileContent(content);
-      logger.debug('Successfully loaded file content', {
-        filename: file.filename,
-        contentLength: content.length,
-      });
-    } catch (error) {
-      logger.error('Failed to load file content:', {
-        filename: file.filename,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      setFileContent(t('sessionFiles.readError', 'Error reading file.'));
-    } finally {
-      setIsLoadingContent(false);
-    }
-  }, []);
+    },
+    [t],
+  );
 
   const formatFileSize = (bytes: number) => {
     if (bytes < 1024) return `${bytes}B`;
@@ -136,20 +143,34 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
     return SESSION_FILE_DATE_FORMATTER.format(new Date(dateString));
   };
 
+  const viewFilesLabel = t('sessionFiles.viewFiles', 'View session files');
+
   return (
     <>
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <button
-            className="text-xs hover:text-primary transition-colors flex items-center gap-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-sm"
-            title={t('sessionFiles.viewFiles', 'View session files')}
-          >
-            <Folder className="w-3 h-3" />
-            <span>{currentSessionFiles.length}</span>
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-80 p-0" side="bottom" align="end">
-          <div className="border-b px-3 py-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={viewFilesLabel}
+                className="h-6 gap-1 px-2"
+              >
+                <Paperclip className="h-4 w-4" />
+                <span className="text-xs">{currentSessionFiles.length}</span>
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{viewFilesLabel}</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent
+          className="w-80 border bg-popover p-0 text-popover-foreground shadow-md"
+          side="bottom"
+          align="end"
+        >
+          <div className="border-b bg-muted/40 px-3 py-2">
             <h4 className="text-sm font-medium">
               {t('sessionFiles.fileList', 'Session file list')}
             </h4>
@@ -172,15 +193,15 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
                     file.workspacePath ??
                     `${file.filename}-${file.uploadedAt}`
                   }
-                  className="px-3 py-2 cursor-pointer border-b last:border-b-0 block"
+                  className="block cursor-pointer border-b px-3 py-2 last:border-b-0"
                   onClick={() => handleFileClick(file)}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <div className="text-xs font-medium truncate">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-xs font-medium">
                         {file.filename}
                       </div>
-                      <div className="text-xs text-muted-foreground mt-1">
+                      <div className="mt-1 text-xs text-muted-foreground">
                         {file.mimeType && (
                           <span className="mr-2">{file.mimeType}</span>
                         )}
@@ -195,19 +216,19 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
                           </span>
                         )}
                         {file.workspacePath && (
-                          <span className="text-success flex items-center gap-1">
-                            <FolderOpen className="w-3 h-3" />
+                          <span className="flex items-center gap-1 text-success">
+                            <FolderOpen className="h-3 w-3" />
                             {t('sessionFiles.workspaceValue', 'Workspace')}
                           </span>
                         )}
                       </div>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      <FileText className="w-4 h-4" />
+                      <FileText className="h-4 w-4" />
                     </div>
                   </div>
                   {file.preview && (
-                    <div className="text-xs text-muted-foreground mt-1 truncate">
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
                       {file.preview.slice(0, 50)}...
                     </div>
                   )}
@@ -222,7 +243,7 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
         open={!!selectedFile}
         onOpenChange={(open) => !open && setSelectedFile(null)}
       >
-        <DialogContent className="max-w-4xl max-h-[80%] flex flex-col">
+        <DialogContent className="flex max-h-[80%] max-w-4xl flex-col">
           <DialogHeader>
             <DialogTitle className="text-sm">
               {selectedFile?.filename}
@@ -272,16 +293,16 @@ export function SessionFilesPopover({ sessionId }: SessionFilesPopoverProps) {
             </div>
           </DialogHeader>
 
-          <div className="flex-1 min-h-0 mt-4">
+          <div className="mt-4 min-h-0 flex-1">
             {isLoadingContent ? (
-              <div className="flex items-center justify-center h-32">
+              <div className="flex h-32 items-center justify-center">
                 <div className="text-sm text-muted-foreground">
                   {t('common.loading', 'Loading...')}
                 </div>
               </div>
             ) : (
-              <div className="h-full overflow-auto border rounded p-3 bg-muted">
-                <pre className="text-xs whitespace-pre-wrap font-mono">
+              <div className="h-full overflow-auto rounded border bg-muted p-3">
+                <pre className="whitespace-pre-wrap font-mono text-xs">
                   {fileContent}
                 </pre>
               </div>


### PR DESCRIPTION
## Summary
- Persist session attachments to SQLite by wiring `AttachmentsServer` through `new_with_db` in the MCP service proxy factory
- Hydrate in-memory content/chunk caches when an existing store is loaded so list/read survive app restart
- Align `SessionFilesPopover` trigger with header ghost button + Tooltip chrome

Fixes #1699

## Test plan
- [ ] `cargo test --lib mcp::builtin::attachments::test_functional` passes (restart / missing store / empty store cases)
- [ ] Attach a file in a session, quit the app, relaunch, reopen the session — popover count is non-zero
- [ ] Open an attachment from the popover after restart and confirm content loads
- [ ] Confirm header attachment control matches neighboring ghost buttons (icon size, tooltip)


Made with [Cursor](https://cursor.com)