### PR TITLE
feat(agent): checkSession structured UI with Stop for subagents

### DIFF
--- a/src-tauri/src/agent/workflow/cancel.rs
+++ b/src-tauri/src/agent/workflow/cancel.rs
@@ -240,6 +240,10 @@ pub async fn cancel_workflow(
         }
     }
 
+    // Parent checkSession(wait=true) should treat this as user Stop, not
+    // automatic paused-recovery guidance.
+    crate::state::mark_session_user_stopped(&session_id).await;
+
     abort_pending_tool_approvals(active_sessions, &session_id).await;
 
     // SP6: wake awaitAgent/pollProcess waiters suspended in this session's tools.

--- a/src-tauri/src/agent/workflow/start.rs
+++ b/src-tauri/src/agent/workflow/start.rs
@@ -17,6 +17,7 @@ pub async fn reset_session_execution_state(session: &mut AgentSession) {
     *session.repeated_text_loop_retry_count.write().await = 0;
     *session.bad_tool_args_retry_count.write().await = 0;
     *session.bad_tool_args_incident_count.write().await = 0;
+    crate::state::clear_session_user_stopped(&session.metadata.id).await;
     // Safety valve: clear any stale in-flight compaction state before
     // explicitly starting or restarting a workflow from the current stack.
     session.compaction.clear_runtime_state(false).await;

--- a/src-tauri/src/commands/agent_commands.rs
+++ b/src-tauri/src/commands/agent_commands.rs
@@ -32,9 +32,9 @@ pub use session_commands::{
 };
 pub use ui_actions::agent_execute_ui_tauri_action;
 pub use workflow_commands::{
-    agent_cancel_pending_prompt, agent_cancel_workflow, agent_get_pending_queue,
-    agent_handle_llm_error, agent_handle_llm_response, agent_handle_tool_result,
-    agent_inject_messages, agent_pause_workflow, agent_report_llm_streaming_issue,
-    agent_respond_tool_approval, agent_resume_workflow, agent_send_message,
-    agent_terminate_workflow,
+    agent_cancel_delegated_workflow, agent_cancel_pending_prompt, agent_cancel_workflow,
+    agent_get_pending_queue, agent_handle_llm_error, agent_handle_llm_response,
+    agent_handle_tool_result, agent_inject_messages, agent_pause_workflow,
+    agent_report_llm_streaming_issue, agent_respond_tool_approval, agent_resume_workflow,
+    agent_send_message, agent_terminate_workflow,
 };

--- a/src-tauri/src/commands/agent_commands/workflow_commands.rs
+++ b/src-tauri/src/commands/agent_commands/workflow_commands.rs
@@ -244,6 +244,55 @@ pub async fn agent_cancel_workflow(
     })
 }
 
