### PR TITLE
fix(agent): prevent /clear hang leaving pending requests stuck

### DIFF
--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -875,10 +875,7 @@ impl AgentSessionManager {
                     .close_agent_browser_sessions(&browser_session_id)
                     .await
                 {
-                    log::warn!(
-                        "Failed to close browser session during reset: {}",
-                        e
-                    );
+                    log::warn!("Failed to close browser session during reset: {}", e);
                 }
             }
         });

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -750,6 +750,42 @@ impl AgentSessionManager {
     }
 
     pub async fn reset_session(&self, session_id: &str) -> Result<(), String> {
+        // `/clear` must return quickly with Idle + empty history/pending queue.
+        //
+        // Observed failure mode (session x9b7rtc… 08:12):
+        // 1. Clear awaited browser dispose (often 5s+ timeout) BEFORE wiping
+        //    messages / emitting ResourceUpdated.
+        // 2. FE kept showing history and `agent_execute_command` stayed pending,
+        //    so the user issued another `/clear` (nested clear).
+        // 3. Meanwhile a new inject could reach Busy; the late clear then wiped
+        //    expected_response without re-settling Idle → zombie Busy → later
+        //    submits sat in pending forever.
+        //
+        // Fix: settle transcript/status first, emit clear, return; browser
+        // teardown is best-effort and must not gate the command.
+        async fn settle_idle(
+            manager: &AgentSessionManager,
+            session_id: &str,
+            is_active: bool,
+        ) -> Result<(), String> {
+            if is_active {
+                crate::agent::lifecycle::update_session_status(
+                    &manager.session_repo,
+                    &manager.active_sessions,
+                    &manager.app_handle,
+                    session_id,
+                    crate::repositories::SessionStatus::Idle,
+                )
+                .await
+            } else {
+                manager
+                    .session_repo
+                    .update_status(session_id, crate::repositories::SessionStatus::Idle)
+                    .await
+                    .map_err(|e| format!("Failed to update session status in DB: {}", e))
+            }
+        }
+
         // 0. Cancel workflow if running
         {
             let sessions = self.active_sessions.read().await;
@@ -758,40 +794,12 @@ impl AgentSessionManager {
             }
         }
 
-        // 0b. Transition session status to Idle (DB and Memory) and release active permit
+        // 0b. Transition to Idle early (release active permit / UI feedback)
         let is_active = {
             let sessions = self.active_sessions.read().await;
             sessions.contains_key(session_id)
         };
-        if is_active {
-            crate::agent::lifecycle::update_session_status(
-                &self.session_repo,
-                &self.active_sessions,
-                &self.app_handle,
-                session_id,
-                crate::repositories::SessionStatus::Idle,
-            )
-            .await?;
-        } else {
-            self.session_repo
-                .update_status(session_id, crate::repositories::SessionStatus::Idle)
-                .await
-                .map_err(|e| format!("Failed to update session status in DB: {}", e))?;
-        }
-
-        // 0c. Close browser sessions associated with the agent
-        let browser_server = self
-            .app_handle
-            .try_state::<crate::services::InteractiveBrowserServer>();
-        if let Some(browser_svc) = browser_server {
-            if let Err(e) = browser_svc
-                .inner()
-                .close_agent_browser_sessions(session_id)
-                .await
-            {
-                log::warn!("Failed to close browser session during reset: {}", e);
-            }
-        }
+        settle_idle(self, session_id, is_active).await?;
 
         // 1. Delete messages from DB
         let repo = crate::state::get_message_repository();
@@ -820,12 +828,60 @@ impl AgentSessionManager {
             }
         }
 
-        // 5. Notify frontend
+        // 5. Drop durable + in-memory pending waiters (clear is a hard reset)
+        if let Err(e) = crate::agent::pending_queue::discard_all_pending_messages(
+            &self.active_sessions,
+            Some(&self.app_handle),
+            session_id,
+        )
+        .await
+        {
+            log::warn!(
+                "Failed to discard pending messages during reset for {}: {}",
+                session_id,
+                e
+            );
+        }
+
+        // 6. Re-cancel + force Idle again — closes mid-clear Busy race window
+        {
+            let sessions = self.active_sessions.read().await;
+            if let Some(session) = sessions.get(session_id) {
+                session.cancellation_token.cancel();
+            }
+        }
+        let is_active = {
+            let sessions = self.active_sessions.read().await;
+            sessions.contains_key(session_id)
+        };
+        settle_idle(self, session_id, is_active).await?;
+
+        // 7. Notify frontend that history is gone (drives UI clear)
         crate::agent::tauri_events::emit_resource_updated(
             "session",
             "clear",
             Some(session_id.to_string()),
         );
