### PR TITLE
fix(agent): stop older-page loads from yanking chat scroll to bottom

### DIFF
--- a/src/features/agent/components/AgentChatMessages.tsx
+++ b/src/features/agent/components/AgentChatMessages.tsx
@@ -122,16 +122,6 @@ export function AgentChatMessages() {
     : undefined;
   const { refetchSessionFiles } = useAgentResourceAttachment();
 
-  const handleReachTop = useCallback(() => {
-    if (!hasOlderMessages || isLoadingOlderMessages) {
-      return;
-    }
-
-    void loadOlderMessages().catch(() => {
-      // Swallowed: loadOlderMessages already handles and logs errors internally.
-    });
-  }, [hasOlderMessages, isLoadingOlderMessages, loadOlderMessages]);
-
   useFileRefetcher({ messages, refetchSessionFiles });
 
   // Group messages for display
@@ -145,7 +135,6 @@ export function AgentChatMessages() {
   // Get assistant name for message (Agent V2 uses generic "Agent" label)
   const assistantName = session?.assistant?.name || 'Agent';
 
-  // Instantiate our scroll, observers, and bottom alignment engine
   const {
     virtuosoRef,
     footerEndRef,
@@ -155,6 +144,7 @@ export function AgentChatMessages() {
     handleVirtuosoAtBottomStateChange,
     handleTotalListHeightChanged,
     handleManualScrollToBottom,
+    handleStartReached,
     initialTopMostItemIndex,
     bottomThreshold,
     logScrollState,
@@ -166,7 +156,24 @@ export function AgentChatMessages() {
     pendingApprovals,
     agentError: error,
     agentLlmError: llmError,
+    isLoadingOlderMessages,
   });
+
+  const handleReachTop = useCallback(() => {
+    handleStartReached();
+    if (!hasOlderMessages || isLoadingOlderMessages) {
+      return;
+    }
+
+    void loadOlderMessages().catch(() => {
+      // Swallowed: loadOlderMessages already handles and logs errors internally.
+    });
+  }, [
+    handleStartReached,
+    hasOlderMessages,
+    isLoadingOlderMessages,
+    loadOlderMessages,
+  ]);
 
   const compactedEvent = useMemo(() => {
     if (!compactedRange) {

--- a/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.streaming.test.tsx
+++ b/src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.streaming.test.tsx
@@ -7,6 +7,7 @@ import type { GroupedMessage } from '@/hooks/useMessageGrouping';
 import {
   setScrollerMetrics,
   baseMessage,
+  makeSingleGroupEntry,
   makeStreamingGroupEntry,
   makeStreamingMessage,
 } from './AgentChatMessages.compaction-setup';
@@ -22,6 +23,12 @@ const {
   resizeObserverCallbacks,
   resetHarness,
 } = setupScrollFollowHarness();
+
+const olderPageState = vi.hoisted(() => ({
+  isLoadingOlderMessages: false,
+  hasOlderMessages: true,
+  loadOlderMessages: vi.fn(async () => undefined),
+}));
 
 vi.mock('@/context/AgentChatContext', () => ({
   useAgentChat: () => ({
@@ -40,6 +47,9 @@ vi.mock('@/context/AgentSessionContext', () => ({
     session: sessionState.session,
     pendingApprovals: [],
     respondToToolApproval: vi.fn(),
+    hasOlderMessages: olderPageState.hasOlderMessages,
+    isLoadingOlderMessages: olderPageState.isLoadingOlderMessages,
+    loadOlderMessages: olderPageState.loadOlderMessages,
   }),
 }));
 
@@ -112,6 +122,9 @@ vi.mock('react-virtuoso', () => ({
 
 beforeEach(() => {
   resetHarness();
+  olderPageState.isLoadingOlderMessages = false;
+  olderPageState.hasOlderMessages = true;
+  olderPageState.loadOlderMessages.mockClear();
 });
 
 describe('AgentChatMessages – streaming follow & prepend preservation', () => {
@@ -643,12 +656,11 @@ describe('AgentChatMessages – streaming follow & prepend preservation', () => 
       ];
       rerender(<AgentChatMessages />);
 
-      expect(scrollToIndexMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          align: 'start',
-          behavior: 'auto',
-        }),
+      // Position is preserved via firstItemIndex only — no manual anchor scroll.
+      const anchorScrollCalls = scrollToIndexMock.mock.calls.filter(
+        (call) => call[0]?.align === 'start',
       );
+      expect(anchorScrollCalls).toHaveLength(0);
       scrollToIndexMock.mockClear();
 
       const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
@@ -667,6 +679,234 @@ describe('AgentChatMessages – streaming follow & prepend preservation', () => 
       expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
     } finally {
       performanceNowSpy.mockRestore();
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('pauses bottom follow when older-page loading starts before prepend', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+
+    chatState.messages = [makeStreamingMessage('visible head')];
+    chatState.workflowStatus = 'busy';
+    groupedMessagesMock.splice(
+      0,
+      groupedMessagesMock.length,
+      makeStreamingGroupEntry('visible head'),
+    );
+
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      const { rerender } = render(<AgentChatMessages />);
+
+      // Still following bottom (default) when older fetch begins — header height
+      // can change and must not schedule scrollToBottom.
+      olderPageState.isLoadingOlderMessages = true;
+      scrollToIndexMock.mockClear();
+      scrollIntoView.mockClear();
+      rerender(<AgentChatMessages />);
+
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+
+      act(() => {
+        resizeObserverCallbacks.current.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
+      });
+
+      const bottomScrollCalls = scrollToIndexMock.mock.calls.filter(
+        (call) => call[0]?.align === 'end' || call[0]?.index === 'LAST',
+      );
+      expect(bottomScrollCalls).toHaveLength(0);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('does not re-init to bottom across older-page load rerenders (same session)', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+
+    const page2Head = {
+      ...baseMessage,
+      id: 'page-2-head',
+      content: [{ type: 'text' as const, text: 'page-2 head' }],
+    };
+    const page1Older = {
+      ...baseMessage,
+      id: 'page-1-older',
+      content: [{ type: 'text' as const, text: 'page-1 older' }],
+    };
+
+    chatState.messages = [page2Head];
+    chatState.workflowStatus = 'idle';
+    groupedMessagesMock.splice(
+      0,
+      groupedMessagesMock.length,
+      makeSingleGroupEntry(page2Head),
+    );
+
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      const { container, rerender } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+      expect(scroller).not.toBeNull();
+
+      // Consume initial session-changed bottom alignment.
+      scrollToIndexMock.mockClear();
+      scrollIntoView.mockClear();
+
+      olderPageState.isLoadingOlderMessages = true;
+      rerender(<AgentChatMessages />);
+
+      // Same session: scroller already attached; multiple load-related
+      // rerenders must not re-fire force session-changed bottom scroll.
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 2400,
+        clientHeight: 400,
+        scrollTop: 8,
+      });
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      groupedMessagesMock.splice(
+        0,
+        groupedMessagesMock.length,
+        makeSingleGroupEntry(page1Older),
+        makeSingleGroupEntry(page2Head),
+      );
+      olderPageState.isLoadingOlderMessages = false;
+      rerender(<AgentChatMessages />);
+
+      act(() => {
+        resizeObserverCallbacks.current.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
+      });
+
+      const bottomScrollCalls = scrollToIndexMock.mock.calls.filter(
+        (call) => call[0]?.align === 'end' || call[0]?.index === 'LAST',
+      );
+      expect(bottomScrollCalls).toHaveLength(0);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      global.requestAnimationFrame = originalRequestAnimationFrame;
+      global.cancelAnimationFrame = originalCancelAnimationFrame;
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it('does not jump to bottom after startReached when top-edge reports false bottom', () => {
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalCancelAnimationFrame = global.cancelAnimationFrame;
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+
+    chatState.messages = [makeStreamingMessage('visible head')];
+    chatState.workflowStatus = 'idle';
+    groupedMessagesMock.splice(
+      0,
+      groupedMessagesMock.length,
+      makeStreamingGroupEntry('visible head'),
+    );
+
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = vi.fn();
+
+    try {
+      const { container, rerender } = render(<AgentChatMessages />);
+      const scroller = container.querySelector(
+        '.agent-chat-scrollbar',
+      ) as HTMLDivElement | null;
+      expect(scroller).not.toBeNull();
+
+      const virtuosoProps = virtuosoMock.mock.lastCall?.[0] as {
+        startReached?: () => void;
+        totalListHeightChanged?: (height: number) => void;
+      };
+
+      scrollToIndexMock.mockClear();
+      scrollIntoView.mockClear();
+
+      act(() => {
+        virtuosoProps.startReached?.();
+      });
+
+      // Top-edge prepend race: viewport briefly fits / distanceFromBottom≈0
+      // while scrollTop≈0. Must not re-arm follow → bottom yank.
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 400,
+        clientHeight: 400,
+        scrollTop: 0,
+      });
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+      });
+
+      olderPageState.isLoadingOlderMessages = true;
+      rerender(<AgentChatMessages />);
+
+      groupedMessagesMock.splice(
+        0,
+        groupedMessagesMock.length,
+        makeSingleGroupEntry({
+          ...baseMessage,
+          id: 'older-1',
+          content: [{ type: 'text', text: 'older' }],
+        }),
+        makeStreamingGroupEntry('visible head'),
+      );
+      olderPageState.isLoadingOlderMessages = false;
+      rerender(<AgentChatMessages />);
+
+      setScrollerMetrics(scroller!, {
+        scrollHeight: 2_400,
+        clientHeight: 400,
+        scrollTop: 0,
+      });
+      act(() => {
+        scroller?.dispatchEvent(new Event('scroll'));
+        virtuosoProps.totalListHeightChanged?.(2_400);
+        resizeObserverCallbacks.current.forEach((callback) =>
+          callback([], {} as ResizeObserver),
+        );
+      });
+
+      const bottomScrollCalls = scrollToIndexMock.mock.calls.filter(
+        (call) => call[0]?.align === 'end' || call[0]?.index === 'LAST',
+      );
+      expect(bottomScrollCalls).toHaveLength(0);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(screen.getByLabelText('Scroll to latest')).toBeInTheDocument();
+    } finally {
       global.requestAnimationFrame = originalRequestAnimationFrame;
       global.cancelAnimationFrame = originalCancelAnimationFrame;
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;

--- a/src/features/agent/components/agent-chat-messages/__tests__/utils.trusted-visual-bottom.test.ts
+++ b/src/features/agent/components/agent-chat-messages/__tests__/utils.trusted-visual-bottom.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { isTrustedVisualBottom } from '../utils';
+
+describe('isTrustedVisualBottom', () => {
+  it('rejects a collapsed-height false bottom while scrollTop is at the list top', () => {
+    // Prepend race: distanceFromBottom≈0 but the list is taller than the
+    // viewport and scrollTop is still at the top.
+    expect(
+      isTrustedVisualBottom(0, 0, {
+        scrollHeight: 2_000,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedVisualBottom(0, 4, {
+        scrollHeight: 2_000,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a real bottom pin when scrollTop is away from the top', () => {
+    expect(
+      isTrustedVisualBottom(0, 400, {
+        scrollHeight: 2_000,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts content that fits entirely in the viewport (top === bottom)', () => {
+    expect(
+      isTrustedVisualBottom(0, 0, {
+        scrollHeight: 300,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects when distance-from-bottom is outside the pin threshold', () => {
+    expect(
+      isTrustedVisualBottom(20, 400, {
+        scrollHeight: 2_000,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/agent/components/agent-chat-messages/components/VirtuosoListComponents.tsx
+++ b/src/features/agent/components/agent-chat-messages/components/VirtuosoListComponents.tsx
@@ -43,8 +43,11 @@ export function AgentChatMessagesHeader({
 
   return (
     <div
-      className="box-border flex shrink-0 items-center justify-center px-4"
-      style={{ minHeight: CHAT_LIST_HEADER_MIN_HEIGHT_PX }}
+      className="box-border flex shrink-0 items-center justify-center overflow-hidden px-4"
+      style={{
+        height: CHAT_LIST_HEADER_MIN_HEIGHT_PX,
+        minHeight: CHAT_LIST_HEADER_MIN_HEIGHT_PX,
+      }}
       aria-hidden={!showOlderMessagesHint}
       data-testid="agent-chat-messages-header"
     >

--- a/src/features/agent/components/agent-chat-messages/components/__tests__/VirtuosoListComponents.test.tsx
+++ b/src/features/agent/components/agent-chat-messages/components/__tests__/VirtuosoListComponents.test.tsx
@@ -34,12 +34,13 @@ function createContext(
 }
 
 describe('VirtuosoListComponents', () => {
-  it('keeps a stable header min-height when there are no older messages', () => {
+  it('keeps a fixed header height when there are no older messages', () => {
     render(<AgentChatMessagesHeader context={createContext()} />);
 
     const header = screen.getByTestId('agent-chat-messages-header');
     expect(header).toHaveAttribute('aria-hidden', 'true');
     expect(header).toHaveStyle({
+      height: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
       minHeight: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
     });
     expect(
@@ -47,7 +48,7 @@ describe('VirtuosoListComponents', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('reuses the same header min-height when showing the load-older pill', () => {
+  it('reuses the same fixed header height when showing the load-older pill', () => {
     render(
       <AgentChatMessagesHeader
         context={createContext({ hasOlderMessages: true })}
@@ -57,11 +58,30 @@ describe('VirtuosoListComponents', () => {
     const header = screen.getByTestId('agent-chat-messages-header');
     expect(header).toHaveAttribute('aria-hidden', 'false');
     expect(header).toHaveStyle({
+      height: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
       minHeight: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
     });
     expect(
       screen.getByText('Scroll up to load older messages'),
     ).toBeInTheDocument();
+  });
+
+  it('keeps the same fixed header height while the older-page loading pill is shown', () => {
+    render(
+      <AgentChatMessagesHeader
+        context={createContext({
+          hasOlderMessages: true,
+          isLoadingOlderMessages: true,
+        })}
+      />,
+    );
+
+    const header = screen.getByTestId('agent-chat-messages-header');
+    expect(header).toHaveStyle({
+      height: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
+      minHeight: `${CHAT_LIST_HEADER_MIN_HEIGHT_PX}px`,
+    });
+    expect(screen.getByText('Loading older messages...')).toBeInTheDocument();
   });
 
   it('preserves Virtuoso List paddingTop while adding horizontal padding', () => {

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/__tests__/useScrollScheduler.test.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/__tests__/useScrollScheduler.test.ts
@@ -1,0 +1,234 @@
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import type { VirtuosoHandle } from 'react-virtuoso';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BottomAlignmentPhase } from '../../../types';
+import { useScrollScheduler } from '../useScrollScheduler';
+
+function mockVirtuoso(
+  scrollToIndex: VirtuosoHandle['scrollToIndex'],
+): VirtuosoHandle {
+  return { scrollToIndex } as VirtuosoHandle;
+}
+
+function mockFooter(scrollIntoView: HTMLDivElement['scrollIntoView']) {
+  return { scrollIntoView } as HTMLDivElement;
+}
+
+function useSchedulerHarness(overrides?: {
+  upwardReleaseDistance?: number;
+  visualBottom?: boolean;
+  shouldFollowLatest?: boolean;
+  itemCount?: number;
+  virtuoso?: VirtuosoHandle | null;
+  footerEnd?: HTMLDivElement | null;
+}) {
+  const virtuosoRef = useRef<VirtuosoHandle | null>(overrides?.virtuoso ?? null);
+  const footerEndRef = useRef<HTMLDivElement | null>(
+    overrides?.footerEnd ?? null,
+  );
+  const groupedMessageCountRef = useRef(overrides?.itemCount ?? 3);
+  const selfScrollIgnoreUntilRef = useRef(0);
+  const shouldFollowLatestRef = useRef(overrides?.shouldFollowLatest ?? true);
+  const isPreservingPrependPositionRef = useRef(false);
+  const isHistoryBrowsingRef = useRef(false);
+  const upwardReleaseDistanceRef = useRef(
+    overrides?.upwardReleaseDistance ?? 0,
+  );
+  const bottomAlignmentPhaseRef = useRef<BottomAlignmentPhase>('idle');
+  const bottomAlignmentLayoutVersionRef = useRef(0);
+  const bottomAlignmentRequestedVersionRef = useRef(0);
+  const visualBottomRef = useRef(overrides?.visualBottom ?? true);
+  const scrollTopRef = useRef(200);
+  const logScrollState = vi.fn();
+
+  const scheduler = useScrollScheduler({
+    virtuosoRef,
+    footerEndRef,
+    groupedMessageCountRef,
+    selfScrollIgnoreUntilRef,
+    shouldFollowLatestRef,
+    isPreservingPrependPositionRef,
+    isHistoryBrowsingRef,
+    upwardReleaseDistanceRef,
+    bottomAlignmentPhaseRef,
+    bottomAlignmentLayoutVersionRef,
+    bottomAlignmentRequestedVersionRef,
+    visualBottomRef,
+    scrollTopRef,
+    setBottomAlignmentPhase: vi.fn(),
+    scheduleBottomAlignmentVerification: vi.fn(),
+    logScrollState,
+  });
+
+  return { ...scheduler, logScrollState };
+}
+
+describe('useScrollScheduler', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('aligns footer sentinel after Virtuoso scrollToIndex (#1647)', () => {
+    const scrollToIndex = vi.fn();
+    const scrollIntoView = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSchedulerHarness({
+        virtuoso: mockVirtuoso(scrollToIndex),
+        footerEnd: mockFooter(scrollIntoView),
+      }),
+    );
+
+    act(() => {
+      result.current.scheduleScrollToBottom('manual-scroll-to-bottom');
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({
+      index: 'LAST',
+      align: 'end',
+      behavior: 'auto',
+    });
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'end',
+      inline: 'nearest',
+      behavior: 'auto',
+    });
+  });
+
+  it('falls back to footer sentinel when Virtuoso is unavailable', () => {
+    const scrollIntoView = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSchedulerHarness({
+        virtuoso: null,
+        footerEnd: mockFooter(scrollIntoView),
+        itemCount: 2,
+      }),
+    );
+
+    act(() => {
+      result.current.scheduleScrollToBottom('manual-scroll-to-bottom');
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'end',
+      inline: 'nearest',
+      behavior: 'auto',
+    });
+  });
+
+  it('suppresses new auto-scroll while upward release distance is accumulating', () => {
+    const scrollToIndex = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSchedulerHarness({
+        virtuoso: mockVirtuoso(scrollToIndex),
+        upwardReleaseDistance: 12,
+        visualBottom: false,
+        shouldFollowLatest: true,
+      }),
+    );
+
+    act(() => {
+      result.current.scheduleScrollToBottom('content-resize-observer');
+    });
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+    expect(result.current.logScrollState).toHaveBeenCalledWith(
+      'scheduleScrollToBottom:suppressed',
+      expect.objectContaining({
+        shouldSuppressForUpwardIntent: true,
+        upwardReleaseDistance: 12,
+      }),
+    );
+  });
+
+  it('suppresses auto-scroll when follow is paused even if visualBottom is true', () => {
+    const scrollToIndex = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSchedulerHarness({
+        virtuoso: mockVirtuoso(scrollToIndex),
+        visualBottom: true,
+        shouldFollowLatest: false,
+      }),
+    );
+
+    act(() => {
+      result.current.scheduleScrollToBottom('content-resize-observer');
+    });
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+    expect(result.current.logScrollState).toHaveBeenCalledWith(
+      'scheduleScrollToBottom:suppressed',
+      expect.objectContaining({
+        shouldSuppressForPausedFollow: true,
+      }),
+    );
+  });
+
+  it('suppresses auto-scroll while history browsing even if follow is still on', () => {
+    const scrollToIndex = vi.fn();
+    const isHistoryBrowsingRef = { current: true };
+
+    const { result } = renderHook(() => {
+      const virtuosoRef = useRef(mockVirtuoso(scrollToIndex));
+      const footerEndRef = useRef<HTMLDivElement | null>(null);
+      const groupedMessageCountRef = useRef(3);
+      const selfScrollIgnoreUntilRef = useRef(0);
+      const shouldFollowLatestRef = useRef(true);
+      const isPreservingPrependPositionRef = useRef(false);
+      const upwardReleaseDistanceRef = useRef(0);
+      const bottomAlignmentPhaseRef = useRef<BottomAlignmentPhase>('idle');
+      const bottomAlignmentLayoutVersionRef = useRef(0);
+      const bottomAlignmentRequestedVersionRef = useRef(0);
+      const visualBottomRef = useRef(true);
+      const scrollTopRef = useRef(200);
+      const logScrollState = vi.fn();
+
+      return {
+        ...useScrollScheduler({
+          virtuosoRef,
+          footerEndRef,
+          groupedMessageCountRef,
+          selfScrollIgnoreUntilRef,
+          shouldFollowLatestRef,
+          isPreservingPrependPositionRef,
+          isHistoryBrowsingRef,
+          upwardReleaseDistanceRef,
+          bottomAlignmentPhaseRef,
+          bottomAlignmentLayoutVersionRef,
+          bottomAlignmentRequestedVersionRef,
+          visualBottomRef,
+          scrollTopRef,
+          setBottomAlignmentPhase: vi.fn(),
+          scheduleBottomAlignmentVerification: vi.fn(),
+          logScrollState,
+        }),
+        logScrollState,
+      };
+    });
+
+    act(() => {
+      result.current.scheduleScrollToBottom('total-list-height-changed');
+    });
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+    expect(result.current.logScrollState).toHaveBeenCalledWith(
+      'scheduleScrollToBottom:suppressed',
+      expect.objectContaining({
+        shouldSuppressForHistoryBrowsing: true,
+      }),
+    );
+  });
+});

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/usePrependPreservation.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/usePrependPreservation.ts
@@ -1,17 +1,7 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type MutableRefObject,
-} from 'react';
-import type { VirtuosoHandle } from 'react-virtuoso';
+import { useEffect, useRef, useState } from 'react';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
 import { getLogger } from '@/lib/logger';
-import {
-  INITIAL_FIRST_ITEM_INDEX,
-  SELF_SCROLL_IGNORE_WINDOW_MS,
-} from '../../types';
+import { INITIAL_FIRST_ITEM_INDEX } from '../../types';
 import {
   findGroupedMessageIndexByBoundary,
   getPrependedFirstItemIndex,
@@ -29,8 +19,6 @@ export interface PreviousListState {
 export interface UsePrependPreservationOptions {
   groupedMessages: GroupedMessage[];
   sessionId: string | undefined;
-  virtuosoRef: MutableRefObject<VirtuosoHandle | null>;
-  selfScrollIgnoreUntilRef: MutableRefObject<number>;
   logScrollState: (
     event: string,
     extra?: Record<string, boolean | number | string | undefined>,
@@ -40,8 +28,6 @@ export interface UsePrependPreservationOptions {
 export function usePrependPreservation({
   groupedMessages,
   sessionId,
-  virtuosoRef,
-  selfScrollIgnoreUntilRef,
   logScrollState,
 }: UsePrependPreservationOptions) {
   const isPreservingPrependPositionRef = useRef(false);
@@ -90,6 +76,9 @@ export function usePrependPreservation({
     isPreservingPrependPositionRef.current = true;
   }
 
+  // Virtuoso preserves scroll when firstItemIndex decreases by prependCount.
+  // Do not also scrollToIndex(align:'start') — that double-corrects and nudges
+  // the viewport (especially mid-list / startReached overscan loads).
   const effectiveFirstItemIndex = didSessionChangeForListState
     ? INITIAL_FIRST_ITEM_INDEX
     : prependCount > 0
@@ -120,37 +109,6 @@ export function usePrependPreservation({
     });
   }
 
-  useLayoutEffect(() => {
-    if (prependCount <= 0) {
-      return;
-    }
-
-    const virtuoso = virtuosoRef.current;
-    if (!virtuoso) {
-      return;
-    }
-
-    const anchorVirtuosoIndex = effectiveFirstItemIndex + prependCount;
-    logScrollState('prepend-preservation:anchor-scroll', {
-      prependCount,
-      anchorVirtuosoIndex,
-      effectiveFirstItemIndex,
-    });
-    selfScrollIgnoreUntilRef.current =
-      performance.now() + SELF_SCROLL_IGNORE_WINDOW_MS;
-    virtuoso.scrollToIndex({
-      index: anchorVirtuosoIndex,
-      align: 'start',
-      behavior: 'auto',
-    });
-  }, [
-    effectiveFirstItemIndex,
-    logScrollState,
-    prependCount,
-    selfScrollIgnoreUntilRef,
-    virtuosoRef,
-  ]);
-
   useEffect(() => {
     if (didSessionChangeForListState) {
       logScrollState('listState:session-changed', {
@@ -173,6 +131,7 @@ export function usePrependPreservation({
       }, 250);
       logScrollState('prepend-preservation:start', {
         prependCount,
+        effectiveFirstItemIndex,
       });
       setFirstItemIndex(effectiveFirstItemIndex);
     }

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollFollowState.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollFollowState.ts
@@ -16,11 +16,36 @@ export function useScrollFollowState({
   const shouldFollowLatestRef = useRef(true);
   const upwardReleaseDistanceRef = useRef(0);
   const selfScrollIgnoreUntilRef = useRef(0);
+  // After startReached / older-page load / reached-top: stay in history mode
+  // until the user is genuinely back at the latest content (or taps pin).
+  // Prevents collapsed-height / top-edge false bottoms from re-arming follow.
+  const isHistoryBrowsingRef = useRef(false);
 
   const setEffectivePinnedState = useCallback((nextPinned: boolean) => {
     isPinnedToBottomRef.current = nextPinned;
     setIsPinned(nextPinned);
   }, []);
+
+  const enterHistoryBrowsing = useCallback(
+    (reason: string) => {
+      if (!isHistoryBrowsingRef.current) {
+        isHistoryBrowsingRef.current = true;
+        logScrollState('history-browsing:enter', { reason });
+      }
+    },
+    [logScrollState],
+  );
+
+  const exitHistoryBrowsing = useCallback(
+    (reason: string) => {
+      if (!isHistoryBrowsingRef.current) {
+        return;
+      }
+      isHistoryBrowsingRef.current = false;
+      logScrollState('history-browsing:exit', { reason });
+    },
+    [logScrollState],
+  );
 
   const resumeBottomFollow = useCallback(
     (reason: string) => {
@@ -63,7 +88,10 @@ export function useScrollFollowState({
     shouldFollowLatestRef,
     upwardReleaseDistanceRef,
     selfScrollIgnoreUntilRef,
+    isHistoryBrowsingRef,
     setEffectivePinnedState,
+    enterHistoryBrowsing,
+    exitHistoryBrowsing,
     resumeBottomFollow,
     pauseBottomFollow,
   };

--- a/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollScheduler.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/subhooks/useScrollScheduler.ts
@@ -18,6 +18,10 @@ export interface UseScrollSchedulerOptions {
   selfScrollIgnoreUntilRef: MutableRefObject<number>;
   shouldFollowLatestRef: MutableRefObject<boolean>;
   isPreservingPrependPositionRef: MutableRefObject<boolean>;
+  /** True while reading history / older pages — suppress auto bottom until exit. */
+  isHistoryBrowsingRef: MutableRefObject<boolean>;
+  /** >0 while the user is mid upward-read but before follow is fully paused. */
+  upwardReleaseDistanceRef: MutableRefObject<number>;
   bottomAlignmentPhaseRef: MutableRefObject<BottomAlignmentPhase>;
   bottomAlignmentLayoutVersionRef: MutableRefObject<number>;
   bottomAlignmentRequestedVersionRef: MutableRefObject<number>;
@@ -45,6 +49,8 @@ export function useScrollScheduler({
   selfScrollIgnoreUntilRef,
   shouldFollowLatestRef,
   isPreservingPrependPositionRef,
+  isHistoryBrowsingRef,
+  upwardReleaseDistanceRef,
   bottomAlignmentPhaseRef,
   bottomAlignmentLayoutVersionRef,
   bottomAlignmentRequestedVersionRef,
@@ -99,6 +105,10 @@ export function useScrollScheduler({
         });
       }
 
+      // #1647: Virtuoso scrollToIndex(LAST) does not include Footer spacer
+      // (composer overlap). Always align the footer sentinel when present so
+      // the last bubble clears the composer — even after a successful Virtuoso
+      // scroll.
       if (footerEndRef.current) {
         logScrollState('executeScrollToBottom:footer-sentinel-align', {
           itemCount,
@@ -140,31 +150,68 @@ export function useScrollScheduler({
     (reason: string, virtuosoAtBottom: boolean = false) => {
       const isForceReason = forceBottomScrollReasons.has(reason);
       const isNearTop = scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
-      const shouldForce =
-        isForceReason || (shouldFollowLatestRef.current && !isNearTop);
+      const alignmentActive = isBottomAlignmentActive(
+        bottomAlignmentPhaseRef.current,
+      );
+      const shouldFollow = shouldFollowLatestRef.current;
+      const shouldForce = isForceReason || (shouldFollow && !isNearTop);
+
       const shouldSuppressForPrepend =
         isPreservingPrependPositionRef.current && !isForceReason;
 
-      const shouldSuppressForUserScroll =
-        !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
-        !visualBottomRef.current &&
-        !shouldForce;
+      // History/older-page browsing: never auto-yank to bottom (resize/stream),
+      // even if follow briefly re-arms from a false visual bottom.
+      const shouldSuppressForHistoryBrowsing =
+        isHistoryBrowsingRef.current && !isForceReason;
+
+      // Follow paused (history / older-page): never yank from resize/stream.
+      // Do not trust visualBottom alone — prepend can false-positive bottom.
+      const shouldSuppressForPausedFollow =
+        !isForceReason && !alignmentActive && !shouldFollow;
 
       const shouldSuppressForNearTop =
-        isNearTop && !visualBottomRef.current && !isForceReason;
+        isNearTop && !isForceReason && !alignmentActive && !shouldFollow;
+
+      // Pre-pause race: upward distance accumulating while follow still on.
+      // Reject only this new request; leave any already-queued frame alone.
+      const shouldSuppressForUpwardIntent =
+        upwardReleaseDistanceRef.current > 0 &&
+        shouldFollow &&
+        !isForceReason &&
+        !alignmentActive;
 
       if (
         shouldSuppressForPrepend ||
-        shouldSuppressForUserScroll ||
+        shouldSuppressForHistoryBrowsing ||
+        shouldSuppressForPausedFollow ||
         shouldSuppressForNearTop
       ) {
         clearScheduledAutoScroll();
         logScrollState('scheduleScrollToBottom:suppressed', {
           reason,
           shouldSuppressForPrepend,
-          shouldSuppressForUserScroll,
+          shouldSuppressForHistoryBrowsing,
+          shouldSuppressForPausedFollow,
           shouldSuppressForNearTop,
+          shouldSuppressForUpwardIntent: false,
           shouldForce,
+          shouldFollow,
+          upwardReleaseDistance: upwardReleaseDistanceRef.current,
+        });
+        return;
+      }
+
+      if (shouldSuppressForUpwardIntent) {
+        logScrollState('scheduleScrollToBottom:suppressed', {
+          reason,
+          shouldSuppressForPrepend: false,
+          shouldSuppressForHistoryBrowsing: false,
+          shouldSuppressForPausedFollow: false,
+          shouldSuppressForNearTop: false,
+          shouldSuppressForUpwardIntent: true,
+          shouldForce,
+          shouldFollow,
+          upwardReleaseDistance: upwardReleaseDistanceRef.current,
         });
         return;
       }
@@ -179,28 +226,40 @@ export function useScrollScheduler({
         const isForceReasonOnFire = forceBottomScrollReasons.has(reason);
         const isNearTopOnFire =
           scrollTopRef.current <= NEAR_TOP_SCROLL_THRESHOLD;
+        const alignmentActiveOnFire = isBottomAlignmentActive(
+          bottomAlignmentPhaseRef.current,
+        );
+        const shouldFollowOnFire = shouldFollowLatestRef.current;
         const shouldForceOnFire =
-          isForceReasonOnFire ||
-          (shouldFollowLatestRef.current && !isNearTopOnFire);
+          isForceReasonOnFire || (shouldFollowOnFire && !isNearTopOnFire);
+
+        // Frame-time checks are state-only. Upward noise must not cancel a
+        // frame that was accepted while follow was still active; pauseBottomFollow
+        // clears the queue when the user fully releases follow.
         const shouldSuppressForPrependOnFire =
           isPreservingPrependPositionRef.current && !isForceReasonOnFire;
-        const shouldSuppressForUserScrollOnFire =
-          !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
-          !visualBottomRef.current &&
-          !shouldForceOnFire;
+        const shouldSuppressForHistoryBrowsingOnFire =
+          isHistoryBrowsingRef.current && !isForceReasonOnFire;
+        const shouldSuppressForPausedFollowOnFire =
+          !isForceReasonOnFire && !alignmentActiveOnFire && !shouldFollowOnFire;
         const shouldSuppressForNearTopOnFire =
-          isNearTopOnFire && !visualBottomRef.current && !isForceReasonOnFire;
+          isNearTopOnFire &&
+          !isForceReasonOnFire &&
+          !alignmentActiveOnFire &&
+          !shouldFollowOnFire;
 
         if (
           shouldSuppressForPrependOnFire ||
-          shouldSuppressForUserScrollOnFire ||
+          shouldSuppressForHistoryBrowsingOnFire ||
+          shouldSuppressForPausedFollowOnFire ||
           shouldSuppressForNearTopOnFire
         ) {
           logScrollState('scheduleScrollToBottom:frame-suppressed', {
             reason,
             isPreservingPrepend: isPreservingPrependPositionRef.current,
+            isHistoryBrowsing: isHistoryBrowsingRef.current,
             isNearTop: isNearTopOnFire,
-            shouldFollowLatest: shouldFollowLatestRef.current,
+            shouldFollowLatest: shouldFollowOnFire,
             visualBottom: visualBottomRef.current,
           });
           return;
@@ -208,6 +267,7 @@ export function useScrollScheduler({
 
         logScrollState('scheduleScrollToBottom:frame-fired', {
           reason,
+          shouldForce: shouldForceOnFire,
         });
         const didScroll = executeScrollToBottom(reason);
         if (didScroll && bottomAlignmentPhaseRef.current === 'requesting') {
@@ -229,12 +289,14 @@ export function useScrollScheduler({
       clearScheduledAutoScroll,
       executeScrollToBottom,
       forceBottomScrollReasons,
+      isHistoryBrowsingRef,
       isPreservingPrependPositionRef,
       logScrollState,
       scheduleBottomAlignmentVerification,
       setBottomAlignmentPhase,
       shouldFollowLatestRef,
       scrollTopRef,
+      upwardReleaseDistanceRef,
       visualBottomRef,
     ],
   );

--- a/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
+++ b/src/features/agent/components/agent-chat-messages/hooks/useAgentChatScroll.ts
@@ -13,7 +13,7 @@ import {
 import {
   getInitialTopMostItemIndex,
   getVisualBottomThreshold,
-  isPinnedToBottom,
+  isTrustedVisualBottom,
   isBottomAlignmentActive,
   getScrollContentElement,
   isLayoutNeutralLatestMessageUpdate,
@@ -36,6 +36,8 @@ export interface UseAgentChatScrollOptions {
   pendingApprovals: ReturnType<typeof useAgentSession>['pendingApprovals'];
   agentError: ReturnType<typeof useAgentChat>['error'];
   agentLlmError: ReturnType<typeof useAgentChat>['llmError'];
+  /** True while an older-page fetch is in flight (header height may change). */
+  isLoadingOlderMessages?: boolean;
 }
 
 export function useAgentChatScroll({
@@ -46,6 +48,7 @@ export function useAgentChatScroll({
   pendingApprovals,
   agentError,
   agentLlmError,
+  isLoadingOlderMessages = false,
 }: UseAgentChatScrollOptions) {
   const footerEndRef = useRef<HTMLDivElement | null>(null);
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
@@ -58,6 +61,8 @@ export function useAgentChatScroll({
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(
     null,
   );
+  const scrollerElementRef = useRef<HTMLDivElement | null>(null);
+  scrollerElementRef.current = scrollerElement;
 
   const bottomThreshold = getVisualBottomThreshold();
 
@@ -74,6 +79,9 @@ export function useAgentChatScroll({
     );
   }, [sessionId]);
 
+  // Keep identity stable — logScrollState used to depend on scrollerElement and
+  // cascaded into scheduleScrollToBottom / requestBottomAlignment, which
+  // re-fired the session-reset effect (force bottom) on unrelated re-renders.
   const logScrollState = useCallback(
     (
       event: string,
@@ -95,12 +103,12 @@ export function useAgentChatScroll({
         shouldFollowLatest: shouldFollowLatestRef.current,
         bottomAlignmentPhase: bottomAlignmentPhaseRef.current,
         hasVirtuosoHandle: !!virtuosoRef.current,
-        hasScroller: !!scrollerElement,
+        hasScroller: !!scrollerElementRef.current,
         hasFooterSentinel: !!footerEndRef.current,
         ...extra,
       });
     },
-    [scrollerElement],
+    [],
   );
 
   // 1. Follow state management
@@ -111,7 +119,10 @@ export function useAgentChatScroll({
     shouldFollowLatestRef,
     upwardReleaseDistanceRef,
     selfScrollIgnoreUntilRef,
+    isHistoryBrowsingRef,
     setEffectivePinnedState,
+    enterHistoryBrowsing,
+    exitHistoryBrowsing,
     resumeBottomFollow,
     pauseBottomFollow,
   } = useScrollFollowState({ logScrollState });
@@ -126,8 +137,6 @@ export function useAgentChatScroll({
   } = usePrependPreservation({
     groupedMessages,
     sessionId,
-    virtuosoRef,
-    selfScrollIgnoreUntilRef,
     logScrollState,
   });
 
@@ -164,6 +173,8 @@ export function useAgentChatScroll({
       selfScrollIgnoreUntilRef,
       shouldFollowLatestRef,
       isPreservingPrependPositionRef,
+      isHistoryBrowsingRef,
+      upwardReleaseDistanceRef,
       bottomAlignmentPhaseRef,
       bottomAlignmentLayoutVersionRef,
       bottomAlignmentRequestedVersionRef,
@@ -186,9 +197,64 @@ export function useAgentChatScroll({
     logScrollState,
   });
 
+  // Older-page fetch changes header height before messages arrive. Pause follow
+  // immediately so ResizeObserver / height churn cannot yank to bottom.
+  useEffect(() => {
+    if (!isLoadingOlderMessages) {
+      return;
+    }
+
+    isPreservingPrependPositionRef.current = true;
+    // Treat as away-from-bottom so resumeBottomFollow('bottom-context-restored')
+    // cannot re-arm follow while older messages are loading.
+    visualBottomRef.current = false;
+    enterHistoryBrowsing('loading-older-messages');
+    abortBottomAlignment('loading-older-messages');
+    clearScheduledAutoScroll();
+    pauseBottomFollow('loading-older-messages');
+    setEffectivePinnedState(false);
+    logScrollState('loading-older:armed');
+  }, [
+    abortBottomAlignment,
+    clearScheduledAutoScroll,
+    enterHistoryBrowsing,
+    isLoadingOlderMessages,
+    isPreservingPrependPositionRef,
+    logScrollState,
+    pauseBottomFollow,
+    setEffectivePinnedState,
+    visualBottomRef,
+  ]);
+
+  const handleStartReached = useCallback(() => {
+    // Virtuoso can fire startReached before scrollTop hits NEAR_TOP — pause
+    // follow so the subsequent older-page load cannot auto-scroll to bottom.
+    visualBottomRef.current = false;
+    enterHistoryBrowsing('start-reached');
+    abortBottomAlignment('start-reached');
+    clearScheduledAutoScroll();
+    pauseBottomFollow('start-reached');
+    setEffectivePinnedState(false);
+    logScrollState('start-reached:pause-follow');
+  }, [
+    abortBottomAlignment,
+    clearScheduledAutoScroll,
+    enterHistoryBrowsing,
+    logScrollState,
+    pauseBottomFollow,
+    setEffectivePinnedState,
+    visualBottomRef,
+  ]);
+
   const handleResizeObserverLayoutChange = useCallback(
     (reason: 'content-resize-observer' | 'scroller-resize-observer') => {
       if (prependCount > 0 || isPreservingPrependPositionRef.current) {
+        return;
+      }
+
+      // Mid upward-read: height changes must not force-follow the stream.
+      if (upwardReleaseDistanceRef.current > 0 && !visualBottomRef.current) {
+        markBottomAlignmentLayoutChanged(reason);
         return;
       }
 
@@ -216,6 +282,7 @@ export function useAgentChatScroll({
       scheduleBottomAlignmentVerification,
       scheduleScrollToBottom,
       shouldFollowLatestRef,
+      upwardReleaseDistanceRef,
       visualBottomRef,
     ],
   );
@@ -257,6 +324,15 @@ export function useAgentChatScroll({
         return;
       }
 
+      if (upwardReleaseDistanceRef.current > 0 && !visualBottomRef.current) {
+        markBottomAlignmentLayoutChanged('total-list-height-changed');
+        logScrollState('virtuoso:totalListHeightChanged:upward-skip', {
+          height,
+          upwardReleaseDistance: upwardReleaseDistanceRef.current,
+        });
+        return;
+      }
+
       markBottomAlignmentLayoutChanged('total-list-height-changed');
       scheduleBottomAlignmentVerification(
         'total-list-height-changed',
@@ -266,7 +342,7 @@ export function useAgentChatScroll({
 
       if (
         !isBottomAlignmentActive(bottomAlignmentPhaseRef.current) &&
-        !isPinnedToBottomRef.current
+        !shouldFollowLatestRef.current
       ) {
         logScrollState('virtuoso:totalListHeightChanged:skip', {
           height,
@@ -281,21 +357,55 @@ export function useAgentChatScroll({
     },
     [
       bottomAlignmentPhaseRef,
-      isPinnedToBottomRef,
       isPreservingPrependPositionRef,
       logScrollState,
       markBottomAlignmentLayoutChanged,
       prependCount,
       scheduleBottomAlignmentVerification,
       scheduleScrollToBottom,
+      shouldFollowLatestRef,
+      upwardReleaseDistanceRef,
       visualBottomRef,
     ],
   );
 
-  // Session change reset effect
+  // Session change only. Callbacks live in a ref so scroller attach / rerenders
+  // cannot re-trigger force bottom (`session-changed` bypasses all suppressors).
+  const sessionResetActionsRef = useRef({
+    setBottomAlignmentPhase,
+    clearBottomAlignmentVerifyFrame,
+    setEffectivePinnedState,
+    clearScheduledAutoScroll,
+    logScrollState,
+    requestBottomAlignment,
+    scheduleScrollToBottom,
+    exitHistoryBrowsing,
+  });
+  sessionResetActionsRef.current = {
+    setBottomAlignmentPhase,
+    clearBottomAlignmentVerifyFrame,
+    setEffectivePinnedState,
+    clearScheduledAutoScroll,
+    logScrollState,
+    requestBottomAlignment,
+    scheduleScrollToBottom,
+    exitHistoryBrowsing,
+  };
+
   useEffect(() => {
-    setBottomAlignmentPhase('idle', 'session-reset');
-    clearBottomAlignmentVerifyFrame();
+    const {
+      setBottomAlignmentPhase: setPhase,
+      clearBottomAlignmentVerifyFrame: clearVerify,
+      setEffectivePinnedState: setPinned,
+      clearScheduledAutoScroll: clearAutoScroll,
+      logScrollState: logState,
+      requestBottomAlignment: requestAlignment,
+      scheduleScrollToBottom: scheduleBottom,
+      exitHistoryBrowsing: exitHistory,
+    } = sessionResetActionsRef.current;
+
+    setPhase('idle', 'session-reset');
+    clearVerify();
     bottomAlignmentRequestedVersionRef.current =
       bottomAlignmentLayoutVersionRef.current;
     virtuosoAtBottomRef.current = false;
@@ -303,34 +413,19 @@ export function useAgentChatScroll({
     shouldFollowLatestRef.current = true;
     isPreservingPrependPositionRef.current = false;
     upwardReleaseDistanceRef.current = 0;
-    setEffectivePinnedState(true);
-    clearScheduledAutoScroll();
+    exitHistory('session-changed');
+    setPinned(true);
+    clearAutoScroll();
     if (prependStabilizeTimeoutRef.current !== null) {
       window.clearTimeout(prependStabilizeTimeoutRef.current);
       prependStabilizeTimeoutRef.current = null;
     }
     previousScrollTopRef.current = null;
     scrollTopRef.current = 0;
-    logScrollState('sessionEffect:reset-bottom-alignment');
-    requestBottomAlignment('session-changed');
-    scheduleScrollToBottom('session-changed', false);
-  }, [
-    bottomAlignmentLayoutVersionRef,
-    bottomAlignmentRequestedVersionRef,
-    clearBottomAlignmentVerifyFrame,
-    clearScheduledAutoScroll,
-    isPreservingPrependPositionRef,
-    logScrollState,
-    prependStabilizeTimeoutRef,
-    requestBottomAlignment,
-    scheduleScrollToBottom,
-    sessionId,
-    setBottomAlignmentPhase,
-    setEffectivePinnedState,
-    shouldFollowLatestRef,
-    upwardReleaseDistanceRef,
-    visualBottomRef,
-  ]);
+    logState('sessionEffect:reset-bottom-alignment');
+    requestAlignment('session-changed');
+    scheduleBottom('session-changed', false);
+  }, [sessionId]);
 
   // Unmount cleanup
   useEffect(() => {
@@ -365,17 +460,33 @@ export function useAgentChatScroll({
         scrollerElement.scrollHeight -
         currentScrollTop -
         scrollerElement.clientHeight;
-      const visualPinned = isPinnedToBottom(
-        distanceFromBottom,
-        bottomThreshold,
-      );
       const isSelfScroll = performance.now() < selfScrollIgnoreUntilRef.current;
 
-      visualBottomRef.current = visualPinned;
+      // Prepend/older-page layout can briefly report distanceFromBottom≈0 while
+      // scrollTop is still at the top. Never treat that as "reached bottom".
+      const trustedVisualBottom = isTrustedVisualBottom(
+        distanceFromBottom,
+        currentScrollTop,
+        {
+          threshold: bottomThreshold,
+          scrollHeight: scrollerElement.scrollHeight,
+          clientHeight: scrollerElement.clientHeight,
+        },
+      );
+      visualBottomRef.current = trustedVisualBottom;
 
-      if (visualPinned) {
+      if (trustedVisualBottom) {
         upwardReleaseDistanceRef.current = 0;
-        resumeBottomFollow('bottom-reached');
+        // Leave history browsing only when the user is actually at the latest
+        // end — not when top-edge / collapsed-height falsely reports bottom.
+        if (isHistoryBrowsingRef.current) {
+          if (currentScrollTop > NEAR_TOP_SCROLL_THRESHOLD) {
+            exitHistoryBrowsing('bottom-reached');
+            resumeBottomFollow('bottom-reached');
+          }
+        } else {
+          resumeBottomFollow('bottom-reached');
+        }
       } else {
         if (scrollDelta > 0) {
           upwardReleaseDistanceRef.current = 0;
@@ -402,13 +513,14 @@ export function useAgentChatScroll({
           !isSelfScroll &&
           currentScrollTop <= NEAR_TOP_SCROLL_THRESHOLD
         ) {
+          enterHistoryBrowsing('reached-top');
           abortBottomAlignment('reached-top');
           clearScheduledAutoScroll();
           pauseBottomFollow('reached-top');
         }
       }
 
-      if (!visualPinned && !shouldFollowLatestRef.current) {
+      if (!trustedVisualBottom && !shouldFollowLatestRef.current) {
         virtuosoAtBottomRef.current = false;
         abortBottomAlignment('visual-bottom-lost');
         clearScheduledAutoScroll();
@@ -416,16 +528,18 @@ export function useAgentChatScroll({
 
       scheduleBottomAlignmentVerification(
         'scroll:updatePinnedState',
-        visualPinned,
+        trustedVisualBottom,
         virtuosoAtBottomRef.current,
       );
 
-      setEffectivePinnedState(visualPinned || shouldFollowLatestRef.current);
+      setEffectivePinnedState(
+        trustedVisualBottom || shouldFollowLatestRef.current,
+      );
       logScrollState('scroll:updatePinnedState', {
         currentScrollTop,
         scrollDelta,
         distanceFromBottom,
-        visualPinned,
+        trustedVisualBottom,
         isSelfScroll,
         upwardReleaseDistance: upwardReleaseDistanceRef.current,
       });
@@ -445,6 +559,9 @@ export function useAgentChatScroll({
     abortBottomAlignment,
     bottomThreshold,
     clearScheduledAutoScroll,
+    enterHistoryBrowsing,
+    exitHistoryBrowsing,
+    isHistoryBrowsingRef,
     isPreservingPrependPositionRef,
     logScrollState,
     pauseBottomFollow,
@@ -461,6 +578,7 @@ export function useAgentChatScroll({
   const handleManualScrollToBottom = useCallback(() => {
     visualBottomRef.current = true;
     upwardReleaseDistanceRef.current = 0;
+    exitHistoryBrowsing('manual-scroll-to-bottom');
     requestBottomAlignment('manual-scroll-to-bottom');
     resumeBottomFollow('manual-scroll-to-bottom');
     setEffectivePinnedState(true);
@@ -470,6 +588,7 @@ export function useAgentChatScroll({
       virtuosoAtBottomRef.current,
     );
   }, [
+    exitHistoryBrowsing,
     logScrollState,
     requestBottomAlignment,
     resumeBottomFollow,
@@ -523,12 +642,23 @@ export function useAgentChatScroll({
     if (
       groupedMessages.length > 0 &&
       hasHydratedMessagesRef.current.hasMessages &&
-      visualBottomRef.current
+      visualBottomRef.current &&
+      scrollTopRef.current > NEAR_TOP_SCROLL_THRESHOLD &&
+      !isPreservingPrependPositionRef.current &&
+      !isLoadingOlderMessages
     ) {
+      if (isHistoryBrowsingRef.current) {
+        exitHistoryBrowsing('bottom-context-restored');
+      }
       resumeBottomFollow('bottom-context-restored');
     }
 
-    if (prependCount > 0 || isPreservingPrependPositionRef.current) {
+    if (
+      prependCount > 0 ||
+      isPreservingPrependPositionRef.current ||
+      isLoadingOlderMessages ||
+      isHistoryBrowsingRef.current
+    ) {
       logScrollState('reactive-state-change:prepend-skip', {
         prependCount,
         messageId: latestMessage?.id,
@@ -536,7 +666,7 @@ export function useAgentChatScroll({
       return;
     }
 
-    if (!shouldFollowLatestRef.current && !isPinnedToBottomRef.current) {
+    if (!shouldFollowLatestRef.current) {
       return;
     }
 
@@ -566,13 +696,16 @@ export function useAgentChatScroll({
     agentLlmError,
     groupedMessages.length,
     hasHydratedMessagesRef,
-    isPinnedToBottomRef,
+    isHistoryBrowsingRef,
+    isLoadingOlderMessages,
     isPreservingPrependPositionRef,
     logScrollState,
     prependCount,
+    exitHistoryBrowsing,
     resumeBottomFollow,
     scheduleScrollToBottom,
     shouldFollowLatestRef,
+    scrollTopRef,
     visualBottomRef,
   ]);
 
@@ -586,6 +719,7 @@ export function useAgentChatScroll({
     handleVirtuosoAtBottomStateChange,
     handleTotalListHeightChanged,
     handleManualScrollToBottom,
+    handleStartReached,
     initialTopMostItemIndex,
     bottomThreshold,
     logScrollState,

--- a/src/features/agent/components/agent-chat-messages/types.ts
+++ b/src/features/agent/components/agent-chat-messages/types.ts
@@ -18,9 +18,8 @@ export const BOTTOM_FOLLOW_RELEASE_SCROLL_DISTANCE = 36;
 // release distance has not yet hit BOTTOM_FOLLOW_RELEASE_SCROLL_DISTANCE.
 // Short Non-Thinking sessions often reach the top in one gesture.
 export const NEAR_TOP_SCROLL_THRESHOLD = 8;
-// Stable Virtuoso Header height so switching between "no older messages"
-// and the load-older pill does not jump the first bubble. Also provides the
-// top clearance that used to disappear when Header returned null.
+// Fixed Virtuoso Header height so switching between empty / load-older /
+// loading-older pills cannot reflow the first bubble (mid-prepend nudge).
 export const CHAT_LIST_HEADER_MIN_HEIGHT_PX = 28;
 // Ignore scroll events caused by our own bottom-forcing scroll for one short
 // window so programmatic movement does not look like user intent.

--- a/src/features/agent/components/agent-chat-messages/utils.tsx
+++ b/src/features/agent/components/agent-chat-messages/utils.tsx
@@ -6,7 +6,11 @@ import {
 import type { Message } from '@/models/chat';
 import type { GroupedMessage } from '@/hooks/useMessageGrouping';
 import type { useAgentChat } from '@/context/AgentChatContext';
-import { VISUAL_BOTTOM_THRESHOLD, type BottomAlignmentPhase } from './types';
+import {
+  VISUAL_BOTTOM_THRESHOLD,
+  NEAR_TOP_SCROLL_THRESHOLD,
+  type BottomAlignmentPhase,
+} from './types';
 
 /**
  * Fingerprint of latest-message fields that can change chat list *structure*.
@@ -113,6 +117,45 @@ export function isPinnedToBottom(
   threshold = VISUAL_BOTTOM_THRESHOLD,
 ): boolean {
   return distanceFromBottom <= threshold;
+}
+
+/**
+ * True when the viewport is genuinely pinned to the latest content.
+ *
+ * - Content that fits in the viewport is both "at top" and "at bottom"; treat
+ *   that as a trusted bottom so follow is not paused via reached-top.
+ * - During older-message prepend, scrollHeight can briefly collapse so
+ *   distanceFromBottom≈0 while scrollTop is still ~0 — reject that case.
+ */
+export function isTrustedVisualBottom(
+  distanceFromBottom: number,
+  scrollTop: number,
+  options?: {
+    threshold?: number;
+    nearTopThreshold?: number;
+    scrollHeight?: number;
+    clientHeight?: number;
+  },
+): boolean {
+  const threshold = options?.threshold ?? VISUAL_BOTTOM_THRESHOLD;
+  const nearTopThreshold =
+    options?.nearTopThreshold ?? NEAR_TOP_SCROLL_THRESHOLD;
+
+  if (!isPinnedToBottom(distanceFromBottom, threshold)) {
+    return false;
+  }
+
+  const scrollHeight = options?.scrollHeight;
+  const clientHeight = options?.clientHeight;
+  if (
+    scrollHeight !== undefined &&
+    clientHeight !== undefined &&
+    scrollHeight <= clientHeight + threshold
+  ) {
+    return true;
+  }
+
+  return scrollTop > nearTopThreshold;
 }
 
 export function isBottomAlignmentActive(phase: BottomAlignmentPhase): boolean {


### PR DESCRIPTION
## Summary
- Keep follow paused in history-browsing mode across `startReached` / older-page prepend so top-edge loads cannot force-scroll to the latest messages.
- Rely on Virtuoso `firstItemIndex` only (remove double `scrollToIndex` anchor) and lock the list header height to avoid the mid-list downward nudge on next-page load.
- Harden session-reset / trusted-bottom guards so re-renders and false bottoms do not re-init to the bottom.

## Test plan
- [ ] Scroll to the absolute top → load older page → viewport stays near the previous head (no jump to latest)
- [ ] Scroll up enough to trigger older-page load mid-history → position stays stable (no noticeable downward push)
- [ ] Pin / scroll-to-latest still returns to bottom and resumes follow
- [ ] `pnpm exec vitest run src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.streaming.test.tsx src/features/agent/components/__tests__/AgentChatMessages.scroll-follow.intent.test.tsx src/features/agent/components/agent-chat-messages/hooks/subhooks/__tests__/useScrollScheduler.test.ts`


Made with [Cursor](https://cursor.com)