### PR TITLE
fix(db): isolate debug default SQLite path from release DB

### DIFF
--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -269,7 +269,7 @@ Each stage below is broken into its constituent components with behavioral descr
   - `main()` (L14): Entry point — checks for browser sidecar mode, loads `.env` files, sets SQLite DB path, calls `run_with_sqlite_sync()`
   - Browser sidecar detection (L13-20): If `--browser-sidecar` flag present, runs `browser_sidecar::run_sidecar_mode()`
   - Environment loading (L31-73): Development loads `.env.dev` → `.env`; Production loads `.env` from CWD or executable directory
-  - SQLite path resolution (L76-87): Uses `LIBRAGENT_DB_PATH` env or default `~/.local/share/com.fritzprix.libragent/libragent_v2.db`
+  - SQLite path resolution: Uses `LIBRAGENT_DB_PATH` env, else debug → `libragent_v2.dev.db`, release → `libragent_v2.db` under the app data dir (so `tauri dev` never migrates the production DB by default)
 
 #### `lifecycle/app_setup.rs` — Application Setup
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,7 +18,8 @@
 /// - `LIBRAGENT_GRACEFUL_SHUTDOWN_TIMEOUT`: Graceful shutdown timeout in seconds (default: 3)
 /// - `LIBRAGENT_POLL_THRESHOLD`: Excessive polling detection threshold (default: 5 consecutive polls)
 /// - `MESSAGE_INDEX_SNIPPET_LENGTH`: Message snippet length for search index (default: 200)
-/// - `LIBRAGENT_DB_PATH`: SQLite database file path (default: user data directory)
+/// - `LIBRAGENT_DB_PATH`: SQLite database file path (default: `libragent_v2.dev.db` in
+///   debug builds, `libragent_v2.db` in release builds, under the user data directory)
 /// - `LIBRAGENT_MCP_IDLE_TIMEOUT_MINUTES`: MCP server idle timeout in minutes (default: 5)
 /// - `LIBRAGENT_MCP_CLEANUP_INTERVAL_MINUTES`: MCP cleanup interval in minutes (default: 5)
 use std::env;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,7 +6,8 @@
 /// This function is responsible for:
 /// 1. Loading environment variables from .env file (development mode only)
 /// 2. Determining the path for the SQLite database. It prioritizes the `LIBRAGENT_DB_PATH`
-///    environment variable, falling back to a default location within the user's data directory.
+///    environment variable, falling back to `libragent_v2.dev.db` (debug) or
+///    `libragent_v2.db` (release) within the user's data directory.
 /// 3. Ensuring the directory for the database exists.
 /// 4. Constructing the final SQLite connection URL.
 /// 5. Calling the main application runner (`run_with_sqlite_sync`) from the `tauri_mcp_agent_lib`
@@ -90,16 +91,20 @@ fn main() {
     }
 
     // Set the SQLite database path - stored in the user's data directory.
+    // Debug builds default to a separate file so `pnpm tauri dev` / migration
+    // experiments never mutate the production release DB. Override anytime with
+    // LIBRAGENT_DB_PATH (e.g. to intentionally reuse or inspect prod data).
     let db_path = std::env::var("LIBRAGENT_DB_PATH").unwrap_or_else(|_| {
-        // Default to storing in the user's data directory.
         let data_dir = dirs::data_dir()
             .expect("Failed to get data directory")
             .join("com.fritzprix.libragent");
-        // Use a different filename to avoid potential locking issues.
-        data_dir
-            .join("libragent_v2.db")
-            .to_string_lossy()
-            .to_string()
+
+        #[cfg(debug_assertions)]
+        let db_file = "libragent_v2.dev.db";
+        #[cfg(not(debug_assertions))]
+        let db_file = "libragent_v2.db";
+
+        data_dir.join(db_file).to_string_lossy().to_string()
     });
 
     // Check if the database directory exists and create it if it doesn't.
@@ -108,6 +113,13 @@ fn main() {
     }
 
     let db_url = tauri_mcp_agent_lib::utils::sqlite::format_sqlite_url(&db_path);
+
+    #[cfg(debug_assertions)]
+    if std::env::var("LIBRAGENT_DB_PATH").is_err() {
+        println!(
+            "ℹ️  Debug build using isolated DB (set LIBRAGENT_DB_PATH to override): {db_path}"
+        );
+    }
 
     println!("🚀 Starting LibrAgent with SQLite database: {db_url}");
 


### PR DESCRIPTION
## Summary
- Debug builds (pnpm tauri dev) now default to `libragent_v2.dev.db` instead of the shared production `libragent_v2.db`
- Prevents new migration experiments from mutating the release/user database by default
- `LIBRAGENT_DB_PATH` still overrides when you intentionally want a specific DB

## Test plan
- [ ] Run `pnpm tauri dev` and confirm startup log shows isolated path (`libragent_v2.dev.db`)
- [ ] Confirm release/default path remains `libragent_v2.db` when unset
- [ ] Confirm `LIBRAGENT_DB_PATH` override still wins in debug builds

Made with [Cursor](https://cursor.com)