### PR TITLE
refactor(builtin-tools): prune redundant SuccessHint follow-ups

### DIFF
--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -428,7 +428,6 @@ impl SuccessHint {
                 "workspace__readFile and workspace__listDirectory still use workspace root, not the shell CWD".to_string(),
             ],
             ("spawnProcess", ToolGroup::Workspace) => vec![
-                "Use workspace__listProcesses to see the status of the background task".to_string(),
                 "Use workspace__waitForProcess with timeout=0 to check if it's still running".to_string(),
                 "Use workspace__readProcessOutput to see standard output and error".to_string(),
             ],
@@ -440,36 +439,18 @@ impl SuccessHint {
                 "Use workspace__waitForProcess(processId, 0) only to check status, not to unlock reading".to_string(),
                 "If processId is missing from the registry, use workspace__listProcesses() — do not assume it is still starting".to_string(),
             ],
+            // Steady-path success catalogs stay empty; handlers add outcome-conditioned follow-ups.
             ("listProcesses", ToolGroup::Workspace) => vec![],
-            ("writeFile", ToolGroup::Workspace) => vec![
-                "Use workspace__readFile to verify the content".to_string(),
-                "Use workspace__listDirectory to see the file in context".to_string(),
-            ],
-            ("readFile", ToolGroup::Workspace) => vec![
-                format!(
-                    "Use workspace__{} for targeted in-place edits",
-                    crate::mcp::builtin::workspace::edit_mode::PRIMARY_EDIT_TOOL
-                ),
-                "Use workspace__writeFile only to create, overwrite, or append whole files".to_string(),
-            ],
-            ("listDirectory", ToolGroup::Workspace) => vec![
-                "Use workspace__readFile to view file contents".to_string(),
-                "Use workspace__writeFile to create new files".to_string(),
-                "Use workspace__globFiles with filePattern to narrow down names".to_string(),
-            ],
+            ("writeFile", ToolGroup::Workspace) => vec![],
+            ("readFile", ToolGroup::Workspace) => vec![],
+            ("listDirectory", ToolGroup::Workspace) => vec![],
             #[cfg(feature = "workspace-edit-file")]
             (
                 "editFile" | "replaceLines" | "insertAfterLine" | "deleteLines",
                 ToolGroup::Workspace,
-            ) => vec![
-                "Use workspace__readFile to verify your edits".to_string(),
-                "Use workspace__runShell to execute the updated code".to_string(),
-            ],
+            ) => vec![],
             #[cfg(feature = "workspace-str-replace")]
-            ("strReplace", ToolGroup::Workspace) => vec![
-                "Use workspace__readFile to verify your edits".to_string(),
-                "Use workspace__runShell to execute the updated code".to_string(),
-            ],
+            ("strReplace", ToolGroup::Workspace) => vec![],
             ("globFiles", ToolGroup::Workspace) => vec![
                 "Use workspace__grepFiles to search inside matched files".to_string(),
                 "Use workspace__readFile to inspect a specific match".to_string(),

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/async_exec.rs
@@ -345,11 +345,10 @@ impl WorkspaceServer {
                     "Use workspace__waitForProcess(\"{}\", 0) to check status and completion",
                     process_id
                 ),
-                "Use workspace__listProcesses to map optional names back to process IDs"
-                    .to_string(),
-                "Use workspace__readProcessOutput with 'both' to inspect stdout and stderr"
-                    .to_string(),
-                "Use workspace__listProcesses to see all running processes".to_string(),
+                format!(
+                    "Use workspace__readProcessOutput(\"{}\", \"both\") to inspect stdout and stderr",
+                    process_id
+                ),
             ],
         );
 

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/isolated.rs
@@ -446,8 +446,9 @@ impl WorkspaceServer {
                 );
 
                 let might_be_interactive = validation::is_likely_interactive_command(command);
+                // Keep body factual; parameterized wait/read/stop live in Suggested Follow-ups.
                 let mut message = format!(
-                    "Sync timeout handoff: command was still running after {} seconds, so it continues in background.\n\nProcess ID: {}\nStatus: {}\nExit code: pending\n\nUse workspace__waitForProcess/workspace__readProcessOutput only with this processId — completed sync runs (success or failure) never get a processId.",
+                    "Sync timeout handoff: command was still running after {} seconds, so it continues in background.\n\nProcess ID: {}\nStatus: {}\nExit code: pending",
                     timeout_secs, process_id, status
                 );
 

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
@@ -245,11 +245,8 @@ impl WorkspaceServer {
         let message =
             format!("Replaced {replacements} occurrence(s) in '{path_str}'.\n\n{diff_output}");
 
-        Ok(SuccessHint::new(
-            message,
-            vec!["Use workspace__readFile to verify the updated content".to_string()],
-        )
-        .to_mcp_result())
+        // Diff in the body is enough — do not burn tokens on a re-read follow-up.
+        Ok(SuccessHint::new(message, vec![]).to_mcp_result())
     }
 }
 

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/list.rs
@@ -140,25 +140,11 @@ impl WorkspaceServer {
             let mut actions = Vec::new();
 
             match first_status {
-                "failed" => {
+                "failed" | "finished" => {
                     actions.push(format!(
                         "Use workspace__readProcessOutput('{}', 'both') to inspect stdout and stderr",
                         first_id
                     ));
-                    actions.push(
-                        "Use workspace__listProcesses() again if you need another processId from this session"
-                            .to_string(),
-                    );
-                }
-                "finished" => {
-                    actions.push(format!(
-                        "Use workspace__readProcessOutput('{}', 'both') to inspect stdout and stderr",
-                        first_id
-                    ));
-                    actions.push(
-                        "Use workspace__listProcesses() again if you need another processId from this session"
-                            .to_string(),
-                    );
                 }
                 "running" => {
                     actions.push(format!(

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/read_output.rs
@@ -356,6 +356,7 @@ impl WorkspaceServer {
             ),
         ]);
 
+        // Finished reads already include the captured output — no patronizing follow-ups.
         let next_actions = if is_process_running {
             vec![
                 format!(
@@ -368,11 +369,7 @@ impl WorkspaceServer {
                 ),
             ]
         } else {
-            vec![
-                "Analyze the captured output to verify command success".to_string(),
-                "Use workspace__listProcesses() if you need another processId from this session"
-                    .to_string(),
-            ]
+            vec![]
         };
 
         let hint = SuccessHint::new(text, next_actions);

--- a/src-tauri/tests/integration/read_process_output_tests.rs
+++ b/src-tauri/tests/integration/read_process_output_tests.rs
@@ -279,6 +279,19 @@ async fn spawn_and_list_processes_surface_optional_name_labels() {
         spawn_text.contains("• Name: demo-process"),
         "spawn response should expose process name label: {spawn_text}"
     );
+    assert!(
+        spawn_text.contains("waitForProcess"),
+        "spawn success should keep parameterized wait follow-up: {spawn_text}"
+    );
+    assert!(
+        spawn_text.contains("readProcessOutput"),
+        "spawn success should keep parameterized read follow-up: {spawn_text}"
+    );
+    assert!(
+        !spawn_text.contains("listProcesses to see all running")
+            && !spawn_text.contains("map optional names"),
+        "spawn success must not pad with redundant listProcesses hints: {spawn_text}"
+    );
 
     let structured = spawn_result
         .structured_content
@@ -361,6 +374,10 @@ async fn list_processes_prefers_read_output_for_finished_processes() {
         !text.contains("workspace__stopProcess") && !text.contains("stopProcess("),
         "finished processes should not suggest stopProcess: {text}"
     );
+    assert!(
+        !text.contains("listProcesses() again"),
+        "listProcesses must not tell the agent to call itself again: {text}"
+    );
 }
 
 #[tokio::test]
@@ -401,8 +418,12 @@ async fn read_process_output_avoids_stop_hint_after_process_has_finished() {
 
     let text = extract_text_content(&result);
     assert!(
-        text.contains("Analyze the captured output to verify command success"),
-        "finished processes should suggest analyzing the finished output: {text}"
+        !text.contains("Analyze the captured output to verify command success"),
+        "finished processes should not lecture the agent to analyze output it just requested: {text}"
+    );
+    assert!(
+        !text.contains("💡 Suggested Follow-ups:"),
+        "finished readProcessOutput should not append follow-ups: {text}"
     );
     assert!(
         !text.contains("workspace__stopProcess") && !text.contains("stopProcess("),

--- a/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
+++ b/src-tauri/tests/integration/session_and_workspace_timeout_regression_tests.rs
@@ -240,6 +240,10 @@ async fn run_shell_timeout_hands_off_to_background_process() {
         "timeout handoff text should include processId: {text}"
     );
     assert!(
+        !text.contains("never get a processId"),
+        "timeout handoff body must not lecture about when processIds are absent: {text}"
+    );
+    assert!(
         text.contains("waitForProcess("),
         "timeout handoff should suggest the next wait action: {text}"
     );

--- a/src-tauri/tests/integration/workspace_str_replace_tests.rs
+++ b/src-tauri/tests/integration/workspace_str_replace_tests.rs
@@ -56,6 +56,18 @@ async fn str_replace_replaces_single_unique_match() {
     );
     let text = extract_text_content(&result);
     assert!(text.contains("Replaced 1 occurrence"), "{text}");
+    assert!(
+        text.contains("@@"),
+        "success body should include a unified diff so re-read is unnecessary: {text}"
+    );
+    assert!(
+        !text.contains("readFile to verify"),
+        "strReplace must not suggest re-reading after returning a diff: {text}"
+    );
+    assert!(
+        !text.contains("💡 Suggested Follow-ups:"),
+        "strReplace success should not append follow-ups: {text}"
+    );
 
     let updated = std::fs::read_to_string(file_path).expect("read updated file");
     assert_eq!(updated, "alpha\nBETA\ngamma\n");


### PR DESCRIPTION
## Summary
- Remove self-evident workspace success-path hints that restate diffs, process lists, or already-returned output.
- Keep parameterized `waitForProcess` / `readProcessOutput` follow-ups on background handoff and running-process paths.
- Add regression assertions so re-read / self-call / processId lecture bloat does not return.

Fixes #1695

## Test plan
- [ ] `cargo test --test integration_tests --features workspace-str-replace -- str_replace_replaces_single_unique read_process_output_avoids_stop list_processes_prefers_read spawn_and_list_processes_surface run_shell_timeout_hands_off run_shell_success_hint_no_longer`
- [ ] Confirm `strReplace` success returns a unified diff and no `Suggested Follow-ups`
- [ ] Confirm finished `readProcessOutput` has no analyze/listProcesses follow-ups
- [ ] Confirm sync timeout handoff still exposes `Process ID` + wait/read follow-ups, without the “never get a processId” lecture


Made with [Cursor](https://cursor.com)