### PR TITLE
feat(agent): human-facing cards for agent__* session tool results

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -10,7 +10,7 @@ use crate::mcp::builtin::error_guidance::{
 };
 use crate::mcp::types::MCPResult;
 use crate::models::chat::MessageSource;
-use crate::repositories::SessionStatus;
+use crate::repositories::{AssistantRepository, SessionStatus};
 
 use super::super::AgentServer;
 use super::check_session::check_session;
@@ -97,10 +97,13 @@ async fn start_session_impl(
     };
 
     let explicit_org = caller_explicit_org.clone();
+    let assistant_id = read_required_string(&args, "agentId")?;
+    let task = read_required_string(&args, "task")?;
     let requested_workspace_override = args
         .get("workspaceOverride")
         .and_then(|v| v.as_str())
         .map(str::to_string);
+    let workspace_override_set = requested_workspace_override.is_some();
 
     let effective_workspace_path = if let Some(workspace_override) = requested_workspace_override {
         Some(workspace_override)
@@ -120,8 +123,8 @@ async fn start_session_impl(
 
     let body: crate::agent::types::CreateSessionRequest = serde_json::from_value(json!({
         "parentSessionId": caller_session_id,
-        "assistantId": read_required_string(&args, "agentId")?,
-        "request": read_required_string(&args, "task")?,
+        "assistantId": assistant_id.clone(),
+        "request": task.clone(),
         "workspacePath": effective_workspace_path.as_deref(),
         "orgId": explicit_org.as_ref().map(|(org_id, _, _)| org_id.as_str()),
         "orgName": explicit_org.as_ref().map(|(_, org_name, _)| org_name.as_str()),
@@ -198,8 +201,37 @@ async fn start_session_impl(
     );
     response_data.insert("sessionId".to_string(), Value::String(display_id));
     response_data.insert("status".to_string(), Value::String("started".to_string()));
+    response_data.insert(
+        "assistantId".to_string(),
+        Value::String(assistant_id.clone()),
+    );
+    response_data.insert("task".to_string(), Value::String(task.clone()));
+    response_data.insert(
+        "workspaceOverride".to_string(),
+        Value::Bool(workspace_override_set),
+    );
     if let Some(workspace_path) = effective_workspace_path {
         response_data.insert("workspacePath".to_string(), Value::String(workspace_path));
+    }
+
+    // Human card identity: prefer assistant display name over session id.
+    {
+        match crate::state::get_assistant_repository()
+            .get_assistant(&assistant_id)
+            .await
+        {
+            Ok(Some(assistant)) => {
+                response_data.insert("assistantName".to_string(), Value::String(assistant.name));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                log::warn!(
+                    "agent__startSession: failed to resolve assistantName for {}: {}",
+                    assistant_id,
+                    error
+                );
+            }
+        }
     }
 
     Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
@@ -243,6 +275,7 @@ pub async fn message_to_session(
     };
     let session_id = target_session.id.clone();
     let display_id = crate::utils::session_id::display_session_id(&session_id);
+    let instruction_text = message_text.clone();
     let response = match crate::services::AgentService::send_message_to_session(
         manager,
         &session_id,
@@ -291,6 +324,35 @@ pub async fn message_to_session(
     response_data.insert("sessionId".to_string(), Value::String(display_id));
     response_data.insert("messageId".to_string(), Value::String(response.message_id));
     response_data.insert("status".to_string(), Value::String(response.status));
+    // Persist message body for human card (collapsed preview).
+    response_data.insert("instruction".to_string(), Value::String(instruction_text));
+
+    // Prefer assistant display name over opaque session id in the parent chat card.
+    {
+        if let Some(assistant_id) = target_session.assistant_id.as_deref() {
+            response_data.insert(
+                "assistantId".to_string(),
+                Value::String(assistant_id.to_string()),
+            );
+            match crate::state::get_assistant_repository()
+                .get_assistant(assistant_id)
+                .await
+            {
+                Ok(Some(assistant)) => {
+                    response_data
+                        .insert("assistantName".to_string(), Value::String(assistant.name));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    log::warn!(
+                        "agent__messageToSession: failed to resolve assistantName for {}: {}",
+                        assistant_id,
+                        error
+                    );
+                }
+            }
+        }
+    }
 
     Ok(hint.to_mcp_result_with_data(Some(Value::Object(response_data))))
 }

--- a/src-tauri/src/repositories/message_repository.rs
+++ b/src-tauri/src/repositories/message_repository.rs
@@ -285,36 +285,59 @@ impl SqliteMessageRepository {
 
     /// Rebuild UI-facing metadata / error fields from persisted columns.
     ///
-    /// `messages.metadata` is not a DB column. Tool failures are persisted as
-    /// `error: {"toolError": true}` (new) or legacy `content[].isError` in the
-    /// raw content JSON (old rows; the typed `MCPContent::Text` field is gone).
+    /// `messages.metadata` is not a DB column. Tool UI state is persisted in the
+    /// `error` column as a JSON envelope:
+    /// - `{"toolError": true}` — tool failure marker (also legacy `content[].isError`)
+    /// - `{"structuredContent": ...}` — MCP structured_content for chat UI cards
+    /// - both keys may appear together
+    ///
+    /// When the column only holds this envelope, `Message.error` stays `None`
+    /// (that field is reserved for LLM/service failure UI payloads).
     fn decode_persisted_tool_error(
         content_json: &str,
         error: Option<serde_json::Value>,
     ) -> (Option<serde_json::Value>, Option<serde_json::Value>) {
-        let tool_error_from_column = error
-            .as_ref()
-            .and_then(|value| value.get("toolError"))
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
         let tool_error_from_legacy_content =
             crate::mcp::types::raw_content_json_has_legacy_item_error(content_json);
+
+        let envelope = error.as_ref().and_then(|value| value.as_object());
+        let tool_error_from_column = envelope
+            .and_then(|object| object.get("toolError"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let structured_content = envelope
+            .and_then(|object| object.get("structuredContent"))
+            .cloned();
+        let is_ui_envelope = tool_error_from_column || structured_content.is_some();
+
         let tool_error = tool_error_from_column || tool_error_from_legacy_content;
 
-        let metadata = if tool_error {
-            Some(serde_json::json!({ "toolError": true }))
-        } else {
-            None
+        let metadata = {
+            let mut map = serde_json::Map::new();
+            if tool_error {
+                map.insert("toolError".to_string(), serde_json::Value::Bool(true));
+            }
+            if let Some(structured) = structured_content {
+                map.insert("structuredContent".to_string(), structured);
+            }
+            if map.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(map))
+            }
         };
 
-        // Tool-error marker occupies the error column; do not expose it as Message.error
-        // (that field is reserved for LLM/service failure UI payloads).
-        let error = if tool_error_from_column { None } else { error };
+        // UI envelope occupies the error column; do not expose it as Message.error.
+        let error = if is_ui_envelope { None } else { error };
 
         (error, metadata)
     }
 
-    /// Encode in-memory `metadata.toolError` into the durable `error` column marker.
+    /// Encode in-memory tool UI metadata into the durable `error` column envelope.
+    ///
+    /// Persists `metadata.toolError` and/or `metadata.structuredContent` so chat
+    /// structured cards survive session reload. Falls back to `message.error` for
+    /// real LLM/service failure payloads when no UI envelope keys are present.
     fn encode_persisted_error(message: &Message) -> Option<serde_json::Value> {
         let tool_error = message
             .metadata
@@ -322,9 +345,21 @@ impl SqliteMessageRepository {
             .and_then(|metadata| metadata.get("toolError"))
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
+        let structured_content = message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("structuredContent"))
+            .cloned();
 
-        if tool_error {
-            return Some(serde_json::json!({ "toolError": true }));
+        if tool_error || structured_content.is_some() {
+            let mut map = serde_json::Map::new();
+            if tool_error {
+                map.insert("toolError".to_string(), serde_json::Value::Bool(true));
+            }
+            if let Some(structured) = structured_content {
+                map.insert("structuredContent".to_string(), structured);
+            }
+            return Some(serde_json::Value::Object(map));
         }
 
         message.error.clone()
@@ -858,6 +893,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn encode_decode_preserves_structured_content_envelope() {
+        let structured = serde_json::json!({
+            "sessionId": "a1b2c3d4e5",
+            "status": "started",
+            "responseStatus": "pending",
+        });
+        let mut message = create_dummy_message("tool-structured", "session1");
+        message.role = "tool".to_string();
+        message.metadata = Some(serde_json::json!({
+            "structuredContent": structured,
+        }));
+
+        let encoded = SqliteMessageRepository::encode_persisted_error(&message);
+        assert_eq!(
+            encoded
+                .as_ref()
+                .and_then(|value| value.get("structuredContent")),
+            Some(&structured)
+        );
+
+        let (error, metadata) = SqliteMessageRepository::decode_persisted_tool_error("[]", encoded);
+        assert!(error.is_none());
+        assert_eq!(
+            metadata
+                .as_ref()
+                .and_then(|value| value.get("structuredContent")),
+            Some(&structured)
+        );
+    }
+
+    #[test]
+    fn encode_decode_preserves_tool_error_and_structured_content() {
+        let structured = serde_json::json!({ "path": "a.txt", "action": "created" });
+        let mut message = create_dummy_message("tool-both", "session1");
+        message.metadata = Some(serde_json::json!({
+            "toolError": true,
+            "structuredContent": structured,
+        }));
+
+        let encoded = SqliteMessageRepository::encode_persisted_error(&message);
+        let (error, metadata) = SqliteMessageRepository::decode_persisted_tool_error("[]", encoded);
+
+        assert!(error.is_none());
+        assert_eq!(
+            metadata
+                .as_ref()
+                .and_then(|value| value.get("toolError"))
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            metadata
+                .as_ref()
+                .and_then(|value| value.get("structuredContent")),
+            Some(&structured)
+        );
+    }
+
     #[tokio::test]
     async fn test_insert_and_get_messages() {
         let repo = setup_test_db().await;
@@ -909,6 +1003,97 @@ mod tests {
             loaded.error.is_none(),
             "toolError marker must not surface as Message.error"
         );
+    }
+
+    #[tokio::test]
+    async fn test_reload_preserves_structured_content_in_error_column_envelope() {
+        let repo = setup_test_db().await;
+        create_test_session(&repo.db, "session1").await;
+
+        let structured = serde_json::json!({
+            "sessionId": "a1b2c3d4e5",
+            "status": "started",
+            "responseStatus": "pending",
+            "toolName": "startSession",
+        });
+
+        let mut message = create_dummy_message("tool-structured", "session1");
+        message.role = "tool".to_string();
+        message.tool_call_id = Some("call-spawn".to_string());
+        message.content = vec![MCPContent::Text {
+            text: "Session started successfully".to_string(),
+        }];
+        message.metadata = Some(serde_json::json!({
+            "structuredContent": structured,
+        }));
+
+        repo.insert(&message).await.expect("Failed to insert");
+
+        let loaded = repo
+            .get_by_id("tool-structured")
+            .await
+            .expect("Failed to get message")
+            .expect("message should exist");
+
+        assert_eq!(
+            loaded
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("structuredContent")),
+            Some(&structured),
+            "structuredContent must survive DB reload for structured tool cards"
+        );
+        assert!(
+            loaded.error.is_none(),
+            "structuredContent envelope must not surface as Message.error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reload_preserves_structured_content_with_tool_error() {
+        let repo = setup_test_db().await;
+        create_test_session(&repo.db, "session1").await;
+
+        let structured = serde_json::json!({
+            "path": "a.txt",
+            "action": "created",
+        });
+
+        let mut message = create_dummy_message("tool-both", "session1");
+        message.role = "tool".to_string();
+        message.tool_call_id = Some("call-both".to_string());
+        message.content = vec![MCPContent::Text {
+            text: "write failed".to_string(),
+        }];
+        message.metadata = Some(serde_json::json!({
+            "toolError": true,
+            "structuredContent": structured,
+        }));
+
+        repo.insert(&message).await.expect("Failed to insert");
+
+        let loaded = repo
+            .get_by_id("tool-both")
+            .await
+            .expect("Failed to get message")
+            .expect("message should exist");
+
+        assert_eq!(
+            loaded
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("toolError"))
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            loaded
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("structuredContent")),
+            Some(&structured)
+        );
+        assert!(loaded.error.is_none());
     }
 
     #[tokio::test]

--- a/src/features/agent/components/AgentToolCallDetails.tsx
+++ b/src/features/agent/components/AgentToolCallDetails.tsx
@@ -114,6 +114,7 @@ export const AgentToolCallDetails: React.FC<AgentToolCallDetailsProps> = ({
                 <ToolStructuredResult
                   toolName={toolCall.function.name}
                   data={structuredContent}
+                  toolArgs={params}
                 />
               ) : (
                 <AgentMessageRenderer

--- a/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
+++ b/src/features/agent/components/tool-structured/AgentSessionToolCard.tsx
@@ -1,0 +1,422 @@
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleDashed,
+  Copy,
+  ExternalLink,
+  FolderOpen,
+  Loader2,
+  PauseCircle,
+  Send,
+  Sparkles,
+  StopCircle,
+  Trash2,
+  Timer,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { getLogger } from '@/lib/logger';
+import { ExpandableScrollText } from './ExpandableScrollText';
+import {
+  classifyAgentSessionCard,
+  readAgentToolArgString,
+  resolveAgentSessionId,
+  type AgentSessionCardKind,
+  type AgentSessionToolResult,
+} from './agent-types';
+
+const logger = getLogger('AgentSessionToolCard');
+
+export interface AgentSessionToolCardProps {
+  toolName: string;
+  data: AgentSessionToolResult;
+  /** Tool-call arguments (task / message) for human context fallback. */
+  toolArgs?: Record<string, unknown>;
+}
+
+function statusKey(status: string | undefined): string {
+  return (status ?? '').toLowerCase();
+}
+
+function kindIcon(kind: AgentSessionCardKind, status?: string) {
+  if (kind === 'needs_attention' && statusKey(status) === 'paused') {
+    return PauseCircle;
+  }
+  switch (kind) {
+    case 'spawned':
+      return Sparkles;
+    case 'instruction_sent':
+      return Send;
+    case 'in_progress':
+      return Loader2;
+    case 'wait_timeout':
+      return Timer;
+    case 'finished':
+      return CheckCircle2;
+    case 'needs_attention':
+      return AlertTriangle;
+    case 'stopped':
+      return StopCircle;
+    case 'deleted':
+      return Trash2;
+    default:
+      return CircleDashed;
+  }
+}
+
+function kindBadgeClass(kind: AgentSessionCardKind): string {
+  switch (kind) {
+    case 'finished':
+      return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300';
+    case 'needs_attention':
+    case 'stopped':
+      return 'bg-destructive/15 text-destructive';
+    case 'wait_timeout':
+    case 'in_progress':
+      return 'bg-warning/15 text-warning-foreground';
+    case 'deleted':
+      return 'bg-muted text-muted-foreground';
+    default:
+      return 'bg-muted text-foreground';
+  }
+}
+
+/**
+ * Human-facing structured view for agent__* session tools.
+ * CTAs are user actions only (open child / copy) — never agent wait/message next-steps.
+ */
+export const AgentSessionToolCard: React.FC<AgentSessionToolCardProps> = ({
+  toolName,
+  data,
+  toolArgs,
+}) => {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const [copying, setCopying] = useState(false);
+
+  const kind = classifyAgentSessionCard(toolName, data);
+  const sessionId = resolveAgentSessionId(data);
+
+  const mission =
+    data.task?.trim() || readAgentToolArgString(toolArgs, 'task') || undefined;
+  const instruction =
+    data.instruction?.trim() ||
+    readAgentToolArgString(toolArgs, 'message') ||
+    undefined;
+
+  const resultText = data.result?.trim() || '';
+  const recentSummaries =
+    data.latestMessages
+      ?.map((m) => m.summary.trim())
+      .filter((s) => s.length > 0)
+      .slice(0, 3) ?? [];
+
+  const title = (() => {
+    if (!kind) {
+      return t('agent.toolStructured.agentCard.fallback', 'Sub-agent');
+    }
+    switch (kind) {
+      case 'spawned':
+        return t('agent.toolStructured.agentCard.spawned', 'Started');
+      case 'instruction_sent':
+        return t('agent.toolStructured.agentCard.messageSent', 'Messaged');
+      case 'in_progress':
+        return t('agent.toolStructured.agentCard.inProgress', 'Working');
+      case 'wait_timeout':
+        return t('agent.toolStructured.agentCard.waitTimeout', 'Still working');
+      case 'finished':
+        return t('agent.toolStructured.agentCard.finished', 'Finished');
+      case 'needs_attention':
+        if (statusKey(data.status) === 'paused') {
+          return t('agent.toolStructured.agentCard.paused', 'Paused');
+        }
+        if (statusKey(data.status) === 'terminated') {
+          return t(
+            'agent.toolStructured.agentCard.terminated',
+            'Stopped early',
+          );
+        }
+        return t('agent.toolStructured.agentCard.failed', 'Needs attention');
+      case 'stopped':
+        return data.stopped === false
+          ? t('agent.toolStructured.agentCard.stopNoop', 'Already stopped')
+          : t('agent.toolStructured.agentCard.stopped', 'Stopped');
+      case 'deleted':
+        return t('agent.toolStructured.agentCard.deleted', 'Removed');
+      default:
+        return t('agent.toolStructured.agentCard.fallback', 'Sub-agent');
+    }
+  })();
+
+  // Hide raw transport statuses (processed/accepted/pending) — not meaningful to laypeople.
+  const statusLabel = (() => {
+    if (!kind) return null;
+    if (kind === 'instruction_sent' || kind === 'spawned') return null;
+    const raw = (data.status ?? data.responseStatus ?? '').toLowerCase();
+    if (!raw) return null;
+    if (['pending', 'accepted', 'processed', 'started', 'noop'].includes(raw)) {
+      return null;
+    }
+    return data.status ?? data.responseStatus ?? null;
+  })();
+
+  const assistantName = data.assistantName?.trim() || undefined;
+  // Prefer persona name; fall back to session id only when name is unknown.
+  const primaryIdentity = assistantName ?? sessionId ?? undefined;
+
+  const handleOpen = useCallback(() => {
+    if (!sessionId) return;
+    navigate(`/agent/${sessionId}`);
+  }, [navigate, sessionId]);
+
+  const handleCopyResult = useCallback(async () => {
+    if (!resultText || copying) return;
+    setCopying(true);
+    try {
+      await navigator.clipboard.writeText(resultText);
+      toast.success(
+        t('agent.toolStructured.agentCard.copied', 'Result copied'),
+      );
+    } catch (error) {
+      logger.error('Failed to copy child result', error);
+      toast.error(
+        t('agent.toolStructured.agentCard.copyError', 'Failed to copy result'),
+      );
+    } finally {
+      setCopying(false);
+    }
+  }, [copying, resultText, t]);
+
+  if (!kind) return null;
+
+  const Icon = kindIcon(kind, data.status);
+  const canOpen = Boolean(sessionId) && kind !== 'deleted';
+  const showResultPanel =
+    (kind === 'finished' || kind === 'needs_attention') &&
+    resultText.length > 0;
+  const collapsedBodyText =
+    kind === 'instruction_sent'
+      ? instruction
+      : kind === 'spawned'
+        ? mission
+        : undefined;
+  const showWorkspaceMeta = kind === 'spawned';
+
+  return (
+    <div
+      data-testid="tool-structured-agent-session"
+      data-card-kind={kind}
+      className="space-y-2.5 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <Icon
+          className={cn(
+            'mt-0.5 h-4 w-4 shrink-0 text-muted-foreground',
+            kind === 'in_progress' && 'animate-spin',
+          )}
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium">{title}</span>
+            {statusLabel ? (
+              <span
+                className={cn(
+                  'rounded px-1.5 py-0.5 text-xs font-medium capitalize',
+                  kindBadgeClass(kind),
+                )}
+              >
+                {statusLabel}
+              </span>
+            ) : null}
+            {typeof data.turnCount === 'number' ? (
+              <span className="text-xs text-muted-foreground">
+                {t('agent.toolStructured.agentCard.turns', '{{count}} turns', {
+                  count: data.turnCount,
+                })}
+              </span>
+            ) : null}
+          </div>
+
+          {primaryIdentity ? (
+            <p
+              className={cn(
+                'truncate',
+                assistantName
+                  ? 'text-sm font-medium text-foreground'
+                  : 'font-mono text-xs text-muted-foreground',
+              )}
+              title={primaryIdentity}
+            >
+              {primaryIdentity}
+            </p>
+          ) : null}
+
+          {showWorkspaceMeta ? (
+            <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+              {data.workspaceOverride ? (
+                <span
+                  className="truncate"
+                  title={data.workspacePath}
+                  data-testid="agent-session-workspace-override"
+                >
+                  {t(
+                    'agent.toolStructured.agentCard.workspaceOverride',
+                    'Workspace override',
+                  )}
+                  {data.workspacePath ? `: ${data.workspacePath}` : ''}
+                </span>
+              ) : (
+                <span data-testid="agent-session-workspace-default">
+                  {data.workspacePath
+                    ? t(
+                        'agent.toolStructured.agentCard.workspaceInherited',
+                        'Shared workspace (org default)',
+                      )
+                    : t(
+                        'agent.toolStructured.agentCard.workspaceIsolated',
+                        'Isolated workspace (default)',
+                      )}
+                </span>
+              )}
+            </div>
+          ) : null}
+
+          {kind === 'wait_timeout' ? (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'agent.toolStructured.agentCard.waitTimeoutHint',
+                'The parent agent stopped waiting; the child may still be working.',
+              )}
+              {typeof data.timeoutSeconds === 'number'
+                ? ` (${data.timeoutSeconds}s)`
+                : null}
+            </p>
+          ) : null}
+
+          {kind === 'stopped' && data.stopped !== false ? (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'agent.toolStructured.agentCard.stoppedHint',
+                'Forced stop by the parent agent — work may be incomplete.',
+              )}
+            </p>
+          ) : null}
+
+          {kind === 'deleted' ? (
+            <p className="text-xs text-muted-foreground">
+              {typeof data.descendantCount === 'number' &&
+              data.descendantCount > 0
+                ? t(
+                    'agent.toolStructured.agentCard.deletedCascade',
+                    'Removed with {{count}} descendant session(s).',
+                    { count: data.descendantCount },
+                  )
+                : t(
+                    'agent.toolStructured.agentCard.deletedHint',
+                    'Session data removed — no longer available.',
+                  )}
+            </p>
+          ) : null}
+
+          {kind === 'in_progress' && !resultText ? (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'agent.toolStructured.agentCard.noResultYet',
+                'No final answer yet.',
+              )}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {collapsedBodyText ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {kind === 'spawned'
+              ? t('agent.toolStructured.agentCard.task', 'Task')
+              : t('agent.toolStructured.agentCard.message', 'Message')}
+          </div>
+          <ExpandableScrollText
+            text={collapsedBodyText}
+            showLabel={t(
+              'agent.toolStructured.agentCard.showMore',
+              'Show more',
+            )}
+            hideLabel={t(
+              'agent.toolStructured.agentCard.showLess',
+              'Show less',
+            )}
+            data-testid="agent-session-instruction-text"
+          />
+        </div>
+      ) : null}
+
+      {showResultPanel ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {kind === 'finished'
+              ? t('agent.toolStructured.agentCard.result', 'Result')
+              : t('agent.toolStructured.agentCard.lastOutput', 'Last output')}
+          </div>
+          <ExpandableScrollText
+            text={resultText}
+            data-testid="agent-session-result-text"
+          />
+        </div>
+      ) : null}
+
+      {kind === 'wait_timeout' && recentSummaries.length > 0 ? (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {t(
+              'agent.toolStructured.agentCard.recentActivity',
+              'Recent activity',
+            )}
+          </div>
+          <ul className="max-h-32 space-y-1 overflow-y-auto rounded border bg-muted/30 px-2.5 py-2 text-xs text-muted-foreground">
+            {recentSummaries.map((summary, index) => (
+              <li key={index} className="truncate">
+                · {summary}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {(canOpen || (kind === 'finished' && resultText)) && (
+        <div className="flex flex-wrap gap-2">
+          {canOpen ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleOpen}
+            >
+              <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+              {t('agent.toolStructured.agentCard.openChild', 'Open session')}
+            </Button>
+          ) : null}
+          {kind === 'finished' && resultText ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={copying}
+              onClick={() => {
+                void handleCopyResult();
+              }}
+            >
+              <Copy className="mr-1.5 h-3.5 w-3.5" />
+              {t('agent.toolStructured.agentCard.copyResult', 'Copy result')}
+            </Button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/ExpandableScrollText.tsx
+++ b/src/features/agent/components/tool-structured/ExpandableScrollText.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface ExpandableScrollTextProps {
+  text: string;
+  /** Collapsed preview line clamp (default 3). */
+  collapsedLines?: number;
+  /** Max height class when expanded (default max-h-64). */
+  expandedMaxHeightClassName?: string;
+  /** Expand control label (default: Show result). */
+  showLabel?: string;
+  /** Collapse control label (default: Hide result). */
+  hideLabel?: string;
+  className?: string;
+  'data-testid'?: string;
+}
+
+/**
+ * Human skim pattern: short clamp → expand into a fixed-height scroll panel.
+ * Does not grow the chat row without bound.
+ */
+export const ExpandableScrollText: React.FC<ExpandableScrollTextProps> = ({
+  text,
+  collapsedLines = 3,
+  expandedMaxHeightClassName = 'max-h-64',
+  showLabel,
+  hideLabel,
+  className,
+  'data-testid': testId,
+}) => {
+  const { t } = useTranslation('common');
+  const [expanded, setExpanded] = useState(false);
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  const lineCount = trimmed.split(/\r?\n/).length;
+  const roughlyLong = trimmed.length > 180 || lineCount > collapsedLines;
+  const showToggle = roughlyLong;
+  const expandLabel =
+    showLabel ?? t('agent.toolStructured.agentCard.showResult', 'Show result');
+  const collapseLabel =
+    hideLabel ?? t('agent.toolStructured.agentCard.hideResult', 'Hide result');
+
+  return (
+    <div data-testid={testId} className={cn('space-y-1', className)}>
+      <div
+        className={cn(
+          'rounded border bg-muted/40 px-2.5 py-2 text-sm whitespace-pre-wrap break-words',
+          expanded
+            ? cn(expandedMaxHeightClassName, 'overflow-y-auto')
+            : 'overflow-hidden',
+        )}
+        style={
+          expanded
+            ? undefined
+            : {
+                display: '-webkit-box',
+                WebkitLineClamp: collapsedLines,
+                WebkitBoxOrient: 'vertical',
+              }
+        }
+      >
+        {trimmed}
+      </div>
+      {showToggle ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="mr-1 h-3.5 w-3.5" />
+              {collapseLabel}
+            </>
+          ) : (
+            <>
+              <ChevronDown className="mr-1 h-3.5 w-3.5" />
+              {expandLabel}
+            </>
+          )}
+        </Button>
+      ) : null}
+    </div>
+  );
+};

--- a/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
+++ b/src/features/agent/components/tool-structured/ToolStructuredResult.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { FileWriteActions } from './FileWriteActions';
 import { StrReplaceDiffView } from './StrReplaceDiffView';
 import { TerminalOutputBlock } from './TerminalOutputBlock';
+import { AgentSessionToolCard } from './AgentSessionToolCard';
+import {
+  classifyAgentSessionCard,
+  isAgentSessionStructuredTool,
+  parseAgentSessionToolResult,
+} from './agent-types';
 import {
   parseRunShellResult,
   parseStrReplaceResult,
@@ -12,6 +18,8 @@ import {
 export interface ToolStructuredResultProps {
   toolName: string;
   data: unknown;
+  /** Optional tool-call arguments (e.g. task / message for agent cards). */
+  toolArgs?: Record<string, unknown>;
 }
 
 /**
@@ -19,7 +27,7 @@ export interface ToolStructuredResultProps {
  * Returns null when the tool is unsupported or the payload fails validation.
  *
  * Extending for a new tool:
- * 1. Add a Zod schema + parse* helper in `./types`
+ * 1. Add a Zod schema + parse* helper in `./types` (or domain module)
  * 2. Add a `case` here that renders the view
  * 3. Register the same key in {@link canRenderStructuredToolResult}
  * Visibility override (always-visible compact UI) follows automatically via
@@ -28,6 +36,7 @@ export interface ToolStructuredResultProps {
 export const ToolStructuredResult: React.FC<ToolStructuredResultProps> = ({
   toolName,
   data,
+  toolArgs,
 }) => {
   const key = resolveStructuredToolKey(toolName);
 
@@ -43,6 +52,23 @@ export const ToolStructuredResult: React.FC<ToolStructuredResultProps> = ({
     case 'workspace__runShell': {
       const parsed = parseRunShellResult(data);
       return parsed ? <TerminalOutputBlock data={parsed} /> : null;
+    }
+    case 'agent__startSession':
+    case 'agent__messageToSession':
+    case 'agent__checkSession':
+    case 'agent__stopSession':
+    case 'agent__deleteSession': {
+      const parsed = parseAgentSessionToolResult(data);
+      if (!parsed || !classifyAgentSessionCard(toolName, parsed)) {
+        return null;
+      }
+      return (
+        <AgentSessionToolCard
+          toolName={toolName}
+          data={parsed}
+          toolArgs={toolArgs}
+        />
+      );
     }
     default:
       return null;
@@ -65,7 +91,12 @@ export function canRenderStructuredToolResult(
       return parseStrReplaceResult(data) !== null;
     case 'workspace__runShell':
       return parseRunShellResult(data) !== null;
-    default:
-      return false;
+    default: {
+      if (!isAgentSessionStructuredTool(toolName)) return false;
+      const parsed = parseAgentSessionToolResult(data);
+      return (
+        parsed !== null && classifyAgentSessionCard(toolName, parsed) !== null
+      );
+    }
   }
 }

--- a/src/features/agent/components/tool-structured/__tests__/AgentSessionToolCard.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/AgentSessionToolCard.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ToolStructuredResult } from '../ToolStructuredResult';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/lib/backend', () => ({
+  openPathWithDefaultApp: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderAgentCard(
+  toolName: string,
+  data: Record<string, unknown>,
+  toolArgs?: Record<string, unknown>,
+) {
+  return render(
+    <MemoryRouter>
+      <ToolStructuredResult
+        toolName={toolName}
+        data={data}
+        toolArgs={toolArgs}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('ToolStructuredResult agent session cards', () => {
+  it('renders spawn card with assistant name, workspace override, and collapsed mission', () => {
+    const longMission = Array.from(
+      { length: 6 },
+      (_, i) => `Mission line ${i + 1}`,
+    ).join('\n');
+
+    renderAgentCard(
+      'agent__startSession',
+      {
+        sessionId: 'a1b2c3d4e5',
+        status: 'started',
+        responseStatus: 'pending',
+        assistantName: 'Writer Agent',
+        workspaceOverride: true,
+        workspacePath: 'C:/work/shared',
+        task: longMission,
+      },
+    );
+
+    const card = screen.getByTestId('tool-structured-agent-session');
+    expect(card).toHaveAttribute('data-card-kind', 'spawned');
+    expect(screen.getByText('Writer Agent')).toBeInTheDocument();
+    expect(screen.queryByText('a1b2c3d4e5')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('agent-session-workspace-override'),
+    ).toHaveTextContent(/Workspace override/i);
+    expect(
+      screen.getByTestId('agent-session-instruction-text'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /open session/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows isolated workspace when override was not set', () => {
+    renderAgentCard('agent__startSession', {
+      sessionId: 'a1b2c3d4e5',
+      status: 'started',
+      responseStatus: 'pending',
+      assistantName: 'Researcher',
+      workspaceOverride: false,
+      task: 'Quick task',
+    });
+
+    expect(
+      screen.getByTestId('agent-session-workspace-default'),
+    ).toHaveTextContent(/Isolated workspace/i);
+  });
+
+  it('renders harvest finished card with expandable result', () => {
+    const longResult = Array.from({ length: 8 }, (_, i) => `Line ${i + 1}`).join(
+      '\n',
+    );
+
+    renderAgentCard('agent__checkSession', {
+      sessionId: 'a1b2c3d4e5',
+      status: 'idle',
+      responseStatus: 'success',
+      turnCount: 3,
+      assistantName: 'Writer',
+      result: longResult,
+    });
+
+    expect(screen.getByTestId('tool-structured-agent-session')).toHaveAttribute(
+      'data-card-kind',
+      'finished',
+    );
+    expect(screen.getByTestId('agent-session-result-text')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show result/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /show result/i }));
+    expect(
+      screen.getByRole('button', { name: /hide result/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders wait timeout without agent wait CTAs', () => {
+    renderAgentCard('agent__checkSession', {
+      sessionId: 'a1b2c3d4e5',
+      status: 'busy',
+      responseStatus: 'timeout',
+      timeout: true,
+      timeoutSeconds: 600,
+      latestMessages: [{ role: 'assistant', summary: 'Drafting section 3' }],
+    });
+
+    const card = screen.getByTestId('tool-structured-agent-session');
+    expect(card).toHaveAttribute('data-card-kind', 'wait_timeout');
+    expect(screen.getByText(/stopped waiting/i)).toBeInTheDocument();
+    expect(screen.getByText(/Drafting section 3/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /wait again/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders message card with assistant name, not session id or jargon', () => {
+    renderAgentCard(
+      'agent__messageToSession',
+      {
+        sessionId: '01c8d89ccb',
+        messageId: 'msg-1',
+        status: 'processed',
+        responseStatus: 'pending',
+        assistantName: 'Research Buddy',
+        instruction: 'Please add margins to the draft',
+      },
+    );
+
+    const card = screen.getByTestId('tool-structured-agent-session');
+    expect(card).toHaveAttribute('data-card-kind', 'instruction_sent');
+    expect(screen.getByText('Messaged')).toBeInTheDocument();
+    expect(screen.getByText('Research Buddy')).toBeInTheDocument();
+    expect(screen.queryByText('01c8d89ccb')).not.toBeInTheDocument();
+    expect(screen.queryByText(/instruction sent/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/processed/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Message')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('agent-session-instruction-text'),
+    ).toHaveTextContent(/Please add margins/i);
+  });
+
+  it('navigates to child session on open', () => {
+    navigateMock.mockClear();
+
+    renderAgentCard(
+      'agent__messageToSession',
+      {
+        sessionId: 'a1b2c3d4e5',
+        messageId: 'msg-1',
+        status: 'accepted',
+        responseStatus: 'pending',
+        assistantName: 'Helper',
+      },
+      { message: 'Please add margins' },
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open session/i }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith('/agent/a1b2c3d4e5');
+  });
+
+  it('hides open for deleted sessions', () => {
+    renderAgentCard('agent__deleteSession', {
+      sessionId: 'a1b2c3d4e5',
+      deleted: true,
+      descendantCount: 1,
+      responseStatus: 'success',
+    });
+
+    expect(screen.getByTestId('tool-structured-agent-session')).toHaveAttribute(
+      'data-card-kind',
+      'deleted',
+    );
+    expect(
+      screen.queryByRole('button', { name: /open session/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/agent/components/tool-structured/__tests__/agent-types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/agent-types.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyAgentSessionCard,
+  parseAgentSessionToolResult,
+  resolveAgentSessionId,
+} from '../agent-types';
+import { canRenderStructuredToolResult } from '../ToolStructuredResult';
+
+describe('agent session structured types', () => {
+  it('parseAgentSessionToolResult accepts checkSession harvest payload', () => {
+    const parsed = parseAgentSessionToolResult({
+      toolName: 'agent__checkSession',
+      sessionId: 'a1b2c3d4e5',
+      status: 'idle',
+      responseStatus: 'success',
+      turnCount: 4,
+      result: 'Final answer',
+      assistantName: 'Writer',
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.result).toBe('Final answer');
+    expect(
+      classifyAgentSessionCard('agent__checkSession', parsed!),
+    ).toBe('finished');
+  });
+
+  it('classifies wait timeout separately from in-progress', () => {
+    const parsed = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'busy',
+      responseStatus: 'timeout',
+      timeout: true,
+      timeoutSeconds: 3600,
+      turnCount: 7,
+    });
+    expect(parsed).not.toBeNull();
+    expect(classifyAgentSessionCard('agent__checkSession', parsed!)).toBe(
+      'wait_timeout',
+    );
+    expect(classifyAgentSessionCard('agent__startSession', parsed!)).toBe(
+      'wait_timeout',
+    );
+  });
+
+  it('classifies spawn and instruction ack as pending outcomes', () => {
+    const spawn = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'started',
+      responseStatus: 'pending',
+    });
+    expect(classifyAgentSessionCard('agent__startSession', spawn!)).toBe(
+      'spawned',
+    );
+
+    const inject = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      messageId: 'msg-1',
+      status: 'accepted',
+      responseStatus: 'pending',
+    });
+    expect(classifyAgentSessionCard('agent__messageToSession', inject!)).toBe(
+      'instruction_sent',
+    );
+  });
+
+  it('does not treat responseStatus success alone as harvest finished', () => {
+    // Regression: success/result heuristics must not override spawn/inject acks
+    // or mis-label non-terminal session status.
+    const falseSpawnHarvest = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'started',
+      responseStatus: 'success',
+      result: 'misleading body',
+      task: 'do something',
+    });
+    expect(
+      classifyAgentSessionCard('agent__startSession', falseSpawnHarvest!),
+    ).toBe('spawned');
+
+    const falseInjectHarvest = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'busy',
+      responseStatus: 'success',
+      result: 'not a final answer',
+      instruction: 'follow up',
+    });
+    expect(
+      classifyAgentSessionCard('agent__messageToSession', falseInjectHarvest!),
+    ).toBe('instruction_sent');
+  });
+
+  it('classifies wait-settled startSession/messageToSession as harvest kinds', () => {
+    const waitSettled = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'idle',
+      responseStatus: 'success',
+      result: 'Final answer',
+    });
+    expect(classifyAgentSessionCard('agent__startSession', waitSettled!)).toBe(
+      'finished',
+    );
+    expect(
+      classifyAgentSessionCard('agent__messageToSession', waitSettled!),
+    ).toBe('finished');
+
+    const waitFailed = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'error',
+      responseStatus: 'error',
+      result: 'boom',
+    });
+    expect(classifyAgentSessionCard('agent__startSession', waitFailed!)).toBe(
+      'needs_attention',
+    );
+  });
+
+  it('classifies paused/error/terminated as needs_attention', () => {
+    const paused = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'paused',
+      responseStatus: 'paused',
+      result: 'Waiting on approval',
+    });
+    expect(classifyAgentSessionCard('agent__checkSession', paused!)).toBe(
+      'needs_attention',
+    );
+
+    const failed = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      status: 'error',
+      responseStatus: 'error',
+      result: 'Permission denied',
+    });
+    expect(classifyAgentSessionCard('agent__checkSession', failed!)).toBe(
+      'needs_attention',
+    );
+  });
+
+  it('classifies stop and delete', () => {
+    const stopped = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      stopped: true,
+      status: 'terminated',
+      responseStatus: 'success',
+    });
+    expect(classifyAgentSessionCard('agent__stopSession', stopped!)).toBe(
+      'stopped',
+    );
+
+    const stopNoop = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      stopped: false,
+      status: 'idle',
+      responseStatus: 'noop',
+    });
+    expect(classifyAgentSessionCard('agent__stopSession', stopNoop!)).toBe(
+      'stopped',
+    );
+
+    const stopFailed = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      stopped: false,
+      status: 'busy',
+      responseStatus: 'error',
+    });
+    expect(classifyAgentSessionCard('agent__stopSession', stopFailed!)).toBe(
+      'needs_attention',
+    );
+
+    const deleted = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      deleted: true,
+      descendantCount: 2,
+      deletedIds: ['a1b2c3d4e5', 'bbbbbbbbbb', 'cccccccccc'],
+      responseStatus: 'success',
+    });
+    expect(classifyAgentSessionCard('agent__deleteSession', deleted!)).toBe(
+      'deleted',
+    );
+
+    const deleteWithoutMarker = parseAgentSessionToolResult({
+      sessionId: 'a1b2c3d4e5',
+      responseStatus: 'success',
+    });
+    expect(
+      classifyAgentSessionCard('agent__deleteSession', deleteWithoutMarker!),
+    ).toBeNull();
+  });
+
+  it('rejects payloads without session identity', () => {
+    expect(parseAgentSessionToolResult({ responseStatus: 'pending' })).toBeNull();
+  });
+
+  it('resolveAgentSessionId prefers sessionId over resourceId', () => {
+    expect(
+      resolveAgentSessionId({
+        sessionId: 'abc',
+        resourceId: 'xyz',
+      }),
+    ).toBe('abc');
+  });
+
+  it('canRenderStructuredToolResult accepts agent session tools', () => {
+    expect(
+      canRenderStructuredToolResult('agent__checkSession', {
+        sessionId: 'a1b2c3d4e5',
+        status: 'idle',
+        responseStatus: 'success',
+        result: 'done',
+      }),
+    ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('agent__startSession', {
+        sessionId: 'a1b2c3d4e5',
+        status: 'started',
+        responseStatus: 'pending',
+      }),
+    ).toBe(true);
+    expect(
+      canRenderStructuredToolResult('agent__listAgents', {
+        sessionId: 'a1b2c3d4e5',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/agent/components/tool-structured/agent-types.ts
+++ b/src/features/agent/components/tool-structured/agent-types.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+import { resolveStructuredToolKey } from './types';
+
+const LatestMessageSchema = z.object({
+  role: z.string(),
+  summary: z.string(),
+  createdAt: z.number().optional(),
+});
+
+/**
+ * Shared shape for agent__* structured_content payloads.
+ * Backend fields are camelCase; optional keys vary by tool / outcome.
+ */
+export const AgentSessionToolResultSchema = z
+  .object({
+    toolName: z.string().optional(),
+    resourceType: z.string().optional(),
+    resourceId: z.string().optional(),
+    message: z.string().optional(),
+    responseStatus: z.string().optional(),
+    sessionId: z.string().optional(),
+    status: z.string().optional(),
+    turnCount: z.number().optional(),
+    workspacePath: z.string().optional(),
+    /** True when caller passed workspaceOverride explicitly. */
+    workspaceOverride: z.boolean().optional(),
+    assistantName: z.string().optional(),
+    assistantId: z.string().optional(),
+    /** Mission text from startSession (also may come from tool args). */
+    task: z.string().optional(),
+    /** Instruction text from messageToSession. */
+    instruction: z.string().optional(),
+    result: z.string().optional(),
+    timeout: z.boolean().optional(),
+    timeoutSeconds: z.number().optional(),
+    latestMessages: z.array(LatestMessageSchema).optional(),
+    messageId: z.string().optional(),
+    stopped: z.boolean().optional(),
+    deleted: z.boolean().optional(),
+    deletedIds: z.array(z.string()).optional(),
+    descendantCount: z.number().optional(),
+    abnormalTermination: z.boolean().optional(),
+    recoverable: z.boolean().optional(),
+    hasMoreDetail: z.boolean().optional(),
+    orgId: z.string().optional(),
+  })
+  .passthrough();
+
+export type AgentSessionToolResult = z.infer<
+  typeof AgentSessionToolResultSchema
+>;
+
+export type AgentSessionCardKind =
+  | 'spawned'
+  | 'instruction_sent'
+  | 'in_progress'
+  | 'wait_timeout'
+  | 'finished'
+  | 'needs_attention'
+  | 'stopped'
+  | 'deleted';
+
+const AGENT_SESSION_TOOLS = new Set([
+  'agent__startSession',
+  'agent__messageToSession',
+  'agent__checkSession',
+  'agent__stopSession',
+  'agent__deleteSession',
+]);
+
+export function isAgentSessionStructuredTool(toolName: string): boolean {
+  return AGENT_SESSION_TOOLS.has(resolveStructuredToolKey(toolName));
+}
+
+export function parseAgentSessionToolResult(
+  value: unknown,
+): AgentSessionToolResult | null {
+  const parsed = AgentSessionToolResultSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const data = parsed.data;
+  // Require at least a session reference or delete/stop marker so random objects fail closed.
+  if (
+    !data.sessionId &&
+    !data.resourceId &&
+    data.deleted !== true &&
+    data.stopped === undefined
+  ) {
+    return null;
+  }
+  return data;
+}
+
+function statusKey(status: string | undefined): string {
+  return (status ?? '').toLowerCase();
+}
+
+function isAttentionStatus(status: string | undefined): boolean {
+  return ['paused', 'error', 'failed', 'terminated'].includes(
+    statusKey(status),
+  );
+}
+
+function isFinishedStatus(status: string | undefined): boolean {
+  return statusKey(status) === 'idle';
+}
+
+/**
+ * Map tool name + structured payload to a human card kind.
+ * Wait/poll are agent parameters — kinds describe outcomes, not user actions.
+ *
+ * Harvest/attention require real session lifecycle status (`idle` / `paused` /
+ * `error` / …). Do not treat `responseStatus === 'success'` alone as finished —
+ * stop/delete/spawn envelopes can also carry that string.
+ */
+export function classifyAgentSessionCard(
+  toolName: string,
+  data: AgentSessionToolResult,
+): AgentSessionCardKind | null {
+  const key = resolveStructuredToolKey(toolName);
+  if (!AGENT_SESSION_TOOLS.has(key)) return null;
+
+  if (key === 'agent__deleteSession') {
+    // Require explicit deleted marker — do not infer from responseStatus alone.
+    return data.deleted === true ? 'deleted' : null;
+  }
+
+  if (key === 'agent__stopSession') {
+    // Successful stop sets status=terminated; only treat explicit error as failure.
+    if (data.responseStatus === 'error') {
+      return 'needs_attention';
+    }
+    return 'stopped';
+  }
+
+  if (data.timeout === true || data.responseStatus === 'timeout') {
+    return 'wait_timeout';
+  }
+
+  // Settled child outcomes — driven by session status, not responseStatus alone.
+  // (startSession/messageToSession wait=* reuse checkSession-shaped payloads.)
+  if (isAttentionStatus(data.status)) {
+    return 'needs_attention';
+  }
+  if (isFinishedStatus(data.status)) {
+    return 'finished';
+  }
+
+  if (key === 'agent__startSession') {
+    return 'spawned';
+  }
+  if (key === 'agent__messageToSession') {
+    return 'instruction_sent';
+  }
+  if (key === 'agent__checkSession') {
+    return 'in_progress';
+  }
+
+  return null;
+}
+
+export function resolveAgentSessionId(
+  data: AgentSessionToolResult,
+): string | null {
+  const id = data.sessionId?.trim() || data.resourceId?.trim();
+  return id && id.length > 0 ? id : null;
+}
+
+export function readAgentToolArgString(
+  toolArgs: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = toolArgs?.[key];
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}


### PR DESCRIPTION
## Summary
- Add structured UI cards for `agent__startSession` / `messageToSession` / `checkSession` / `stopSession` / `deleteSession` that prefer assistant name over session ids and show task/message context for laypeople
- Enrich backend structured_content with assistantName (and related fields); persist `structuredContent` through message reload via the error-column JSON envelope
- Classify harvest outcomes from session lifecycle status (not `responseStatus` alone); harden stop/delete classification

Fixes #1737

## Test plan
- [ ] Spawn a child session and confirm card shows assistant name + task, Open session works
- [ ] messageToSession shows Messaged + assistant name + message body (no hex id / processed badge)
- [ ] checkSession wait timeout / finished harvest cards render; Copy result works on finished
- [ ] Switch away and reopen parent session — structured cards still render after DB reload
- [ ] `pnpm exec vitest run src/features/agent/components/tool-structured/__tests__`

Made with [Cursor](https://cursor.com)