+
+        // 8. Browser dispose can hang for seconds — never block `/clear` on it
+        let app_handle = self.app_handle.clone();
+        let browser_session_id = session_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            let browser_server =
+                app_handle.try_state::<crate::services::InteractiveBrowserServer>();
+            if let Some(browser_svc) = browser_server {
+                if let Err(e) = browser_svc
+                    .inner()
+                    .close_agent_browser_sessions(&browser_session_id)
+                    .await
+                {
+                    log::warn!(
+                        "Failed to close browser session during reset: {}",
+                        e
+                    );
+                }
+            }
+        });
 
         Ok(())
     }

--- a/src/features/agent/components/AgentChatInput.tsx
+++ b/src/features/agent/components/AgentChatInput.tsx
@@ -143,8 +143,10 @@ export function AgentChatInput({ children }: AgentChatInputProps) {
   );
 
   // Cancel is only for an active agent turn. Do NOT map slash-command
-  // `isSubmitting` (e.g. hung `/clear`) or session hydrate onto Cancel —
+  // `isSubmitting` (e.g. in-flight `/clear`) or session hydrate onto Cancel —
   // that falsely enables Cancel while workflowStatus is still idle.
+  // `/clear` itself must finish quickly on the backend (browser dispose is
+  // detached); FE also clears history optimistically and ignores nested submit.
   const isBusy = useMemo(() => {
     return (
       workflowStatus === 'busy' ||

--- a/src/features/agent/hooks/__tests__/useChatSubmit.test.tsx
+++ b/src/features/agent/hooks/__tests__/useChatSubmit.test.tsx
@@ -9,7 +9,10 @@ const mockState = vi.hoisted(() => ({
   clearPendingFiles: vi.fn(),
   refetchSessionFiles: vi.fn(),
   onSubmitted: vi.fn(),
+  onClearSession: vi.fn(),
   toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  safeInvoke: vi.fn(),
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({
@@ -27,6 +30,7 @@ vi.mock('@/hooks/use-settings', () => ({
 vi.mock('sonner', () => ({
   toast: {
     error: mockState.toastError,
+    success: mockState.toastSuccess,
   },
 }));
 
@@ -45,11 +49,19 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
+vi.mock('@/lib/backend/core', () => ({
+  safeInvoke: (...args: unknown[]) => mockState.safeInvoke(...args),
+}));
+
 describe('useChatSubmit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.commitPendingFiles.mockResolvedValue([]);
     mockState.submit.mockResolvedValue(undefined);
+    mockState.safeInvoke.mockResolvedValue({
+      success: true,
+      message: 'cleared',
+    });
   });
 
   it('blocks an obvious oversize first input before submit', async () => {
@@ -160,5 +172,100 @@ describe('useChatSubmit', () => {
 
     expect(mockState.toastError).not.toHaveBeenCalled();
     expect(mockState.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears session history optimistically for /clear before invoke resolves', async () => {
+    let resolveInvoke:
+      | ((value: { success: boolean; message: string }) => void)
+      | undefined;
+    mockState.safeInvoke.mockImplementation(
+      () =>
+        new Promise<{ success: boolean; message: string }>((resolve) => {
+          resolveInvoke = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useChatSubmit({
+        session: { id: 'session-1' },
+        submit: mockState.submit,
+        pendingFiles: [],
+        commitPendingFiles: mockState.commitPendingFiles,
+        clearPendingFiles: mockState.clearPendingFiles,
+        refetchSessionFiles: mockState.refetchSessionFiles,
+        hasPersistedMessages: true,
+        onClearSession: mockState.onClearSession,
+      }),
+    );
+
+    act(() => {
+      result.current.setInput('/clear');
+    });
+
+    let submitPromise: Promise<void> | undefined;
+    act(() => {
+      submitPromise = result.current.handleSubmit();
+    });
+
+    expect(mockState.onClearSession).toHaveBeenCalledTimes(1);
+    expect(mockState.clearPendingFiles).toHaveBeenCalledTimes(1);
+    expect(mockState.safeInvoke).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInvoke?.({ success: true, message: 'Session cleared' });
+      await submitPromise;
+    });
+
+    expect(mockState.toastSuccess).toHaveBeenCalledWith('Session cleared');
+    expect(mockState.onClearSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores nested submit while a command invoke is in flight', async () => {
+    let resolveInvoke:
+      | ((value: { success: boolean; message: string }) => void)
+      | undefined;
+    mockState.safeInvoke.mockImplementation(
+      () =>
+        new Promise<{ success: boolean; message: string }>((resolve) => {
+          resolveInvoke = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useChatSubmit({
+        session: { id: 'session-1' },
+        submit: mockState.submit,
+        pendingFiles: [],
+        commitPendingFiles: mockState.commitPendingFiles,
+        clearPendingFiles: mockState.clearPendingFiles,
+        refetchSessionFiles: mockState.refetchSessionFiles,
+        hasPersistedMessages: true,
+        onClearSession: mockState.onClearSession,
+      }),
+    );
+
+    act(() => {
+      result.current.setInput('/clear');
+    });
+
+    let firstSubmit: Promise<void> | undefined;
+    act(() => {
+      firstSubmit = result.current.handleSubmit();
+    });
+
+    act(() => {
+      result.current.setInput('/clear');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mockState.safeInvoke).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInvoke?.({ success: true, message: 'Session cleared' });
+      await firstSubmit;
+    });
   });
 });

--- a/src/features/agent/hooks/useChatSubmit.ts
+++ b/src/features/agent/hooks/useChatSubmit.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { createId } from '@paralleldrive/cuid2';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -65,10 +65,17 @@ export function useChatSubmit({
   const { value: settings } = useSettings();
   const [input, setInput] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Ref avoids stale closure and blocks nested `/clear` while invoke is in flight.
+  const isSubmittingRef = useRef(false);
 
   const handleSubmit = useCallback(
     async (e?: React.FormEvent<HTMLFormElement>) => {
       e?.preventDefault();
+
+      if (isSubmittingRef.current) {
+        logger.info('Submit ignored: already submitting');
+        return;
+      }
 
       const messageText = input.trim();
       const hasInput = messageText.length > 0 || pendingFiles.length > 0;
@@ -84,9 +91,17 @@ export function useChatSubmit({
 
       // Intercept CLI command execution (allowed before Session Ready)
       if (messageText.startsWith('/')) {
+        isSubmittingRef.current = true;
         setIsSubmitting(true);
         const currentInput = input;
         setInput(''); // Clear input immediately for better UX
+        // Optimistic UI clear: do not wait for invoke. Backend also emits
+        // resourceUpdated(clear); without this, a slow command looks like a
+        // failed clear and users re-issue `/clear` (nested reset race).
+        if (messageText === '/clear') {
+          onClearSession?.();
+          clearPendingFiles();
+        }
 
         try {
           const result = await safeInvoke<{
@@ -97,10 +112,8 @@ export function useChatSubmit({
             commandText: messageText,
           });
           if (result.success) {
-            clearPendingFiles();
-            if (messageText === '/clear') {
-              onClearSession?.();
-            } else {
+            if (messageText !== '/clear') {
+              clearPendingFiles();
               const permissionMode = parsePermissionCommand(messageText);
               if (permissionMode) {
                 onExecutionModeChange?.(permissionMode);
@@ -118,6 +131,7 @@ export function useChatSubmit({
           );
           setInput(currentInput); // Restore input on error
         } finally {
+          isSubmittingRef.current = false;
           setIsSubmitting(false);
         }
         return;
@@ -210,6 +224,7 @@ export function useChatSubmit({
       }
 
       setIsSubmitting(true);
+      isSubmittingRef.current = true;
       const currentInput = input;
       setInput(''); // Clear input immediately for better UX
       clearPendingFiles();
@@ -238,6 +253,7 @@ export function useChatSubmit({
         setInput(currentInput);
         logger.error('Failed to submit message:', err);
       } finally {
+        isSubmittingRef.current = false;
         setIsSubmitting(false);
       }
     },


### PR DESCRIPTION
## Summary
- `/clear` no longer awaits browser session dispose (spawned best-effort), so `agent_execute_command` and `ResourceUpdated(clear)` complete quickly instead of hanging for seconds and looking failed.
- `reset_session` re-cancels and re-settles Idle after wipe, and discards durable pending waiters, closing the mid-clear Busy race that left new submits queued forever.
- Frontend clears history optimistically for `/clear` and ignores nested submits while a command invoke is in flight.

## Test plan
- [ ] While a browser session is open, run `/clear` — chat history should clear immediately; command should not hang ~5s.
- [ ] Rapidly try a second `/clear` while the first is in flight — second submit ignored; no nested reset race.
- [ ] After `/clear`, send a new user message — workflow should start (Queued→Busy), not sit as pending indefinitely.
- [ ] `npx vitest run src/features/agent/hooks/__tests__/useChatSubmit.test.tsx`

Made with [Cursor](https://cursor.com)