### PR TITLE
fix(agent): open child sessions via storage id / alias resolve

### DIFF
--- a/src-tauri/src/commands/agent_commands/session_commands.rs
+++ b/src-tauri/src/commands/agent_commands/session_commands.rs
@@ -11,11 +11,34 @@ use crate::repositories::SessionMetadata;
 use crate::services::agent_service::remove_lineage;
 use crate::services::AgentService;
 use crate::state::get_session_repository;
+use crate::utils::session_id::{resolve_session_id_among, SessionIdResolve};
 use std::collections::HashMap;
 use tauri::{command, AppHandle, State};
 
 const DEFAULT_SESSION_LIST_LIMIT: u64 = 20;
 const MAX_SESSION_LIST_LIMIT: u64 = 200;
+
+/// Resolve a UI/route session reference to the stored session id.
+///
+/// Accepts full storage ids, bare short tokens, or optional `session-{short}` forms
+/// (same contract as HTTP helpers / MCP tools).
+async fn resolve_tauri_session_ref(session_ref: &str) -> Result<String, String> {
+    let sessions = get_session_repository()
+        .get_all_sessions()
+        .await
+        .map_err(|e| format!("Failed to list sessions: {}", e))?;
+    let candidates: Vec<String> = sessions.into_iter().map(|session| session.id).collect();
+    let candidate_refs: Vec<&str> = candidates.iter().map(|id| id.as_str()).collect();
+
+    match resolve_session_id_among(candidate_refs, session_ref) {
+        SessionIdResolve::Unique(id) => Ok(id.to_string()),
+        SessionIdResolve::Missing => Err(format!("Session not found: {}", session_ref)),
+        SessionIdResolve::Ambiguous(count) => Err(format!(
+            "Ambiguous session reference '{}': matches {} sessions. Use the full storage id.",
+            session_ref, count
+        )),
+    }
+}
 
 /// Create a new agent session
 #[command]
@@ -43,6 +66,9 @@ pub async fn agent_open_session(
     initial_message_limit: Option<u64>,
 ) -> Result<AgentOpenSessionResponse, String> {
     const DEFAULT_INITIAL_MESSAGE_LIMIT: u64 = 40;
+
+    // Route / tool cards may pass a display alias; hydrate + resume need the storage key.
+    let session_id = resolve_tauri_session_ref(&session_id).await?;
 
     let session_manager = crate::session::get_session_manager()?;
     crate::session::hydrate_persisted_workspace_override_from_global(session_manager, &session_id)

--- a/src-tauri/src/mcp/builtin/agent/handlers.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::utils::{
     build_agent_session_tool_data, build_agent_tool_data, fetch_session_messages_for_result,
-    latest_session_output, CHECK_SESSION_RESULT_MESSAGE_LIMIT,
+    insert_agent_session_id_fields, latest_session_output, CHECK_SESSION_RESULT_MESSAGE_LIMIT,
 };
 use crate::mcp::builtin::error_guidance::{guided_error, ErrorCategory, SuccessHint, ToolGroup};
 use crate::mcp::types::{MCPContent, MCPResult};
@@ -426,12 +426,7 @@ pub async fn prepare_teamwork_workspace(
             }),
         ],
     );
-    response_data.insert(
-        "sessionId".to_string(),
-        Value::String(crate::utils::session_id::display_session_id(
-            caller_session_id,
-        )),
-    );
+    insert_agent_session_id_fields(&mut response_data, caller_session_id);
     response_data.insert("artifactPath".to_string(), Value::String(artifact_path));
     response_data.insert("mode".to_string(), Value::String("teamwork".to_string()));
 

--- a/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/sessions.rs
@@ -2,7 +2,8 @@ use serde_json::{json, Value};
 use std::time::Duration;
 
 use super::super::utils::{
-    build_agent_tool_data, check_session_next_actions, read_required_string,
+    build_agent_tool_data, check_session_next_actions, insert_agent_session_id_fields,
+    read_required_string,
 };
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_agent_config_error, missing_agent_session_error, ErrorCategory,
@@ -199,7 +200,7 @@ async fn start_session_impl(
         "pending",
         check_session_next_actions(&session_id),
     );
-    response_data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut response_data, &session_id);
     response_data.insert("status".to_string(), Value::String("started".to_string()));
     response_data.insert(
         "assistantId".to_string(),
@@ -321,7 +322,7 @@ pub async fn message_to_session(
         "pending",
         check_session_next_actions(&display_id),
     );
-    response_data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut response_data, &session_id);
     response_data.insert("messageId".to_string(), Value::String(response.message_id));
     response_data.insert("status".to_string(), Value::String(response.status));
     // Persist message body for human card (collapsed preview).
@@ -409,7 +410,7 @@ pub async fn stop_session(
             "noop",
             vec![],
         );
-        response_data.insert("sessionId".to_string(), Value::String(display_id));
+        insert_agent_session_id_fields(&mut response_data, &session_id);
         response_data.insert("stopped".to_string(), Value::Bool(false));
         response_data.insert("status".to_string(), Value::String(current_status));
 