+/// Cancel a delegated child workflow from the parent chat Stop control.
+///
+/// Resolves `target_session_ref` among the caller's delegated descendants
+/// (display token or storage id), then soft-cancels that child so a waiting
+/// `agent__checkSession` unblocks with a user-stopped result.
+#[command]
+pub async fn agent_cancel_delegated_workflow(
+    manager: State<'_, AgentSessionManager>,
+    caller_session_id: String,
+    target_session_ref: String,
+) -> Result<AgentResponse, String> {
+    let target = crate::mcp::builtin::agent::handlers::load_accessible_delegated_session(
+        &manager,
+        &caller_session_id,
+        &target_session_ref,
+        "cancelDelegatedWorkflow",
+    )
+    .await
+    .map_err(|mcp_err| {
+        mcp_err
+            .content
+            .as_ref()
+            .and_then(|items| {
+                items.iter().find_map(|item| match item {
+                    crate::mcp::types::MCPContent::Text { text, .. } => Some(text.clone()),
+                    _ => None,
+                })
+            })
+            .unwrap_or_else(|| {
+                format!(
+                    "Delegated session '{}' is not accessible from caller '{}'",
+                    target_session_ref, caller_session_id
+                )
+            })
+    })?;
+
+    let session_id = target.id;
+    manager.cancel_workflow(session_id.clone()).await?;
+
+    Ok(AgentResponse {
+        success: true,
+        message: format!(
+            "Delegated workflow cancel requested for session: {}",
+            session_id
+        ),
+        data: None,
+    })
+}
+
 /// Handle tool execution result from frontend (called by ToolBridgeProvider in TS)
 #[command]
 pub async fn agent_handle_tool_result(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,8 +31,9 @@ pub use migration;
 pub use services::SecureFileManager;
 
 use commands::agent_commands::{
-    agent_add_attachment, agent_call_builtin_tool, agent_cancel_pending_prompt,
-    agent_cancel_workflow, agent_clear_all_sessions, agent_create_session,
+    agent_add_attachment, agent_call_builtin_tool, agent_cancel_delegated_workflow,
+    agent_cancel_pending_prompt, agent_cancel_workflow, agent_clear_all_sessions,
+    agent_create_session,
     agent_create_session_with_initial_message, agent_delete_attachment, agent_delete_session,
     agent_delete_session_only, agent_execute_command, agent_execute_ui_tauri_action,
     agent_factory_reset, agent_get_all_sessions, agent_get_available_tools,
@@ -285,6 +286,7 @@ pub fn run() {
                 agent_resume_workflow,
                 agent_terminate_workflow,
                 agent_cancel_workflow,
+                agent_cancel_delegated_workflow,
                 agent_call_builtin_tool,
                 agent_add_attachment,
                 agent_delete_attachment,

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -613,6 +613,47 @@ pub async fn resolve_check_session_enrichment(meta: &SessionMetadata) -> CheckSe
     check_session_enrichment_from_metadata(meta, assistant_name)
 }
 
+/// Build a checkSession result when the child was soft-stopped by the user.
+///
+/// Unlike the paused recovery result, this explicitly tells the parent LLM not
+/// to auto-resume the child — the user requested termination via Stop.
+pub fn build_user_stopped_check_session_result_from_messages(
+    session_id: &str,
+    turn_count: usize,
+    messages_value: &[Value],
+    enrichment: Option<&CheckSessionEnrichment>,
+) -> MCPResult {
+    let display_id = crate::utils::session_id::display_session_id(session_id);
+    let latest_output = latest_session_output(messages_value);
+    let mut message = format!(
+        "Session {} was stopped by the user.\n\nLast known output:\n{}\n\nDo not automatically resume this child session. Ask the user whether they want to continue, change direction, or leave the work stopped.",
+        display_id, latest_output
+    );
+    if let Some(enrichment) = enrichment {
+        message = append_check_session_context_to_message(&message, enrichment);
+    }
+    let hint = SuccessHint::new(message.clone(), vec![]);
+    let mut response_data = build_agent_session_tool_data(
+        "agent__checkSession",
+        session_id,
+        &message,
+        "paused",
+        "cancelled",
+        turn_count,
+        vec![],
+    );
+    response_data.insert("result".to_string(), Value::String(latest_output));
+    response_data.insert("terminatedByUser".to_string(), Value::Bool(true));
+    response_data.insert("abnormalTermination".to_string(), Value::Bool(false));
+    response_data.insert("recoverable".to_string(), Value::Bool(false));
+    response_data.insert("hasMoreDetail".to_string(), Value::Bool(true));
+    if let Some(enrichment) = enrichment {
+        apply_check_session_enrichment(&mut response_data, enrichment);
+    }
+
+    hint.to_mcp_result_with_data(Some(Value::Object(response_data)))
+}
+
 /// Build a paused checkSession MCP result from pre-fetched messages.
 ///
 /// `session_id` must be the opaque storage key (`SessionMetadata.id`). It is
@@ -807,6 +848,15 @@ async fn build_paused_check_session_result(
     let messages_value =
         fetch_session_messages_for_result(storage_session_id, CHECK_SESSION_RESULT_MESSAGE_LIMIT)
             .await?;
+
+    if crate::state::take_session_user_stopped(storage_session_id.as_str()).await {
+        return Ok(build_user_stopped_check_session_result_from_messages(
+            storage_session_id.as_str(),
+            turn_count,
+            &messages_value,
+            Some(enrichment),
+        ));
+    }
 
     Ok(build_paused_check_session_result_from_messages(
         storage_session_id.as_str(),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -16,7 +16,7 @@ use crate::repositories::{
     SqliteSettingsRepository,
 };
 use sea_orm::DatabaseConnection;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
@@ -84,6 +84,11 @@ static CONCURRENCY_GATE: OnceLock<ConcurrencyGate> = OnceLock::new();
 /// Shared Arc from AgentSessionManager so external subsystems (e.g. builtin MCP tools)
 /// can read per-session cancellation tokens without going through Tauri managed state.
 static ACTIVE_SESSIONS: OnceLock<Arc<TokioRwLock<HashMap<String, AgentSession>>>> = OnceLock::new();
+
+/// Sessions soft-cancelled by the user (Stop / cancel_workflow). Consumed by
+/// `agent__checkSession` so parents receive a non-recovery "user stopped" result
+/// instead of the default paused recovery hints.
+static USER_STOPPED_SESSIONS: OnceLock<TokioRwLock<HashSet<String>>> = OnceLock::new();
 
 /// Shared clone of AgentSessionManager for native channel notification dispatch.
 static CHANNEL_DISPATCH_AGENT: OnceLock<AgentSessionManager> = OnceLock::new();
@@ -587,6 +592,28 @@ pub async fn get_session_cancel_pending(session_id: &str) -> Option<Arc<AtomicBo
     sessions.get(session_id).map(|s| s.cancel_pending.clone())
 }
 
+fn user_stopped_sessions() -> &'static TokioRwLock<HashSet<String>> {
+    USER_STOPPED_SESSIONS.get_or_init(|| TokioRwLock::new(HashSet::new()))
+}
+
+/// Mark that a session was soft-cancelled by the user (Stop button / cancel_workflow).
+pub async fn mark_session_user_stopped(session_id: &str) {
+    user_stopped_sessions()
+        .write()
+        .await
+        .insert(session_id.to_string());
+}
+
+/// Clear the user-stopped marker (e.g. when a new workflow starts on the session).
+pub async fn clear_session_user_stopped(session_id: &str) {
+    user_stopped_sessions().write().await.remove(session_id);
+}
+
+/// Take (and clear) the user-stopped marker for `session_id`.
+pub async fn take_session_user_stopped(session_id: &str) -> bool {
+    user_stopped_sessions().write().await.remove(session_id)
+}
+
 unsafe fn reset_lock<T>(lock: &OnceLock<T>) {
     let ptr = lock as *const OnceLock<T> as *mut OnceLock<T>;
     let _ = std::ptr::replace(ptr, OnceLock::new());
@@ -621,6 +648,7 @@ pub fn reset_state() {
         reset_lock(&SESSION_BUS);
         reset_lock(&CONCURRENCY_GATE);
         reset_lock(&ACTIVE_SESSIONS);
+        reset_lock(&USER_STOPPED_SESSIONS);
         reset_lock(&CHANNEL_DISPATCH_AGENT);
         reset_lock(&SKILLS_CATALOG_REVISION);
         reset_lock(&MANAGED_SKILLS_SYNC_STATE);

--- a/src-tauri/tests/check_session_enrichment_tests.rs
+++ b/src-tauri/tests/check_session_enrichment_tests.rs
@@ -5,7 +5,8 @@ use serde_json::json;
 use tauri_mcp_agent_lib::execution_mode::ExecutionMode;
 use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::{
     append_check_session_context_to_message, apply_check_session_enrichment,
-    build_terminal_check_session_result_from_messages, check_session_enrichment_from_metadata,
+    build_terminal_check_session_result_from_messages,
+    build_user_stopped_check_session_result_from_messages, check_session_enrichment_from_metadata,
     format_check_session_context_text,
 };
 use tauri_mcp_agent_lib::mcp::builtin::error_guidance::SuccessHint;
@@ -221,4 +222,51 @@ More analysis after the quoted marker.";
     assert!(meta_idx < result_idx);
     assert!(result_idx < quoted_idx);
     assert!(text.contains("orgId: org-9"));
+}
+
+#[test]
+fn user_stopped_check_session_result_does_not_auto_recover() {
+    let result = build_user_stopped_check_session_result_from_messages(
+        "session-user-stop-123",
+        3,
+        &[json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Still working on the delegated task."
+                }
+            ]
+        })],
+        None,
+    );
+
+    let text = extract_text(&result);
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+
+    assert!(text.contains("was stopped by the user"));
+    assert!(text.contains("Do not automatically resume"));
+    assert!(!text.contains("Wake the paused child session"));
+    assert_eq!(
+        structured
+            .get("responseStatus")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        structured
+            .get("terminatedByUser")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        structured
+            .get("recoverable")
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+    assert!(structured.get("nextActions").is_none());
 }

--- a/src-tauri/tests/integration/check_session_terminal_result_tests.rs
+++ b/src-tauri/tests/integration/check_session_terminal_result_tests.rs
@@ -2,6 +2,7 @@ use serde_json::json;
 use tauri_mcp_agent_lib::mcp::builtin::agent::handlers::{
     build_paused_check_session_result_from_messages,
     build_terminal_check_session_result_from_messages,
+    build_user_stopped_check_session_result_from_messages,
 };
 use tauri_mcp_agent_lib::mcp::types::MCPContent;
 
@@ -313,4 +314,51 @@ fn paused_check_session_result_includes_recovery_guidance() {
             .and_then(|value| value.as_bool()),
         Some(true)
     );
+}
+
+#[test]
+fn user_stopped_check_session_result_does_not_auto_recover() {
+    let result = build_user_stopped_check_session_result_from_messages(
+        "session-user-stop-123",
+        3,
+        &[json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Still working on the delegated task."
+                }
+            ]
+        })],
+        None,
+    );
+
+    let text = extract_text(&result);
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("structured content expected");
+
+    assert!(text.contains("was stopped by the user"));
+    assert!(text.contains("Do not automatically resume"));
+    assert!(!text.contains("Wake the paused child session"));
+    assert_eq!(
+        structured
+            .get("responseStatus")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        structured
+            .get("terminatedByUser")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        structured
+            .get("recoverable")
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+    assert!(structured.get("nextActions").is_none());
 }

