### PR TITLE
fix(agent): dismiss MCP discovery loading toast for builtin-only sessions

### DIFF
--- a/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
+++ b/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
@@ -72,6 +72,52 @@ describe('useMcpDiscoveryToasts', () => {
     );
   });
 
+  it('dismisses loading toast when builtin-only session becomes ready', () => {
+    const { rerender } = renderHook(
+      ({
+        isProxyReady,
+        phase,
+        initResult,
+      }: {
+        isProxyReady: boolean;
+        phase: 'hydrating' | 'ready';
+        initResult: 'pending' | 'success';
+      }) =>
+        useMcpDiscoveryToasts({
+          hasSession: true,
+          isProxyReady,
+          phase,
+          initResult,
+          servers: [],
+          sessionId: 's-builtin',
+          currentStep: 'Starting session...',
+        }),
+      {
+        initialProps: {
+          isProxyReady: false,
+          phase: 'hydrating' as const,
+          initResult: 'pending' as const,
+        },
+      },
+    );
+
+    expect(toast.loading).toHaveBeenCalledWith('Starting session...', {
+      id: 'mcp-discovery:s-builtin',
+    });
+    vi.clearAllMocks();
+
+    rerender({
+      isProxyReady: true,
+      phase: 'ready',
+      initResult: 'success',
+    });
+
+    expect(toast.dismiss).toHaveBeenCalledWith('mcp-discovery:s-builtin');
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it('shows warning toast with deterministic ID for partial discovery', () => {
     renderHook(() =>
       useMcpDiscoveryToasts({

--- a/src/features/agent/hooks/useMcpDiscoveryToasts.ts
+++ b/src/features/agent/hooks/useMcpDiscoveryToasts.ts
@@ -62,11 +62,11 @@ export function useMcpDiscoveryToasts({
       return;
     }
 
-    // Dismiss loading toast only if discovery failed or ended without terminal result toast
-    if (!discoveryFinished) {
-      toast.dismiss(id);
-    }
-  }, [sessionId, hasSession, showLoading, discoveryFinished, currentStep, t]);
+    // Always clear the loading toast once proxy init is no longer in progress.
+    // Builtin-only sessions (servers=[]) never show a result toast, so dismiss is
+    // required here. Sessions with external MCP reuse the same id for success/warn/error.
+    toast.dismiss(id);
+  }, [sessionId, hasSession, showLoading, currentStep, t]);
 
   useEffect(() => {
     if (!sessionId || !hasSession || showLoading) {


### PR DESCRIPTION
## Summary
- Fix stuck Sonner loading toast after session start when the assistant has no external MCP servers (builtin-only).
- Dismiss the discovery loading toast whenever proxy init leaves the loading state; result toasts still replace the same id when external servers exist.

## Test plan
- [ ] Open/resume a builtin-only session (no external MCP) and confirm the “Loading tools / Starting session…” toast dismisses once ready
- [ ] Open a session with external MCP servers and confirm loading → success/partial/failed result toast still works
- [ ] `pnpm exec vitest run src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts`


Made with [Cursor](https://cursor.com)