### PR TITLE
fix(ui): dismiss MCP load failure toasts on session switch (#1696)

### DIFF
--- a/src/context/agent-session/__tests__/notifyRuntimeStateErrors.test.ts
+++ b/src/context/agent-session/__tests__/notifyRuntimeStateErrors.test.ts
@@ -79,7 +79,7 @@ describe('notifyRuntimeStateErrors', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('toasts generic init failure when phase is failed without server list', () => {
+  it('toasts generic init failure with deterministic ID when phase is failed without server list', () => {
     const prev = baseState();
     const next = baseState({
       phase: 'failed',
@@ -91,11 +91,12 @@ describe('notifyRuntimeStateErrors', () => {
       servers: [],
     });
 
-    notifyRuntimeStateErrors(prev, next);
+    notifyRuntimeStateErrors(prev, next, 's1');
 
     expect(toast.error).toHaveBeenCalledWith(
       'MCP Server initialization failed',
       expect.objectContaining({
+        id: 'mcp-runtime-error:s1',
         description: 'Loading tool configurations failed',
       }),
     );

--- a/src/context/agent-session/__tests__/useMcpServerFailureToasts.test.ts
+++ b/src/context/agent-session/__tests__/useMcpServerFailureToasts.test.ts
@@ -1,0 +1,180 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+import type { SessionRuntimeState } from '@/models/agent-ipc';
+import {
+  mcpServerFailureToastId,
+  useMcpServerFailureToasts,
+} from '../useMcpServerFailureToasts';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+function mockRuntimeState(
+  servers: SessionRuntimeState['servers'] = [],
+): SessionRuntimeState {
+  return {
+    sequence: 1,
+    phase: 'degraded',
+    proxy: { exists: true, mode: 'configured', ready: true },
+    initialization: { result: 'partial' },
+    servers,
+  };
+}
+
+describe('useMcpServerFailureToasts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('toasts server failures with deterministic toast IDs', () => {
+    const state = mockRuntimeState([
+      {
+        name: 'exa',
+        transport: 'http',
+        status: 'failed',
+        toolCount: 0,
+        error: 'Connection refused',
+      },
+    ]);
+
+    renderHook(() => useMcpServerFailureToasts('s1', state));
+
+    const expectedId = mcpServerFailureToastId(
+      's1',
+      'http:exa:failed:Connection refused',
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      'agent.statusBar.mcpServerFailed',
+      expect.objectContaining({
+        id: expectedId,
+        duration: 8000,
+      }),
+    );
+  });
+
+  it('dismisses active toasts when switching sessions', () => {
+    const state = mockRuntimeState([
+      {
+        name: 'exa',
+        transport: 'http',
+        status: 'failed',
+        toolCount: 0,
+        error: 'Connection refused',
+      },
+    ]);
+
+    let sessionId = 's1';
+    const { rerender } = renderHook(() =>
+      useMcpServerFailureToasts(sessionId, state),
+    );
+
+    const expectedIdS1 = mcpServerFailureToastId(
+      's1',
+      'http:exa:failed:Connection refused',
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      'agent.statusBar.mcpServerFailed',
+      expect.objectContaining({ id: expectedIdS1 }),
+    );
+
+    // Switch to session s2
+    sessionId = 's2';
+    rerender();
+
+    expect(toast.dismiss).toHaveBeenCalledWith(expectedIdS1);
+  });
+
+  it('dismisses active toasts when unmounted', () => {
+    const state = mockRuntimeState([
+      {
+        name: 'exa',
+        transport: 'http',
+        status: 'failed',
+        toolCount: 0,
+        error: 'Connection refused',
+      },
+    ]);
+
+    const { unmount } = renderHook(() =>
+      useMcpServerFailureToasts('s1', state),
+    );
+
+    const expectedId = mcpServerFailureToastId(
+      's1',
+      'http:exa:failed:Connection refused',
+    );
+    unmount();
+
+    expect(toast.dismiss).toHaveBeenCalledWith(expectedId);
+  });
+
+  it('does not duplicate toasts when switching back to a previously toasted session', () => {
+    const state = mockRuntimeState([
+      {
+        name: 'exa',
+        transport: 'http',
+        status: 'failed',
+        toolCount: 0,
+        error: 'Connection refused',
+      },
+    ]);
+
+    let sessionId = 's1';
+    const { rerender } = renderHook(() =>
+      useMcpServerFailureToasts(sessionId, state),
+    );
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+
+    // Switch to session s2
+    sessionId = 's2';
+    rerender();
+
+    vi.clearAllMocks();
+
+    // Switch back to s1
+    sessionId = 's1';
+    rerender();
+
+    // Should not trigger a new toast because s1 already toasted 'exa:failed'
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('toasts server timeouts when status is timed_out', () => {
+    const state = mockRuntimeState([
+      {
+        name: 'slow-stdio',
+        transport: 'stdio',
+        status: 'timed_out',
+        toolCount: 0,
+        error: 'Tool discovery timed out after 30s',
+      },
+    ]);
+
+    renderHook(() => useMcpServerFailureToasts('s1', state));
+
+    const expectedId = mcpServerFailureToastId(
+      's1',
+      'stdio:slow-stdio:timed_out:Tool discovery timed out after 30s',
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      'agent.statusBar.mcpServerTimeout',
+      expect.objectContaining({
+        id: expectedId,
+        duration: 8000,
+      }),
+    );
+  });
+});

--- a/src/context/agent-session/notifyRuntimeStateErrors.ts
+++ b/src/context/agent-session/notifyRuntimeStateErrors.ts
@@ -9,6 +9,7 @@ import type { SessionRuntimeState } from '@/models/agent-ipc';
 export function notifyRuntimeStateErrors(
   prevState: SessionRuntimeState,
   nextState: SessionRuntimeState,
+  sessionId?: string,
 ): void {
   // Skip when per-server failed/timed_out rows exist — those toast via
   // useMcpServerFailureToasts.
@@ -23,6 +24,7 @@ export function notifyRuntimeStateErrors(
     nextState.initialization.error
   ) {
     toast.error('MCP Server initialization failed', {
+      id: sessionId ? `mcp-runtime-error:${sessionId}` : undefined,
       description: nextState.initialization.error,
       duration: 8000,
     });

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -113,7 +113,7 @@ export function useAgentSessionEvents(
                 return nextState;
               });
               if (applied && previousState) {
-                notifyRuntimeStateErrors(previousState, nextState);
+                notifyRuntimeStateErrors(previousState, nextState, sessionId);
               }
               break;
             }
@@ -383,7 +383,11 @@ export function useAgentSessionEvents(
           return currentState;
         });
         if (previousRuntimeState) {
-          notifyRuntimeStateErrors(previousRuntimeState, nextRuntimeState);
+          notifyRuntimeStateErrors(
+            previousRuntimeState,
+            nextRuntimeState,
+            sessionId,
+          );
         }
         void actions.persistViewedAt().catch((err) => {
           logger.error(

--- a/src/context/agent-session/useMcpServerFailureToasts.ts
+++ b/src/context/agent-session/useMcpServerFailureToasts.ts
@@ -4,6 +4,13 @@ import { toast } from 'sonner';
 import type { SessionRuntimeState } from '@/models/agent-ipc';
 import { collectNewMcpServerFailures } from './mcpServerFailureFeedback';
 
+export function mcpServerFailureToastId(
+  sessionId: string,
+  failureKey: string,
+): string {
+  return `mcp-failure:${sessionId}:${failureKey}`;
+}
+
 /**
  * Show Sonner feedback when session MCP servers fail or time out during init/resume.
  * One server's failure must not suppress toasts for others.
@@ -13,22 +20,37 @@ export function useMcpServerFailureToasts(
   runtimeState: SessionRuntimeState,
 ): void {
   const { t } = useTranslation();
-  const toastedKeysRef = useRef<Set<string>>(new Set());
-  const previousSessionIdRef = useRef(sessionId);
+  const toastedKeysBySessionRef = useRef<Map<string, Set<string>>>(new Map());
+  const activeToastIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    if (previousSessionIdRef.current !== sessionId) {
-      toastedKeysRef.current = new Set();
-      previousSessionIdRef.current = sessionId;
+    return () => {
+      for (const toastId of activeToastIdsRef.current) {
+        toast.dismiss(toastId);
+      }
+      activeToastIdsRef.current.clear();
+    };
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      return;
     }
 
+    if (!toastedKeysBySessionRef.current.has(sessionId)) {
+      toastedKeysBySessionRef.current.set(sessionId, new Set());
+    }
+    const sessionToastedKeys = toastedKeysBySessionRef.current.get(sessionId)!;
+
     const newFailures = collectNewMcpServerFailures(
-      toastedKeysRef.current,
+      sessionToastedKeys,
       runtimeState.servers,
     );
 
     for (const failure of newFailures) {
-      toastedKeysRef.current.add(failure.key);
+      sessionToastedKeys.add(failure.key);
+      const toastId = mcpServerFailureToastId(sessionId, failure.key);
+      activeToastIdsRef.current.add(toastId);
 
       if (failure.kind === 'timeout') {
         toast.error(
@@ -37,6 +59,7 @@ export function useMcpServerFailureToasts(
             transport: failure.transport,
           }),
           {
+            id: toastId,
             description: t('agent.statusBar.mcpServerTimeoutDescription', {
               error: failure.error,
             }),
@@ -50,6 +73,7 @@ export function useMcpServerFailureToasts(
             transport: failure.transport,
           }),
           {
+            id: toastId,
             description: t('agent.statusBar.mcpServerFailedDescription', {
               error: failure.error,
             }),

--- a/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
+++ b/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
@@ -53,7 +53,7 @@ describe('useMcpDiscoveryToasts', () => {
     });
   });
 
-  it('shows success toast when discovery completes', () => {
+  it('shows success toast with deterministic ID when discovery completes', () => {
     renderHook(() =>
       useMcpDiscoveryToasts({
         hasSession: true,
@@ -66,14 +66,13 @@ describe('useMcpDiscoveryToasts', () => {
       }),
     );
 
-    expect(toast.dismiss).toHaveBeenCalledWith('mcp-discovery:s1');
     expect(toast.success).toHaveBeenCalledWith(
       'agent.statusBar.mcpResultSuccess',
-      expect.objectContaining({ duration: 2500 }),
+      expect.objectContaining({ id: 'mcp-discovery:s1', duration: 2500 }),
     );
   });
 
-  it('shows warning toast for partial discovery', () => {
+  it('shows warning toast with deterministic ID for partial discovery', () => {
     renderHook(() =>
       useMcpDiscoveryToasts({
         hasSession: true,
@@ -101,7 +100,7 @@ describe('useMcpDiscoveryToasts', () => {
 
     expect(toast.warning).toHaveBeenCalledWith(
       'agent.statusBar.mcpResultPartial',
-      expect.objectContaining({ duration: 5000 }),
+      expect.objectContaining({ id: 'mcp-discovery:s-timeout', duration: 5000 }),
     );
   });
 
@@ -128,7 +127,7 @@ describe('useMcpDiscoveryToasts', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('shows failed summary toast when no per-server feedback exists', () => {
+  it('shows failed summary toast with deterministic ID when no per-server feedback exists', () => {
     renderHook(() =>
       useMcpDiscoveryToasts({
         hasSession: true,
@@ -149,7 +148,60 @@ describe('useMcpDiscoveryToasts', () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       'agent.statusBar.mcpResultFailed',
-      expect.objectContaining({ duration: 8000 }),
+      expect.objectContaining({
+        id: 'mcp-discovery:s-fail-summary',
+        duration: 8000,
+      }),
     );
+  });
+
+  it('dismisses discovery toast on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useMcpDiscoveryToasts({
+        hasSession: true,
+        isProxyReady: false,
+        phase: 'initializing',
+        initResult: 'pending',
+        servers: readyServers,
+        sessionId: 's1',
+      }),
+    );
+
+    vi.clearAllMocks();
+    unmount();
+
+    expect(toast.dismiss).toHaveBeenCalledWith('mcp-discovery:s1');
+  });
+
+  it('does not re-trigger result toast when switching back to an already-ready session', () => {
+    let currentSessionId = 's1';
+    const props = (sessionId: string) => ({
+      hasSession: true,
+      isProxyReady: true,
+      phase: 'ready' as const,
+      initResult: 'success' as const,
+      servers: readyServers,
+      sessionId,
+    });
+
+    const { rerender } = renderHook(() =>
+      useMcpDiscoveryToasts(props(currentSessionId)),
+    );
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+
+    // Switch to s2
+    currentSessionId = 's2';
+    rerender();
+    expect(toast.success).toHaveBeenCalledTimes(2);
+
+    vi.clearAllMocks();
+
+    // Switch back to s1
+    currentSessionId = 's1';
+    rerender();
+
+    // Should not re-fire toast.success for s1
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/src/features/agent/hooks/useMcpDiscoveryToasts.ts
+++ b/src/features/agent/hooks/useMcpDiscoveryToasts.ts
@@ -39,11 +39,7 @@ export function useMcpDiscoveryToasts({
   currentStep,
 }: UseMcpDiscoveryToastsArgs): void {
   const { t } = useTranslation();
-  const resultKeyRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    resultKeyRef.current = null;
-  }, [sessionId]);
+  const resultKeyBySessionRef = useRef<Map<string, string>>(new Map());
 
   const showLoading = hasSession && !isProxyReady && phase !== 'failed';
   const discoveryFinished =
@@ -66,8 +62,11 @@ export function useMcpDiscoveryToasts({
       return;
     }
 
-    toast.dismiss(id);
-  }, [sessionId, hasSession, showLoading, currentStep, t]);
+    // Dismiss loading toast only if discovery failed or ended without terminal result toast
+    if (!discoveryFinished) {
+      toast.dismiss(id);
+    }
+  }, [sessionId, hasSession, showLoading, discoveryFinished, currentStep, t]);
 
   useEffect(() => {
     if (!sessionId || !hasSession || showLoading) {
@@ -78,13 +77,16 @@ export function useMcpDiscoveryToasts({
     }
 
     const resultKey = `${sessionId}:${initResult}:${phase}`;
-    if (resultKeyRef.current === resultKey) {
+    if (resultKeyBySessionRef.current.get(sessionId) === resultKey) {
       return;
     }
-    resultKeyRef.current = resultKey;
+    resultKeyBySessionRef.current.set(sessionId, resultKey);
+
+    const id = discoveryToastId(sessionId);
 
     if (initResult === 'success') {
       toast.success(t('agent.statusBar.mcpResultSuccess'), {
+        id,
         duration: SUCCESS_TOAST_MS,
       });
       return;
@@ -92,6 +94,7 @@ export function useMcpDiscoveryToasts({
 
     if (initResult === 'partial' || phase === 'degraded') {
       toast.warning(t('agent.statusBar.mcpResultPartial'), {
+        id,
         duration: PARTIAL_TOAST_MS,
       });
       return;
@@ -103,6 +106,7 @@ export function useMcpDiscoveryToasts({
       );
       if (!hasPerServerFeedback) {
         toast.error(t('agent.statusBar.mcpResultFailed'), {
+          id,
           duration: 8000,
         });
       }


### PR DESCRIPTION
## Summary
- Bind MCP failure and discovery toasts to session-scoped deterministic IDs so duplicates replace instead of stacking.
- Dismiss active MCP failure/discovery toasts on session switch and unmount so they do not linger across sessions.
- Keep per-session toasted-key tracking so returning to an already-ready session does not re-fire the same result toast.

Fixes https://github.com/fritzprix/libr-agent/issues/1696

## Test plan
- [ ] Trigger MCP server init failure → toast appears once with stable ID
- [ ] Switch sessions while failure toast is visible → toast is dismissed
- [ ] Switch back to a previously ready session → discovery success toast does not reappear
- [ ] `pnpm exec vitest run src/context/agent-session/__tests__/notifyRuntimeStateErrors.test.ts src/context/agent-session/__tests__/useMcpServerFailureToasts.test.ts src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts`