### PR TITLE
fix(windows): keep minimized app visible on the taskbar

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4308,7 +4308,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libragent"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "agent-response-guards",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 agent-response-guards = { path = "agent-response-guards" }
-tauri = { version = "2", features = ["tray-icon", "protocol-asset", "test"] }
+tauri = { version = "2", features = ["protocol-asset", "test"] }
 tauri-plugin-opener = "2"
 
 serde = { version = "1", features = ["derive"] }
@@ -74,8 +74,14 @@ handlebars = "6.4"
 ammonia = "4.0"
 jsonschema = "0.49"
 
-# Windows-only: ANSI code-page decode for stdio; ExpandEnvironmentStrings for registry PATH
-windows-sys = { version = "0.59", features = ["Win32_Globalization", "Win32_System_Environment"] }
+# Windows-only: ANSI code-page decode for stdio; ExpandEnvironmentStrings for registry PATH;
+# taskbar visibility styles (APPWINDOW / TOOLWINDOW) for minimize behavior.
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Globalization",
+  "Win32_System_Environment",
+  "Win32_UI_WindowsAndMessaging",
+] }
 
 # File parsing dependencies
 docx-rs = "0.4"           # DOCX parsing

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -364,6 +364,33 @@ pub fn run() {
                 reset_assistant_skills,
             ])
             .setup(|app| lifecycle::app_setup::setup_app(app))
