### PR TITLE
feat(agent): inject host theme into MCP UI rawHtml resources

### DIFF
--- a/src-tauri/src/mcp/builtin/ui/templates/circuit-break.hbs
+++ b/src-tauri/src/mcp/builtin/ui/templates/circuit-break.hbs
@@ -4,6 +4,10 @@
     <meta charset='utf-8' />
     <meta name='viewport' content='width=device-width,initial-scale=1' />
     <style>
+      /*
+        Warning chrome stays amber; surfaces follow host theme tokens so dark
+        mode does not get a full-bleed light panel.
+      */
       body {
         font-family:
           system-ui,
@@ -11,16 +15,18 @@
           sans-serif;
         margin: 0;
         padding: 32px 16px;
-        background: #fef3c7;
+        background: color-mix(in oklab, #f59e0b 20%, var(--background, #fffbeb));
+        color: var(--foreground, #78350f);
       }
       .circuit-container {
         max-width: 600px;
         margin: 0 auto;
-        background: white;
+        background: var(--card, #ffffff);
+        color: var(--card-foreground, #78350f);
         border: 2px solid #f59e0b;
         border-radius: 8px;
         padding: 32px;
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 4px 6px color-mix(in oklab, var(--foreground, #000000) 12%, transparent);
       }
       .warning-icon {
         font-size: 48px;
@@ -30,18 +36,18 @@
       .title {
         font-size: 24px;
         font-weight: 700;
-        color: #92400e;
+        color: #d97706;
         margin-bottom: 16px;
         text-align: center;
       }
       .message {
         font-size: 16px;
-        color: #78350f;
+        color: var(--muted-foreground, #78350f);
         margin-bottom: 24px;
         line-height: 1.6;
       }
       .tool-info {
-        background: #fef3c7;
+        background: color-mix(in oklab, #f59e0b 16%, var(--muted, #fef3c7));
         border-left: 4px solid #f59e0b;
         padding: 12px 16px;
         margin-bottom: 24px;
@@ -50,12 +56,13 @@
           monospace;
         font-size: 14px;
         word-break: break-all;
+        color: var(--foreground, #78350f);
       }
       .btn-resume {
         width: 100%;
         padding: 14px 24px;
         background: #f59e0b;
-        color: white;
+        color: #ffffff;
         border: none;
         border-radius: 6px;
         font-size: 16px;
@@ -118,7 +125,8 @@
     </script>
     <script>
       // Auto-resize logic for MCP-UI client autoResizeIframe.
-      const resizeTarget = document.querySelector('.card') || document.body;
+      const resizeTarget =
+        document.querySelector('.circuit-container') || document.body;
       const bodyStyles = window.getComputedStyle(document.body);
       const bodyPaddingY =
         parseFloat(bodyStyles.paddingTop || '0') +

--- a/src-tauri/src/mcp/builtin/ui/templates/present-interactive.hbs
+++ b/src-tauri/src/mcp/builtin/ui/templates/present-interactive.hbs
@@ -7,6 +7,10 @@
       * {
         box-sizing: border-box;
       }
+      /*
+        Prefer LibrAgent host-injected tokens (--background, --card, …).
+        Hex fallbacks keep the widget usable when opened outside the app.
+      */
       body {
         font-family:
           system-ui,
@@ -14,8 +18,8 @@
           sans-serif;
         margin: 0;
         padding: 16px;
-        background: #f9fafb;
-        color: #1f2937;
+        background: var(--background, #f9fafb);
+        color: var(--foreground, #1f2937);
         font-size: 15px;
         line-height: 1.6;
       }
@@ -28,10 +32,12 @@
       }
       .content-wrapper {
         position: relative;
-        background: white;
+        background: var(--card, #ffffff);
+        color: var(--card-foreground, #111827);
         border-radius: 8px;
         padding: 24px 28px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 1px 3px color-mix(in oklab, var(--foreground, #000000) 12%, transparent);
+        border: 1px solid var(--border, #e5e7eb);
       }
       .action-buttons {
         position: absolute;
@@ -42,9 +48,9 @@
         z-index: 10;
       }
       .icon-btn {
-        background: #f9fafb;
-        color: #4b5563;
-        border: 1px solid #e5e7eb;
+        background: var(--muted, #f9fafb);
+        color: var(--muted-foreground, #4b5563);
+        border: 1px solid var(--border, #e5e7eb);
         border-radius: 6px;
         padding: 6px;
         cursor: pointer;
@@ -54,8 +60,8 @@
         justify-content: center;
       }
       .icon-btn:hover {
-        background: #e5e7eb;
-        color: #111827;
+        background: var(--accent, #e5e7eb);
+        color: var(--accent-foreground, #111827);
       }
       .icon-btn svg {
         width: 16px;
@@ -64,25 +70,27 @@
       .content-title {
         font-size: 18px;
         font-weight: 700;
-        color: #111827;
+        color: var(--card-foreground, #111827);
         margin: 0 0 16px 0;
         padding-bottom: 12px;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border, #e5e7eb);
         padding-right: 80px;
       }
       
       /* Interaction Section */
       .interaction-wrapper {
-        background: white;
+        background: var(--card, #ffffff);
+        color: var(--card-foreground, #111827);
         border-radius: 8px;
         padding: 20px 28px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 1px 3px color-mix(in oklab, var(--foreground, #000000) 12%, transparent);
+        border: 1px solid var(--border, #e5e7eb);
         border-top: 4px solid #3b82f6;
       }
       .interaction-prompt {
         font-weight: 600;
         margin-bottom: 16px;
-        color: #1f2937;
+        color: var(--card-foreground, #1f2937);
         font-size: 16px;
       }
       .options-list {
@@ -95,13 +103,13 @@
         display: flex;
         align-items: center;
         padding: 12px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border, #e5e7eb);
         border-radius: 6px;
         cursor: pointer;
         transition: all 0.2s;
       }
       .option-item:hover {
-        background: #f9fafb;
+        background: var(--muted, #f9fafb);
         border-color: #3b82f6;
       }
       .option-input {
@@ -111,17 +119,19 @@
       .option-label {
         flex: 1;
         font-size: 14px;
-        color: #374151;
+        color: var(--foreground, #374151);
       }
       .text-input {
         width: 100%;
         padding: 12px;
-        border: 1px solid #d1d5db;
+        border: 1px solid var(--input, #d1d5db);
         border-radius: 6px;
         font-family: inherit;
         font-size: 14px;
         margin-bottom: 20px;
         outline: none;
+        background: var(--background, #ffffff);
+        color: var(--foreground, #1f2937);
       }
       .text-input:focus {
         border-color: #3b82f6;
@@ -143,33 +153,33 @@
       }
       .btn-primary {
         background: #3b82f6;
-        color: white;
+        color: #ffffff;
       }
       .btn-primary:hover {
         background: #2563eb;
       }
       .btn-secondary {
-        background: #e5e7eb;
-        color: #374151;
+        background: var(--secondary, #e5e7eb);
+        color: var(--secondary-foreground, #374151);
       }
       .btn-secondary:hover {
-        background: #d1d5db;
+        background: var(--muted, #d1d5db);
       }
 
       /* Markdown rendered styles */
-      .md h1 { font-size: 1.6em; font-weight: 700; margin: 0 0 12px; color: #111827; }
-      .md h2 { font-size: 1.3em; font-weight: 600; margin: 20px 0 8px; color: #1f2937; }
-      .md h3 { font-size: 1.1em; font-weight: 600; margin: 16px 0 6px; color: #374151; }
+      .md h1 { font-size: 1.6em; font-weight: 700; margin: 0 0 12px; color: var(--card-foreground, #111827); }
+      .md h2 { font-size: 1.3em; font-weight: 600; margin: 20px 0 8px; color: var(--foreground, #1f2937); }
+      .md h3 { font-size: 1.1em; font-weight: 600; margin: 16px 0 6px; color: var(--muted-foreground, #374151); }
       .md p  { margin: 0 0 12px; }
       .md ul, .md ol { margin: 0 0 12px; padding-left: 24px; }
       .md li { margin-bottom: 4px; }
       .md code {
-        background: #f3f4f6;
+        background: var(--muted, #f3f4f6);
         border-radius: 3px;
         padding: 2px 5px;
         font-family: ui-monospace, monospace;
         font-size: 0.88em;
-        color: #4f46e5; /* Professional indigo for standard inline code */
+        color: #4f46e5;
       }
       .md pre {
         background: #1e293b;
@@ -180,8 +190,8 @@
         margin: 0 0 14px;
       }
       .md table { border-collapse: collapse; width: 100%; margin: 0 0 14px; font-size: 0.93em; }
-      .md th { background: #f3f4f6; font-weight: 600; }
-      .md th, .md td { border: 1px solid #d1d5db; padding: 7px 12px; text-align: left; }
+      .md th { background: var(--muted, #f3f4f6); font-weight: 600; }
+      .md th, .md td { border: 1px solid var(--border, #d1d5db); padding: 7px 12px; text-align: left; }
     </style>
   </head>
   <body>

--- a/src-tauri/tests/integration/ui_interaction_template_tests.rs
+++ b/src-tauri/tests/integration/ui_interaction_template_tests.rs
@@ -305,4 +305,14 @@ async fn report_result_renders_and_instructs_stop() {
         uri.starts_with("ui://result/"),
         "reportResult URI should use ui://result/: {uri}"
     );
+    let html = resource["text"].as_str().unwrap_or("");
+    assert!(
+        html.contains("var(--background") && html.contains("var(--card"),
+        "reportResult HTML should use host theme CSS variables: {html}"
+    );
+    assert!(
+        !html.contains("background: #f9fafb;")
+            && !html.contains("background: white;"),
+        "reportResult HTML must not hardcode light-only surfaces"
+    );
 }

--- a/src-tauri/tests/integration/ui_interaction_template_tests.rs
+++ b/src-tauri/tests/integration/ui_interaction_template_tests.rs
@@ -311,8 +311,7 @@ async fn report_result_renders_and_instructs_stop() {
         "reportResult HTML should use host theme CSS variables: {html}"
     );
     assert!(
-        !html.contains("background: #f9fafb;")
-            && !html.contains("background: white;"),
+        !html.contains("background: #f9fafb;") && !html.contains("background: white;"),
         "reportResult HTML must not hardcode light-only surfaces"
     );
 }

--- a/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/components/ContentItemRenderer.tsx
@@ -13,6 +13,7 @@ import {
   VideoContentRenderer,
 } from './MediaContentRenderer';
 import { MarkdownText } from './MarkdownText';
+import { applyThemeToUiResource } from '../utils/injectUiResourceTheme';
 import { isSafeExternalUrl } from '../utils/url';
 
 const logger = getLogger('AgentMessageRenderer');
@@ -32,6 +33,10 @@ interface ContentItemRendererProps {
   remoteDomProps: UIResourceRendererProps['remoteDomProps'];
   supportedContentTypes: UIResourceRendererProps['supportedContentTypes'];
   htmlProps: UIResourceRendererProps['htmlProps'];
+  /** Prebuilt `<style data-libragent-theme>` block; null skips injection. */
+  themeStyleTag: string | null;
+  /** Remount key when host theme resolves / switches (e.g. "dark" | "light"). */
+  themeKey: string;
   onUIAction: NonNullable<UIResourceRendererProps['onUIAction']>;
   onLinkClick: (
     event: MouseEvent<HTMLAnchorElement>,
@@ -97,6 +102,8 @@ export function ContentItemRenderer({
   remoteDomProps,
   supportedContentTypes,
   htmlProps,
+  themeStyleTag,
+  themeKey,
   onUIAction,
   onLinkClick,
 }: ContentItemRendererProps) {
@@ -151,6 +158,29 @@ export function ContentItemRenderer({
         return null;
       }
 
+      const themedResource = applyThemeToUiResource(
+        resourceItem.resource,
+        themeStyleTag,
+      );
+
+      // Wait for next-themes to resolve so we never mount a light-themed iframe
+      // under a dark host (or vice versa) during hydration.
+      if (!themeStyleTag) {
+        return (
+          <div
+            ref={(element) => {
+              resourceRefs.current[itemKey] = element;
+            }}
+            className={
+              expandResources
+                ? 'min-h-96 w-full bg-background'
+                : 'h-96 w-full bg-background'
+            }
+            aria-hidden
+          />
+        );
+      }
+
       return (
         <div
           ref={(element) => {
@@ -159,11 +189,12 @@ export function ContentItemRenderer({
           className={expandResources ? 'min-h-96 w-full overflow-visible' : ''}
         >
           <UIResourceRenderer
+            key={themeKey}
             remoteDomProps={remoteDomProps}
             onUIAction={onUIAction}
             supportedContentTypes={supportedContentTypes}
             htmlProps={htmlProps}
-            resource={resourceItem.resource}
+            resource={themedResource}
           />
         </div>
       );

--- a/src/features/agent/components/AgentMessageRenderer/index.tsx
+++ b/src/features/agent/components/AgentMessageRenderer/index.tsx
@@ -13,6 +13,7 @@ import { CodeBlock } from './components/CodeBlock';
 import { ContentItemRenderer } from './components/ContentItemRenderer';
 import { STATIC_MARKDOWN_COMPONENTS } from './config/markdown';
 import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
+import { useTheme } from 'next-themes';
 import { useUIActionHandler } from './hooks/useUIActionHandler';
 import type { AgentMessageRendererProps, RenderItem } from './types';
 import { groupContent } from './utils/contentGrouping';
@@ -20,6 +21,10 @@ import {
   releaseDisplayMediaCacheSession,
   retainDisplayMediaCacheSession,
 } from './utils/displayMediaCache';
+import {
+  buildUiResourceThemeStyleTag,
+  getUiResourceThemeVars,
+} from './utils/injectUiResourceTheme';
 import { isSafeExternalUrl } from './utils/url';
 
 const logger = getLogger('AgentMessageRenderer');
@@ -44,7 +49,12 @@ const AgentMessageRendererImpl: React.FC<AgentMessageRendererProps> = ({
   followChatScroll = true,
 }) => {
   const { openExternalUrl } = useRustBackend();
+  const { resolvedTheme } = useTheme();
   const isDark = useIsDarkMode();
+  // next-themes leaves resolvedTheme undefined until mounted; do not inject a
+  // speculative light theme (defaultTheme is dark, so undefined !== dark).
+  const themeReady =
+    resolvedTheme === 'dark' || resolvedTheme === 'light';
 
   const markdownComponents = useMemo(
     () => ({
@@ -118,16 +128,36 @@ const AgentMessageRendererImpl: React.FC<AgentMessageRendererProps> = ({
     [supportedContentTypes],
   );
 
-  const htmlProps = useMemo(
-    () => ({
+  // Theme tokens come from static maps keyed by resolvedTheme — not
+  // getComputedStyle — so a dark session load cannot bake light :root values
+  // into the iframe before `<html class="dark">` is applied.
+  const themeCssVars = useMemo(
+    () => (themeReady ? getUiResourceThemeVars(isDark) : null),
+    [themeReady, isDark],
+  );
+  const themeStyleTag = useMemo(
+    () =>
+      themeCssVars
+        ? buildUiResourceThemeStyleTag(isDark, themeCssVars)
+        : null,
+    [isDark, themeCssVars],
+  );
+
+  const htmlProps = useMemo(() => {
+    const backgroundColor = themeCssVars?.['--background'];
+
+    return {
       autoResizeIframe: { height: true, width: false },
       style: { height: '384px', maxHeight: '80vh' },
       iframeProps: {
         className: 'w-full',
+        style: {
+          colorScheme: isDark ? 'dark' : 'light',
+          ...(backgroundColor ? { backgroundColor } : {}),
+        },
       },
-    }),
-    [],
-  );
+    };
+  }, [isDark, themeCssVars]);
 
   const handleLinkClick = async (
     event: React.MouseEvent<HTMLAnchorElement>,
@@ -183,6 +213,8 @@ const AgentMessageRendererImpl: React.FC<AgentMessageRendererProps> = ({
               remoteDomProps={remoteDomProps}
               supportedContentTypes={mutableSupportedContentTypes}
               htmlProps={htmlProps}
+              themeStyleTag={themeStyleTag}
+              themeKey={resolvedTheme ?? 'theme-pending'}
               onUIAction={handleUIAction}
               onLinkClick={handleLinkClick}
             />

--- a/src/features/agent/components/AgentMessageRenderer/utils/__tests__/injectUiResourceTheme.test.ts
+++ b/src/features/agent/components/AgentMessageRenderer/utils/__tests__/injectUiResourceTheme.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DARK_UI_RESOURCE_THEME_VARS,
+  UI_RESOURCE_THEME_MARKER,
+  applyThemeToUiResource,
+  buildUiResourceThemeStyleTag,
+  collectThemeCssVariables,
+  getUiResourceThemeVars,
+  injectUiResourceThemeHtml,
+} from '../injectUiResourceTheme';
+
+describe('injectUiResourceTheme', () => {
+  it('getUiResourceThemeVars returns static dark tokens without DOM', () => {
+    expect(getUiResourceThemeVars(true)['--background']).toBe(
+      DARK_UI_RESOURCE_THEME_VARS['--background'],
+    );
+    expect(getUiResourceThemeVars(false)['--background']).toBe('oklch(1 0 0)');
+  });
+
+  it('builds a style tag with color-scheme and provided tokens', () => {
+    const tag = buildUiResourceThemeStyleTag(true, {
+      '--background': 'oklch(0.145 0 0)',
+      '--foreground': 'oklch(0.985 0 0)',
+    });
+
+    expect(tag).toContain(UI_RESOURCE_THEME_MARKER);
+    expect(tag).toContain('color-scheme: dark');
+    expect(tag).toContain('--background: oklch(0.145 0 0)');
+    expect(tag).toContain('--foreground: oklch(0.985 0 0)');
+    expect(tag).toContain('background-color: var(--background');
+  });
+
+  it('injects before </body> and replaces a previous theme block', () => {
+    const styleTag = buildUiResourceThemeStyleTag(false, {
+      '--background': 'white',
+    });
+    const html = `<html><head><title>x</title></head><body><p>hi</p></body></html>`;
+    const once = injectUiResourceThemeHtml(html, styleTag);
+    expect(once).toMatch(
+      /<p>hi<\/p><style data-libragent-theme="true">[\s\S]*<\/style><\/body>/,
+    );
+
+    const darkTag = buildUiResourceThemeStyleTag(true, {
+      '--background': 'black',
+    });
+    const twice = injectUiResourceThemeHtml(once, darkTag);
+    expect(twice.match(new RegExp(UI_RESOURCE_THEME_MARKER, 'g'))).toHaveLength(
+      1,
+    );
+    expect(twice).toContain('color-scheme: dark');
+    expect(twice).not.toContain('color-scheme: light');
+  });
+
+  it('appends when there is no body/html closer', () => {
+    const styleTag = buildUiResourceThemeStyleTag(true, {});
+    const result = injectUiResourceThemeHtml('<div>widget</div>', styleTag);
+    expect(result.startsWith('<div>widget</div>')).toBe(true);
+    expect(result).toContain(`<style ${UI_RESOURCE_THEME_MARKER}`);
+  });
+
+  it('overrides hardcoded light widget chrome for stored reportResult HTML', () => {
+    const styleTag = buildUiResourceThemeStyleTag(
+      true,
+      getUiResourceThemeVars(true),
+    );
+    const widget = `<!doctype html><html><head><style>
+      body { background: #f9fafb; color: #1f2937; }
+      .content-wrapper { background: white; color: #111827; }
+    </style></head><body><div class="content-wrapper">x</div></body></html>`;
+
+    const themed = injectUiResourceThemeHtml(widget, styleTag);
+    expect(themed.indexOf('background: white')).toBeLessThan(
+      themed.indexOf('data-libragent-theme'),
+    );
+    expect(themed).toContain('.content-wrapper');
+    expect(themed).toContain('background: var(--card');
+    expect(themed).toContain('color-scheme: dark');
+  });
+
+  it('applyThemeToUiResource only mutates text/html with text', () => {
+    const styleTag = buildUiResourceThemeStyleTag(true, {
+      '--background': 'oklch(0.1 0 0)',
+    });
+
+    const htmlResource = {
+      uri: 'ui://x',
+      mimeType: 'text/html',
+      text: '<div>a</div>',
+    };
+    const themed = applyThemeToUiResource(htmlResource, styleTag);
+    expect(themed).not.toBe(htmlResource);
+    expect(themed.text).toContain(UI_RESOURCE_THEME_MARKER);
+
+    const urlResource = {
+      uri: 'ui://y',
+      mimeType: 'text/uri-list',
+      text: 'https://example.com',
+    };
+    expect(applyThemeToUiResource(urlResource, styleTag)).toBe(urlResource);
+
+    const empty = {
+      uri: 'ui://z',
+      mimeType: 'text/html',
+      text: '',
+    };
+    expect(applyThemeToUiResource(empty, styleTag)).toBe(empty);
+
+    expect(applyThemeToUiResource(htmlResource, null)).toBe(htmlResource);
+  });
+
+  it('collectThemeCssVariables reads computed style tokens', () => {
+    const getPropertyValue = vi.fn((name: string) => {
+      if (name === '--background') return '  oklch(0.2 0 0)  ';
+      if (name === '--foreground') return 'oklch(0.9 0 0)';
+      return '';
+    });
+    const root = document.createElement('div');
+
+    const vars = collectThemeCssVariables(root, () => ({ getPropertyValue }));
+    expect(vars).toEqual({
+      '--background': 'oklch(0.2 0 0)',
+      '--foreground': 'oklch(0.9 0 0)',
+    });
+    expect(getPropertyValue).toHaveBeenCalled();
+  });
+});

--- a/src/features/agent/components/AgentMessageRenderer/utils/injectUiResourceTheme.ts
+++ b/src/features/agent/components/AgentMessageRenderer/utils/injectUiResourceTheme.ts
@@ -1,0 +1,286 @@
+/**
+ * Host-side theme injection for MCP UI rawHtml resources.
+ *
+ * rawHtml iframes use `sandbox="allow-scripts"` without `allow-same-origin`,
+ * so the parent cannot touch `contentDocument`. Appending a style block into
+ * the HTML string (before `</body>` / `</html>`) is the reliable path for
+ * uncooperative widgets — including ones that hardcode light colors.
+ */
+
+export const UI_RESOURCE_THEME_MARKER = 'data-libragent-theme';
+
+const THEME_STYLE_RE = new RegExp(
+  `<style\\b[^>]*\\b${UI_RESOURCE_THEME_MARKER}\\b[^>]*>[\\s\\S]*?<\\/style>`,
+  'i',
+);
+
+/** Semantic tokens mirrored into the iframe document. */
+export const UI_RESOURCE_THEME_TOKENS = [
+  '--background',
+  '--foreground',
+  '--card',
+  '--card-foreground',
+  '--popover',
+  '--popover-foreground',
+  '--primary',
+  '--primary-foreground',
+  '--secondary',
+  '--secondary-foreground',
+  '--muted',
+  '--muted-foreground',
+  '--accent',
+  '--accent-foreground',
+  '--destructive',
+  '--border',
+  '--input',
+  '--ring',
+  '--radius',
+] as const;
+
+export type UiResourceThemeToken = (typeof UI_RESOURCE_THEME_TOKENS)[number];
+
+/**
+ * Static tokens mirrored from `src/styles/globals.css`.
+ * Prefer these over `getComputedStyle` at render time: next-themes can report
+ * dark while `<html>` still lacks `.dark`, which would bake light tokens into
+ * the iframe permanently.
+ */
+export const LIGHT_UI_RESOURCE_THEME_VARS: Record<
+  UiResourceThemeToken,
+  string
+> = {
+  '--background': 'oklch(1 0 0)',
+  '--foreground': 'oklch(0.145 0 0)',
+  '--card': 'oklch(1 0 0)',
+  '--card-foreground': 'oklch(0.145 0 0)',
+  '--popover': 'oklch(1 0 0)',
+  '--popover-foreground': 'oklch(0.145 0 0)',
+  '--primary': 'oklch(0.205 0 0)',
+  '--primary-foreground': 'oklch(0.985 0 0)',
+  '--secondary': 'oklch(0.97 0 0)',
+  '--secondary-foreground': 'oklch(0.205 0 0)',
+  '--muted': 'oklch(0.97 0 0)',
+  '--muted-foreground': 'oklch(0.556 0 0)',
+  '--accent': 'oklch(0.97 0 0)',
+  '--accent-foreground': 'oklch(0.205 0 0)',
+  '--destructive': 'oklch(0.577 0.245 27.325)',
+  '--border': 'oklch(0.922 0 0)',
+  '--input': 'oklch(0.922 0 0)',
+  '--ring': 'oklch(0.708 0 0)',
+  '--radius': '0.625rem',
+};
+
+export const DARK_UI_RESOURCE_THEME_VARS: Record<
+  UiResourceThemeToken,
+  string
+> = {
+  '--background': 'oklch(0.145 0 0)',
+  '--foreground': 'oklch(0.985 0 0)',
+  '--card': 'oklch(0.205 0 0)',
+  '--card-foreground': 'oklch(0.985 0 0)',
+  '--popover': 'oklch(0.205 0 0)',
+  '--popover-foreground': 'oklch(0.985 0 0)',
+  '--primary': 'oklch(0.922 0 0)',
+  '--primary-foreground': 'oklch(0.205 0 0)',
+  '--secondary': 'oklch(0.269 0 0)',
+  '--secondary-foreground': 'oklch(0.985 0 0)',
+  '--muted': 'oklch(0.269 0 0)',
+  '--muted-foreground': 'oklch(0.708 0 0)',
+  '--accent': 'oklch(0.269 0 0)',
+  '--accent-foreground': 'oklch(0.985 0 0)',
+  '--destructive': 'oklch(0.704 0.191 22.216)',
+  '--border': 'oklch(1 0 0 / 10%)',
+  '--input': 'oklch(1 0 0 / 15%)',
+  '--ring': 'oklch(0.556 0 0)',
+  '--radius': '0.625rem',
+};
+
+/** Minimal style surface needed to read CSS custom properties. */
+export type CssCustomPropertyReader = {
+  getPropertyValue(property: string): string;
+};
+
+export type UiResourceLike = {
+  uri?: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+  _meta?: Record<string, unknown>;
+};
+
+export function getUiResourceThemeVars(
+  isDark: boolean,
+): Record<UiResourceThemeToken, string> {
+  return isDark ? DARK_UI_RESOURCE_THEME_VARS : LIGHT_UI_RESOURCE_THEME_VARS;
+}
+
+export function collectThemeCssVariables(
+  root: Element | null = typeof document !== 'undefined'
+    ? document.documentElement
+    : null,
+  readStyle: (element: Element) => CssCustomPropertyReader = (element) =>
+    getComputedStyle(element),
+): Partial<Record<UiResourceThemeToken, string>> {
+  if (!root) {
+    return {};
+  }
+
+  const styles = readStyle(root);
+  const vars: Partial<Record<UiResourceThemeToken, string>> = {};
+
+  for (const token of UI_RESOURCE_THEME_TOKENS) {
+    const value = styles.getPropertyValue(token).trim();
+    if (value) {
+      vars[token] = value;
+    }
+  }
+
+  return vars;
+}
+
+export function buildUiResourceThemeStyleTag(
+  isDark: boolean,
+  vars: Partial<Record<UiResourceThemeToken, string>>,
+): string {
+  const declarations = UI_RESOURCE_THEME_TOKENS.flatMap((token) => {
+    const value = vars[token];
+    return value ? [`  ${token}: ${value};`] : [];
+  }).join('\n');
+
+  const colorScheme = isDark ? 'dark' : 'light';
+
+  // Appended after widget CSS so these rules win over hardcoded light colors
+  // in builtin templates (and older stored tool results).
+  return `<style ${UI_RESOURCE_THEME_MARKER}="true">
+:root {
+  color-scheme: ${colorScheme};
+${declarations}
+}
+html, body {
+  background-color: var(--background, ${isDark ? '#0a0a0a' : '#ffffff'}) !important;
+  color: var(--foreground, ${isDark ? '#fafafa' : '#0a0a0a'}) !important;
+  margin: 0;
+}
+.content-wrapper,
+.interaction-wrapper,
+.circuit-container {
+  background: var(--card, ${isDark ? '#1a1a1a' : '#ffffff'}) !important;
+  color: var(--card-foreground, ${isDark ? '#fafafa' : '#111827'}) !important;
+  border-color: var(--border, ${isDark ? 'rgba(255,255,255,0.1)' : '#e5e7eb'}) !important;
+  box-shadow: 0 1px 3px color-mix(in oklab, var(--foreground, #000) 12%, transparent) !important;
+}
+.circuit-container {
+  border-color: #f59e0b !important;
+}
+.tool-info {
+  background: color-mix(in oklab, #f59e0b 16%, var(--muted)) !important;
+  color: var(--foreground) !important;
+}
+.content-title,
+.interaction-prompt,
+.md h1,
+.md h2 {
+  color: var(--card-foreground, inherit) !important;
+  border-bottom-color: var(--border, currentColor) !important;
+}
+.md h3,
+.option-label {
+  color: var(--muted-foreground, inherit) !important;
+}
+.icon-btn {
+  background: var(--muted) !important;
+  color: var(--muted-foreground) !important;
+  border-color: var(--border) !important;
+}
+.icon-btn:hover {
+  background: var(--accent) !important;
+  color: var(--accent-foreground) !important;
+}
+.option-item {
+  border-color: var(--border) !important;
+}
+.option-item:hover {
+  background: var(--muted) !important;
+}
+.text-input {
+  background: var(--background) !important;
+  color: var(--foreground) !important;
+  border-color: var(--input) !important;
+}
+.btn-secondary {
+  background: var(--secondary) !important;
+  color: var(--secondary-foreground) !important;
+}
+.md code,
+.md th {
+  background: var(--muted) !important;
+}
+.md th,
+.md td {
+  border-color: var(--border) !important;
+}
+</style>`;
+}
+
+/**
+ * Strip a previous LibrAgent theme block (if any) and insert `styleTag`
+ * before `</body>` / `</html>` (or at the end) so it overrides widget CSS.
+ */
+export function injectUiResourceThemeHtml(
+  html: string,
+  styleTag: string,
+): string {
+  const withoutTheme = html.replace(THEME_STYLE_RE, '');
+  const bodyClose = withoutTheme.match(/<\/body>/i);
+  if (bodyClose && bodyClose.index !== undefined) {
+    return (
+      withoutTheme.slice(0, bodyClose.index) +
+      styleTag +
+      withoutTheme.slice(bodyClose.index)
+    );
+  }
+
+  const htmlClose = withoutTheme.match(/<\/html>/i);
+  if (htmlClose && htmlClose.index !== undefined) {
+    return (
+      withoutTheme.slice(0, htmlClose.index) +
+      styleTag +
+      withoutTheme.slice(htmlClose.index)
+    );
+  }
+
+  return withoutTheme + styleTag;
+}
+
+function isRawHtmlMimeType(mimeType: string | undefined): boolean {
+  if (!mimeType) return false;
+  return mimeType.split(';')[0]?.trim().toLowerCase() === 'text/html';
+}
+
+/**
+ * Returns a shallow-copied resource with theme CSS appended into `text`
+ * for rawHtml (`text/html`) only. Non-HTML / textless resources are returned
+ * unchanged (same reference).
+ */
+export function applyThemeToUiResource<T extends UiResourceLike>(
+  resource: T,
+  styleTag: string | null | undefined,
+): T {
+  if (!styleTag || !isRawHtmlMimeType(resource.mimeType)) {
+    return resource;
+  }
+
+  if (typeof resource.text !== 'string' || resource.text.length === 0) {
+    return resource;
+  }
+
+  const nextText = injectUiResourceThemeHtml(resource.text, styleTag);
+  if (nextText === resource.text) {
+    return resource;
+  }
+
+  return {
+    ...resource,
+    text: nextText,
+  };
+}

--- a/src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx
+++ b/src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import type { MCPContent } from '@/lib/mcp';
+import type { Message } from '@/models/chat';
+import { AgentMessageRenderer } from '../AgentMessageRenderer';
+import { UI_RESOURCE_THEME_MARKER } from '../AgentMessageRenderer/utils/injectUiResourceTheme';
+
+const uiResourceRendererMock = vi.fn();
+const themeState = vi.hoisted(() => ({
+  resolvedTheme: 'dark' as string | undefined,
+}));
+
+vi.mock('@mcp-ui/client', () => ({
+  basicComponentLibrary: {},
+  remoteButtonDefinition: {},
+  remoteTextDefinition: {},
+  remoteCardDefinition: {},
+  remoteImageDefinition: {},
+  remoteStackDefinition: {},
+  UIResourceRenderer: (props: unknown) => {
+    uiResourceRendererMock(props);
+    return <div data-testid="ui-resource" />;
+  },
+}));
+
+vi.mock('@/hooks/use-rust-backend', () => ({
+  useRustBackend: () => ({
+    openExternalUrl: vi.fn(),
+    downloadMediaFile: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/AgentChatContext', () => ({
+  useAgentChatActions: () => ({
+    submit: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/AgentSessionContext', () => ({
+  useAgentSessionState: () => ({
+    session: { id: 'test-session', assistant: { id: 'test-assistant' } },
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    resolvedTheme: themeState.resolvedTheme,
+  }),
+}));
+
+const resourceContent: MCPContent[] = [
+  {
+    type: 'resource',
+    resource: {
+      uri: 'ui://resource',
+      mimeType: 'text/html',
+      text: '<div>ui</div>',
+    },
+  } as MCPContent,
+];
+
+const message = {
+  id: 'msg-ui',
+  role: 'assistant',
+  content: resourceContent,
+} as Message;
+
+describe('AgentMessageRenderer UI resource theme', () => {
+  beforeEach(() => {
+    uiResourceRendererMock.mockReset();
+    themeState.resolvedTheme = 'dark';
+  });
+
+  it('injects host theme CSS into rawHtml and sets iframe color-scheme', () => {
+    render(
+      <AgentMessageRenderer content={resourceContent} message={message} />,
+    );
+
+    const props = uiResourceRendererMock.mock.calls[0]?.[0] as {
+      resource: { text?: string };
+      htmlProps: {
+        iframeProps?: {
+          style?: { colorScheme?: string; backgroundColor?: string };
+        };
+      };
+    };
+
+    expect(props.resource.text).toContain(UI_RESOURCE_THEME_MARKER);
+    expect(props.resource.text).toContain('color-scheme: dark');
+    expect(props.resource.text).toContain('--background: oklch(0.145 0 0)');
+    expect(props.resource.text).toContain('<div>ui</div>');
+    expect(props.htmlProps.iframeProps?.style?.colorScheme).toBe('dark');
+    expect(props.htmlProps.iframeProps?.style?.backgroundColor).toBe(
+      'oklch(0.145 0 0)',
+    );
+  });
+
+  it('waits for resolvedTheme before mounting the iframe', () => {
+    themeState.resolvedTheme = undefined;
+
+    render(
+      <AgentMessageRenderer content={resourceContent} message={message} />,
+    );
+
+    expect(uiResourceRendererMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('ui-resource')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Append host light/dark CSS tokens into MCP UI `rawHtml` iframes (sandbox blocks `contentDocument` access)
- Wait for `resolvedTheme` before mounting themed iframes; remount on theme switch via `themeKey`
- Update builtin `present-interactive` / `circuit-break` HBS templates to use `var(--*)` with fallbacks so dark mode is not a full-bleed light panel

## Test plan
- [ ] Open a session with a builtin UI resource (e.g. report / circuit-break) in dark mode — iframe background/text should match app chrome
- [ ] Toggle light/dark while the iframe is open — resource remounts with the new theme
- [ ] Confirm external MCP rawHtml that uses CSS variables picks up tokens; hardcoded third-party colors may still stay light
- [ ] `pnpm exec vitest run src/features/agent/components/AgentMessageRenderer/utils/__tests__/injectUiResourceTheme.test.ts src/features/agent/components/__tests__/AgentMessageRenderer.ui-resource.test.tsx`


Made with [Cursor](https://cursor.com)