@@ -436,7 +437,7 @@ pub async fn stop_session(
         "success",
         vec![],
     );
-    response_data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut response_data, &session_id);
     response_data.insert("stopped".to_string(), Value::Bool(true));
     response_data.insert(
         "status".to_string(),
@@ -553,7 +554,7 @@ pub async fn compact_session_context(
             "noop",
             check_session_next_actions(&display_id),
         );
-        response_data.insert("sessionId".to_string(), Value::String(display_id));
+        insert_agent_session_id_fields(&mut response_data, &session_id);
         response_data.insert("status".to_string(), Value::String("noop".to_string()));
         response_data.insert("compacted".to_string(), Value::Bool(false));
 
@@ -626,7 +627,7 @@ pub async fn compact_session_context(
         status,
         check_session_next_actions(&display_id),
     );
-    response_data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut response_data, &session_id);
     response_data.insert("status".to_string(), Value::String(status.to_string()));
     response_data.insert("compacted".to_string(), Value::Bool(!unchanged));
     response_data.insert("toId".to_string(), Value::String(compact_record.to_id));
@@ -719,7 +720,7 @@ pub async fn delete_session(
         "success",
         vec![],
     );
-    response_data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut response_data, &session_id);
     response_data.insert("deleted".to_string(), Value::Bool(true));
     response_data.insert(
         "descendantCount".to_string(),

--- a/src-tauri/src/mcp/builtin/agent/utils.rs
+++ b/src-tauri/src/mcp/builtin/agent/utils.rs
@@ -266,6 +266,23 @@ pub fn build_agent_tool_data(
     data
 }
 
+/// Insert agent-facing `sessionId` (display token) plus UI-only `storageSessionId`.
+///
+/// Agents must keep using the short display token. The desktop UI Open Session
+/// button must navigate with the opaque storage key so `agent_open_session` /
+/// event filters match DB rows (legacy `session-…` display ≠ storage).
+pub fn insert_agent_session_id_fields(
+    data: &mut serde_json::Map<String, Value>,
+    storage_session_id: &str,
+) {
+    let display_id = crate::utils::session_id::display_session_id(storage_session_id);
+    data.insert("sessionId".to_string(), Value::String(display_id));
+    data.insert(
+        "storageSessionId".to_string(),
+        Value::String(storage_session_id.to_string()),
+    );
+}
+
 pub fn build_agent_session_tool_data(
     tool_name: &str,
     session_id: &str,
@@ -285,7 +302,7 @@ pub fn build_agent_session_tool_data(
         response_status,
         next_actions,
     );
-    data.insert("sessionId".to_string(), Value::String(display_id));
+    insert_agent_session_id_fields(&mut data, session_id);
     data.insert(
         "status".to_string(),
         Value::String(session_status.to_string()),
@@ -702,6 +719,32 @@ mod tests {
             "role": "assistant",
             "content": [{"type": "text", "text": text}]
         })
+    }
+
+    #[test]
+    fn build_agent_session_tool_data_emits_display_and_storage_ids() {
+        let data = build_agent_session_tool_data(
+            "checkSession",
+            "session-1735123456789012345",
+            "ok",
+            "idle",
+            "success",
+            1,
+            vec![],
+        );
+
+        assert_eq!(
+            data.get("sessionId").and_then(|v| v.as_str()),
+            Some("6789012345")
+        );
+        assert_eq!(
+            data.get("storageSessionId").and_then(|v| v.as_str()),
+            Some("session-1735123456789012345")
+        );
+        assert_eq!(
+            data.get("resourceId").and_then(|v| v.as_str()),
+            Some("6789012345")
+        );
     }
 
     #[test]

--- a/src/context/__tests__/agent-session-test-utils.tsx
+++ b/src/context/__tests__/agent-session-test-utils.tsx
@@ -15,10 +15,21 @@ export const mockRenameSession = vi.fn();
 export const mockRefreshCompactedRange = vi.fn();
 export const mockClearStreamingMessage = vi.fn();
 export const mockCancelCompletionRequest = vi.fn();
+export const navigateMock = vi.fn();
 export const listenMock = listen as ReturnType<typeof vi.fn>;
 export const safeInvokeMock = safeInvoke as ReturnType<typeof vi.fn>;
 export const openAgentSessionMock =
   agentCommandsBackend.openAgentSession as ReturnType<typeof vi.fn>;
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 // Mock Tauri APIs
 vi.mock('@tauri-apps/api/event', () => ({

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { listen } from '@tauri-apps/api/event';
 import { openAgentSession } from '@/lib/backend/agent-commands';
 import { getAssistant } from '@/lib/backend/assistants';
@@ -67,6 +68,7 @@ export function useAgentSessionEvents(
     clearStreamingMessage: (sessionId: string) => void;
   },
 ) {
+  const navigate = useNavigate();
   const { setters, refs } = stateProps;
   const clearStreamingOnInactive = () =>
     applyWorkflowInactiveCleanup({
@@ -341,6 +343,20 @@ export function useAgentSessionEvents(
         });
 
         const response = await openAgentSession(sessionId);
+        if (!isMounted) return;
+
+        // Events and further commands use storage ids. If the route still has a
+        // display alias, remount on the resolved storage key.
+        const resolvedSessionId = response.session.id;
+        if (resolvedSessionId !== sessionId) {
+          logger.info('Normalizing session route to storage id', {
+            from: sessionId,
+            to: resolvedSessionId,
+          });
+          navigate(`/agent/${resolvedSessionId}`, { replace: true });
+          return;
+        }
+
         const sessionMetadata = response.session;
 
         if (!isMounted) return;
@@ -419,7 +435,7 @@ export function useAgentSessionEvents(
       isMounted = false;
       if (unlisten) unlisten();
     };
-  }, [sessionId, actions.persistViewedAt, actions.clearStreamingMessage]);
+  }, [sessionId, navigate, actions.persistViewedAt, actions.clearStreamingMessage]);
 
   useEffect(() => {
     const markViewedOnReturn = () => {

--- a/src/features/agent/components/tool-structured/__tests__/AgentSessionToolCard.test.tsx
+++ b/src/features/agent/components/tool-structured/__tests__/AgentSessionToolCard.test.tsx
@@ -200,6 +200,23 @@ describe('ToolStructuredResult agent session cards', () => {
     expect(navigateMock).toHaveBeenCalledWith('/agent/a1b2c3d4e5');
   });
 
+  it('navigates using storageSessionId when display token differs', () => {
+    navigateMock.mockClear();
+
+    renderAgentCard('agent__checkSession', {
+      sessionId: '6789012345',
+      storageSessionId: 'session-1735123456789012345',
+      status: 'idle',
+      responseStatus: 'success',
+      result: 'done',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /open session/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/agent/session-1735123456789012345',
+    );
+  });
+
   it('hides open for deleted sessions', () => {
     renderAgentCard('agent__deleteSession', {
       sessionId: 'a1b2c3d4e5',

--- a/src/features/agent/components/tool-structured/__tests__/agent-types.test.ts
+++ b/src/features/agent/components/tool-structured/__tests__/agent-types.test.ts
@@ -200,6 +200,16 @@ describe('agent session structured types', () => {
     ).toBe('abc');
   });
 
+  it('resolveAgentSessionId prefers storageSessionId for Open navigation', () => {
+    expect(
+      resolveAgentSessionId({
+        sessionId: '6789012345',
+        storageSessionId: 'session-1735123456789012345',
+        resourceId: 'xyz',
+      }),
+    ).toBe('session-1735123456789012345');
+  });
+
   it('canRenderStructuredToolResult accepts agent session tools', () => {
     expect(
       canRenderStructuredToolResult('agent__checkSession', {

--- a/src/features/agent/components/tool-structured/agent-types.ts
+++ b/src/features/agent/components/tool-structured/agent-types.ts
@@ -19,6 +19,11 @@ export const AgentSessionToolResultSchema = z
     message: z.string().optional(),
     responseStatus: z.string().optional(),
     sessionId: z.string().optional(),
+    /**
+     * Opaque DB/storage key for UI navigation. Prefer over `sessionId` when opening
+     * a session route — display tokens may differ from storage for legacy ids.
+     */
+    storageSessionId: z.string().optional(),
     status: z.string().optional(),
     turnCount: z.number().optional(),
     workspacePath: z.string().optional(),
@@ -161,7 +166,11 @@ export function classifyAgentSessionCard(
 export function resolveAgentSessionId(
   data: AgentSessionToolResult,
 ): string | null {
-  const id = data.sessionId?.trim() || data.resourceId?.trim();
+  // Prefer storage key for Open Session navigation; fall back to display/resource ids.
+  const id =
+    data.storageSessionId?.trim() ||
+    data.sessionId?.trim() ||
+    data.resourceId?.trim();
   return id && id.length > 0 ? id : null;
 }
 


### PR DESCRIPTION
## Summary
- Agent tool structured payloads now emit both `sessionId` (display token) and `storageSessionId` (opaque DB key); Open Session prefers storage id.
- `agent_open_session` resolves display-token / `session-{token}` aliases the same way as the HTTP session API.
- After a successful open, the UI replace-navigates to the resolved storage id so event filters keep matching.

## Test plan
- [ ] From a parent agent tool card, open a child session that still uses a legacy `session-…` storage id — chat should load (no `agent.chat.sessionNotFoundOrFailed`).
- [ ] Open a modern short-hex child session — still works; URL ends on the storage id after resolve.
- [ ] Confirm `pnpm test:run` for `agent-types` + `AgentSessionToolCard` passes.
- [ ] Smoke: live session events still arrive after opening via the tool card.