--- a/src/features/agent/components/AgentToolCallDetails.tsx
+++ b/src/features/agent/components/AgentToolCallDetails.tsx
@@ -15,7 +15,7 @@ import {
   ToolStructuredResult,
 } from './tool-structured/ToolStructuredResult';
 import { AgentSessionToolWaiting } from './tool-structured/AgentSessionToolWaiting';
-import { isCheckSessionWaitTool } from './tool-structured/types';
+import { isDelegatedSessionWaitTool } from './tool-structured/types';
 
 interface AgentToolCallDetailsProps {
   toolCall: ToolCall;
@@ -61,7 +61,7 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
   const showSessionWaiting =
     isLoading &&
     !toolResult &&
-    isCheckSessionWaitTool(toolCall.function.name, params);
+    isDelegatedSessionWaitTool(toolCall.function.name, params);
   const childSessionRef =
     typeof params.sessionId === 'string' ? params.sessionId : '';
 

--- a/src/features/agent/components/AgentToolCallDetails.tsx
+++ b/src/features/agent/components/AgentToolCallDetails.tsx
@@ -9,10 +9,13 @@ import {
 } from '@/lib/tool-call-utils';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
+import { useAgentSessionState } from '@/context/AgentSessionContext';
 import {
   canRenderStructuredToolResult,
   ToolStructuredResult,
 } from './tool-structured/ToolStructuredResult';
+import { AgentSessionToolWaiting } from './tool-structured/AgentSessionToolWaiting';
+import { isCheckSessionWaitTool } from './tool-structured/types';
 
 interface AgentToolCallDetailsProps {
   toolCall: ToolCall;
@@ -44,6 +47,7 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
   hideParameters = false,
 }) => {
   const { t } = useTranslation('common');
+  const { session } = useAgentSessionState();
   const params = useMemo(
     () => parsedArgs || parseToolArguments(toolCall.function.arguments),
     [parsedArgs, toolCall.function.arguments],
@@ -54,6 +58,12 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
     !hasError &&
     structuredContent !== undefined &&
     canRenderStructuredToolResult(toolCall.function.name, structuredContent);
+  const showSessionWaiting =
+    isLoading &&
+    !toolResult &&
+    isCheckSessionWaitTool(toolCall.function.name, params);
+  const childSessionRef =
+    typeof params.sessionId === 'string' ? params.sessionId : '';
 
   if (!showDetails) return null;
 
@@ -74,6 +84,15 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
           </div>
         </div>
       )}
+
+      {/* In-flight delegated wait — before tool result exists */}
+      {showSessionWaiting && session?.id && childSessionRef ? (
+        <AgentSessionToolWaiting
+          callerSessionId={session.id}
+          childSessionRef={childSessionRef}
+          displayName={childSessionRef}
+        />
+      ) : null}
 
       {/* Result or Error section */}
       {toolResult && (
@@ -127,8 +146,8 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
         </div>
       )}
 
