### PR TITLE
fix(agent): open assistant tools editor in-place from draft chat

### DIFF
--- a/src/features/agent/AgentDraftChatView.tsx
+++ b/src/features/agent/AgentDraftChatView.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { type CSSProperties } from 'react';
+import { useCallback, useState, type CSSProperties } from 'react';
+import { toast } from 'sonner';
 
 import {
   Button,
@@ -14,7 +15,12 @@ import AgentSessionHeader from './components/AgentSessionHeader';
 import { DraftCapabilitiesSection } from './components/DraftCapabilitiesSection';
 import { Send, Loader2, Bot } from 'lucide-react';
 import { useSettings } from '@/context/SettingsContext';
+import { EditorProvider } from '@/context/EditorContext';
+import { updateAssistant } from '@/lib/backend/assistants';
+import { getLogger } from '@/lib/logger';
 import { cn } from '@/lib/utils';
+import type { Assistant } from '@/models/chat';
+import AssistantEditor from '@/features/assistant/AssistantEditor';
 import { InputTokenDropdown } from './components/InputTokenDropdown';
 import { useAgentDraftChat } from './hooks/useAgentDraftChat';
 import { useWorkspaceFiles } from './hooks/useWorkspaceFiles';
@@ -24,6 +30,8 @@ import { AGENT_ATTACHMENT_PICKER_ACCEPT } from './lib/attachment-picker';
 import { useTextareaAutosize } from '@/hooks/useTextareaAutosize';
 import { useClipboardImage } from './hooks/useClipboardImage';
 
+const logger = getLogger('AgentDraftChatView');
+
 const textareaStyle = {
   msOverflowStyle: 'none',
   scrollbarWidth: 'none',
@@ -32,9 +40,11 @@ const textareaStyle = {
 function DraftChatInner() {
   const { t } = useTranslation();
   const { value: settings } = useSettings();
+  const [toolsEditorOpen, setToolsEditorOpen] = useState(false);
 
   const {
     assistant,
+    setAssistant,
     isLoadingAssistant,
     input,
     setInput,
@@ -73,6 +83,22 @@ function DraftChatInner() {
     dockerError,
     setDockerError,
   } = useAgentDraftChat();
+
+  const handleAssistantToolsSave = useCallback(
+    async (updated: Assistant) => {
+      try {
+        const saved = await updateAssistant(updated);
+        setAssistant(saved);
+      } catch (error) {
+        logger.error('Failed to save assistant tools from draft view', error);
+        toast.error(
+          t('agent.draft.failedToSaveTools', 'Failed to save assistant tools'),
+        );
+        throw error;
+      }
+    },
+    [setAssistant, t],
+  );
 
   const fileQuery =
     stage.kind === 'typing-arg' && stage.typeName === 'file'
@@ -122,335 +148,350 @@ function DraftChatInner() {
   const hasAttachedFiles = pendingFiles.length > 0;
 
   return (
-    <div className="flex h-full w-full overflow-hidden rounded-2xl border border-border/50 bg-background font-sans shadow-[0_18px_48px_-28px_rgba(0,0,0,0.35)]">
-      {/* Workspace Side Panel */}
-      {workspaceOverride && (
-        <AgentDraftWorkspacePreviewPanel
-          workspacePath={workspaceOverride}
-          workspaceIsolation={workspaceIsolation}
-          setWorkspaceIsolation={setWorkspaceIsolation}
-          dockerImage={dockerImage}
-          setDockerImage={setDockerImage}
-          onClear={() => setWorkspaceOverride(null)}
-        />
-      )}
-
-      {/* Main Chat Area */}
-      <div
-        className="flex min-h-0 min-w-0 flex-1 flex-col"
-        style={
-          {
-            '--agent-chat-composer-overlap': '64px',
-          } as CSSProperties
-        }
-      >
-        <AgentSessionHeader
-          assistantName={`[${assistant.name}]`}
-          assistantNameClassName="text-xs font-semibold text-primary"
-          sessionName={t('agent.draft.newSession', 'New Session')}
-          sessionNameClassName="max-w-xs truncate text-xs italic text-muted-foreground/80"
-        />
-
-        {/* Scrollable Content Area */}
-        <div className="flex-1 overflow-y-auto no-scrollbar relative">
-          <div
-            ref={profileAreaRef}
-            className={cn(
-              'min-h-full p-8 pb-32 flex flex-col items-center justify-center text-center gap-10 transition-all duration-500',
-              profileDragState === 'valid' &&
-                'bg-primary/5 ring-2 ring-primary/30 ring-inset',
-              profileDragState === 'invalid' &&
-                'bg-destructive/10 ring-2 ring-destructive/30 ring-inset',
-            )}
-          >
-            {/* Identity Section */}
-            <div className="flex flex-col items-center space-y-6 animate-in fade-in zoom-in duration-700">
-              <div className="w-24 h-24 bg-primary/10 rounded-[1.5rem] flex items-center justify-center shadow-xl ring-1 ring-primary/20 transition-transform hover:scale-105 duration-300">
-                <Bot className="w-12 h-12 text-primary" />
-              </div>
-              <div className="space-y-3 max-w-xl">
-                <h1 className="text-4xl font-bold tracking-tight text-foreground">
-                  {assistant.name}
-                </h1>
-                {assistant.description && (
-                  <p className="text-muted-foreground text-base leading-relaxed max-w-md mx-auto font-sans">
-                    {assistant.description}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            {/* Workspace State / Drop Hint */}
-            {!workspaceOverride && (
-              <div
-                className={cn(
-                  'text-[11px] uppercase tracking-wider font-sans transition-all duration-300 border border-dashed rounded-full px-6 py-2 bg-background/50 backdrop-blur-sm shadow-sm',
-                  profileDragState === 'valid'
-                    ? 'opacity-100 font-bold border-primary/50 text-primary bg-primary/5 scale-105'
-                    : 'opacity-40 text-muted-foreground border-border hover:opacity-100',
-                )}
-              >
-                {t(
-                  'agent.workspace.dropFolderHint',
-                  'Drop folder to set workspace context',
-                )}
-              </div>
-            )}
-
-            <DraftCapabilitiesSection
-              assistant={assistant}
-              builtinServices={builtinServices}
-              mcpServers={mcpServers}
-              currentModel={
-                overrideModel ?? settings?.preferredModel?.model ?? 'gpt-4'
-              }
-              currentProvider={
-                overrideProvider ??
-                settings?.preferredModel?.provider ??
-                'openai'
-              }
-              onConfigUpdate={(model, provider) => {
-                setOverrideModel(model);
-                setOverrideProvider(provider);
-              }}
-              workspaceIsolation={workspaceIsolation}
-              setWorkspaceIsolation={setWorkspaceIsolation}
-              dockerImage={dockerImage}
-              setDockerImage={setDockerImage}
-              workspaceOverride={workspaceOverride}
-            />
-          </div>
-        </div>
-
-        <div className="relative shrink-0 px-4 pb-4">
-          <div
-            aria-hidden="true"
-            style={{ height: 'var(--agent-chat-composer-overlap, 64px)' }}
+    <EditorProvider
+      key={assistant.id}
+      initialValue={assistant}
+      onFinalize={handleAssistantToolsSave}
+    >
+      <div className="flex h-full w-full overflow-hidden rounded-2xl border border-border/50 bg-background font-sans shadow-[0_18px_48px_-28px_rgba(0,0,0,0.35)]">
+        {/* Workspace Side Panel */}
+        {workspaceOverride && (
+          <AgentDraftWorkspacePreviewPanel
+            workspacePath={workspaceOverride}
+            workspaceIsolation={workspaceIsolation}
+            setWorkspaceIsolation={setWorkspaceIsolation}
+            dockerImage={dockerImage}
+            setDockerImage={setDockerImage}
+            onClear={() => setWorkspaceOverride(null)}
           />
-          <div
-            className="relative z-10"
-            style={{
-              marginTop: 'calc(var(--agent-chat-composer-overlap, 64px) * -1)',
-            }}
-          >
-            <div className="pointer-events-none absolute inset-x-0 -top-12 h-32 bg-gradient-to-t from-background/80 via-background/28 to-transparent" />
-            <div className="pointer-events-auto mx-auto w-full max-w-5xl">
-              {/* Attached Files List - Mirrored from AgentChatAttachedFiles */}
-              {hasAttachedFiles && (
-                <AgentAttachedFilesBar
-                  files={pendingFiles.map((file, index) => ({
-                    id: `${file.name}-${index}`,
-                    name: file.name,
-                    onRemove: () => handleFileRemove(index),
-                  }))}
-                  title={t('agent.draft.attachedFiles', 'Attached Files:')}
-                />
+        )}
+
+        {/* Main Chat Area */}
+        <div
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+          style={
+            {
+              '--agent-chat-composer-overlap': '64px',
+            } as CSSProperties
+          }
+        >
+          <AgentSessionHeader
+            assistantName={`[${assistant.name}]`}
+            assistantNameClassName="text-xs font-semibold text-primary"
+            sessionName={t('agent.draft.newSession', 'New Session')}
+            sessionNameClassName="max-w-xs truncate text-xs italic text-muted-foreground/80"
+          />
+
+          {/* Scrollable Content Area */}
+          <div className="flex-1 overflow-y-auto no-scrollbar relative">
+            <div
+              ref={profileAreaRef}
+              className={cn(
+                'min-h-full p-8 pb-32 flex flex-col items-center justify-center text-center gap-10 transition-all duration-500',
+                profileDragState === 'valid' &&
+                  'bg-primary/5 ring-2 ring-primary/30 ring-inset',
+                profileDragState === 'invalid' &&
+                  'bg-destructive/10 ring-2 ring-destructive/30 ring-inset',
               )}
-
-              {/* Input Form - Exact match for AgentChatInput formClassName */}
-              <div className="relative group">
-                {stage.kind !== 'idle' &&
-                  (typeResults.length > 0 ||
-                    skillResults.length > 0 ||
-                    workspaceFileResults.length > 0) && (
-                    <InputTokenDropdown
-                      mode={
-                        stage.kind === 'typing-type'
-                          ? { kind: 'types', items: typeResults }
-                          : stage.kind === 'typing-arg' &&
-                              stage.typeName === 'file'
-                            ? { kind: 'files', items: workspaceFileResults }
-                            : { kind: 'skills', items: skillResults }
-                      }
-                      onSelectType={(typeName) => {
-                        const cursorPos =
-                          textareaRef.current?.selectionStart ?? input.length;
-                        const newValue = onTypeSelect(
-                          typeName,
-                          input,
-                          cursorPos,
-                        );
-                        setInput(newValue);
-                        requestAnimationFrame(() => {
-                          if (textareaRef.current) {
-                            const pos =
-                              newValue.length - (input.length - cursorPos);
-                            textareaRef.current.setSelectionRange(pos, pos);
-                            textareaRef.current.focus();
-                          }
-                        });
-                      }}
-                      onSelectArg={(arg) => {
-                        const cursorPos =
-                          textareaRef.current?.selectionStart ?? input.length;
-                        const newValue = onArgSelect(arg, input, cursorPos);
-                        setInput(newValue);
-                        requestAnimationFrame(() =>
-                          textareaRef.current?.focus(),
-                        );
-                      }}
-                      onDismiss={onDismiss}
-                    />
+            >
+              {/* Identity Section */}
+              <div className="flex flex-col items-center space-y-6 animate-in fade-in zoom-in duration-700">
+                <div className="w-24 h-24 bg-primary/10 rounded-[1.5rem] flex items-center justify-center shadow-xl ring-1 ring-primary/20 transition-transform hover:scale-105 duration-300">
+                  <Bot className="w-12 h-12 text-primary" />
+                </div>
+                <div className="space-y-3 max-w-xl">
+                  <h1 className="text-4xl font-bold tracking-tight text-foreground">
+                    {assistant.name}
+                  </h1>
+                  {assistant.description && (
+                    <p className="text-muted-foreground text-base leading-relaxed max-w-md mx-auto font-sans">
+                      {assistant.description}
+                    </p>
                   )}
+                </div>
+              </div>
 
-                <form
-                  ref={formRef}
-                  onSubmit={handleSubmit}
+              {/* Workspace State / Drop Hint */}
+              {!workspaceOverride && (
+                <div
                   className={cn(
-                    'flex items-end gap-2 bg-background/60 backdrop-blur-md p-3 border border-border/50 shadow-2xl focus-within:ring-1 focus-within:ring-primary/20 transition-all duration-300',
-                    hasAttachedFiles ? 'rounded-b-xl border-t-0' : 'rounded-xl',
-                    dragState === 'valid' &&
-                      'bg-success/5 border-success/50 shadow-success/10',
-                    dragState === 'invalid' &&
-                      'bg-destructive/5 border-destructive/50 shadow-destructive/10',
+                    'text-[11px] uppercase tracking-wider font-sans transition-all duration-300 border border-dashed rounded-full px-6 py-2 bg-background/50 backdrop-blur-sm shadow-sm',
+                    profileDragState === 'valid'
+                      ? 'opacity-100 font-bold border-primary/50 text-primary bg-primary/5 scale-105'
+                      : 'opacity-40 text-muted-foreground border-border hover:opacity-100',
                   )}
                 >
-                  <FileAttachment
-                    files={pendingFiles.map((file) => ({
+                  {t(
+                    'agent.workspace.dropFolderHint',
+                    'Drop folder to set workspace context',
+                  )}
+                </div>
+              )}
+
+              <DraftCapabilitiesSection
+                assistant={assistant}
+                builtinServices={builtinServices}
+                mcpServers={mcpServers}
+                currentModel={
+                  overrideModel ?? settings?.preferredModel?.model ?? 'gpt-4'
+                }
+                currentProvider={
+                  overrideProvider ??
+                  settings?.preferredModel?.provider ??
+                  'openai'
+                }
+                onConfigUpdate={(model, provider) => {
+                  setOverrideModel(model);
+                  setOverrideProvider(provider);
+                }}
+                workspaceIsolation={workspaceIsolation}
+                setWorkspaceIsolation={setWorkspaceIsolation}
+                dockerImage={dockerImage}
+                setDockerImage={setDockerImage}
+                workspaceOverride={workspaceOverride}
+                onAddTools={() => setToolsEditorOpen(true)}
+              />
+            </div>
+          </div>
+
+          <div className="relative shrink-0 px-4 pb-4">
+            <div
+              aria-hidden="true"
+              style={{ height: 'var(--agent-chat-composer-overlap, 64px)' }}
+            />
+            <div
+              className="relative z-10"
+              style={{
+                marginTop:
+                  'calc(var(--agent-chat-composer-overlap, 64px) * -1)',
+              }}
+            >
+              <div className="pointer-events-none absolute inset-x-0 -top-12 h-32 bg-gradient-to-t from-background/80 via-background/28 to-transparent" />
+              <div className="pointer-events-auto mx-auto w-full max-w-5xl">
+                {/* Attached Files List - Mirrored from AgentChatAttachedFiles */}
+                {hasAttachedFiles && (
+                  <AgentAttachedFilesBar
+                    files={pendingFiles.map((file, index) => ({
+                      id: `${file.name}-${index}`,
                       name: file.name,
-                      content: '',
+                      onRemove: () => handleFileRemove(index),
                     }))}
-                    onAdd={handleFileAdd}
-                    compact={true}
-                    disabled={isSubmitting || isAttachmentLoading}
-                    showFileCount={false}
-                    accept={AGENT_ATTACHMENT_PICKER_ACCEPT}
-                    buttonClassName="mb-1 h-8 w-8 hover:text-primary hover:bg-primary/5 transition-colors"
+                    title={t('agent.draft.attachedFiles', 'Attached Files:')}
                   />
+                )}
 
-                  <textarea
-                    ref={textareaRef}
-                    value={input}
-                    onChange={(e) => {
-                      setInput(e.target.value);
-                      onInputChange(
-                        e.target.value,
-                        e.target.selectionStart ?? e.target.value.length,
-                      );
-                    }}
-                    onPaste={handlePaste}
-                    placeholder={inputPlaceholder}
-                    rows={1}
-                    autoComplete="off"
-                    spellCheck="false"
-                    style={textareaStyle}
-                    className="flex-1 resize-none bg-transparent outline-none border-none py-3 px-2 text-sm leading-relaxed max-h-32 min-h-[44px] overflow-y-auto transition-colors"
-                    onKeyDown={(e) => {
-                      if (
-                        stage.kind !== 'idle' &&
-                        (typeResults.length > 0 ||
-                          skillResults.length > 0 ||
-                          workspaceFileResults.length > 0) &&
-                        [
-                          'ArrowUp',
-                          'ArrowDown',
-                          'Enter',
-                          'Tab',
-                          'Escape',
-                        ].includes(e.key)
-                      ) {
-                        return;
-                      }
+                {/* Input Form - Exact match for AgentChatInput formClassName */}
+                <div className="relative group">
+                  {stage.kind !== 'idle' &&
+                    (typeResults.length > 0 ||
+                      skillResults.length > 0 ||
+                      workspaceFileResults.length > 0) && (
+                      <InputTokenDropdown
+                        mode={
+                          stage.kind === 'typing-type'
+                            ? { kind: 'types', items: typeResults }
+                            : stage.kind === 'typing-arg' &&
+                                stage.typeName === 'file'
+                              ? { kind: 'files', items: workspaceFileResults }
+                              : { kind: 'skills', items: skillResults }
+                        }
+                        onSelectType={(typeName) => {
+                          const cursorPos =
+                            textareaRef.current?.selectionStart ?? input.length;
+                          const newValue = onTypeSelect(
+                            typeName,
+                            input,
+                            cursorPos,
+                          );
+                          setInput(newValue);
+                          requestAnimationFrame(() => {
+                            if (textareaRef.current) {
+                              const pos =
+                                newValue.length - (input.length - cursorPos);
+                              textareaRef.current.setSelectionRange(pos, pos);
+                              textareaRef.current.focus();
+                            }
+                          });
+                        }}
+                        onSelectArg={(arg) => {
+                          const cursorPos =
+                            textareaRef.current?.selectionStart ?? input.length;
+                          const newValue = onArgSelect(arg, input, cursorPos);
+                          setInput(newValue);
+                          requestAnimationFrame(() =>
+                            textareaRef.current?.focus(),
+                          );
+                        }}
+                        onDismiss={onDismiss}
+                      />
+                    )}
 
-                      if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
+                  <form
+                    ref={formRef}
+                    onSubmit={handleSubmit}
+                    className={cn(
+                      'flex items-end gap-2 bg-background/60 backdrop-blur-md p-3 border border-border/50 shadow-2xl focus-within:ring-1 focus-within:ring-primary/20 transition-all duration-300',
+                      hasAttachedFiles
+                        ? 'rounded-b-xl border-t-0'
+                        : 'rounded-xl',
+                      dragState === 'valid' &&
+                        'bg-success/5 border-success/50 shadow-success/10',
+                      dragState === 'invalid' &&
+                        'bg-destructive/5 border-destructive/50 shadow-destructive/10',
+                    )}
+                  >
+                    <FileAttachment
+                      files={pendingFiles.map((file) => ({
+                        name: file.name,
+                        content: '',
+                      }))}
+                      onAdd={handleFileAdd}
+                      compact={true}
+                      disabled={isSubmitting || isAttachmentLoading}
+                      showFileCount={false}
+                      accept={AGENT_ATTACHMENT_PICKER_ACCEPT}
+                      buttonClassName="mb-1 h-8 w-8 hover:text-primary hover:bg-primary/5 transition-colors"
+                    />
+
+                    <textarea
+                      ref={textareaRef}
+                      value={input}
+                      onChange={(e) => {
+                        setInput(e.target.value);
+                        onInputChange(
+                          e.target.value,
+                          e.target.selectionStart ?? e.target.value.length,
+                        );
+                      }}
+                      onPaste={handlePaste}
+                      placeholder={inputPlaceholder}
+                      rows={1}
+                      autoComplete="off"
+                      spellCheck="false"
+                      style={textareaStyle}
+                      className="flex-1 resize-none bg-transparent outline-none border-none py-3 px-2 text-sm leading-relaxed max-h-32 min-h-[44px] overflow-y-auto transition-colors"
+                      onKeyDown={(e) => {
                         if (
-                          !isAttachmentLoading &&
-                          (input.trim() || hasAttachedFiles)
+                          stage.kind !== 'idle' &&
+                          (typeResults.length > 0 ||
+                            skillResults.length > 0 ||
+                            workspaceFileResults.length > 0) &&
+                          [
+                            'ArrowUp',
+                            'ArrowDown',
+                            'Enter',
+                            'Tab',
+                            'Escape',
+                          ].includes(e.key)
                         ) {
-                          handleSubmit(e);
+                          return;
                         }
-                      }
-                    }}
-                    disabled={isSubmitting || isAttachmentLoading}
-                  />
 
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        tabIndex={
-                          (!input.trim() && !hasAttachedFiles) ||
-                          isSubmitting ||
-                          isAttachmentLoading
-                            ? 0
-                            : undefined
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          if (
+                            !isAttachmentLoading &&
+                            (input.trim() || hasAttachedFiles)
+                          ) {
+                            handleSubmit(e);
+                          }
                         }
-                        className={cn(
-                          'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0',
-                          ((!input.trim() && !hasAttachedFiles) ||
-                            isSubmitting ||
-                            isAttachmentLoading) &&
-                            'cursor-not-allowed',
-                        )}
-                        aria-label={
-                          (!input.trim() && !hasAttachedFiles) ||
-                          isSubmitting ||
-                          isAttachmentLoading
-                            ? t('agent.input.sendAriaLabel', 'Send message')
-                            : undefined
-                        }
-                        aria-disabled={
-                          (!input.trim() && !hasAttachedFiles) ||
-                          isSubmitting ||
-                          isAttachmentLoading
-                            ? true
-                            : undefined
-                        }
-                        role={
-                          (!input.trim() && !hasAttachedFiles) ||
-                          isSubmitting ||
-                          isAttachmentLoading
-                            ? 'button'
-                            : undefined
-                        }
-                      >
-                        <Button
-                          type="submit"
-                          disabled={
+                      }}
+                      disabled={isSubmitting || isAttachmentLoading}
+                    />
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          tabIndex={
                             (!input.trim() && !hasAttachedFiles) ||
                             isSubmitting ||
                             isAttachmentLoading
+                              ? 0
+                              : undefined
                           }
-                          size="icon"
                           className={cn(
-                            'shadow-lg transition-all active:scale-95',
+                            'inline-block rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none mb-1 shrink-0',
                             ((!input.trim() && !hasAttachedFiles) ||
                               isSubmitting ||
                               isAttachmentLoading) &&
-                              'pointer-events-none',
+                              'cursor-not-allowed',
                           )}
-                          aria-label={t(
-                            'agent.input.sendAriaLabel',
-                            'Send message',
-                          )}
+                          aria-label={
+                            (!input.trim() && !hasAttachedFiles) ||
+                            isSubmitting ||
+                            isAttachmentLoading
+                              ? t('agent.input.sendAriaLabel', 'Send message')
+                              : undefined
+                          }
+                          aria-disabled={
+                            (!input.trim() && !hasAttachedFiles) ||
+                            isSubmitting ||
+                            isAttachmentLoading
+                              ? true
+                              : undefined
+                          }
+                          role={
+                            (!input.trim() && !hasAttachedFiles) ||
+                            isSubmitting ||
+                            isAttachmentLoading
+                              ? 'button'
+                              : undefined
+                          }
                         >
-                          {isSubmitting || isAttachmentLoading ? (
-                            <Loader2 className="animate-spin h-4 w-4" />
-                          ) : (
-                            <Send className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {t('agent.input.sendTooltip', 'Send')}
-                    </TooltipContent>
-                  </Tooltip>
-                </form>
+                          <Button
+                            type="submit"
+                            disabled={
+                              (!input.trim() && !hasAttachedFiles) ||
+                              isSubmitting ||
+                              isAttachmentLoading
+                            }
+                            size="icon"
+                            className={cn(
+                              'shadow-lg transition-all active:scale-95',
+                              ((!input.trim() && !hasAttachedFiles) ||
+                                isSubmitting ||
+                                isAttachmentLoading) &&
+                                'pointer-events-none',
+                            )}
+                            aria-label={t(
+                              'agent.input.sendAriaLabel',
+                              'Send message',
+                            )}
+                          >
+                            {isSubmitting || isAttachmentLoading ? (
+                              <Loader2 className="animate-spin h-4 w-4" />
+                            ) : (
+                              <Send className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {t('agent.input.sendTooltip', 'Send')}
+                      </TooltipContent>
+                    </Tooltip>
+                  </form>
+                </div>
               </div>
             </div>
           </div>
         </div>
+        <DockerErrorModal
+          isOpen={!!dockerError}
+          onClose={() => setDockerError(null)}
+          onRetry={() => {
+            void retryDraftSubmit();
+          }}
+          errorDetails={dockerError}
+        />
+        <AssistantEditor.Dialog
+          open={toolsEditorOpen}
+          onOpenChange={setToolsEditorOpen}
+          initialTab="tools"
+        />
       </div>
-      <DockerErrorModal
-        isOpen={!!dockerError}
-        onClose={() => setDockerError(null)}
-        onRetry={() => {
-          void retryDraftSubmit();
-        }}
-        errorDetails={dockerError}
-      />
-    </div>
+    </EditorProvider>
   );
 }
 

--- a/src/features/agent/__tests__/AgentDraftChatView.test.tsx
+++ b/src/features/agent/__tests__/AgentDraftChatView.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +20,7 @@ const createDraftChatState = () => ({
     description: 'Draft description',
     allowedBuiltInServiceAliases: [],
   },
+  setAssistant: vi.fn(),
   isLoadingAssistant: false,
   input: '@file:src',
   setInput: vi.fn(),
@@ -104,6 +105,27 @@ vi.mock('../components/AgentDraftWorkspacePreviewPanel', () => ({
   ),
 }));
 
+vi.mock('@/features/assistant/AssistantEditor', () => {
+  function MockAssistantEditor() {
+    return <div data-testid="assistant-editor" />;
+  }
+  function MockAssistantEditorDialog({
+    open,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    initialTab?: string;
+  }) {
+    return open ? <div data-testid="assistant-editor-dialog" /> : null;
+  }
+  MockAssistantEditor.Dialog = MockAssistantEditorDialog;
+  return { default: MockAssistantEditor };
+});
+
+vi.mock('@/lib/backend/assistants', () => ({
+  updateAssistant: vi.fn(),
+}));
+
 describe('AgentDraftChatView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -161,5 +183,28 @@ describe('AgentDraftChatView', () => {
       kind: 'files',
       items: ['src/main.ts'],
     });
+  });
+
+  it('opens the assistant tools editor from + Add tools without leaving draft', () => {
+    mockUseAgentDraftChat.mockReturnValue({
+      ...createDraftChatState(),
+      workspaceOverride: null,
+      stage: { kind: 'idle' },
+      input: '',
+    });
+
+    render(
+      <MemoryRouter>
+        <AgentDraftChatView />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByTestId('assistant-editor-dialog'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add tools' }));
+
+    expect(screen.getByTestId('assistant-editor-dialog')).toBeInTheDocument();
   });
 });

--- a/src/features/agent/components/DraftCapabilitiesSection.tsx
+++ b/src/features/agent/components/DraftCapabilitiesSection.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Badge,
@@ -43,6 +42,7 @@ interface DraftCapabilitiesSectionProps {
   dockerImage: string;
   setDockerImage: (value: string) => void;
   workspaceOverride: string | null;
+  onAddTools: () => void;
 }
 
 function getIconForService(iconId?: string) {
@@ -80,6 +80,7 @@ export function DraftCapabilitiesSection({
   dockerImage,
   setDockerImage,
   workspaceOverride,
+  onAddTools,
 }: DraftCapabilitiesSectionProps) {
   const { t } = useTranslation();
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -165,26 +166,26 @@ export function DraftCapabilitiesSection({
           );
         })}
 
-        <Link to="/assistants">
-          <Tooltip delayDuration={300}>
-            <TooltipTrigger asChild>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button type="button" onClick={onAddTools} className="inline-flex">
               <Badge
                 variant="outline"
                 className="text-[11px] text-muted-foreground/60 border-dashed font-sans font-normal cursor-pointer hover:opacity-100 hover:bg-muted hover:text-foreground transition-all px-3 py-1.5"
               >
                 {t('agent.draft.addTools', '+ Add tools')}
               </Badge>
-            </TooltipTrigger>
-            <TooltipContent className="mb-1 bg-popover text-popover-foreground border shadow-xl">
-              <p className="text-xs">
-                {t(
-                  'agent.draft.addMoreCapabilities',
-                  'Add more capabilities in the settings',
-                )}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </Link>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="mb-1 bg-popover text-popover-foreground border shadow-xl">
+            <p className="text-xs">
+              {t(
+                'agent.draft.addMoreCapabilities',
+                'Configure tools for this assistant',
+              )}
+            </p>
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       <div className="flex flex-col items-center gap-5 mt-4 pt-8 border-t border-border/40 w-full max-w-md animate-in fade-in duration-1000">

--- a/src/features/agent/hooks/useAgentDraftChat.ts
+++ b/src/features/agent/hooks/useAgentDraftChat.ts
@@ -583,6 +583,7 @@ export function useAgentDraftChat() {
 
   return {
     assistant,
+    setAssistant,
     isLoadingAssistant,
     input,
     setInput,

--- a/src/features/assistant/AssistantEditor.tsx
+++ b/src/features/assistant/AssistantEditor.tsx
@@ -26,13 +26,21 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Settings, Wrench, Server } from 'lucide-react';
 
-export default function AssistantEditor() {
+export type AssistantEditorTab = 'general' | 'tools' | 'skills';
+
+type AssistantEditorProps = {
+  initialTab?: AssistantEditorTab;
+};
+
+export default function AssistantEditor({
+  initialTab = 'general',
+}: AssistantEditorProps) {
   const { draft, update } = useEditor<Assistant>();
   const { t } = useTranslation('common');
 
   return (
     <div className="w-full">
-      <Tabs defaultValue="general" className="w-full">
+      <Tabs key={initialTab} defaultValue={initialTab} className="w-full">
         <TabsList className="w-full grid grid-cols-3 mb-4">
           <TabsTrigger value="general" className="flex items-center gap-2">
             <Settings className="h-4 w-4" />
@@ -230,7 +238,14 @@ function MCPServersTab() {
   );
 }
 
-function AssistantDialog(props: DialogProps) {
+type AssistantDialogProps = DialogProps & {
+  initialTab?: AssistantEditorTab;
+};
+
+function AssistantDialog({
+  initialTab = 'general',
+  ...props
+}: AssistantDialogProps) {
   const { draft, commit, isLoading } = useEditor<Assistant>();
   const { t } = useTranslation('common');
 
@@ -266,7 +281,7 @@ function AssistantDialog(props: DialogProps) {
           </DialogDescription>
         </DialogHeader>
         <div className="flex-1 overflow-y-auto min-h-0">
-          <AssistantEditor />
+          {props.open ? <AssistantEditor initialTab={initialTab} /> : null}
         </div>
         <div className="flex-shrink-0 flex justify-end gap-2 px-6 py-4 border-t bg-muted/20">
           <Button variant="outline" onClick={handleCancel} disabled={isLoading}>


### PR DESCRIPTION
## Summary
- Replace Draft `+ Add tools` navigation to `/assistants` with an in-place `AssistantEditor.Dialog` opened on the **tools** tab, so draft input/context is preserved.
- Add `initialTab` support to `AssistantEditor` / `AssistantEditor.Dialog`, and sync saved assistant tools back into draft state via `setAssistant`.
- Cover the open flow with a unit test that asserts the dialog opens without leaving the draft view.

## Test plan
- [ ] Open Agent start → select assistant → Draft view
- [ ] Click `+ Add tools` → assistant editor opens on Tools tab (no route change)
- [ ] Toggle a built-in tool and/or MCP server → Save → capability badges update on Draft
- [ ] Confirm draft input / attachments remain after closing the dialog
- [ ] `pnpm exec vitest run src/features/agent/__tests__/AgentDraftChatView.test.tsx`
- [ ] `pnpm exec eslint` on the touched agent/assistant files


Made with [Cursor](https://cursor.com)