### PR TITLE
fix(agent): stop clipping UI resources with max-height scroll

### DIFF
--- a/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
@@ -156,7 +156,7 @@ export function ContentItemRenderer({
           ref={(element) => {
             resourceRefs.current[itemKey] = element;
           }}
-          className={expandResources ? 'min-h-96 w-full overflow-visible' : ''}
+          className={expandResources ? 'w-full overflow-visible' : ''}
         >
           <UIResourceRenderer
             remoteDomProps={remoteDomProps}

--- a/src/features/agent/components/AgentMessageRenderer/index.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/index.tsx
@@ -118,15 +118,20 @@ const AgentMessageRendererImpl: React.FC<AgentMessageRendererProps> = ({
     [supportedContentTypes],
   );
 
+  // Expanded tool results: let autoResizeIframe grow with content (no 384px /
+  // max-h-96-style cap — that caused an inner iframe scrollbar). Compact /
+  // inline resources keep a fixed viewport with an 80vh ceiling.
   const htmlProps = useMemo(
     () => ({
       autoResizeIframe: { height: true, width: false },
-      style: { height: '384px', maxHeight: '80vh' },
+      style: expandResources
+        ? { width: '100%', minHeight: '200px' }
+        : { height: '384px', maxHeight: '80vh' },
       iframeProps: {
         className: 'w-full',
       },
     }),
-    [],
+    [expandResources],
   );
 
   const handleLinkClick = async (

--- a/src/features/agent/components/AgentToolCallDetails.tsx
+++ b/src/features/agent/components/AgentToolCallDetails.tsx
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react';
 import type { ToolCall, Message } from '@/models/chat';
 import { AgentMessageRenderer } from './AgentMessageRenderer';
 import { AlertCircle, Loader2 } from 'lucide-react';
-import { parseToolArguments } from '@/lib/tool-call-utils';
+import { hasUIResource, parseToolArguments } from '@/lib/tool-call-utils';
+import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 
 interface AgentToolCallDetailsProps {
@@ -39,6 +40,7 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
     () => parsedArgs || parseToolArguments(toolCall.function.arguments),
     [parsedArgs, toolCall.function.arguments],
   );
+  const containsUIResource = hasUIResource(toolResult);
 
   if (!showDetails) return null;
 
@@ -69,7 +71,12 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
               : t('agent.toolDetails.result', 'Result')}
           </div>
           {hasError ? (
-            <div className="bg-destructive/10 border border-destructive/20 rounded p-3 max-h-96 overflow-y-auto">
+            <div
+              className={cn(
+                'bg-destructive/10 border border-destructive/20 rounded p-3',
+                !containsUIResource && 'max-h-96 overflow-y-auto',
+              )}
+            >
               <div className="flex items-start gap-2">
                 <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
                 <div className="flex-1 min-w-0">
@@ -81,7 +88,13 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
               </div>
             </div>
           ) : (
-            <div className="bg-background rounded border p-2 max-h-96 overflow-y-auto">
+            <div
+              data-testid="tool-call-result"
+              className={cn(
+                'bg-background rounded border p-2',
+                !containsUIResource && 'max-h-96 overflow-y-auto',
+              )}
+            >
               <AgentMessageRenderer
                 message={toolResult}
                 className="text-sm"

--- a/src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx
+++ b/src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx
@@ -1,0 +1,118 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import type { MCPContent } from '@/lib/mcp';
+import type { Message } from '@/models/chat';
+import { AgentMessageRenderer } from '../AgentMessageRenderer';
+
+const uiResourceRendererMock = vi.fn();
+
+vi.mock('@mcp-ui/client', () => ({
+  basicComponentLibrary: {},
+  remoteButtonDefinition: {},
+  remoteTextDefinition: {},
+  remoteCardDefinition: {},
+  remoteImageDefinition: {},
+  remoteStackDefinition: {},
+  UIResourceRenderer: (props: unknown) => {
+    uiResourceRendererMock(props);
+    return <div data-testid="ui-resource" />;
+  },
+}));
+
+vi.mock('@/hooks/use-rust-backend', () => ({
+  useRustBackend: () => ({
+    openExternalUrl: vi.fn(),
+    downloadMediaFile: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChatActions: () => ({
+    submit: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: { id: 'test-session', assistant: { id: 'test-assistant' } },
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    resolvedTheme: 'light',
+  }),
+}));
+
+const resourceContent: MCPContent[] = [
+  {
+    type: 'resource',
+    resource: {
+      uri: 'ui://resource',
+      mimeType: 'text/html',
+      text: '<div>ui</div>',
+    },
+  } as MCPContent,
+];
+
+const message = {
+  id: 'msg-ui',
+  role: 'assistant',
+  content: resourceContent,
+} as Message;
+
+describe('AgentMessageRenderer UI resource iframe sizing', () => {
+  beforeEach(() => {
+    uiResourceRendererMock.mockReset();
+  });
+
+  it('uses fixed 384px height when expandResources is false', () => {
+    render(
+      <AgentMessageRenderer content={resourceContent} message={message} />,
+    );
+
+    expect(uiResourceRendererMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        htmlProps: expect.objectContaining({
+          style: expect.objectContaining({
+            height: '384px',
+            maxHeight: '80vh',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('drops the 384px height cap when expandResources is true', () => {
+    render(
+      <AgentMessageRenderer
+        content={resourceContent}
+        message={message}
+        expandResources
+      />,
+    );
+
+    const htmlProps = uiResourceRendererMock.mock.calls[0]?.[0]?.htmlProps as {
+      style?: Record<string, string>;
+    };
+
+    expect(htmlProps.style?.height).toBeUndefined();
+    expect(htmlProps.style?.maxHeight).toBeUndefined();
+    expect(htmlProps.style).toEqual(
+      expect.objectContaining({
+        width: '100%',
+        minHeight: '200px',
+      }),
+    );
+  });
+});

--- a/src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx
+++ b/src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx
@@ -63,6 +63,25 @@ const makeToolResult = (text: string): Message =>
         tool_call_id: 'call-1',
     }) as Message;
 
+const makeUIResourceResult = (): Message =>
+    ({
+        id: 'msg-result-ui',
+        sessionId: 'session-1',
+        threadId: 'session-1',
+        role: 'tool',
+        content: [
+            {
+                type: 'resource',
+                resource: {
+                    uri: 'ui://test',
+                    mimeType: 'text/html',
+                    text: '<p>widget</p>',
+                },
+            },
+        ],
+        tool_call_id: 'call-1',
+    }) as Message;
+
 describe('AgentToolCallDetails', () => {
     it('renders nothing when showDetails is false', () => {
         const { container } = render(
@@ -137,5 +156,29 @@ describe('AgentToolCallDetails', () => {
         expect(parseSpy).not.toHaveBeenCalled();
 
         parseSpy.mockRestore();
+    });
+
+    it('applies max-h-96 to text tool results', () => {
+        const { getByTestId } = render(
+            <AgentToolCallDetails
+                toolCall={makeToolCall()}
+                toolResult={makeToolResult('plain text result')}
+                showDetails={true}
+            />,
+        );
+        expect(getByTestId('tool-call-result').className).toContain('max-h-96');
+        expect(getByTestId('tool-call-result').className).toContain('overflow-y-auto');
+    });
+
+    it('skips max-h-96 when tool result contains a UI resource', () => {
+        const { getByTestId } = render(
+            <AgentToolCallDetails
+                toolCall={makeToolCall()}
+                toolResult={makeUIResourceResult()}
+                showDetails={true}
+            />,
+        );
+        expect(getByTestId('tool-call-result').className).not.toContain('max-h-96');
+        expect(getByTestId('tool-call-result').className).not.toContain('overflow-y-auto');
     });
 });


### PR DESCRIPTION
## Summary
- Exempt UI resource / multimedia tool results from `max-h-96 overflow-y-auto` in `AgentToolCallDetails`
- When `expandResources` is on, drop the fixed iframe `height: 384px` / `maxHeight: 80vh` so MCP widgets can auto-resize without an inner scrollbar
- Remove the expanded-resource wrapper `min-h-96` that reserved empty space

## Test plan
- [ ] Expand a plain-text tool result — still capped / scrollable at `max-h-96`
- [ ] Expand a UI resource (rawHtml) tool result — no outer `max-h-96` scroll, iframe grows with content
- [ ] Compact (non-expanded) UI resource still uses the 384px / 80vh viewport
- [ ] `pnpm exec vitest run src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx`


Made with [Cursor](https://cursor.com)