-      {/* Loading state */}
-      {isLoading && (
+      {/* Generic loading — skipped when specialized waiting chrome is shown */}
+      {isLoading && !showSessionWaiting && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="w-4 h-4 animate-spin" />
           <span>{t('agent.toolDetails.executing', 'Executing tool...')}</span>

--- a/src/features/agent/components/ToolCallCompactItem.tsx
+++ b/src/features/agent/components/ToolCallCompactItem.tsx
@@ -138,8 +138,10 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
     toolCall.function.name,
     toolResult,
     detailMode,
+    parsedArgs,
   );
   const forceVisible = uiOverride?.alwaysVisible === true;
+  const showInFlightWaiting = forceVisible && !toolResult;
 
   const executionTime = toolResult?.metadata?.executionTime;
   const detailsId = `tool-call-details-${toolCall.id}`;
@@ -156,19 +158,20 @@ const ToolCallCompactItemImpl: React.FC<ToolCallCompactItemProps> = ({
     prevHasErrorRef.current = hasError;
   }
 
-  const details = toolResult ? (
-    <div id={detailsId} className="mt-2 pt-2 border-t border-muted/50 min-w-0">
-      <AgentToolCallDetails
-        toolCall={toolCall}
-        toolResult={toolResult}
-        hasError={hasError}
-        isLoading={false}
-        showDetails={true}
-        parsedArgs={parsedArgs}
-        hideParameters={uiOverride?.hideParameters ?? false}
-      />
-    </div>
-  ) : null;
+  const details =
+    toolResult || showInFlightWaiting ? (
+      <div id={detailsId} className="mt-2 pt-2 border-t border-muted/50 min-w-0">
+        <AgentToolCallDetails
+          toolCall={toolCall}
+          toolResult={toolResult}
+          hasError={hasError}
+          isLoading={!toolResult}
+          showDetails={true}
+          parsedArgs={parsedArgs}
+          hideParameters={uiOverride?.hideParameters ?? false}
+        />
+      </div>
+    ) : null;
 
   // ── Simple Mode ─────────────────────────────────────────────────────────
   if (isSimpleMode) {

--- a/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
+++ b/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  CheckCircle2,
+  ChevronDown,
+  Ban,
+  PauseCircle,
+  ExternalLink,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import type { CheckSessionResult } from './types';
+
+export interface AgentSessionToolCardProps {
+  data: CheckSessionResult;
+}
+
+function truncatePreview(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars).trimEnd()}…`;
+}
+
+function resolveCardKind(
+  data: CheckSessionResult,
+): 'cancelled' | 'paused' | 'completed' {
+  if (data.terminatedByUser || data.responseStatus === 'cancelled') {
+    return 'cancelled';
+  }
+  if (
+    data.status.toLowerCase() === 'paused' ||
+    data.responseStatus === 'paused'
+  ) {
+    return 'paused';
+  }
+  return 'completed';
+}
+
+/**
+ * Compact structured result card for agent__checkSession.
+ * Default collapsed so parent chat is not flooded with child output.
+ */
+export const AgentSessionToolCard: React.FC<AgentSessionToolCardProps> = ({
+  data,
+}) => {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const kind = resolveCardKind(data);
+  const label =
+    data.assistantName?.trim() ||
+    data.sessionId ||
+    t('agent.toolStructured.sessionFallback', 'Subagent');
+  const summary = (data.result ?? data.message ?? '').trim();
+  const preview = summary
+    ? truncatePreview(summary, 160)
+    : t('agent.toolStructured.sessionNoSummary', 'No summary available');
+
+  const toneClass =
+    kind === 'cancelled'
+      ? 'border-destructive/30 bg-destructive/5'
+      : kind === 'paused'
+        ? 'border-amber-500/30 bg-amber-500/5'
+        : 'border-emerald-500/30 bg-emerald-500/5';
+
+  const Icon =
+    kind === 'cancelled'
+      ? Ban
+      : kind === 'paused'
+        ? PauseCircle
+        : CheckCircle2;
+
+  const iconClass =
+    kind === 'cancelled'
+      ? 'text-destructive'
+      : kind === 'paused'
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-emerald-600 dark:text-emerald-400';
+
+  const title =
+    kind === 'cancelled'
+      ? t(
+          'agent.toolStructured.sessionStoppedTitle',
+          '"{{name}}" stopped by user',
+          { name: label },
+        )
+      : kind === 'paused'
+        ? t('agent.toolStructured.sessionPausedTitle', '"{{name}}" paused', {
+            name: label,
+          })
+        : t(
+            'agent.toolStructured.sessionCompletedTitle',
+            '"{{name}}" completed',
+            { name: label },
+          );
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className={cn('rounded-lg border p-3', toneClass)}
+      data-testid="tool-structured-check-session"
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-2 text-left"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon className={cn('h-4 w-4 shrink-0', iconClass)} />
+            <span className="truncate text-sm font-medium">{title}</span>
+            {typeof data.turnCount === 'number' ? (
+              <Badge variant="outline" className="shrink-0 text-[10px]">
+                {t('agent.toolStructured.sessionTurns', '{{count}} turns', {
+                  count: data.turnCount,
+                })}
+              </Badge>
+            ) : null}
+          </div>
+          <Badge variant="outline" className="shrink-0 gap-1">
+            {open
+              ? t('agent.toolStructured.hideResult', 'Hide')
+              : t('agent.toolStructured.viewResult', 'View result')}
+            <ChevronDown
+              className={cn(
+                'h-3 w-3 transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </Badge>
+        </button>
+      </CollapsibleTrigger>
+
+      {!open ? (
+        <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+          {preview}
+        </p>
+      ) : null}
+
+      <CollapsibleContent className="mt-2 border-t border-border/60 pt-2">
+        <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
+          {summary || preview}
+        </pre>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="mt-1 h-auto px-0 text-xs"
+          onClick={() => navigate(`/agent/${data.sessionId}`)}
+        >
+          {t(
+            'agent.toolStructured.openChildSession',
+            'Open child session',
+          )}
+          <ExternalLink className="ml-1 h-3 w-3" />
+        </Button>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};

--- a/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
+++ b/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
@@ -44,7 +44,8 @@ function resolveCardKind(
 }
 
 /**
- * Compact structured result card for agent__checkSession.
+ * Compact structured result card for delegated-session wait tools
+ * (checkSession / messageToSession / startSession after wait).
  * Default collapsed so parent chat is not flooded with child output.
  */
 export const AgentSessionToolCard: React.FC<AgentSessionToolCardProps> = ({

--- a/src/features/agent/components/tool-structured/AgentSessionToolWaiting.tsx
+++ b/src/features/agent/components/tool-structured/AgentSessionToolWaiting.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Square } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { cancelDelegatedWorkflow } from '@/lib/backend/agent-commands';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('AgentSessionToolWaiting');
+
+export interface AgentSessionToolWaitingProps {
+  /** Parent (caller) session storage id */
+  callerSessionId: string;
+  /** Child session ref from tool args (display token or storage id) */
+  childSessionRef: string;
+  /** Optional display label (assistant name or session id) */
+  displayName?: string;
+}
+
+/**
+ * In-flight UI for agent__checkSession(wait=true): live status + Stop.
+ * Lives outside ToolStructuredResult — there is no structured_content yet.
+ */
+export const AgentSessionToolWaiting: React.FC<AgentSessionToolWaitingProps> = ({
+  callerSessionId,
+  childSessionRef,
+  displayName,
+}) => {
+  const { t } = useTranslation('common');
+  const [stopping, setStopping] = useState(false);
+  const label = displayName?.trim() || childSessionRef;
+
+  const handleStop = async () => {
+    if (stopping) return;
+    setStopping(true);
+    try {
+      await cancelDelegatedWorkflow(callerSessionId, childSessionRef);
+      toast.message(
+        t(
+          'agent.toolStructured.sessionStopRequested',
+          'Stop requested for "{{name}}"',
+          { name: label },
+        ),
+      );
+    } catch (error) {
+      logger.error('Failed to stop delegated session', {
+        callerSessionId,
+        childSessionRef,
+        error,
+      });
+      toast.error(
+        t(
+          'agent.toolStructured.sessionStopFailed',
+          'Could not stop the subagent session',
+        ),
+      );
+      setStopping(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3"
+      data-testid="tool-structured-check-session-waiting"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-amber-600 dark:text-amber-400" />
+        <span className="truncate text-sm font-medium">
+          {t(
+            'agent.toolStructured.sessionWaitingTitle',
+            'Running subagent: "{{name}}"',
+            { name: label },
+          )}
+        </span>
+      </div>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        className="shrink-0"
+        disabled={stopping}
+        onClick={() => {
+          void handleStop();
+        }}
+      >
+        <Square className="mr-1 h-3 w-3 fill-current" />
+        {stopping
+          ? t('agent.toolStructured.sessionStopping', 'Stopping…')
+          : t('agent.toolStructured.sessionStop', 'Stop')}
+      </Button>
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/AgentSessionToolWaiting.tsx
+++ b/src/features/agent/components/tool-structured/AgentSessionToolWaiting.tsx
@@ -18,7 +18,8 @@ export interface AgentSessionToolWaitingProps {
 }
 
 /**
- * In-flight UI for agent__checkSession(wait=true): live status + Stop.
+ * In-flight UI for blocking delegated waits (checkSession / messageToSession /
+ * startSession): live status + Stop.
  * Lives outside ToolStructuredResult — there is no structured_content yet.
  */
 export const AgentSessionToolWaiting: React.FC<AgentSessionToolWaitingProps> = ({

--- a/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
+++ b/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { AgentSessionToolCard } from './AgentSessionToolCard';
 import { FileWriteActions } from './FileWriteActions';
 import { StrReplaceDiffView } from './StrReplaceDiffView';
 import { TerminalOutputBlock } from './TerminalOutputBlock';
 import {
+  parseCheckSessionResult,
   parseRunShellResult,
   parseStrReplaceResult,
   parseWriteFileResult,
@@ -44,6 +46,10 @@ export const ToolStructuredResult: React.FC<ToolStructuredResultProps> = ({
       const parsed = parseRunShellResult(data);
       return parsed ? <TerminalOutputBlock data={parsed} /> : null;
     }
+    case 'agent__checkSession': {
+      const parsed = parseCheckSessionResult(data);
+      return parsed ? <AgentSessionToolCard data={parsed} /> : null;
+    }
     default:
       return null;
   }
@@ -65,6 +71,8 @@ export function canRenderStructuredToolResult(
       return parseStrReplaceResult(data) !== null;
     case 'workspace__runShell':
       return parseRunShellResult(data) !== null;
+    case 'agent__checkSession':
+      return parseCheckSessionResult(data) !== null;
     default:
       return false;
   }

--- a/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
+++ b/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
@@ -4,7 +4,7 @@ import { FileWriteActions } from './FileWriteActions';
 import { StrReplaceDiffView } from './StrReplaceDiffView';
 import { TerminalOutputBlock } from './TerminalOutputBlock';
 import {
-  parseCheckSessionResult,
+  parseDelegatedSessionWaitResult,
   parseRunShellResult,
   parseStrReplaceResult,
   parseWriteFileResult,
@@ -46,8 +46,10 @@ export const ToolStructuredResult: React.FC<ToolStructuredResultProps> = ({
       const parsed = parseRunShellResult(data);
       return parsed ? <TerminalOutputBlock data={parsed} /> : null;
     }
-    case 'agent__checkSession': {
-      const parsed = parseCheckSessionResult(data);
+    case 'agent__checkSession':
+    case 'agent__messageToSession':
+    case 'agent__startSession': {
+      const parsed = parseDelegatedSessionWaitResult(data);
       return parsed ? <AgentSessionToolCard data={parsed} /> : null;
     }
     default:
@@ -72,7 +74,9 @@ export function canRenderStructuredToolResult(
     case 'workspace__runShell':
       return parseRunShellResult(data) !== null;
     case 'agent__checkSession':
-      return parseCheckSessionResult(data) !== null;
+    case 'agent__messageToSession':
+    case 'agent__startSession':
+      return parseDelegatedSessionWaitResult(data) !== null;
     default:
       return false;
   }

--- a/src/features/agent/components/tool-structured/__tests__/AgentSessionToolWaiting.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/AgentSessionToolWaiting.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { AgentSessionToolWaiting } from '../AgentSessionToolWaiting';
+
+const cancelDelegatedWorkflow = vi.fn();
+
+vi.mock('@/lib/backend/agent-commands', () => ({
+  cancelDelegatedWorkflow: (...args: unknown[]) =>
+    cancelDelegatedWorkflow(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    message: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('AgentSessionToolWaiting', () => {
+  beforeEach(() => {
+    cancelDelegatedWorkflow.mockReset();
+    cancelDelegatedWorkflow.mockResolvedValue({ success: true });
+  });
+
+  it('calls cancelDelegatedWorkflow when Stop is clicked', async () => {
+    render(
+      <AgentSessionToolWaiting
+        callerSessionId="parent-1"
+        childSessionRef="child-abc"
+        displayName="Helper"
+      />,
+    );
+
+    expect(
+      screen.getByTestId('tool-structured-check-session-waiting'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Helper/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    await waitFor(() => {
+      expect(cancelDelegatedWorkflow).toHaveBeenCalledWith(
+        'parent-1',
+        'child-abc',
+      );
+    });
+  });
+});

--- a/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
@@ -148,4 +148,39 @@ describe('ToolStructuredResult', () => {
     );
     expect(screen.getByText(/stopped by user/i)).toBeInTheDocument();
   });
+
+  it('renders messageToSession wait-complete card', () => {
+    render(
+      <MemoryRouter>
+        <ToolStructuredResult
+          toolName="agent__messageToSession"
+          data={{
+            sessionId: '272c7e19e8',
+            status: 'idle',
+            responseStatus: 'success',
+            result: 'Review complete.',
+            turnCount: 3,
+          }}
+        />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByTestId('tool-structured-check-session'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Review complete/)).toBeInTheDocument();
+  });
+
+  it('skips fire-and-forget messageToSession pending acks', () => {
+    const { container } = render(
+      <ToolStructuredResult
+        toolName="agent__messageToSession"
+        data={{
+          sessionId: '272c7e19e8',
+          status: 'queued',
+          responseStatus: 'pending',
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/ToolStructuredResult.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { ToolStructuredResult } from '../ToolStructuredResult';
@@ -103,5 +104,48 @@ describe('ToolStructuredResult', () => {
       />,
     );
     expect(invalid.firstChild).toBeNull();
+  });
+
+  it('renders checkSession completed card', () => {
+    render(
+      <MemoryRouter>
+        <ToolStructuredResult
+          toolName="agent__checkSession"
+          data={{
+            sessionId: 'abc1234567',
+            status: 'idle',
+            responseStatus: 'success',
+            assistantName: 'Researcher',
+            result: 'All subtasks completed successfully.',
+            turnCount: 4,
+          }}
+        />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByTestId('tool-structured-check-session'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Researcher/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/All subtasks completed successfully/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders checkSession user-stopped card', () => {
+    render(
+      <MemoryRouter>
+        <ToolStructuredResult
+          toolName="agent__checkSession"
+          data={{
+            sessionId: 'abc1234567',
+            status: 'paused',
+            responseStatus: 'cancelled',
+            terminatedByUser: true,
+            result: 'Halfway done.',
+          }}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/stopped by user/i)).toBeInTheDocument();
   });
 });

--- a/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
@@ -110,4 +110,29 @@ describe('resolveToolResultUiOverride', () => {
       ),
     ).toBeNull();
   });
+
+  it('returns alwaysVisible for in-flight checkSession wait tools', () => {
+    expect(
+      resolveToolResultUiOverride(
+        'agent__checkSession',
+        undefined,
+        'simple',
+        { sessionId: 'abc1234567', wait: true },
+      ),
+    ).toEqual({
+      alwaysVisible: true,
+      hideParameters: true,
+    });
+  });
+
+  it('does not force visibility for non-waiting checkSession', () => {
+    expect(
+      resolveToolResultUiOverride(
+        'agent__checkSession',
+        undefined,
+        'developer',
+        { sessionId: 'abc1234567', wait: false },
+      ),
+    ).toBeNull();
+  });
 });

--- a/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/presentation.test.ts
@@ -125,6 +125,20 @@ describe('resolveToolResultUiOverride', () => {
     });
   });
 
+  it('returns alwaysVisible for in-flight messageToSession waits', () => {
+    expect(
+      resolveToolResultUiOverride(
+        'agent__messageToSession',
+        undefined,
+        'developer',
+        { sessionId: 'abc1234567', message: 'continue' },
+      ),
+    ).toEqual({
+      alwaysVisible: true,
+      hideParameters: false,
+    });
+  });
+
   it('does not force visibility for non-waiting checkSession', () => {
     expect(
       resolveToolResultUiOverride(
@@ -132,6 +146,21 @@ describe('resolveToolResultUiOverride', () => {
         undefined,
         'developer',
         { sessionId: 'abc1234567', wait: false },
+      ),
+    ).toBeNull();
+  });
+
+  it('does not force visibility when messageToSession disables wait', () => {
+    expect(
+      resolveToolResultUiOverride(
+        'agent__messageToSession',
+        undefined,
+        'simple',
+        {
+          sessionId: 'abc1234567',
+          message: 'ping',
+          waitForResponse: false,
+        },
       ),
     ).toBeNull();
   });

--- a/src/features/agent/components/tool-structured/__tests__/types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/types.test.ts
@@ -3,6 +3,8 @@ import {
   canRenderStructuredToolResult,
 } from '../ToolStructuredResult';
 import {
+  isCheckSessionWaitTool,
+  parseCheckSessionResult,
   parseRunShellResult,
   parseStrReplaceResult,
   parseWriteFileResult,
@@ -85,6 +87,52 @@ describe('tool-structured types', () => {
     expect(
       canRenderStructuredToolResult('knowledge__searchKnowledge', {
         results: [],
+      }),
+    ).toBe(false);
+    expect(
+      canRenderStructuredToolResult('agent__checkSession', {
+        sessionId: 'abc1234567',
+        status: 'idle',
+        responseStatus: 'success',
+        result: 'done',
+        turnCount: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it('parseCheckSessionResult requires sessionId and status', () => {
+    expect(
+      parseCheckSessionResult({
+        sessionId: 'abc1234567',
+        status: 'paused',
+        terminatedByUser: true,
+        responseStatus: 'cancelled',
+      }),
+    ).toMatchObject({
+      sessionId: 'abc1234567',
+      status: 'paused',
+      terminatedByUser: true,
+    });
+    expect(parseCheckSessionResult({ status: 'idle' })).toBeNull();
+  });
+
+  it('isCheckSessionWaitTool only matches blocking waits', () => {
+    expect(
+      isCheckSessionWaitTool('agent__checkSession', {
+        sessionId: 'abc',
+        wait: true,
+      }),
+    ).toBe(true);
+    expect(
+      isCheckSessionWaitTool('agent__checkSession', {
+        sessionId: 'abc',
+        wait: false,
+      }),
+    ).toBe(false);
+    expect(
+      isCheckSessionWaitTool('workspace__runShell', {
+        sessionId: 'abc',
+        wait: true,
       }),
     ).toBe(false);
   });

--- a/src/features/agent/components/tool-structured/__tests__/types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/types.test.ts
@@ -3,8 +3,9 @@ import {
   canRenderStructuredToolResult,
 } from '../ToolStructuredResult';
 import {
-  isCheckSessionWaitTool,
+  isDelegatedSessionWaitTool,
   parseCheckSessionResult,
+  parseDelegatedSessionWaitResult,
   parseRunShellResult,
   parseStrReplaceResult,
   parseWriteFileResult,
@@ -98,6 +99,22 @@ describe('tool-structured types', () => {
         turnCount: 2,
       }),
     ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('agent__messageToSession', {
+        sessionId: 'abc1234567',
+        status: 'idle',
+        responseStatus: 'success',
+        result: 'done',
+        turnCount: 2,
+      }),
+    ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('agent__messageToSession', {
+        sessionId: 'abc1234567',
+        status: 'queued',
+        responseStatus: 'pending',
+      }),
+    ).toBe(false);
   });
 
   it('parseCheckSessionResult requires sessionId and status', () => {
@@ -116,21 +133,53 @@ describe('tool-structured types', () => {
     expect(parseCheckSessionResult({ status: 'idle' })).toBeNull();
   });
 
-  it('isCheckSessionWaitTool only matches blocking waits', () => {
+  it('parseDelegatedSessionWaitResult rejects fire-and-forget acks', () => {
     expect(
-      isCheckSessionWaitTool('agent__checkSession', {
+      parseDelegatedSessionWaitResult({
+        sessionId: 'abc1234567',
+        status: 'started',
+        responseStatus: 'pending',
+      }),
+    ).toBeNull();
+    expect(
+      parseDelegatedSessionWaitResult({
+        sessionId: 'abc1234567',
+        status: 'idle',
+        responseStatus: 'success',
+        turnCount: 1,
+        result: 'ok',
+      }),
+    ).not.toBeNull();
+  });
+
+  it('isDelegatedSessionWaitTool matches blocking checkSession and messageToSession', () => {
+    expect(
+      isDelegatedSessionWaitTool('agent__checkSession', {
         sessionId: 'abc',
         wait: true,
       }),
     ).toBe(true);
     expect(
-      isCheckSessionWaitTool('agent__checkSession', {
+      isDelegatedSessionWaitTool('agent__checkSession', {
         sessionId: 'abc',
         wait: false,
       }),
     ).toBe(false);
     expect(
-      isCheckSessionWaitTool('workspace__runShell', {
+      isDelegatedSessionWaitTool('agent__messageToSession', {
+        sessionId: 'abc',
+        message: 'hello',
+      }),
+    ).toBe(true);
+    expect(
+      isDelegatedSessionWaitTool('agent__messageToSession', {
+        sessionId: 'abc',
+        message: 'hello',
+        waitForResponse: false,
+      }),
+    ).toBe(false);
+    expect(
+      isDelegatedSessionWaitTool('workspace__runShell', {
         sessionId: 'abc',
         wait: true,
       }),

--- a/src/features/agent/components/tool-structured/presentation.ts
+++ b/src/features/agent/components/tool-structured/presentation.ts
@@ -1,7 +1,7 @@
 import type { Message } from '@/models/chat';
 import { getToolStructuredContent, hasUIResource } from '@/lib/tool-call-utils';
 import { canRenderStructuredToolResult } from './ToolStructuredResult';
-import { isCheckSessionWaitTool } from './types';
+import { isDelegatedSessionWaitTool } from './types';
 
 export type ToolResultDetailMode = 'simple' | 'developer';
 
@@ -20,7 +20,7 @@ export type ToolResultUiOverride = {
  * Resolves whether a tool result should override the default collapsed compact UI.
  *
  * Order:
- * 1. In-flight checkSession(wait=true) — waiting chrome + Stop
+ * 1. In-flight delegated wait (checkSession / messageToSession / startSession) — Stop chrome
  * 2. MCP UI resources (e.g. circuit-break widgets)
  * 3. Structured content with a registered renderer
  * Otherwise returns null → keep default collapse behavior.
@@ -36,7 +36,7 @@ export function resolveToolResultUiOverride(
   if (
     !toolResult &&
     parsedArgs &&
-    isCheckSessionWaitTool(toolName, parsedArgs)
+    isDelegatedSessionWaitTool(toolName, parsedArgs)
   ) {
     return { alwaysVisible: true, hideParameters };
   }

--- a/src/features/agent/components/tool-structured/presentation.ts
+++ b/src/features/agent/components/tool-structured/presentation.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@/models/chat';
 import { getToolStructuredContent, hasUIResource } from '@/lib/tool-call-utils';
 import { canRenderStructuredToolResult } from './ToolStructuredResult';
+import { isCheckSessionWaitTool } from './types';
 
 export type ToolResultDetailMode = 'simple' | 'developer';
 
@@ -19,18 +20,28 @@ export type ToolResultUiOverride = {
  * Resolves whether a tool result should override the default collapsed compact UI.
  *
  * Order:
- * 1. MCP UI resources (e.g. circuit-break widgets)
- * 2. Structured content with a registered renderer
+ * 1. In-flight checkSession(wait=true) — waiting chrome + Stop
+ * 2. MCP UI resources (e.g. circuit-break widgets)
+ * 3. Structured content with a registered renderer
  * Otherwise returns null → keep default collapse behavior.
  */
 export function resolveToolResultUiOverride(
   toolName: string,
   toolResult: Message | undefined,
   mode: ToolResultDetailMode,
+  parsedArgs?: Record<string, unknown>,
 ): ToolResultUiOverride | null {
-  if (!toolResult) return null;
-
   const hideParameters = mode === 'simple';
+
+  if (
+    !toolResult &&
+    parsedArgs &&
+    isCheckSessionWaitTool(toolName, parsedArgs)
+  ) {
+    return { alwaysVisible: true, hideParameters };
+  }
+
+  if (!toolResult) return null;
 
   if (hasUIResource(toolResult)) {
     return { alwaysVisible: true, hideParameters };

--- a/src/features/agent/components/tool-structured/types.ts
+++ b/src/features/agent/components/tool-structured/types.ts
@@ -100,20 +100,58 @@ export function parseCheckSessionResult(
   return parsed.success ? parsed.data : null;
 }
 
-/** True when a tool call is an in-flight delegated-session wait worth a Stop card. */
-export function isCheckSessionWaitTool(
+/**
+ * Wait-complete delegated-session payloads (checkSession / messageToSession /
+ * startSession after an internal wait). Excludes fire-and-forget acks
+ * (`responseStatus: pending`, `status: started`).
+ */
+export function parseDelegatedSessionWaitResult(
+  value: unknown,
+): CheckSessionResult | null {
+  const parsed = parseCheckSessionResult(value);
+  if (!parsed) return null;
+  if (parsed.responseStatus === 'pending') return null;
+  if (parsed.status.toLowerCase() === 'started') return null;
+  const hasWaitCompleteSignal =
+    typeof parsed.turnCount === 'number' ||
+    typeof parsed.result === 'string' ||
+    parsed.terminatedByUser === true;
+  return hasWaitCompleteSignal ? parsed : null;
+}
+
+function hasSessionIdArg(args: Record<string, unknown>): boolean {
+  const sessionId = args.sessionId;
+  return typeof sessionId === 'string' && sessionId.trim().length > 0;
+}
+
+/**
+ * True when a tool call is an in-flight delegated-session wait worth a Stop card.
+ * Covers checkSession(wait), messageToSession(waitForResponse), and
+ * startSession(waitForResult) when a child sessionId is already known in args.
+ */
+export function isDelegatedSessionWaitTool(
   toolName: string,
   args: Record<string, unknown>,
 ): boolean {
   const key = resolveStructuredToolKey(toolName);
-  if (key !== 'agent__checkSession') return false;
-  const sessionId = args.sessionId;
-  if (typeof sessionId !== 'string' || sessionId.trim().length === 0) {
-    return false;
+  if (!hasSessionIdArg(args)) return false;
+
+  switch (key) {
+    case 'agent__checkSession':
+      return args.wait === true;
+    case 'agent__messageToSession':
+      // Backend default is waitForResponse=true when omitted.
+      return args.waitForResponse !== false;
+    case 'agent__startSession':
+      // Child id is usually absent from start args; only match if present.
+      return args.waitForResult === true;
+    default:
+      return false;
   }
-  // Default wait is false in the backend; only show Stop for blocking waits.
-  return args.wait === true;
 }
+
+/** @deprecated Use {@link isDelegatedSessionWaitTool} */
+export const isCheckSessionWaitTool = isDelegatedSessionWaitTool;
 
 /** Canonical `service__tool` name used by the structured-result dispatcher. */
 export function resolveStructuredToolKey(toolName: string): string {

--- a/src/features/agent/components/tool-structured/types.ts
+++ b/src/features/agent/components/tool-structured/types.ts
@@ -55,6 +55,29 @@ export const RunShellResultSchema = z.object({
 
 export type RunShellResult = z.infer<typeof RunShellResultSchema>;
 
+/**
+ * Structured content from agent__checkSession (and wait-complete siblings).
+ * Field names mirror Rust `build_agent_session_tool_data` + enrichment.
+ */
+export const CheckSessionResultSchema = z
+  .object({
+    toolName: z.string().optional(),
+    sessionId: z.string(),
+    status: z.string(),
+    responseStatus: z.string().optional(),
+    turnCount: z.number().optional(),
+    message: z.string().optional(),
+    result: z.string().optional(),
+    assistantName: z.string().optional(),
+    assistantId: z.string().optional(),
+    terminatedByUser: z.boolean().optional(),
+    recoverable: z.boolean().optional(),
+    hasMoreDetail: z.boolean().optional(),
+  })
+  .passthrough();
+
+export type CheckSessionResult = z.infer<typeof CheckSessionResultSchema>;
+
 export function parseWriteFileResult(value: unknown): WriteFileResult | null {
   const parsed = WriteFileResultSchema.safeParse(value);
   return parsed.success ? parsed.data : null;
@@ -68,6 +91,28 @@ export function parseStrReplaceResult(value: unknown): StrReplaceResult | null {
 export function parseRunShellResult(value: unknown): RunShellResult | null {
   const parsed = RunShellResultSchema.safeParse(value);
   return parsed.success ? parsed.data : null;
+}
+
+export function parseCheckSessionResult(
+  value: unknown,
+): CheckSessionResult | null {
+  const parsed = CheckSessionResultSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/** True when a tool call is an in-flight delegated-session wait worth a Stop card. */
+export function isCheckSessionWaitTool(
+  toolName: string,
+  args: Record<string, unknown>,
+): boolean {
+  const key = resolveStructuredToolKey(toolName);
+  if (key !== 'agent__checkSession') return false;
+  const sessionId = args.sessionId;
+  if (typeof sessionId !== 'string' || sessionId.trim().length === 0) {
+    return false;
+  }
+  // Default wait is false in the backend; only show Stop for blocking waits.
+  return args.wait === true;
 }
 
 /** Canonical `service__tool` name used by the structured-result dispatcher. */

--- a/src/lib/backend/agent-commands.ts
+++ b/src/lib/backend/agent-commands.ts
@@ -279,3 +279,17 @@ export async function cancelInteractiveShellInput(
     },
   });
 }
+
+/**
+ * Soft-cancel a delegated child session from the parent chat Stop control.
+ * Resolves display tokens among the caller's descendants.
+ */
+export async function cancelDelegatedWorkflow(
+  callerSessionId: string,
+  targetSessionRef: string,
+): Promise<AgentResponse> {
+  return safeInvoke<AgentResponse>('agent_cancel_delegated_workflow', {
+    callerSessionId,
+    targetSessionRef,
+  });
+}


### PR DESCRIPTION
## Summary
- Add in-flight waiting UI with Stop for `agent__checkSession(wait=true)`, plus a compact collapsible result card when the wait completes.
- Soft-cancel marks user-stop so the parent receives `terminatedByUser` / cancelled guidance instead of paused auto-resume hints.
- New `agent_cancel_delegated_workflow` resolves display tokens among the caller's descendants before cancel.

## Test plan
- [ ] Parent runs `agent__checkSession(wait=true)` on a busy child — waiting card + Stop appear in the parent tool call.
- [ ] Click Stop — child soft-cancels; parent tool result shows user-stopped (no automatic `messageToSession` recovery).
- [ ] Let a child finish normally — completed collapsible card shows summary/turns without flooding the chat.
- [ ] `pnpm exec vitest run src/features/agent/components/tool-structured`
- [ ] `cargo test --test check_session_enrichment_tests user_stopped_check_session`

Made with [Cursor](https://cursor.com)