+            .on_window_event(|window, event| {
+                // Re-assert taskbar membership around minimize/focus changes on Windows.
+                // Native minimize can transiently drop the shell taskbar button when a
+                // tray host / tool-window style is also present in the process.
+                #[cfg(windows)]
+                {
+                    use tauri::WindowEvent;
+                    if window.label() != "main" {
+                        return;
+                    }
+                    let minimized = window.is_minimized().unwrap_or(false);
+                    let should_ensure = minimized
+                        || matches!(
+                            event,
+                            WindowEvent::Focused(true) | WindowEvent::ScaleFactorChanged { .. }
+                        );
+                    if should_ensure {
+                        lifecycle::windows_taskbar::ensure_main_window_taskbar_button(
+                            window.app_handle(),
+                        );
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = (window, event);
+                }
+            })
             .build(tauri::generate_context!())
             .expect("error while building tauri application")
             .run(|app_handle, event| {

--- a/src-tauri/src/lifecycle/app_setup/mod.rs
+++ b/src-tauri/src/lifecycle/app_setup/mod.rs
@@ -360,6 +360,9 @@ pub fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Windows: keep minimize → taskbar behavior reliable (no orphan tray tool-window).
+    crate::lifecycle::windows_taskbar::ensure_main_window_taskbar_button(app.handle());
+
     info!("✅ LibrAgent setup completed successfully");
     Ok(())
 }

--- a/src-tauri/src/lifecycle/mod.rs
+++ b/src-tauri/src/lifecycle/mod.rs
@@ -9,6 +9,7 @@ pub mod repositories;
 pub mod retry_utils;
 pub mod schema_version; // Schema version tracking (matches migration #10 table layout)
 pub mod settings;
+pub mod windows_taskbar;
 
 use crate::session::get_session_manager;
 use crate::state::{set_sqlite_db_url, start_startup_timer};

--- a/src-tauri/src/lifecycle/windows_taskbar.rs
+++ b/src-tauri/src/lifecycle/windows_taskbar.rs
@@ -7,10 +7,7 @@
 //! This module re-asserts `WS_EX_APPWINDOW` (and clears `WS_EX_TOOLWINDOW`) and
 //! calls Tauri's `set_skip_taskbar(false)` after startup and around minimize.
 
-use log::{debug, warn};
-use tauri::{AppHandle, Manager, Runtime};
-
-const MAIN_WINDOW_LABEL: &str = "main";
+use tauri::{AppHandle, Runtime};
 
 /// Ensure the main window stays listed on the Windows taskbar.
 pub fn ensure_main_window_taskbar_button<R: Runtime>(app: &AppHandle<R>) {
@@ -21,6 +18,11 @@ pub fn ensure_main_window_taskbar_button<R: Runtime>(app: &AppHandle<R>) {
 
     #[cfg(windows)]
     {
+        use log::{debug, warn};
+        use tauri::Manager;
+
+        const MAIN_WINDOW_LABEL: &str = "main";
+
         let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
             debug!("Taskbar ensure skipped: main window not ready");
             return;
@@ -45,6 +47,7 @@ pub fn ensure_main_window_taskbar_button<R: Runtime>(app: &AppHandle<R>) {
 
 #[cfg(windows)]
 fn apply_appwindow_exstyle(hwnd: isize) {
+    use log::debug;
     use windows_sys::Win32::Foundation::HWND;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, SWP_FRAMECHANGED,
@@ -58,8 +61,7 @@ fn apply_appwindow_exstyle(hwnd: isize) {
     unsafe {
         let hwnd = hwnd as HWND;
         let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-        let updated =
-            (current | WS_EX_APPWINDOW as isize) & !(WS_EX_TOOLWINDOW as isize);
+        let updated = (current | WS_EX_APPWINDOW as isize) & !(WS_EX_TOOLWINDOW as isize);
         if updated == current {
             return;
         }

--- a/src-tauri/src/lifecycle/windows_taskbar.rs
+++ b/src-tauri/src/lifecycle/windows_taskbar.rs
@@ -1,0 +1,81 @@
+//! Keep the main LibrAgent window visible on the Windows taskbar.
+//!
+//! A leftover `trayIcon` config (without handlers) used to spawn a hidden
+//! `tray_icon_app` tool-window. Combined with WebView2 top-level style quirks,
+//! minimize could leave the app running with no discoverable taskbar entry.
+//!
+//! This module re-asserts `WS_EX_APPWINDOW` (and clears `WS_EX_TOOLWINDOW`) and
+//! calls Tauri's `set_skip_taskbar(false)` after startup and around minimize.
+
+use log::{debug, warn};
+use tauri::{AppHandle, Manager, Runtime};
+
+const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Ensure the main window stays listed on the Windows taskbar.
+pub fn ensure_main_window_taskbar_button<R: Runtime>(app: &AppHandle<R>) {
+    #[cfg(not(windows))]
+    {
+        let _ = app;
+    }
+
+    #[cfg(windows)]
+    {
+        let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+            debug!("Taskbar ensure skipped: main window not ready");
+            return;
+        };
+
+        if let Err(error) = window.set_skip_taskbar(false) {
+            warn!("Failed to clear skip_taskbar on main window: {error}");
+        }
+
+        if let Some(icon) = app.default_window_icon().cloned() {
+            if let Err(error) = window.set_icon(icon) {
+                warn!("Failed to re-apply main window icon: {error}");
+            }
+        }
+
+        match window.hwnd() {
+            Ok(hwnd) => apply_appwindow_exstyle(hwnd.0 as isize),
+            Err(error) => warn!("Failed to read main window HWND for taskbar fix: {error}"),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn apply_appwindow_exstyle(hwnd: isize) {
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, SWP_FRAMECHANGED,
+        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW,
+    };
+
+    if hwnd == 0 {
+        return;
+    }
+
+    unsafe {
+        let hwnd = hwnd as HWND;
+        let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        let updated =
+            (current | WS_EX_APPWINDOW as isize) & !(WS_EX_TOOLWINDOW as isize);
+        if updated == current {
+            return;
+        }
+
+        SetWindowLongPtrW(hwnd, GWL_EXSTYLE, updated);
+        let _ = SetWindowPos(
+            hwnd,
+            std::ptr::null_mut(),
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+        );
+        debug!(
+            "Reasserted WS_EX_APPWINDOW on main window (exstyle 0x{current:X} -> 0x{updated:X})"
+        );
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,9 +32,6 @@
           "workspace/**"
         ]
       }
-    },
-    "trayIcon": {
-      "iconPath": "icons/icon.png"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Remove unused `trayIcon` config that spawned a hidden Windows `tray_icon_app` tool-window with no handlers
- Re-assert `WS_EX_APPWINDOW` / `skip_taskbar(false)` on startup and around minimize so the shell keeps a recoverable taskbar button

## Test plan
- [ ] On Windows, launch LibrAgent and confirm no LibrAgent entry appears in the system-tray overflow
- [ ] Minimize via the title-bar button and confirm LibrAgent remains on the taskbar
- [ ] Click the taskbar button and confirm the window restores and focuses
- [ ] `cargo check` / smoke `pnpm tauri dev` still starts normally

Made with [Cursor](https://cursor.com)