### PR TITLE
feat(agent): render MCP structured tool results in chat UI

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/str_replace.rs
@@ -246,15 +246,48 @@ impl WorkspaceServer {
             format!("Replaced {replacements} occurrence(s) in '{path_str}'.\n\n{diff_output}");
 
         // Diff in the body is enough — do not burn tokens on a re-read follow-up.
-        Ok(SuccessHint::new(message, vec![]).to_mcp_result())
+        // structured_content powers the chat UI diff viewer (not re-sent to the LLM as tools).
+        Ok(
+            SuccessHint::new(message, vec![]).to_mcp_result_with_data(Some(serde_json::json!({
+                "path": path_str,
+                "replacements": replacements,
+                "unified_diff": diff_output,
+            }))),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{count_occurrences, read_validated_utf8_file};
+    use crate::mcp::builtin::error_guidance::SuccessHint;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn success_result_includes_str_replace_structured_content() {
+        let structured = serde_json::json!({
+            "path": "src/main.rs",
+            "replacements": 2,
+            "unified_diff": "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        });
+        let result = SuccessHint::new("Replaced 2 occurrence(s)".to_string(), vec![])
+            .to_mcp_result_with_data(Some(structured.clone()));
+
+        let data = result
+            .structured_content
+            .expect("strReplace success should include structured_content");
+        assert_eq!(
+            data.get("path").and_then(|v| v.as_str()),
+            Some("src/main.rs")
+        );
+        assert_eq!(data.get("replacements").and_then(|v| v.as_u64()), Some(2));
+        assert!(data
+            .get("unified_diff")
+            .and_then(|v| v.as_str())
+            .is_some_and(|diff| diff.contains("-old") && diff.contains("+new")));
+        assert_eq!(result.is_error, Some(false));
+    }
 
     #[test]
     fn count_occurrences_handles_empty_needle() {

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -597,8 +597,15 @@ impl WorkspaceServer {
 
                 let hint = SuccessHint::new(message, next_steps);
 
+                let absolute_path = write_safe_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| write_safe_path.clone())
+                    .to_string_lossy()
+                    .to_string();
+
                 let mut structured = json!({
                     "path": write_display_path,
+                    "absolute_path": absolute_path,
                     "requested_path": requested_path_str,
                     "path_adjusted": path_adjusted,
                     "suffix": create_suffix,

--- a/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
+++ b/src-tauri/src/mcp/builtin/workspace/file_operations/write.rs
@@ -619,6 +619,7 @@ impl WorkspaceServer {
                         "lines_added": diff.stats.lines_added,
                         "lines_removed": diff.stats.lines_removed,
                     });
+                    structured["unified_diff"] = json!(diff.text);
                 }
 
                 Ok(hint.to_mcp_result_with_data(Some(structured)))

--- a/src/features/agent/components/AgentToolCallDetails.tsx
+++ b/src/features/agent/components/AgentToolCallDetails.tsx
@@ -2,9 +2,17 @@ import React, { useMemo } from 'react';
 import type { ToolCall, Message } from '@/models/chat';
 import { AgentMessageRenderer } from './AgentMessageRenderer';
 import { AlertCircle, Loader2 } from 'lucide-react';
-import { hasUIResource, parseToolArguments } from '@/lib/tool-call-utils';
+import {
+  getToolStructuredContent,
+  hasUIResource,
+  parseToolArguments,
+} from '@/lib/tool-call-utils';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
+import {
+  canRenderStructuredToolResult,
+  ToolStructuredResult,
+} from './tool-structured/ToolStructuredResult';
 
 interface AgentToolCallDetailsProps {
   toolCall: ToolCall;
@@ -41,6 +49,11 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
     [parsedArgs, toolCall.function.arguments],
   );
   const containsUIResource = hasUIResource(toolResult);
+  const structuredContent = getToolStructuredContent(toolResult);
+  const showStructuredResult =
+    !hasError &&
+    structuredContent !== undefined &&
+    canRenderStructuredToolResult(toolCall.function.name, structuredContent);
 
   if (!showDetails) return null;
 
@@ -92,14 +105,23 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
               data-testid="tool-call-result"
               className={cn(
                 'bg-background rounded border p-2',
-                !containsUIResource && 'max-h-96 overflow-y-auto',
+                !containsUIResource &&
+                  !showStructuredResult &&
+                  'max-h-96 overflow-y-auto',
               )}
             >
-              <AgentMessageRenderer
-                message={toolResult}
-                className="text-sm"
-                expandResources={true}
-              />
+              {showStructuredResult ? (
+                <ToolStructuredResult
+                  toolName={toolCall.function.name}
+                  data={structuredContent}
+                />
+              ) : (
+                <AgentMessageRenderer
+                  message={toolResult}
+                  className="text-sm"
+                  expandResources={true}
+                />
+              )}
             </div>
           )}
         </div>

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -9,10 +9,10 @@ import {
   formatExecutionTime,
   parseToolArguments,
   formatToolArgumentsSummary,
-  hasUIResource,
 } from '@/lib/tool-call-utils';
 import { AgentToolCallDetails } from './AgentToolCallDetails';
 import { useSettings } from '@/hooks/use-settings';
+import { resolveToolResultUiOverride } from './tool-structured/presentation';
 
 export interface ToolCallCompactItemProps {
   toolCall: ToolCall;
@@ -45,6 +45,51 @@ export const ToolStatusIcon: React.FC<ToolStatusIconProps> = ({
   return <CheckCircle className="w-3.5 h-3.5 text-success flex-shrink-0" />;
 };
 
+interface CompactHeaderRowProps {
+  toolResult?: Message;
+  hasError: boolean;
+  displayToolName: string;
+  paramSummary: string;
+  executionTime?: number;
+  showChevron?: boolean;
+  isExpanded?: boolean;
+}
+
+const CompactHeaderRow: React.FC<CompactHeaderRowProps> = ({
+  toolResult,
+  hasError,
+  displayToolName,
+  paramSummary,
+  executionTime,
+  showChevron = false,
+  isExpanded = false,
+}) => (
+  <div className="flex items-center gap-2">
+    <ToolStatusIcon hasResult={!!toolResult} hasError={hasError} />
+    <span className="flex-shrink-0 font-medium">{displayToolName}</span>
+    {paramSummary ? (
+      <span className="flex-1 text-xs text-muted-foreground truncate font-mono opacity-70 min-w-0">
+        {paramSummary}
+      </span>
+    ) : (
+      <span className="flex-1" />
+    )}
+    {executionTime !== undefined ? (
+      <span className="text-xs text-muted-foreground flex-shrink-0">
+        {formatExecutionTime(executionTime)}
+      </span>
+    ) : null}
+    {showChevron ? (
+      <ChevronDown
+        className={cn(
+          'w-3.5 h-3.5 transition-transform flex-shrink-0 text-muted-foreground',
+          isExpanded && 'rotate-180',
+        )}
+      />
+    ) : null}
+  </div>
+);
+
 /**
  * Compact tool call item - no individual border, tight spacing.
  *
@@ -53,23 +98,24 @@ export const ToolStatusIcon: React.FC<ToolStatusIconProps> = ({
  *             no background colour change on error, no expand capability.
  * - 'developer': full detail view (current behaviour) with params summary,
  *               execution time, error details, and expand/collapse.
+ *
+ * Results with a UI override (MCP UI resource or structured tool UI) always
+ * show details and skip collapse — see {@link resolveToolResultUiOverride}.
  */
 const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   toolCall,
   toolResult,
-  isLast = false,
 }) => {
   const { t } = useTranslation('common');
   const {
     value: { display },
   } = useSettings();
   const isSimpleMode = (display?.toolDetailLevel ?? 'simple') === 'simple';
+  const detailMode = isSimpleMode ? 'simple' : 'developer';
 
   const [isExpanded, setIsExpanded] = useState(false);
   const prevHasErrorRef = useRef(false);
-  const prevHasResourceRef = useRef(false);
 
-  // Parse tool name (remove server prefix)
   const toolName = useMemo(
     () => parseToolName(toolCall.function.name),
     [toolCall.function.name],
@@ -77,82 +123,98 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
   const displayToolName =
     toolName || t('agent.toolDetails.preparingTool', 'Preparing tool...');
 
-  // Parse arguments once to share between summary and details
   const parsedArgs = useMemo(
     () => parseToolArguments(toolCall.function.arguments),
     [toolCall.function.arguments],
   );
 
-  // Parse arguments for summary (developer mode only)
   const paramSummary = useMemo(
     () => formatToolArgumentsSummary(parsedArgs),
     [parsedArgs],
   );
 
-  // Check for error using utility function
   const hasError = hasToolCallError(toolResult);
-  const hasResource = hasUIResource(toolResult);
+  const uiOverride = resolveToolResultUiOverride(
+    toolCall.function.name,
+    toolResult,
+    detailMode,
+  );
+  const forceVisible = uiOverride?.alwaysVisible === true;
 
-  // Get execution time
   const executionTime = toolResult?.metadata?.executionTime;
   const detailsId = `tool-call-details-${toolCall.id}`;
 
-  // Auto-expand when an error first appears or a UI resource arrives (last item only).
-  // Tracks transitions using refs during render to avoid extra effect or state re-renders.
-  if (
-    !isSimpleMode &&
-    (hasError !== prevHasErrorRef.current ||
-      hasResource !== prevHasResourceRef.current)
-  ) {
+  // Auto-expand on error transition in developer mode (non-forced results only).
+  // Forced-visible results already mount details without expand state.
+  if (!isSimpleMode && !forceVisible && hasError !== prevHasErrorRef.current) {
     const errorBecameVisible = !prevHasErrorRef.current && hasError;
-    const resourceBecameVisible = !prevHasResourceRef.current && hasResource;
-
     prevHasErrorRef.current = hasError;
-    prevHasResourceRef.current = hasResource;
-
-    if (errorBecameVisible || (resourceBecameVisible && isLast)) {
+    if (errorBecameVisible) {
       setIsExpanded(true);
     }
+  } else if (hasError !== prevHasErrorRef.current) {
+    prevHasErrorRef.current = hasError;
   }
 
+  const details = toolResult ? (
+    <div id={detailsId} className="mt-2 pt-2 border-t border-muted/50 min-w-0">
+      <AgentToolCallDetails
+        toolCall={toolCall}
+        toolResult={toolResult}
+        hasError={hasError}
+        isLoading={false}
+        showDetails={true}
+        parsedArgs={parsedArgs}
+        hideParameters={uiOverride?.hideParameters ?? false}
+      />
+    </div>
+  ) : null;
+
   // ── Simple Mode ─────────────────────────────────────────────────────────
-  // Shows tool name + status + brief param summary. No expand, no execution
-  // time. UI Resources (e.g. circuit break) are always rendered inline so
-  // they are never hidden from the user.
   if (isSimpleMode) {
     return (
       <div
         className="rounded px-3 py-2 text-sm bg-background"
         style={{ overflowAnchor: 'none' }}
       >
-        <div className="flex items-center gap-2">
-          <ToolStatusIcon hasResult={!!toolResult} hasError={hasError} />
-          <span className="font-medium flex-shrink-0">{displayToolName}</span>
-          {paramSummary && (
-            <span className="flex-1 text-xs text-muted-foreground truncate font-mono opacity-70 min-w-0">
-              {paramSummary}
-            </span>
-          )}
-        </div>
-        {/* Always show UI Resources inline (e.g. circuit break prompt) */}
-        {hasResource && toolResult && (
-          <div className="mt-2 pt-2 border-t border-muted/50">
-            <AgentToolCallDetails
-              toolCall={toolCall}
-              toolResult={toolResult}
-              hasError={hasError}
-              isLoading={false}
-              showDetails={true}
-              parsedArgs={parsedArgs}
-              hideParameters={true}
-            />
-          </div>
-        )}
+        <CompactHeaderRow
+          toolResult={toolResult}
+          hasError={hasError}
+          displayToolName={displayToolName}
+          paramSummary={paramSummary}
+        />
+        {forceVisible ? details : null}
       </div>
     );
   }
 
-  // ── Developer Mode ───────────────────────────────────────────────────────
+  // ── Developer Mode — forced visible (static header, no collapse) ────────
+  if (forceVisible) {
+    return (
+      <div
+        className={cn(
+          'rounded px-3 py-2 text-sm transition-colors',
+          hasError
+            ? 'bg-destructive/10 hover:bg-destructive/20'
+            : 'bg-background hover:bg-muted/50',
+        )}
+        style={{ overflowAnchor: 'none' }}
+      >
+        <CompactHeaderRow
+          toolResult={toolResult}
+          hasError={hasError}
+          displayToolName={displayToolName}
+          paramSummary={paramSummary}
+          executionTime={
+            typeof executionTime === 'number' ? executionTime : undefined
+          }
+        />
+        {details}
+      </div>
+    );
+  }
+
+  // ── Developer Mode — default expand/collapse ────────────────────────────
   return (
     <div
       className={cn(
@@ -163,7 +225,6 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
       )}
       style={{ overflowAnchor: 'none' }}
     >
-      {/* Collapsed header line */}
       <button
         type="button"
         className="w-full text-left focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded-md"
@@ -176,39 +237,20 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
         )}
         onClick={() => setIsExpanded((prev) => !prev)}
       >
-        <div className="flex items-center gap-2">
-          <ToolStatusIcon hasResult={!!toolResult} hasError={hasError} />
-
-          {/* Tool name */}
-          <span className="flex-shrink-0 font-medium">{displayToolName}</span>
-
-          {/* Params Summary */}
-          {paramSummary && (
-            <span className="flex-1 text-xs text-muted-foreground truncate font-mono opacity-70 min-w-0">
-              {paramSummary}
-            </span>
-          )}
-          {!paramSummary && <span className="flex-1" />}
-
-          {/* Execution time */}
-          {executionTime !== undefined && (
-            <span className="text-xs text-muted-foreground flex-shrink-0">
-              {formatExecutionTime(executionTime)}
-            </span>
-          )}
-
-          {/* Expand indicator */}
-          <ChevronDown
-            className={cn(
-              'w-3.5 h-3.5 transition-transform flex-shrink-0 text-muted-foreground',
-              isExpanded && 'rotate-180',
-            )}
-          />
-        </div>
+        <CompactHeaderRow
+          toolResult={toolResult}
+          hasError={hasError}
+          displayToolName={displayToolName}
+          paramSummary={paramSummary}
+          executionTime={
+            typeof executionTime === 'number' ? executionTime : undefined
+          }
+          showChevron
+          isExpanded={isExpanded}
+        />
       </button>
 
-      {/* Expanded details */}
-      {isExpanded && (
+      {isExpanded ? (
         <div
           id={detailsId}
           className="mt-3 pt-3 border-t border-muted/50 min-w-0"
@@ -222,23 +264,17 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
             parsedArgs={parsedArgs}
           />
         </div>
-      )}
+      ) : null}
     </div>
   );
 };
 
-// Custom comparison for React.memo
 function arePropsEqual(
   prev: ToolCallCompactItemProps,
   next: ToolCallCompactItemProps,
 ) {
-  // Check primitive props
   if (prev.isLast !== next.isLast) return false;
-
-  // Check toolResult reference equality (assuming stability from useMessageGrouping)
   if (prev.toolResult !== next.toolResult) return false;
-
-  // Check toolCall content deeply (id, function name, arguments)
   if (prev.toolCall.id !== next.toolCall.id) return false;
   if (prev.toolCall.function.name !== next.toolCall.function.name) return false;
   if (prev.toolCall.function.arguments !== next.toolCall.function.arguments)

--- a/src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx
+++ b/src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx
@@ -46,14 +46,21 @@ vi.mock('@/lib/logger', () => ({
     }),
 }));
 
+vi.mock('@/lib/backend', () => ({
+    openPathWithDefaultApp: vi.fn(),
+}));
+
 // Minimal fixtures
-const makeToolCall = (args = '{}'): ToolCall => ({
+const makeToolCall = (args = '{}', name = 'test__myTool'): ToolCall => ({
     id: 'call-1',
     type: 'function',
-    function: { name: 'test__myTool', arguments: args },
+    function: { name, arguments: args },
 });
 
-const makeToolResult = (text: string): Message =>
+const makeToolResult = (
+    text: string,
+    metadata?: Message['metadata'],
+): Message =>
     ({
         id: 'msg-result-1',
         sessionId: 'session-1',
@@ -61,6 +68,7 @@ const makeToolResult = (text: string): Message =>
         role: 'tool',
         content: [{ type: 'text', text }],
         tool_call_id: 'call-1',
+        metadata,
     }) as Message;
 
 const makeUIResourceResult = (): Message =>
@@ -180,5 +188,40 @@ describe('AgentToolCallDetails', () => {
         );
         expect(getByTestId('tool-call-result').className).not.toContain('max-h-96');
         expect(getByTestId('tool-call-result').className).not.toContain('overflow-y-auto');
+    });
+
+    it('prefers structured writeFile UI over markdown summary', () => {
+        const { getByTestId, queryByText } = render(
+            <AgentToolCallDetails
+                toolCall={makeToolCall('{}', 'workspace__writeFile')}
+                toolResult={makeToolResult('✓ Created file markdown summary', {
+                    structuredContent: {
+                        path: '/workspace/created.ts',
+                        action: 'created',
+                        bytes_written: 10,
+                        lines: 1,
+                    },
+                })}
+                showDetails={true}
+            />,
+        );
+        expect(getByTestId('tool-structured-write-file')).toBeInTheDocument();
+        expect(
+            queryByText('✓ Created file markdown summary'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('falls back to markdown when structured payload is invalid', () => {
+        const { getByText, queryByTestId } = render(
+            <AgentToolCallDetails
+                toolCall={makeToolCall('{}', 'workspace__writeFile')}
+                toolResult={makeToolResult('plain fallback text', {
+                    structuredContent: { action: 'created' },
+                })}
+                showDetails={true}
+            />,
+        );
+        expect(queryByTestId('tool-structured-write-file')).not.toBeInTheDocument();
+        expect(getByText('plain fallback text')).toBeInTheDocument();
     });
 });

--- a/src/features/agent/components/__tests__/ToolCallCompactItem.rendering.test.tsx
+++ b/src/features/agent/components/__tests__/ToolCallCompactItem.rendering.test.tsx
@@ -22,13 +22,20 @@ vi.mock('../AgentToolCallDetails', () => ({
   AgentToolCallDetails: () => <div data-testid="tool-details" />,
 }));
 
-const makeToolCall = (id: string): ToolCall => ({
+const makeToolCall = (
+  id: string,
+  name = 'test_tool',
+): ToolCall => ({
   id,
   type: 'function',
-  function: { name: 'test_tool', arguments: '{}' },
+  function: { name, arguments: '{}' },
 });
 
-const makeToolResult = (id: string, hasError = false): Message => ({
+const makeToolResult = (
+  id: string,
+  hasError = false,
+  overrides: Partial<Message> = {},
+): Message => ({
   id: `res-${id}`,
   sessionId: 'test-session',
   threadId: 'test-session',
@@ -42,6 +49,7 @@ const makeToolResult = (id: string, hasError = false): Message => ({
         recoverable: false,
       }
     : undefined,
+  ...overrides,
 });
 
 describe('ToolCallCompactItem Rendering and Transitions', () => {
@@ -53,17 +61,19 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
   it('auto-expands in developer mode when an error occurs', () => {
     mockDetailLevel = 'developer';
     const toolCall = makeToolCall('call-1');
-    
+
     // First render: no result
     const { rerender, queryByTestId } = render(
-      <ToolCallCompactItem toolCall={toolCall} />
+      <ToolCallCompactItem toolCall={toolCall} />,
     );
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
 
     // Second render: result with error
     const toolResultWithError = makeToolResult('call-1', true);
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
-    
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
+
     // Should be expanded now
     expect(queryByTestId('tool-details')).toBeInTheDocument();
   });
@@ -71,14 +81,16 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
   it('does NOT auto-expand in simple mode when an error occurs', () => {
     mockDetailLevel = 'simple';
     const toolCall = makeToolCall('call-2');
-    
+
     const { rerender, queryByTestId } = render(
-      <ToolCallCompactItem toolCall={toolCall} />
+      <ToolCallCompactItem toolCall={toolCall} />,
     );
 
     const toolResultWithError = makeToolResult('call-2', true);
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
-    
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
+
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
   });
 
@@ -87,18 +99,22 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
     mockDetailLevel = 'simple';
     const toolCall = makeToolCall('call-3');
     const { rerender, queryByTestId } = render(
-      <ToolCallCompactItem toolCall={toolCall} />
+      <ToolCallCompactItem toolCall={toolCall} />,
     );
 
     // 2. Simple mode, error occurs
     const toolResultWithError = makeToolResult('call-3', true);
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
 
     // 3. Switch to developer mode
     mockDetailLevel = 'developer';
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
-    
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
+
     // Critical: Should NOT be expanded because the sentinel synced during simple mode
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
   });
@@ -106,15 +122,17 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
   it('does NOT re-trigger expansion on subsequent renders if no new transition occurred', () => {
     mockDetailLevel = 'developer';
     const toolCall = makeToolCall('call-4');
-    
+
     // 1. Initial render
     const { rerender, queryByTestId, getByLabelText } = render(
-      <ToolCallCompactItem toolCall={toolCall} />
+      <ToolCallCompactItem toolCall={toolCall} />,
     );
 
     // 2. Error occurs -> auto-expand
     const toolResultWithError = makeToolResult('call-4', true);
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
     expect(queryByTestId('tool-details')).toBeInTheDocument();
 
     // 3. User manually collapses it
@@ -123,8 +141,10 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
 
     // 4. Rerender with same props (simulating parent update)
-    rerender(<ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />);
-    
+    rerender(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResultWithError} />,
+    );
+
     // Should stay collapsed (no new transition)
     expect(queryByTestId('tool-details')).not.toBeInTheDocument();
   });
@@ -137,7 +157,9 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
       function: { name: '', arguments: '' },
     };
 
-    const { getByText } = render(<ToolCallCompactItem toolCall={partialToolCall} />);
+    const { getByText } = render(
+      <ToolCallCompactItem toolCall={partialToolCall} />,
+    );
 
     expect(getByText('agent.toolDetails.preparingTool')).toBeInTheDocument();
   });
@@ -148,5 +170,99 @@ describe('ToolCallCompactItem Rendering and Transitions', () => {
     const { container } = render(<ToolCallCompactItem toolCall={toolCall} />);
 
     expect(container.firstElementChild).toHaveStyle({ overflowAnchor: 'none' });
+  });
+
+  it('shows structured UI details in simple mode without expand', () => {
+    mockDetailLevel = 'simple';
+    const toolCall = makeToolCall('call-7', 'workspace__writeFile');
+    const toolResult = makeToolResult('call-7', false, {
+      metadata: {
+        structuredContent: {
+          path: '/workspace/created.ts',
+          action: 'created',
+          bytes_written: 10,
+          lines: 1,
+        },
+      },
+    });
+
+    const { getByTestId, queryByLabelText } = render(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResult} />,
+    );
+
+    expect(getByTestId('tool-details')).toBeInTheDocument();
+    expect(
+      queryByLabelText('agentChat.toolDetails.toggleAriaLabel'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps non-UI structured content collapsed in simple mode', () => {
+    mockDetailLevel = 'simple';
+    const toolCall = makeToolCall('call-8', 'knowledge__searchKnowledge');
+    const toolResult = makeToolResult('call-8', false, {
+      metadata: {
+        structuredContent: { mode: 'semantic', results: [] },
+      },
+    });
+
+    const { queryByTestId } = render(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResult} />,
+    );
+
+    expect(queryByTestId('tool-details')).not.toBeInTheDocument();
+  });
+
+  it('keeps invalid structured payloads collapsed in simple mode', () => {
+    mockDetailLevel = 'simple';
+    const toolCall = makeToolCall('call-9', 'workspace__writeFile');
+    const toolResult = makeToolResult('call-9', false, {
+      metadata: {
+        structuredContent: { action: 'created' },
+      },
+    });
+
+    const { queryByTestId } = render(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResult} />,
+    );
+
+    expect(queryByTestId('tool-details')).not.toBeInTheDocument();
+  });
+
+  it('shows structured UI details in developer mode without a collapse control', () => {
+    mockDetailLevel = 'developer';
+    const toolCall = makeToolCall('call-10', 'workspace__strReplace');
+    const toolResult = makeToolResult('call-10', false, {
+      metadata: {
+        structuredContent: {
+          path: 'src/a.ts',
+          replacements: 1,
+          unified_diff: '-old\n+new\n',
+        },
+      },
+    });
+
+    const { getByTestId, queryByLabelText } = render(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResult} />,
+    );
+
+    expect(getByTestId('tool-details')).toBeInTheDocument();
+    expect(
+      queryByLabelText('agentChat.toolDetails.toggleAriaLabel'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps plain text developer results collapsed by default', () => {
+    mockDetailLevel = 'developer';
+    const toolCall = makeToolCall('call-11', 'workspace__readFile');
+    const toolResult = makeToolResult('call-11');
+
+    const { queryByTestId, getByLabelText } = render(
+      <ToolCallCompactItem toolCall={toolCall} toolResult={toolResult} />,
+    );
+
+    expect(queryByTestId('tool-details')).not.toBeInTheDocument();
+    expect(
+      getByLabelText('agentChat.toolDetails.toggleAriaLabel'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/agent/components/tool-structured/FileWriteActions.tsx
+++ b/src/features/agent/components/tool-structured/FileWriteActions.tsx
@@ -41,7 +41,9 @@ export const FileWriteActions: React.FC<FileWriteActionsProps> = ({ data }) => {
   const [isOpening, setIsOpening] = useState(false);
   const Icon = actionIcon(data.action);
   const sizeLabel = formatBytes(data.bytes_written);
-  const canOpen = data.path.length > 0;
+  // open_path_with_default_app requires an absolute host path
+  const openPath = data.absolute_path?.trim() || '';
+  const canOpen = openPath.length > 0;
 
   const actionLabel = (() => {
     switch (data.action) {
@@ -65,7 +67,7 @@ export const FileWriteActions: React.FC<FileWriteActionsProps> = ({ data }) => {
     if (!canOpen || isOpening) return;
     setIsOpening(true);
     try {
-      await openPathWithDefaultApp(data.path);
+      await openPathWithDefaultApp(openPath);
     } catch (error) {
       logger.error('Failed to open written file', error);
       toast.error(

--- a/src/features/agent/components/tool-structured/FileWriteActions.tsx
+++ b/src/features/agent/components/tool-structured/FileWriteActions.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { ExternalLink, FilePlus2, FilePenLine, FileText } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { openPathWithDefaultApp } from '@/lib/backend';
+import { getLogger } from '@/lib/logger';
+import { Button } from '@/components/ui/button';
+import { UnifiedDiffView } from './UnifiedDiffView';
+import type { WriteFileResult } from './types';
+
+const logger = getLogger('FileWriteActions');
+
+export interface FileWriteActionsProps {
+  data: WriteFileResult;
+}
+
+function actionIcon(action: WriteFileResult['action']) {
+  switch (action) {
+    case 'created':
+    case 'created_alternate_path':
+      return FilePlus2;
+    case 'overwritten':
+      return FilePenLine;
+    default:
+      return FileText;
+  }
+}
+
+function formatBytes(bytes: number | undefined): string | null {
+  if (bytes === undefined || !Number.isFinite(bytes)) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Structured result view for workspace__writeFile.
+ */
+export const FileWriteActions: React.FC<FileWriteActionsProps> = ({ data }) => {
+  const { t } = useTranslation('common');
+  const [isOpening, setIsOpening] = useState(false);
+  const Icon = actionIcon(data.action);
+  const sizeLabel = formatBytes(data.bytes_written);
+  const canOpen = data.path.length > 0;
+
+  const actionLabel = (() => {
+    switch (data.action) {
+      case 'created':
+        return t('agent.toolStructured.writeCreated', 'Created');
+      case 'created_alternate_path':
+        return t(
+          'agent.toolStructured.writeCreatedAlternate',
+          'Created at alternate path',
+        );
+      case 'overwritten':
+        return t('agent.toolStructured.writeOverwritten', 'Overwritten');
+      case 'appended':
+        return t('agent.toolStructured.writeAppended', 'Appended');
+      default:
+        return data.action;
+    }
+  })();
+
+  const handleOpen = async () => {
+    if (!canOpen || isOpening) return;
+    setIsOpening(true);
+    try {
+      await openPathWithDefaultApp(data.path);
+    } catch (error) {
+      logger.error('Failed to open written file', error);
+      toast.error(
+        t('agent.toolStructured.openFileError', 'Failed to open file'),
+      );
+    } finally {
+      setIsOpening(false);
+    }
+  };
+
+  return (
+    <div data-testid="tool-structured-write-file" className="space-y-2 text-sm">
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+              {actionLabel}
+            </span>
+            {sizeLabel ? (
+              <span className="text-xs text-muted-foreground">{sizeLabel}</span>
+            ) : null}
+            {data.lines !== undefined ? (
+              <span className="text-xs text-muted-foreground">
+                {t('agent.toolStructured.lineCount', '{{count}} lines', {
+                  count: data.lines,
+                })}
+              </span>
+            ) : null}
+            {data.changes?.lines_added !== undefined ||
+            data.changes?.lines_removed !== undefined ? (
+              <span className="text-xs text-muted-foreground">
+                +{data.changes.lines_added ?? 0}/-
+                {data.changes.lines_removed ?? 0}
+              </span>
+            ) : null}
+          </div>
+          <p className="break-all font-mono text-xs">{data.path}</p>
+          {data.path_adjusted && data.requested_path ? (
+            <p className="text-xs text-muted-foreground">
+              {t('agent.toolStructured.requestedPath', 'Requested: {{path}}', {
+                path: data.requested_path,
+              })}
+            </p>
+          ) : null}
+        </div>
+        {canOpen ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => {
+              void handleOpen();
+            }}
+            disabled={isOpening}
+          >
+            <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+            {isOpening
+              ? t('agent.toolStructured.openingFile', 'Opening...')
+              : t('agent.toolStructured.openFile', 'Open file')}
+          </Button>
+        ) : null}
+      </div>
+
+      {data.unified_diff ? <UnifiedDiffView diff={data.unified_diff} /> : null}
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/StrReplaceDiffView.tsx
+++ b/src/features/agent/components/tool-structured/StrReplaceDiffView.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { FilePenLine } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { UnifiedDiffView } from './UnifiedDiffView';
+import type { StrReplaceResult } from './types';
+
+export interface StrReplaceDiffViewProps {
+  data: StrReplaceResult;
+}
+
+/**
+ * Structured result view for workspace__strReplace.
+ */
+export const StrReplaceDiffView: React.FC<StrReplaceDiffViewProps> = ({
+  data,
+}) => {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      data-testid="tool-structured-str-replace"
+      className="space-y-2 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <FilePenLine className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+              {t('agent.toolStructured.strReplace', 'Replaced')}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {t(
+                'agent.toolStructured.replacementCount',
+                '{{count}} occurrence(s)',
+                { count: data.replacements },
+              )}
+            </span>
+          </div>
+          <p className="break-all font-mono text-xs">{data.path}</p>
+        </div>
+      </div>
+      <UnifiedDiffView diff={data.unified_diff} />
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/TerminalOutputBlock.tsx
+++ b/src/features/agent/components/tool-structured/TerminalOutputBlock.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { formatExecutionTime } from '@/lib/tool-call-utils';
+import type { RunShellResult } from './types';
+
+export interface TerminalOutputBlockProps {
+  data: RunShellResult;
+}
+
+/**
+ * Structured result view for workspace__runShell success payloads.
+ */
+export const TerminalOutputBlock: React.FC<TerminalOutputBlockProps> = ({
+  data,
+}) => {
+  const { t } = useTranslation('common');
+  const exitOk = data.exit_code === 0;
+  const hasStdout = data.stdout.trim().length > 0;
+  const hasStderr = data.stderr.trim().length > 0;
+
+  return (
+    <div
+      data-testid="tool-structured-run-shell"
+      className="space-y-2 overflow-hidden rounded border bg-zinc-950 text-zinc-100"
+    >
+      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-3 py-2 text-xs">
+        <span
+          className={cn(
+            'rounded px-1.5 py-0.5 font-medium',
+            exitOk
+              ? 'bg-emerald-500/20 text-emerald-300'
+              : 'bg-red-500/20 text-red-300',
+          )}
+        >
+          {t('agent.toolStructured.exitCode', 'exit {{code}}', {
+            code: data.exit_code,
+          })}
+        </span>
+        {data.duration_ms !== undefined ? (
+          <span className="text-zinc-400">
+            {formatExecutionTime(data.duration_ms)}
+          </span>
+        ) : null}
+        {data.cwd ? (
+          <span className="truncate text-zinc-500" title={data.cwd}>
+            {data.cwd}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="px-3 pb-1">
+        <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs text-zinc-200">
+          <span className="select-none text-emerald-400">$ </span>
+          {data.command}
+        </pre>
+      </div>
+
+      {hasStdout ? (
+        <div className="border-t border-zinc-800 px-3 py-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-zinc-500">
+            {t('agent.toolStructured.stdout', 'stdout')}
+          </div>
+          <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-zinc-100">
+            {data.stdout}
+          </pre>
+        </div>
+      ) : null}
+
+      {hasStderr ? (
+        <div className="border-t border-zinc-800 px-3 py-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-red-400/80">
+            {t('agent.toolStructured.stderr', 'stderr')}
+          </div>
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-red-200">
+            {data.stderr}
+          </pre>
+        </div>
+      ) : null}
+
+      {!hasStdout && !hasStderr ? (
+        <div className="border-t border-zinc-800 px-3 py-2 text-xs text-zinc-500">
+          {t('agent.toolStructured.noShellOutput', 'No output captured')}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
+++ b/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { FileWriteActions } from './FileWriteActions';
+import { StrReplaceDiffView } from './StrReplaceDiffView';
+import { TerminalOutputBlock } from './TerminalOutputBlock';
+import {
+  parseRunShellResult,
+  parseStrReplaceResult,
+  parseWriteFileResult,
+  resolveStructuredToolKey,
+} from './types';
+
+export interface ToolStructuredResultProps {
+  toolName: string;
+  data: unknown;
+}
+
+/**
+ * Dispatches MCP structured_content to a typed tool result view.
+ * Returns null when the tool is unsupported or the payload fails validation.
+ *
+ * Extending for a new tool:
+ * 1. Add a Zod schema + parse* helper in `./types`
+ * 2. Add a `case` here that renders the view
+ * 3. Register the same key in {@link canRenderStructuredToolResult}
+ * Visibility override (always-visible compact UI) follows automatically via
+ * {@link resolveToolResultUiOverride}.
+ */
+export const ToolStructuredResult: React.FC<ToolStructuredResultProps> = ({
+  toolName,
+  data,
+}) => {
+  const key = resolveStructuredToolKey(toolName);
+
+  switch (key) {
+    case 'workspace__writeFile': {
+      const parsed = parseWriteFileResult(data);
+      return parsed ? <FileWriteActions data={parsed} /> : null;
+    }
+    case 'workspace__strReplace': {
+      const parsed = parseStrReplaceResult(data);
+      return parsed ? <StrReplaceDiffView data={parsed} /> : null;
+    }
+    case 'workspace__runShell': {
+      const parsed = parseRunShellResult(data);
+      return parsed ? <TerminalOutputBlock data={parsed} /> : null;
+    }
+    default:
+      return null;
+  }
+};
+
+/**
+ * Returns true when `data` can be rendered by {@link ToolStructuredResult}
+ * for the given tool name. Used to suppress duplicate markdown summaries.
+ */
+export function canRenderStructuredToolResult(
+  toolName: string,
+  data: unknown,
+): boolean {
+  const key = resolveStructuredToolKey(toolName);
+  switch (key) {
+    case 'workspace__writeFile':
+      return parseWriteFileResult(data) !== null;
+    case 'workspace__strReplace':
+      return parseStrReplaceResult(data) !== null;
+    case 'workspace__runShell':
+      return parseRunShellResult(data) !== null;
+    default:
+      return false;
+  }
+}

--- a/src/features/agent/components/tool-structured/UnifiedDiffView.tsx
+++ b/src/features/agent/components/tool-structured/UnifiedDiffView.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { useTranslation } from 'react-i18next';
+
+export interface UnifiedDiffViewProps {
+  diff: string;
+  className?: string;
+}
+
+type DiffLineKind = 'add' | 'remove' | 'hunk' | 'meta' | 'context';
+
+function classifyDiffLine(line: string): DiffLineKind {
+  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
+  if (line.startsWith('@@')) return 'hunk';
+  if (line.startsWith('+')) return 'add';
+  if (line.startsWith('-')) return 'remove';
+  return 'context';
+}
+
+const LINE_CLASS: Record<DiffLineKind, string> = {
+  add: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  remove: 'bg-destructive/10 text-destructive',
+  hunk: 'bg-muted/60 text-muted-foreground',
+  meta: 'text-muted-foreground',
+  context: 'text-foreground/90',
+};
+
+/**
+ * Renders a unified diff string with add/remove/context coloring.
+ */
+export const UnifiedDiffView: React.FC<UnifiedDiffViewProps> = ({
+  diff,
+  className,
+}) => {
+  const { t } = useTranslation('common');
+  const lines = useMemo(() => diff.replace(/\r\n/g, '\n').split('\n'), [diff]);
+  const wasTruncated = lines.some((line) =>
+    /more changed line\(s\) omitted/i.test(line),
+  );
+
+  if (!diff.trim()) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {t('agent.toolStructured.diffEmpty', 'No diff to display')}
+      </p>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      {wasTruncated ? (
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'agent.toolStructured.diffTruncated',
+            'Diff preview was truncated by the tool',
+          )}
+        </p>
+      ) : null}
+      <div className="max-h-80 overflow-auto rounded border bg-muted/30">
+        <pre className="min-w-0 p-2 font-mono text-xs leading-5">
+          {lines.map((line, index) => {
+            const kind = classifyDiffLine(line);
+            return (
+              <div
+                key={`${index}-${line.slice(0, 24)}`}
+                className={cn(
+                  'whitespace-pre-wrap break-all px-1',
+                  LINE_CLASS[kind],
+                )}
+              >
+                {line.length > 0 ? line : ' '}
+              </div>
+            );
+          })}
+        </pre>
+      </div>
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ToolStructuredResult } from '../ToolStructuredResult';
+
+vi.mock('@/lib/backend', () => ({
+  openPathWithDefaultApp: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('ToolStructuredResult', () => {
+  it('renders writeFile structured view', () => {
+    render(
+      <ToolStructuredResult
+        toolName="workspace__writeFile"
+        data={{
+          path: '/workspace/new.ts',
+          action: 'created',
+          bytes_written: 42,
+          lines: 3,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('tool-structured-write-file')).toBeInTheDocument();
+    expect(screen.getByText('/workspace/new.ts')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open file/i })).toBeInTheDocument();
+  });
+
+  it('renders strReplace diff view', () => {
+    render(
+      <ToolStructuredResult
+        toolName="workspace__strReplace"
+        data={{
+          path: 'src/a.ts',
+          replacements: 1,
+          unified_diff: '--- a/src/a.ts\n+++ b/src/a.ts\n-old\n+new\n',
+        }}
+      />,
+    );
+    expect(screen.getByTestId('tool-structured-str-replace')).toBeInTheDocument();
+    expect(screen.getByText('src/a.ts')).toBeInTheDocument();
+    expect(screen.getByText('+new')).toBeInTheDocument();
+  });
+
+  it('renders runShell terminal block', () => {
+    render(
+      <ToolStructuredResult
+        toolName="workspace__runShell"
+        data={{
+          command: 'echo hello',
+          exit_code: 0,
+          stdout: 'hello\n',
+          stderr: '',
+          duration_ms: 12,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('tool-structured-run-shell')).toBeInTheDocument();
+    expect(screen.getByText('echo hello')).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('returns null for unsupported or invalid payloads', () => {
+    const { container: unsupported } = render(
+      <ToolStructuredResult
+        toolName="knowledge__searchKnowledge"
+        data={{ results: [] }}
+      />,
+    );
+    expect(unsupported.firstChild).toBeNull();
+
+    const { container: invalid } = render(
+      <ToolStructuredResult
+        toolName="workspace__writeFile"
+        data={{ action: 'created' }}
+      />,
+    );
+    expect(invalid.firstChild).toBeNull();
+  });
+});

--- a/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
@@ -17,12 +17,13 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 describe('ToolStructuredResult', () => {
-  it('renders writeFile structured view', () => {
+  it('renders writeFile structured view with open when absolute_path is present', () => {
     render(
       <ToolStructuredResult
         toolName="workspace__writeFile"
         data={{
-          path: '/workspace/new.ts',
+          path: 'src/new.ts',
+          absolute_path: '/home/user/project/src/new.ts',
           action: 'created',
           bytes_written: 42,
           lines: 3,
@@ -30,8 +31,26 @@ describe('ToolStructuredResult', () => {
       />,
     );
     expect(screen.getByTestId('tool-structured-write-file')).toBeInTheDocument();
-    expect(screen.getByText('/workspace/new.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/new.ts')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /open file/i })).toBeInTheDocument();
+  });
+
+  it('hides open button when writeFile absolute_path is missing', () => {
+    render(
+      <ToolStructuredResult
+        toolName="workspace__writeFile"
+        data={{
+          path: 'src/new.ts',
+          action: 'created',
+          bytes_written: 42,
+          lines: 3,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('tool-structured-write-file')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /open file/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders strReplace diff view', () => {

--- a/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@/models/chat';
+import { resolveToolResultUiOverride } from '../presentation';
+
+function makeResult(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-1',
+    sessionId: 'session-1',
+    threadId: 'session-1',
+    role: 'tool',
+    content: [{ type: 'text', text: 'ok' }],
+    tool_call_id: 'call-1',
+    ...overrides,
+  };
+}
+
+describe('resolveToolResultUiOverride', () => {
+  it('returns alwaysVisible for MCP UI resources', () => {
+    const result = makeResult({
+      content: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'ui://test',
+            mimeType: 'text/html',
+            text: '<p>widget</p>',
+          },
+        },
+      ],
+    });
+
+    expect(resolveToolResultUiOverride('any__tool', result, 'simple')).toEqual({
+      alwaysVisible: true,
+      hideParameters: true,
+    });
+    expect(
+      resolveToolResultUiOverride('any__tool', result, 'developer'),
+    ).toEqual({
+      alwaysVisible: true,
+      hideParameters: false,
+    });
+  });
+
+  it('returns alwaysVisible when structured content has a registered UI', () => {
+    const result = makeResult({
+      metadata: {
+        structuredContent: {
+          path: '/tmp/a.ts',
+          action: 'created',
+          bytes_written: 10,
+          lines: 1,
+        },
+      },
+    });
+
+    expect(
+      resolveToolResultUiOverride('workspace__writeFile', result, 'simple'),
+    ).toEqual({
+      alwaysVisible: true,
+      hideParameters: true,
+    });
+    expect(
+      resolveToolResultUiOverride('workspace__writeFile', result, 'developer'),
+    ).toEqual({
+      alwaysVisible: true,
+      hideParameters: false,
+    });
+  });
+
+  it('returns null for structured content without a UI renderer', () => {
+    const result = makeResult({
+      metadata: {
+        structuredContent: {
+          mode: 'semantic',
+          results: [],
+        },
+      },
+    });
+
+    expect(
+      resolveToolResultUiOverride(
+        'knowledge__searchKnowledge',
+        result,
+        'simple',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for invalid structured payloads of supported tools', () => {
+    const result = makeResult({
+      metadata: {
+        structuredContent: { action: 'created' },
+      },
+    });
+
+    expect(
+      resolveToolResultUiOverride('workspace__writeFile', result, 'developer'),
+    ).toBeNull();
+  });
+
+  it('returns null when there is no result or no override signal', () => {
+    expect(
+      resolveToolResultUiOverride('workspace__writeFile', undefined, 'simple'),
+    ).toBeNull();
+    expect(
+      resolveToolResultUiOverride(
+        'workspace__writeFile',
+        makeResult(),
+        'simple',
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/features/agent/components/tool-structured/__tests__/types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/types.test.ts
@@ -18,13 +18,15 @@ describe('tool-structured types', () => {
 
   it('parseWriteFileResult accepts backend snake_case shape', () => {
     const parsed = parseWriteFileResult({
-      path: '/tmp/a.txt',
+      path: 'src/a.txt',
+      absolute_path: '/tmp/workspace/src/a.txt',
       action: 'created',
       bytes_written: 12,
       lines: 2,
     });
     expect(parsed).toEqual({
-      path: '/tmp/a.txt',
+      path: 'src/a.txt',
+      absolute_path: '/tmp/workspace/src/a.txt',
       action: 'created',
       bytes_written: 12,
       lines: 2,

--- a/src/features/agent/components/tool-structured/__tests__/types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/types.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canRenderStructuredToolResult,
+} from '../ToolStructuredResult';
+import {
+  parseRunShellResult,
+  parseStrReplaceResult,
+  parseWriteFileResult,
+  resolveStructuredToolKey,
+} from '../types';
+
+describe('tool-structured types', () => {
+  it('resolveStructuredToolKey normalizes builtin names', () => {
+    expect(resolveStructuredToolKey('workspace__writeFile')).toBe(
+      'workspace__writeFile',
+    );
+  });
+
+  it('parseWriteFileResult accepts backend snake_case shape', () => {
+    const parsed = parseWriteFileResult({
+      path: '/tmp/a.txt',
+      action: 'created',
+      bytes_written: 12,
+      lines: 2,
+    });
+    expect(parsed).toEqual({
+      path: '/tmp/a.txt',
+      action: 'created',
+      bytes_written: 12,
+      lines: 2,
+    });
+  });
+
+  it('parseWriteFileResult rejects missing path/action', () => {
+    expect(parseWriteFileResult({ action: 'created' })).toBeNull();
+    expect(parseWriteFileResult({ path: '/tmp/a.txt' })).toBeNull();
+  });
+
+  it('parseStrReplaceResult requires unified_diff', () => {
+    expect(
+      parseStrReplaceResult({
+        path: 'a.ts',
+        replacements: 1,
+        unified_diff: '-a\n+b\n',
+      }),
+    ).not.toBeNull();
+    expect(
+      parseStrReplaceResult({
+        path: 'a.ts',
+        replacements: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it('parseRunShellResult defaults missing stdout/stderr', () => {
+    const parsed = parseRunShellResult({
+      command: 'echo hi',
+      exit_code: 0,
+    });
+    expect(parsed).toMatchObject({
+      command: 'echo hi',
+      exit_code: 0,
+      stdout: '',
+      stderr: '',
+    });
+  });
+
+  it('canRenderStructuredToolResult only accepts supported tools', () => {
+    expect(
+      canRenderStructuredToolResult('workspace__writeFile', {
+        path: '/tmp/a.txt',
+        action: 'overwritten',
+        unified_diff: '-a\n+b\n',
+      }),
+    ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('workspace__runShell', {
+        command: 'ls',
+        exit_code: 0,
+        stdout: 'ok',
+      }),
+    ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('knowledge__searchKnowledge', {
+        results: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/agent/components/tool-structured/presentation.ts
+++ b/src/features/agent/components/tool-structured/presentation.ts
@@ -1,0 +1,49 @@
+import type { Message } from '@/models/chat';
+import { getToolStructuredContent, hasUIResource } from '@/lib/tool-call-utils';
+import { canRenderStructuredToolResult } from './ToolStructuredResult';
+
+export type ToolResultDetailMode = 'simple' | 'developer';
+
+/**
+ * Presentation override for tool results that should bypass compact collapse.
+ * New structured UI tools automatically opt in via {@link canRenderStructuredToolResult}.
+ */
+export type ToolResultUiOverride = {
+  /** Bypass compact collapse; details stay visible */
+  alwaysVisible: true;
+  /** Hide the parameters section (typical for simple-mode inline views) */
+  hideParameters: boolean;
+};
+
+/**
+ * Resolves whether a tool result should override the default collapsed compact UI.
+ *
+ * Order:
+ * 1. MCP UI resources (e.g. circuit-break widgets)
+ * 2. Structured content with a registered renderer
+ * Otherwise returns null → keep default collapse behavior.
+ */
+export function resolveToolResultUiOverride(
+  toolName: string,
+  toolResult: Message | undefined,
+  mode: ToolResultDetailMode,
+): ToolResultUiOverride | null {
+  if (!toolResult) return null;
+
+  const hideParameters = mode === 'simple';
+
+  if (hasUIResource(toolResult)) {
+    return { alwaysVisible: true, hideParameters };
+  }
+
+  const structured = getToolStructuredContent(toolResult);
+  if (
+    structured !== undefined &&
+    canRenderStructuredToolResult(toolName, structured)
+  ) {
+    // mode only controls hideParameters — never skip alwaysVisible for simple.
+    return { alwaysVisible: true, hideParameters };
+  }
+
+  return null;
+}

--- a/src/features/agent/components/tool-structured/types.ts
+++ b/src/features/agent/components/tool-structured/types.ts
@@ -12,6 +12,8 @@ export const WriteFileChangesSchema = z.object({
 
 export const WriteFileResultSchema = z.object({
   path: z.string(),
+  /** Host filesystem absolute path for open/reveal actions */
+  absolute_path: z.string().optional(),
   requested_path: z.string().optional(),
   path_adjusted: z.boolean().optional(),
   suffix: z.string().nullish(),

--- a/src/features/agent/components/tool-structured/types.ts
+++ b/src/features/agent/components/tool-structured/types.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { parseBuiltinToolName } from '@/lib/tool-call-utils';
+
+export const WriteFileChangesSchema = z.object({
+  previous_lines: z.number().optional(),
+  previous_bytes: z.number().optional(),
+  new_lines: z.number().optional(),
+  new_bytes: z.number().optional(),
+  lines_added: z.number().optional(),
+  lines_removed: z.number().optional(),
+});
+
+export const WriteFileResultSchema = z.object({
+  path: z.string(),
+  requested_path: z.string().optional(),
+  path_adjusted: z.boolean().optional(),
+  suffix: z.string().nullish(),
+  mode: z.string().optional(),
+  action: z.enum([
+    'created',
+    'overwritten',
+    'appended',
+    'created_alternate_path',
+  ]),
+  bytes_written: z.number().optional(),
+  lines: z.number().optional(),
+  file_exists_before: z.boolean().optional(),
+  requested_path_existed: z.boolean().optional(),
+  changes: WriteFileChangesSchema.optional(),
+  unified_diff: z.string().optional(),
+});
+
+export type WriteFileResult = z.infer<typeof WriteFileResultSchema>;
+
+export const StrReplaceResultSchema = z.object({
+  path: z.string(),
+  replacements: z.number(),
+  unified_diff: z.string(),
+});
+
+export type StrReplaceResult = z.infer<typeof StrReplaceResultSchema>;
+
+export const RunShellResultSchema = z.object({
+  command: z.string(),
+  exit_code: z.number(),
+  stdout: z.string().optional().default(''),
+  stderr: z.string().optional().default(''),
+  status: z.string().optional(),
+  duration_ms: z.number().optional(),
+  execution_type: z.string().optional(),
+  cwd: z.string().optional(),
+});
+
+export type RunShellResult = z.infer<typeof RunShellResultSchema>;
+
+export function parseWriteFileResult(value: unknown): WriteFileResult | null {
+  const parsed = WriteFileResultSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseStrReplaceResult(value: unknown): StrReplaceResult | null {
+  const parsed = StrReplaceResultSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseRunShellResult(value: unknown): RunShellResult | null {
+  const parsed = RunShellResultSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Canonical `service__tool` name used by the structured-result dispatcher. */
+export function resolveStructuredToolKey(toolName: string): string {
+  const parsed = parseBuiltinToolName(toolName);
+  if (parsed) {
+    return `${parsed.serviceId}__${parsed.toolName}`;
+  }
+  return toolName;
+}

--- a/src/lib/__tests__/tool-call-utils.test.ts
+++ b/src/lib/__tests__/tool-call-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   hasToolCallError,
   hasUIResource,
+  getToolStructuredContent,
   isBuiltinTool,
   parseBuiltinToolName,
   parseToolName,
@@ -101,6 +102,26 @@ describe('tool-call-utils', () => {
 
     it('should return false for undefined message', () => {
       expect(hasUIResource(undefined)).toBe(false);
+    });
+  });
+
+  describe('getToolStructuredContent', () => {
+    it('returns structuredContent from metadata when present', () => {
+      const payload = { path: 'src/a.ts', action: 'created' };
+      const message = createTestMessage({
+        metadata: { structuredContent: payload },
+      });
+      expect(getToolStructuredContent(message)).toEqual(payload);
+    });
+
+    it('returns undefined when metadata or structuredContent is absent', () => {
+      expect(getToolStructuredContent(undefined)).toBeUndefined();
+      expect(getToolStructuredContent(createTestMessage())).toBeUndefined();
+      expect(
+        getToolStructuredContent(
+          createTestMessage({ metadata: { executionTime: 12 } }),
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/src/lib/tool-call-utils.ts
+++ b/src/lib/tool-call-utils.ts
@@ -50,6 +50,18 @@ export function hasUIResource(toolResult?: Message): boolean {
 }
 
 /**
+ * Reads MCP structured_content mirrored onto a tool-result message as
+ * `metadata.structuredContent`. Returns `undefined` when absent.
+ */
+export function getToolStructuredContent(toolResult?: Message): unknown {
+  if (!toolResult?.metadata) return undefined;
+  if (!('structuredContent' in toolResult.metadata)) {
+    return undefined;
+  }
+  return toolResult.metadata.structuredContent;
+}
+
+/**
  * ─── Tool Name Utilities ─────────────────────────────────────────────────────
  *
  * All tool-name formatting/parsing lives here.

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -179,6 +179,8 @@ export interface Message {
   metadata?: {
     executionTime?: number; // Tool execution time in milliseconds
     retryCount?: number; // Number of retry attempts
+    /** MCP tool structured_content mirrored from the backend */
+    structuredContent?: unknown;
     [key: string]: unknown; // Extensible for future metadata
   };
 }


### PR DESCRIPTION
## Summary
- Render `metadata.structuredContent` for `writeFile` / `strReplace` / `runShell` as always-visible inline UI (diff, open-file, terminal) instead of only opaque tool text.
- Backend: `strReplace` emits structured `{path, replacements, unified_diff}`; `writeFile` overwrite adds `unified_diff`.
- Compact collapse is bypassed only when a registered structured UI (or MCP UI resource) can render; other tools stay collapsed by default.

## Test plan
- [x] Expand/create file via agent → Open file + metadata visible in simple mode without expand click
- [x] `strReplace` → inline colored diff always visible
- [x] Successful `runShell` → terminal-style stdout/stderr block
- [x] Tool without structured UI renderer (or invalid payload) → remains collapsed in simple mode
- [x] Developer mode: plain text tools still start collapsed; structured UI has no collapse chevron
- [x] `pnpm exec vitest run src/features/agent/components/tool-structured src/features/agent/components/__tests__/ToolCallCompactItem.rendering.test.tsx src/features/agent/components/__tests__/AgentToolCallDetails.test.tsx`


Made with [Cursor](https://cursor.com)