### PR TITLE
feat(agent): keep recent sessions warm for instant switch-back

### DIFF
--- a/src-tauri/src/commands/agent_commands/session_commands.rs
+++ b/src-tauri/src/commands/agent_commands/session_commands.rs
@@ -58,6 +58,8 @@ pub async fn agent_resume_session(
     manager.resume_session(&session_id).await
 }
 
+const DEFAULT_INITIAL_MESSAGE_LIMIT: u64 = 40;
+
 /// Resume a session and return only the recent transcript slice needed for initial UI rendering.
 #[command]
 pub async fn agent_open_session(
@@ -65,7 +67,14 @@ pub async fn agent_open_session(
     session_id: String,
     initial_message_limit: Option<u64>,
 ) -> Result<AgentOpenSessionResponse, String> {
-    const DEFAULT_INITIAL_MESSAGE_LIMIT: u64 = 40;
+    let message_limit = initial_message_limit.unwrap_or(DEFAULT_INITIAL_MESSAGE_LIMIT);
+
+    // Warm reopen: session already active with a ready proxy. Skip alias resolve,
+    // workspace hydrate, and resume/proxy bootstrap — they are no-ops for UX and
+    // dominate switch latency when hopping between recently opened sessions.
+    if let Some(warm) = try_open_warm_session(&manager, &session_id, message_limit).await? {
+        return Ok(warm);
+    }
 
     // Route / tool cards may pass a display alias; hydrate + resume need the storage key.
     let session_id = resolve_tauri_session_ref(&session_id).await?;
@@ -75,12 +84,49 @@ pub async fn agent_open_session(
         .await?;
 
     let session = manager.resume_session(&session_id).await?;
+    build_open_session_response(&manager, session, &session_id, message_limit).await
+}
+
+/// Fast path when the storage id is already in the active map and MCP proxy is ready.
+async fn try_open_warm_session(
+    manager: &AgentSessionManager,
+    session_ref: &str,
+    message_limit: u64,
+) -> Result<Option<AgentOpenSessionResponse>, String> {
+    let runtime_state = manager.get_runtime_state(session_ref).await;
+    if !runtime_state.proxy.ready {
+        return Ok(None);
+    }
+
+    // SessionMetadata is a plain Clone snapshot (owned strings/ints/enums).
+    // Clone while the read lock is held so we never retain a map reference.
+    let session = {
+        let active = manager.active_sessions_arc();
+        let sessions = active.read().await;
+        let Some(active_session) = sessions.get(session_ref) else {
+            return Ok(None);
+        };
+        active_session.metadata.clone()
+    };
+
+    log::debug!(
+        "Opening warm session {} (skip resolve/hydrate/resume)",
+        session_ref
+    );
+    Ok(Some(
+        build_open_session_response(manager, session, session_ref, message_limit).await?,
+    ))
+}
+
+async fn build_open_session_response(
+    manager: &AgentSessionManager,
+    session: SessionMetadata,
+    session_id: &str,
+    message_limit: u64,
+) -> Result<AgentOpenSessionResponse, String> {
     let repo = crate::state::get_message_repository();
     let mut message_slice = repo
-        .get_recent_slice(
-            &session_id,
-            initial_message_limit.unwrap_or(DEFAULT_INITIAL_MESSAGE_LIMIT),
-        )
+        .get_recent_slice(session_id, message_limit)
         .await
         .map_err(|e| format!("Failed to load recent session messages: {}", e))?;
 
@@ -91,7 +137,7 @@ pub async fn agent_open_session(
     let active = manager.active_sessions_arc();
     let (mut protect_ids, pending_approvals) = {
         let sessions = active.read().await;
-        if let Some(active_session) = sessions.get(&session_id) {
+        if let Some(active_session) = sessions.get(session_id) {
             let protect_ids = {
                 let messages = active_session.messages.read().await;
                 messages.iter().map(|m| m.id.clone()).collect()
@@ -127,12 +173,12 @@ pub async fn agent_open_session(
     }
 
     crate::agent::pending_queue::strip_pending_queue_messages_with_protect(
-        &session_id,
+        session_id,
         &mut message_slice.items,
         &protect_ids,
     )
     .await?;
-    let runtime_state = manager.get_runtime_state(&session_id).await;
+    let runtime_state = manager.get_runtime_state(session_id).await;
 
     Ok(AgentOpenSessionResponse {
         session,

--- a/src/context/AgentSessionContext.tsx
+++ b/src/context/AgentSessionContext.tsx
@@ -23,11 +23,17 @@ const AgentSessionActionsContext = createContext<
 interface AgentSessionProviderProps {
   children: React.ReactNode;
   sessionId: string;
+  /**
+   * When false, the provider stays mounted for keep-alive but suppresses
+   * user-visible side effects (toasts, viewed-at on focus, compacted refresh).
+   */
+  isActive?: boolean;
 }
 
 export function AgentSessionProvider({
   children,
   sessionId,
+  isActive = true,
 }: AgentSessionProviderProps) {
   const { markSessionViewed, clearPendingApproval, renameSession } =
     useAgentSessionListActions();
@@ -35,8 +41,11 @@ export function AgentSessionProvider({
   const stateProps = useAgentSessionStateLogic();
 
   React.useEffect(() => {
+    if (!isActive) {
+      return;
+    }
     void refreshCompactedRange(sessionId);
-  }, [refreshCompactedRange, sessionId]);
+  }, [refreshCompactedRange, sessionId, isActive]);
 
   const persistViewedAt = useCallback(
     async (viewedAt = new Date()) => {
@@ -56,9 +65,10 @@ export function AgentSessionProvider({
   useAgentSessionEvents(sessionId, stateProps, {
     persistViewedAt,
     clearStreamingMessage,
+    isActive,
   });
 
-  useMcpServerFailureToasts(sessionId, stateProps.state.runtimeState);
+  useMcpServerFailureToasts(sessionId, stateProps.state.runtimeState, isActive);
 
   const customActions = useAgentSessionActionsLogic(sessionId, stateProps, {
     acknowledgeSessionAttention,

--- a/src/context/__tests__/AgentSessionContext-actions.test.tsx
+++ b/src/context/__tests__/AgentSessionContext-actions.test.tsx
@@ -1,4 +1,5 @@
 import { TEST_SESSION_ID, createDefaultWrapper, mockMarkSessionViewed, mockRefreshCompactedRange, listenMock, openAgentSessionMock, safeInvokeMock, createOpenSessionResponse, mockClearPendingApproval, mockRenameSession } from "./agent-session-test-utils";
+import { clearOpenSessionViewCache } from '../agent-session/openSessionViewCache';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
@@ -11,6 +12,7 @@ describe('AgentSessionContext – User Actions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearOpenSessionViewCache();
     mockMarkSessionViewed.mockResolvedValue(undefined);
     mockRefreshCompactedRange.mockResolvedValue(undefined);
     mockRenameSession.mockResolvedValue(undefined);

--- a/src/context/__tests__/AgentSessionContext-events.test.tsx
+++ b/src/context/__tests__/AgentSessionContext-events.test.tsx
@@ -1,4 +1,5 @@
 import { TEST_SESSION_ID, createDefaultWrapper, mockMarkSessionViewed, mockRefreshCompactedRange, listenMock, openAgentSessionMock, safeInvokeMock, createOpenSessionResponse, createReadyRuntimeState, buildTestMessage, OpenAgentSessionResponse } from "./agent-session-test-utils";
+import { clearOpenSessionViewCache } from '../agent-session/openSessionViewCache';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
@@ -10,6 +11,7 @@ describe('AgentSessionContext – Event Handling', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearOpenSessionViewCache();
     mockMarkSessionViewed.mockResolvedValue(undefined);
     mockRefreshCompactedRange.mockResolvedValue(undefined);
     listenMock.mockResolvedValue(mockUnlisten);

--- a/src/context/__tests__/AgentSessionContext.test.tsx
+++ b/src/context/__tests__/AgentSessionContext.test.tsx
@@ -1,4 +1,5 @@
 import { TEST_SESSION_ID, SessionWrapper, mockMarkSessionViewed, mockRefreshCompactedRange, listenMock, openAgentSessionMock, safeInvokeMock, createOpenSessionResponse, createReadyRuntimeState, AgentSessionStateObserver, AgentSessionStateSnapshot, OpenAgentSessionResponse } from "./agent-session-test-utils";
+import { clearOpenSessionViewCache, putOpenSessionView } from '../agent-session/openSessionViewCache';
 import { render, renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
@@ -13,6 +14,7 @@ describe('AgentSessionContext (Local)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearOpenSessionViewCache();
     mockMarkSessionViewed.mockResolvedValue(undefined);
     mockRefreshCompactedRange.mockResolvedValue(undefined);
     listenMock.mockResolvedValue(mockUnlisten);
@@ -157,6 +159,88 @@ describe('AgentSessionContext (Local)', () => {
             'session-2',
             expect.any(Date)
         );
+    });
+
+    it('paints a warm cached session immediately without hydrating flash', async () => {
+        putOpenSessionView(
+            'session-warm',
+            createOpenSessionResponse('session-warm', {
+                session: { name: 'Warm Session' },
+                messages: [
+                    {
+                        id: 'cached-msg',
+                        sessionId: 'session-warm',
+                        threadId: 'session-warm',
+                        role: 'user',
+                        content: [{ type: 'text', text: 'Cached' }],
+                        createdAt: Date.now(),
+                        updatedAt: Date.now(),
+                    },
+                ],
+            }),
+        );
+
+        let resolveOpen:
+            | ((value: OpenAgentSessionResponse) => void)
+            | undefined;
+        openAgentSessionMock.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveOpen = resolve;
+                }),
+        );
+
+        let latestState: AgentSessionStateSnapshot | undefined;
+        const currentState = () => {
+            if (!latestState) {
+                throw new Error('Expected session state snapshot');
+            }
+            return latestState;
+        };
+
+        render(
+            <SessionWrapper sessionId="session-warm">
+                <AgentSessionStateObserver
+                    onRender={(state) => {
+                        latestState = state;
+                    }}
+                />
+            </SessionWrapper>,
+        );
+
+        await waitFor(() => {
+            expect(currentState().isSessionLoading).toBe(false);
+            expect(currentState().isProxyReady).toBe(true);
+            expect(currentState().session?.id).toBe('session-warm');
+            expect(currentState().messages[0]?.id).toBe('cached-msg');
+        });
+
+        await waitFor(() => {
+            expect(resolveOpen).toBeDefined();
+        });
+
+        await act(async () => {
+            resolveOpen?.(
+                createOpenSessionResponse('session-warm', {
+                    session: { name: 'Warm Session' },
+                    messages: [
+                        {
+                            id: 'fresh-msg',
+                            sessionId: 'session-warm',
+                            threadId: 'session-warm',
+                            role: 'user',
+                            content: [{ type: 'text', text: 'Fresh' }],
+                            createdAt: Date.now(),
+                            updatedAt: Date.now(),
+                        },
+                    ],
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(currentState().messages[0]?.id).toBe('fresh-msg');
+        });
     });
 
     it('keeps the previous session state visible while the next session hydrates', async () => {

--- a/src/context/agent-session/__tests__/mergeOpenSessionState.test.ts
+++ b/src/context/agent-session/__tests__/mergeOpenSessionState.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Message } from '@/models/chat';
+import type { PendingApproval } from '../types';
+import {
+  mergeOpenSessionMessages,
+  mergePendingApprovals,
+} from '../mergeOpenSessionState';
+
+function msg(
+  id: string,
+  overrides: Partial<Message> = {},
+): Message {
+  return {
+    id,
+    sessionId: 's1',
+    threadId: 's1',
+    role: 'user',
+    content: [{ type: 'text', text: id }],
+    createdAt: new Date(1000),
+    ...overrides,
+  } as Message;
+}
+
+describe('mergeOpenSessionMessages', () => {
+  it('keeps event-only messages that the open snapshot missed', () => {
+    const previous = [msg('a'), msg('event-only', { createdAt: new Date(3000) })];
+    const incoming = [msg('a'), msg('b', { createdAt: new Date(2000) })];
+
+    const merged = mergeOpenSessionMessages(previous, incoming);
+
+    expect(merged.map((m) => m.id)).toEqual(['a', 'b', 'event-only']);
+  });
+
+  it('breaks createdAt ties by message id', () => {
+    const previous = [
+      msg('z-live', { createdAt: new Date(1000) }),
+      msg('a-live', { createdAt: new Date(1000) }),
+    ];
+    const incoming = [msg('m-db', { createdAt: new Date(1000) })];
+
+    const merged = mergeOpenSessionMessages(previous, incoming);
+
+    expect(merged.map((m) => m.id)).toEqual(['a-live', 'm-db', 'z-live']);
+  });
+
+  it('prefers live streaming rows over the open snapshot', () => {
+    const previous = [msg('a', { isStreaming: true, content: [{ type: 'text', text: 'live' }] })];
+    const incoming = [msg('a', { isStreaming: false, content: [{ type: 'text', text: 'db' }] })];
+
+    const merged = mergeOpenSessionMessages(previous, incoming);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isStreaming).toBe(true);
+    expect(merged[0]?.content).toEqual([{ type: 'text', text: 'live' }]);
+  });
+});
+
+describe('mergePendingApprovals', () => {
+  it('keeps approvals that arrived via events during open', () => {
+    const previous: PendingApproval[] = [
+      {
+        toolCallId: 't1',
+        toolName: 'shell',
+        arguments: '{}',
+        approvalKind: 'standard',
+      },
+    ];
+    const incoming: PendingApproval[] = [
+      {
+        toolCallId: 't2',
+        toolName: 'browser',
+        arguments: '{}',
+        approvalKind: 'standard',
+      },
+    ];
+
+    expect(mergePendingApprovals(previous, incoming).map((a) => a.toolCallId)).toEqual([
+      't2',
+      't1',
+    ]);
+  });
+});

--- a/src/context/agent-session/__tests__/openSessionViewCache.test.ts
+++ b/src/context/agent-session/__tests__/openSessionViewCache.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { AgentOpenSessionResponse } from '@/models/agent-ipc';
+import {
+  MAX_CACHED_SESSIONS,
+  clearOpenSessionViewCache,
+  getOpenSessionView,
+  invalidateOpenSessionView,
+  isWarmOpenSessionView,
+  putOpenSessionView,
+} from '../openSessionViewCache';
+
+function makeResponse(
+  sessionId: string,
+  overrides?: {
+    phase?: AgentOpenSessionResponse['runtimeState']['phase'];
+    proxy?: Partial<AgentOpenSessionResponse['runtimeState']['proxy']>;
+  },
+): AgentOpenSessionResponse {
+  const timestamp = Date.now();
+  return {
+    session: {
+      id: sessionId,
+      name: sessionId,
+      status: 'idle',
+      model: 'm',
+      provider: 'p',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      executionMode: 'normal',
+      workspaceIsolation: 'host',
+    },
+    messages: {
+      items: [],
+      hasMoreBefore: false,
+      oldestCursor: null,
+    },
+    pendingApprovals: [],
+    runtimeState: {
+      sequence: 1,
+      phase: overrides?.phase ?? 'ready',
+      proxy: {
+        exists: true,
+        mode: 'builtin_only',
+        ready: true,
+        ...overrides?.proxy,
+      },
+      initialization: {
+        result: 'success',
+      },
+      servers: [],
+    },
+  };
+}
+
+describe('openSessionViewCache', () => {
+  beforeEach(() => {
+    clearOpenSessionViewCache();
+  });
+
+  it('stores and returns warm open payloads', () => {
+    const response = makeResponse('s1');
+    putOpenSessionView('s1', response);
+
+    expect(getOpenSessionView('s1')).toEqual(response);
+    expect(isWarmOpenSessionView(response)).toBe(true);
+  });
+
+  it('evicts least-recently-used entries past the max size', () => {
+    for (let i = 0; i < MAX_CACHED_SESSIONS + 1; i += 1) {
+      putOpenSessionView(`s${i}`, makeResponse(`s${i}`));
+    }
+
+    expect(getOpenSessionView('s0')).toBeUndefined();
+    expect(getOpenSessionView(`s${MAX_CACHED_SESSIONS}`)?.session.id).toBe(
+      `s${MAX_CACHED_SESSIONS}`,
+    );
+  });
+
+  it('treats hydrating/not-ready payloads as cold', () => {
+    const cold = makeResponse('s1', {
+      phase: 'hydrating',
+      proxy: { exists: false, mode: 'none', ready: false },
+    });
+    expect(isWarmOpenSessionView(cold)).toBe(false);
+  });
+
+  it('invalidates a single session', () => {
+    putOpenSessionView('s1', makeResponse('s1'));
+    invalidateOpenSessionView('s1');
+    expect(getOpenSessionView('s1')).toBeUndefined();
+  });
+});

--- a/src/context/agent-session/mergeOpenSessionState.ts
+++ b/src/context/agent-session/mergeOpenSessionState.ts
@@ -1,0 +1,68 @@
+import type { Message } from '@/models/chat';
+import type { PendingApproval } from './types';
+
+/**
+ * Reconcile DB open-slice with messages that arrived via agent:event while
+ * openAgentSession was in flight. Keep event-only ids and live streaming rows.
+ */
+export function mergeOpenSessionMessages(
+  previous: Message[],
+  incoming: Message[],
+): Message[] {
+  if (previous.length === 0) {
+    return incoming;
+  }
+  if (incoming.length === 0) {
+    return previous;
+  }
+
+  const byId = new Map<string, Message>();
+  for (const message of incoming) {
+    byId.set(message.id, message);
+  }
+  for (const message of previous) {
+    const existing = byId.get(message.id);
+    if (!existing) {
+      byId.set(message.id, message);
+      continue;
+    }
+    if (message.isStreaming && !existing.isStreaming) {
+      byId.set(message.id, message);
+    }
+  }
+
+  return Array.from(byId.values()).sort((left, right) => {
+    const leftTime = left.createdAt?.getTime() ?? 0;
+    const rightTime = right.createdAt?.getTime() ?? 0;
+    if (leftTime !== rightTime) {
+      return leftTime - rightTime;
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+/**
+ * Keep approvals observed via events that the open snapshot has not caught yet.
+ */
+export function mergePendingApprovals(
+  previous: PendingApproval[],
+  incoming: PendingApproval[],
+): PendingApproval[] {
+  if (previous.length === 0) {
+    return incoming;
+  }
+  if (incoming.length === 0) {
+    return previous;
+  }
+
+  const byId = new Map<string, PendingApproval>();
+  for (const approval of incoming) {
+    byId.set(approval.toolCallId, approval);
+  }
+  for (const approval of previous) {
+    if (!byId.has(approval.toolCallId)) {
+      byId.set(approval.toolCallId, approval);
+    }
+  }
+  return Array.from(byId.values());
+}

--- a/src/context/agent-session/openSessionViewCache.ts
+++ b/src/context/agent-session/openSessionViewCache.ts
@@ -1,0 +1,58 @@
+import type { AgentOpenSessionResponse } from '@/models/agent-ipc';
+
+/** In-memory LRU of last-open payloads. Keep-alive holds 3 providers; this
+ * covers a few extra hops so a remount can paint before openAgentSession. */
+export const MAX_CACHED_SESSIONS = 8;
+
+const cache = new Map<string, AgentOpenSessionResponse>();
+
+function touch(sessionId: string, response: AgentOpenSessionResponse): void {
+  cache.delete(sessionId);
+  cache.set(sessionId, response);
+  while (cache.size > MAX_CACHED_SESSIONS) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    cache.delete(oldestKey);
+  }
+}
+
+/** Last successful open payload for a session (LRU, in-memory only). */
+export function getOpenSessionView(
+  sessionId: string,
+): AgentOpenSessionResponse | undefined {
+  const cached = cache.get(sessionId);
+  if (!cached) {
+    return undefined;
+  }
+  // Refresh LRU order on read so recently revisited sessions stay warm.
+  touch(sessionId, cached);
+  return cached;
+}
+
+export function putOpenSessionView(
+  sessionId: string,
+  response: AgentOpenSessionResponse,
+): void {
+  touch(sessionId, response);
+}
+
+export function invalidateOpenSessionView(sessionId: string): void {
+  cache.delete(sessionId);
+}
+
+export function clearOpenSessionViewCache(): void {
+  cache.clear();
+}
+
+export function isWarmOpenSessionView(
+  response: AgentOpenSessionResponse,
+): boolean {
+  return (
+    response.runtimeState.proxy.ready &&
+    response.runtimeState.phase !== 'failed' &&
+    response.runtimeState.phase !== 'hydrating' &&
+    response.runtimeState.phase !== 'not_started'
+  );
+}

--- a/src/context/agent-session/useAgentSessionEvents.ts
+++ b/src/context/agent-session/useAgentSessionEvents.ts
@@ -5,12 +5,29 @@ import { openAgentSession } from '@/lib/backend/agent-commands';
 import { getAssistant } from '@/lib/backend/assistants';
 import { getLogger } from '@/lib/logger';
 import { mapSessionMetadataToAgentSession } from '@/lib/session-metadata';
-import { rustMessageToMessage } from '@/models/chat';
-import type { AgentEventPayload } from './types';
+import {
+  rustMessageToMessage,
+  type Assistant,
+  type Message,
+} from '@/models/chat';
+import type { AgentEventPayload, PendingApproval } from './types';
 import { buildMessageError, syncSessionMetadataFromBackend } from './utils';
 import type { useAgentSessionState } from './useAgentSessionState';
-import type { SessionRuntimeState } from '@/models/agent-ipc';
+import type {
+  AgentOpenSessionResponse,
+  SessionRuntimeState,
+} from '@/models/agent-ipc';
 import { notifyRuntimeStateErrors } from './notifyRuntimeStateErrors';
+import {
+  getOpenSessionView,
+  invalidateOpenSessionView,
+  isWarmOpenSessionView,
+  putOpenSessionView,
+} from './openSessionViewCache';
+import {
+  mergeOpenSessionMessages,
+  mergePendingApprovals,
+} from './mergeOpenSessionState';
 import {
   applyWorkflowInactiveCleanup,
   isInactiveWorkflowStatus,
@@ -59,6 +76,72 @@ function shouldApplyRuntimeState(
   return nextState.sequence >= currentState.sequence;
 }
 
+type SessionStateSetters = ReturnType<typeof useAgentSessionState>['setters'];
+
+function applyOpenSessionPayload(
+  response: AgentOpenSessionResponse,
+  setters: SessionStateSetters,
+  options: {
+    assistant?: Assistant;
+    clearStreamingOnInactive: () => void;
+    sessionIdForErrors: string;
+    /** When true, preserve event-arrived rows that the open snapshot missed. */
+    mergeWithLiveState?: boolean;
+  },
+): void {
+  const sessionMetadata = response.session;
+  const sessionData = mapSessionMetadataToAgentSession(
+    sessionMetadata,
+    response.pendingApprovals?.length ?? 0,
+    options.assistant,
+  );
+
+  setters.setSession(sessionData);
+  setters.setWorkflowStatus(sessionData.status);
+  setters.applyExecutionMode(sessionData.executionMode);
+
+  const hydratedMessages = response.messages.items.map(rustMessageToMessage);
+  const preparedIncoming = isInactiveWorkflowStatus(sessionData.status)
+    ? stripMessageStreamingFlags(hydratedMessages)
+    : hydratedMessages;
+  const incomingApprovals = response.pendingApprovals ?? [];
+
+  if (options.mergeWithLiveState) {
+    setters.setMessages((previous: Message[]) =>
+      mergeOpenSessionMessages(previous, preparedIncoming),
+    );
+    setters.setPendingApprovals((previous: PendingApproval[]) =>
+      mergePendingApprovals(previous, incomingApprovals),
+    );
+  } else {
+    setters.setMessages(preparedIncoming);
+    setters.setPendingApprovals(incomingApprovals);
+  }
+
+  if (isInactiveWorkflowStatus(sessionData.status)) {
+    options.clearStreamingOnInactive();
+  }
+  setters.setHasOlderMessages(response.messages.hasMoreBefore);
+  setters.setOldestMessageCursor(response.messages.oldestCursor ?? null);
+
+  const nextRuntimeState = response.runtimeState ?? HYDRATING_RUNTIME_STATE;
+  let previousRuntimeState: SessionRuntimeState | null = null;
+  setters.setRuntimeState((currentState) => {
+    if (shouldApplyRuntimeState(currentState, nextRuntimeState)) {
+      previousRuntimeState = currentState;
+      return nextRuntimeState;
+    }
+    return currentState;
+  });
+  if (previousRuntimeState) {
+    notifyRuntimeStateErrors(
+      previousRuntimeState,
+      nextRuntimeState,
+      options.sessionIdForErrors,
+    );
+  }
+}
+
 export function useAgentSessionEvents(
   sessionId: string,
   stateProps: ReturnType<typeof useAgentSessionState>,
@@ -66,10 +149,16 @@ export function useAgentSessionEvents(
     persistViewedAt: (viewedAt?: Date) => Promise<void>;
     /** Clears LLM streaming placeholders when the workflow becomes inactive. */
     clearStreamingMessage: (sessionId: string) => void;
+    /**
+     * Keep-alive inactive panes still receive agent events, but must not mark
+     * the session viewed on window focus / visibility changes.
+     */
+    isActive?: boolean;
   },
 ) {
   const navigate = useNavigate();
   const { setters, refs } = stateProps;
+  const isActive = actions.isActive ?? true;
   const clearStreamingOnInactive = () =>
     applyWorkflowInactiveCleanup({
       sessionId,
@@ -80,268 +169,295 @@ export function useAgentSessionEvents(
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let isMounted = true;
+    let liveMutationEpoch = 0;
 
     const initSession = async () => {
       logger.info('Initializing agent session', { sessionId });
       setters.setError(null);
-      setters.setRuntimeState(HYDRATING_RUNTIME_STATE);
       setters.setPreflightTokenMetrics(null);
 
-      try {
-        unlisten = await listen<AgentEventPayload>('agent:event', (event) => {
-          if (!isMounted) return;
-
-          const payload = event.payload;
-
-          if (
-            payload.type !== 'resourceUpdated' &&
-            'sessionId' in payload &&
-            payload.sessionId !== sessionId
-          ) {
-            return;
-          }
-
-          switch (payload.type) {
-            case 'sessionRuntimeStateUpdated': {
-              const nextState = payload.runtimeState;
-              let applied = false;
-              let previousState: SessionRuntimeState | null = null;
-              setters.setRuntimeState((currentState) => {
-                if (!shouldApplyRuntimeState(currentState, nextState)) {
-                  return currentState;
-                }
-                previousState = currentState;
-                applied = true;
-                return nextState;
-              });
-              if (applied && previousState) {
-                notifyRuntimeStateErrors(previousState, nextState, sessionId);
-              }
-              break;
-            }
-
-            case 'preflightTokenMetricsUpdated': {
-              setters.setPreflightTokenMetrics(payload.metrics);
-              break;
-            }
-
-            case 'workflowStarted': {
-              setters.setError(null);
-              setters.setLlmError(null);
-              logger.info('Workflow started');
-              break;
-            }
-
-            case 'statusChanged': {
-              const newStatus = payload.status;
-              setters.setWorkflowStatus(newStatus);
-              setters.setSession((prev) =>
-                prev ? { ...prev, status: newStatus } : null,
-              );
-
-              if (newStatus === 'busy' || newStatus === 'queued') {
-                setters.setError(null);
-                setters.setLlmError(null);
-                setters.setWorkflowPhase(
-                  newStatus === 'busy' ? 'thinking' : 'idle',
-                );
-              } else if (newStatus === 'idle') {
-                setters.setWorkflowPhase('idle');
-                clearStreamingOnInactive();
-              } else if (newStatus === 'error') {
-                setters.setWorkflowPhase('error');
-                clearStreamingOnInactive();
-              } else if (newStatus === 'paused') {
-                clearStreamingOnInactive();
-              }
-              break;
-            }
-
-            case 'workflowError': {
-              setters.setWorkflowStatus('error');
-              const nextError = buildMessageError(payload.error);
-
-              if (
-                nextError.type === 'MALFORMED_FUNCTION_CALL' ||
-                nextError.type === 'JSON_PARSING_ERROR' ||
-                nextError.type === 'EMPTY_SELECTION_ERROR'
-              ) {
-                setters.setLlmError(nextError);
-                setters.setError(null);
-              } else {
-                setters.setError(nextError);
-                setters.setLlmError(null);
-              }
-              break;
-            }
-
-            case 'messageAdded': {
-              const rustMessage = payload.message;
-              const newMessage = rustMessageToMessage(rustMessage);
-
-              if (
-                newMessage.role === 'assistant' &&
-                newMessage.isStreaming &&
-                refs.workflowPhaseRef.current === 'thinking'
-              ) {
-                setters.setWorkflowPhase('answering');
-                logger.info('Workflow phase: answering');
-              }
-
-              setters.setMessages((prev) => {
-                if (prev.some((m) => m.id === newMessage.id)) return prev;
-                return [...prev, newMessage];
-              });
-
-              if (!newMessage.isStreaming) {
-                setters.applyLocalViewedAt(new Date(rustMessage.createdAt));
-              }
-
-              break;
-            }
-
-            case 'toolExecutionStarted': {
-              setters.setWorkflowPhase('using_tools');
-              logger.info('Workflow phase: using_tools', {
-                toolName: payload.toolName,
-              });
-              break;
-            }
-
-            case 'toolExecutionRequiresApproval': {
-              setters.setWorkflowPhase('waiting_approval');
-              setters.setPendingApprovals((prev) => {
-                if (prev.some((p) => p.toolCallId === payload.toolCallId)) {
-                  return prev;
-                }
-                return [
-                  ...prev,
-                  {
-                    toolCallId: payload.toolCallId,
-                    toolName: payload.toolName,
-                    arguments: payload.arguments,
-                    approvalKind: payload.approvalKind,
-                    requestId: payload.requestId,
-                    description: payload.description,
-                    inputPreview: payload.inputPreview,
-                  },
-                ];
-              });
-              logger.info('Workflow phase: waiting_approval', {
-                toolName: payload.toolName,
-              });
-              break;
-            }
-
-            case 'toolExecutionCompleted': {
-              break;
-            }
-
-            case 'circuitBreakerTriggered': {
-              logger.warn('Circuit breaker triggered', {
-                toolName: payload.toolName,
-                count: payload.count,
-                action: payload.action,
-              });
-              break;
-            }
-
-            case 'toolExecutionApprovalResolved': {
-              setters.setPendingApprovals((prev) =>
-                prev.filter((p) => p.toolCallId !== payload.toolCallId),
-              );
-
-              if (payload.approved) {
-                setters.setWorkflowPhase('using_tools');
-              }
-              break;
-            }
-
-            case 'interactiveShellInputRequested': {
-              setters.setPendingInteractiveShellPrompt({
-                executionId: payload.executionId,
-                prompt: payload.prompt,
-                inputType: payload.inputType,
-                command: payload.command,
-              });
-              setters.setWorkflowPhase('using_tools');
-              break;
-            }
-
-            case 'interactiveShellInputResolved': {
-              setters.setPendingInteractiveShellPrompt((currentPrompt) =>
-                currentPrompt?.executionId === payload.executionId
-                  ? null
-                  : currentPrompt,
-              );
-              break;
-            }
-
-            case 'channelPermissionRequest': {
-              setters.setWorkflowPhase('waiting_approval');
-              setters.setPendingApprovals((prev) => {
-                if (prev.some((p) => p.toolCallId === payload.toolCallId)) {
-                  return prev;
-                }
-                return [
-                  ...prev,
-                  {
-                    toolCallId: payload.toolCallId,
-                    toolName: payload.toolName,
-                    arguments: payload.inputPreview,
-                    approvalKind: payload.approvalKind,
-                    requestId: payload.requestId,
-                    description: payload.description,
-                    inputPreview: payload.inputPreview,
-                  },
-                ];
-              });
-              break;
-            }
-
-            case 'resourceUpdated': {
-              if (
-                payload.resourceType !== 'session' ||
-                payload.resourceId !== sessionId
-              ) {
-                break;
-              }
-
-              if (payload.action === 'clear') {
-                setters.clearSessionHistory();
-                logger.info(
-                  'Session history cleared via resourceUpdated event',
-                );
-                break;
-              }
-
-              if (payload.action === 'update') {
-                void syncSessionMetadataFromBackend(sessionId, setters);
-              }
-              break;
-            }
-
-            case 'workflowCompleted': {
-              // Soft cancel → paused (resume). Terminate / natural stop → idle.
-              const nextStatus =
-                payload.reason === 'cancelled' ? 'paused' : 'idle';
-              setters.setWorkflowStatus(nextStatus);
-              setters.setSession((prev) =>
-                prev ? { ...prev, status: nextStatus } : null,
-              );
-              setters.setWorkflowPhase('idle');
-              setters.setPendingInteractiveShellPrompt(null);
-              clearStreamingOnInactive();
-              logger.info('Workflow phase: idle', {
-                sessionId,
-                reason: payload.reason,
-                status: nextStatus,
-              });
-              break;
-            }
-          }
+      const cachedView = getOpenSessionView(sessionId);
+      if (cachedView && isWarmOpenSessionView(cachedView)) {
+        // Paint last-known ready UI immediately; openAgentSession reconciles below.
+        applyOpenSessionPayload(cachedView, setters, {
+          clearStreamingOnInactive,
+          sessionIdForErrors: sessionId,
         });
+      } else {
+        setters.setRuntimeState(HYDRATING_RUNTIME_STATE);
+      }
 
+      try {
+        const unlistenFn = await listen<AgentEventPayload>(
+          'agent:event',
+          (event) => {
+            if (!isMounted) return;
+
+            const payload = event.payload;
+
+            if (
+              payload.type !== 'resourceUpdated' &&
+              'sessionId' in payload &&
+              payload.sessionId !== sessionId
+            ) {
+              return;
+            }
+
+            switch (payload.type) {
+              case 'sessionRuntimeStateUpdated': {
+                const nextState = payload.runtimeState;
+                let applied = false;
+                let previousState: SessionRuntimeState | null = null;
+                setters.setRuntimeState((currentState) => {
+                  if (!shouldApplyRuntimeState(currentState, nextState)) {
+                    return currentState;
+                  }
+                  previousState = currentState;
+                  applied = true;
+                  return nextState;
+                });
+                if (applied && previousState) {
+                  notifyRuntimeStateErrors(previousState, nextState, sessionId);
+                }
+                break;
+              }
+
+              case 'preflightTokenMetricsUpdated': {
+                setters.setPreflightTokenMetrics(payload.metrics);
+                break;
+              }
+
+              case 'workflowStarted': {
+                setters.setError(null);
+                setters.setLlmError(null);
+                logger.info('Workflow started');
+                break;
+              }
+
+              case 'statusChanged': {
+                const newStatus = payload.status;
+                setters.setWorkflowStatus(newStatus);
+                setters.setSession((prev) =>
+                  prev ? { ...prev, status: newStatus } : null,
+                );
+
+                if (newStatus === 'busy' || newStatus === 'queued') {
+                  setters.setError(null);
+                  setters.setLlmError(null);
+                  setters.setWorkflowPhase(
+                    newStatus === 'busy' ? 'thinking' : 'idle',
+                  );
+                } else if (newStatus === 'idle') {
+                  setters.setWorkflowPhase('idle');
+                  clearStreamingOnInactive();
+                } else if (newStatus === 'error') {
+                  setters.setWorkflowPhase('error');
+                  clearStreamingOnInactive();
+                } else if (newStatus === 'paused') {
+                  clearStreamingOnInactive();
+                }
+                break;
+              }
+
+              case 'workflowError': {
+                setters.setWorkflowStatus('error');
+                const nextError = buildMessageError(payload.error);
+
+                if (
+                  nextError.type === 'MALFORMED_FUNCTION_CALL' ||
+                  nextError.type === 'JSON_PARSING_ERROR' ||
+                  nextError.type === 'EMPTY_SELECTION_ERROR'
+                ) {
+                  setters.setLlmError(nextError);
+                  setters.setError(null);
+                } else {
+                  setters.setError(nextError);
+                  setters.setLlmError(null);
+                }
+                break;
+              }
+
+              case 'messageAdded': {
+                liveMutationEpoch += 1;
+                const rustMessage = payload.message;
+                const newMessage = rustMessageToMessage(rustMessage);
+
+                if (
+                  newMessage.role === 'assistant' &&
+                  newMessage.isStreaming &&
+                  refs.workflowPhaseRef.current === 'thinking'
+                ) {
+                  setters.setWorkflowPhase('answering');
+                  logger.info('Workflow phase: answering');
+                }
+
+                setters.setMessages((prev) => {
+                  if (prev.some((m) => m.id === newMessage.id)) return prev;
+                  return [...prev, newMessage];
+                });
+
+                if (!newMessage.isStreaming) {
+                  setters.applyLocalViewedAt(new Date(rustMessage.createdAt));
+                }
+
+                break;
+              }
+
+              case 'toolExecutionStarted': {
+                setters.setWorkflowPhase('using_tools');
+                logger.info('Workflow phase: using_tools', {
+                  toolName: payload.toolName,
+                });
+                break;
+              }
+
+              case 'toolExecutionRequiresApproval': {
+                liveMutationEpoch += 1;
+                setters.setWorkflowPhase('waiting_approval');
+                setters.setPendingApprovals((prev) => {
+                  if (prev.some((p) => p.toolCallId === payload.toolCallId)) {
+                    return prev;
+                  }
+                  return [
+                    ...prev,
+                    {
+                      toolCallId: payload.toolCallId,
+                      toolName: payload.toolName,
+                      arguments: payload.arguments,
+                      approvalKind: payload.approvalKind,
+                      requestId: payload.requestId,
+                      description: payload.description,
+                      inputPreview: payload.inputPreview,
+                    },
+                  ];
+                });
+                logger.info('Workflow phase: waiting_approval', {
+                  toolName: payload.toolName,
+                });
+                break;
+              }
+
+              case 'toolExecutionCompleted': {
+                break;
+              }
+
+              case 'circuitBreakerTriggered': {
+                logger.warn('Circuit breaker triggered', {
+                  toolName: payload.toolName,
+                  count: payload.count,
+                  action: payload.action,
+                });
+                break;
+              }
+
+              case 'toolExecutionApprovalResolved': {
+                liveMutationEpoch += 1;
+                setters.setPendingApprovals((prev) =>
+                  prev.filter((p) => p.toolCallId !== payload.toolCallId),
+                );
+
+                if (payload.approved) {
+                  setters.setWorkflowPhase('using_tools');
+                }
+                break;
+              }
+
+              case 'interactiveShellInputRequested': {
+                setters.setPendingInteractiveShellPrompt({
+                  executionId: payload.executionId,
+                  prompt: payload.prompt,
+                  inputType: payload.inputType,
+                  command: payload.command,
+                });
+                setters.setWorkflowPhase('using_tools');
+                break;
+              }
+
+              case 'interactiveShellInputResolved': {
+                setters.setPendingInteractiveShellPrompt((currentPrompt) =>
+                  currentPrompt?.executionId === payload.executionId
+                    ? null
+                    : currentPrompt,
+                );
+                break;
+              }
+
+              case 'channelPermissionRequest': {
+                liveMutationEpoch += 1;
+                setters.setWorkflowPhase('waiting_approval');
+                setters.setPendingApprovals((prev) => {
+                  if (prev.some((p) => p.toolCallId === payload.toolCallId)) {
+                    return prev;
+                  }
+                  return [
+                    ...prev,
+                    {
+                      toolCallId: payload.toolCallId,
+                      toolName: payload.toolName,
+                      arguments: payload.inputPreview,
+                      approvalKind: payload.approvalKind,
+                      requestId: payload.requestId,
+                      description: payload.description,
+                      inputPreview: payload.inputPreview,
+                    },
+                  ];
+                });
+                break;
+              }
+
+              case 'resourceUpdated': {
+                if (
+                  payload.resourceType !== 'session' ||
+                  payload.resourceId !== sessionId
+                ) {
+                  break;
+                }
+
+                if (payload.action === 'clear') {
+                  liveMutationEpoch += 1;
+                  setters.clearSessionHistory();
+                  invalidateOpenSessionView(sessionId);
+                  logger.info(
+                    'Session history cleared via resourceUpdated event',
+                  );
+                  break;
+                }
+
+                if (payload.action === 'update') {
+                  void syncSessionMetadataFromBackend(sessionId, setters);
+                }
+                break;
+              }
+
+              case 'workflowCompleted': {
+                // Soft cancel → paused (resume). Terminate / natural stop → idle.
+                const nextStatus =
+                  payload.reason === 'cancelled' ? 'paused' : 'idle';
+                setters.setWorkflowStatus(nextStatus);
+                setters.setSession((prev) =>
+                  prev ? { ...prev, status: nextStatus } : null,
+                );
+                setters.setWorkflowPhase('idle');
+                setters.setPendingInteractiveShellPrompt(null);
+                clearStreamingOnInactive();
+                logger.info('Workflow phase: idle', {
+                  sessionId,
+                  reason: payload.reason,
+                  status: nextStatus,
+                });
+                break;
+              }
+            }
+          },
+        );
+
+        if (!isMounted) {
+          unlistenFn();
+          return;
+        }
+        unlisten = unlistenFn;
+
+        const mutationEpochAtOpen = liveMutationEpoch;
         const response = await openAgentSession(sessionId);
         if (!isMounted) return;
 
@@ -353,58 +469,28 @@ export function useAgentSessionEvents(
             from: sessionId,
             to: resolvedSessionId,
           });
+          putOpenSessionView(resolvedSessionId, response);
           navigate(`/agent/${resolvedSessionId}`, { replace: true });
           return;
         }
 
-        const sessionMetadata = response.session;
-
         if (!isMounted) return;
 
-        const assistant = sessionMetadata.assistantId
-          ? await getAssistant(sessionMetadata.assistantId)
+        const assistant = response.session.assistantId
+          ? await getAssistant(response.session.assistantId)
           : undefined;
+        if (!isMounted) return;
 
-        const sessionData = mapSessionMetadataToAgentSession(
-          sessionMetadata,
-          response.pendingApprovals?.length ?? 0,
+        applyOpenSessionPayload(response, setters, {
           assistant,
-        );
-
-        setters.setSession(sessionData);
-        setters.setWorkflowStatus(sessionData.status);
-        setters.applyExecutionMode(sessionData.executionMode);
-        const hydratedMessages =
-          response.messages.items.map(rustMessageToMessage);
-        setters.setMessages(
-          isInactiveWorkflowStatus(sessionData.status)
-            ? stripMessageStreamingFlags(hydratedMessages)
-            : hydratedMessages,
-        );
-        if (isInactiveWorkflowStatus(sessionData.status)) {
-          clearStreamingOnInactive();
-        }
-        setters.setHasOlderMessages(response.messages.hasMoreBefore);
-        setters.setOldestMessageCursor(response.messages.oldestCursor ?? null);
-        setters.setPendingApprovals(response.pendingApprovals ?? []);
-        // Use runtimeState from response as initial state; sequence check ensures we don't overwrite newer events
-        const nextRuntimeState =
-          response.runtimeState ?? HYDRATING_RUNTIME_STATE;
-        let previousRuntimeState: SessionRuntimeState | null = null;
-        setters.setRuntimeState((currentState) => {
-          if (shouldApplyRuntimeState(currentState, nextRuntimeState)) {
-            previousRuntimeState = currentState;
-            return nextRuntimeState;
-          }
-          return currentState;
+          clearStreamingOnInactive,
+          sessionIdForErrors: sessionId,
+          // Only merge when agent:event mutated transcript/approvals during open;
+          // otherwise replace so warm-cache paint can be fully reconciled from DB.
+          mergeWithLiveState: liveMutationEpoch !== mutationEpochAtOpen,
         });
-        if (previousRuntimeState) {
-          notifyRuntimeStateErrors(
-            previousRuntimeState,
-            nextRuntimeState,
-            sessionId,
-          );
-        }
+        putOpenSessionView(sessionId, response);
+
         void actions.persistViewedAt().catch((err) => {
           logger.error(
             'Failed to mark session viewed during initialization',
@@ -413,6 +499,7 @@ export function useAgentSessionEvents(
         });
       } catch (err) {
         if (!isMounted) return;
+        invalidateOpenSessionView(sessionId);
         const errorMessage = err instanceof Error ? err.message : String(err);
         logger.error('Failed to initialize session', err);
         setters.setSession(null);
@@ -443,6 +530,10 @@ export function useAgentSessionEvents(
   ]);
 
   useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
     const markViewedOnReturn = () => {
       if (document.visibilityState === 'hidden') {
         return;
@@ -459,5 +550,5 @@ export function useAgentSessionEvents(
       window.removeEventListener('focus', markViewedOnReturn);
       document.removeEventListener('visibilitychange', markViewedOnReturn);
     };
-  }, [actions.persistViewedAt]);
+  }, [actions.persistViewedAt, isActive]);
 }

--- a/src/context/agent-session/useMcpServerFailureToasts.ts
+++ b/src/context/agent-session/useMcpServerFailureToasts.ts
@@ -18,6 +18,7 @@ export function mcpServerFailureToastId(
 export function useMcpServerFailureToasts(
   sessionId: string,
   runtimeState: SessionRuntimeState,
+  enabled = true,
 ): void {
   const { t } = useTranslation();
   const toastedKeysBySessionRef = useRef<Map<string, Set<string>>>(new Map());
@@ -33,7 +34,7 @@ export function useMcpServerFailureToasts(
   }, [sessionId]);
 
   useEffect(() => {
-    if (!sessionId) {
+    if (!sessionId || !enabled) {
       return;
     }
 
@@ -82,5 +83,5 @@ export function useMcpServerFailureToasts(
         );
       }
     }
-  }, [runtimeState.servers, sessionId, t]);
+  }, [runtimeState.servers, sessionId, t, enabled]);
 }

--- a/src/features/agent/AgentSessionKeepAliveHost.tsx
+++ b/src/features/agent/AgentSessionKeepAliveHost.tsx
@@ -1,0 +1,37 @@
+import { AgentSessionProvider } from '@/context/AgentSessionContext';
+import AgentChatView from './AgentChatView';
+import { useRetainedSessionIds } from './hooks/useRetainedSessionIds';
+
+interface AgentSessionKeepAliveHostProps {
+  activeSessionId: string;
+}
+
+/**
+ * Keeps the last few AgentSessionProviders mounted so switching back to a
+ * recently viewed session does not re-run openAgentSession / hydrating UX.
+ *
+ * Only the active session mounts AgentChatView (panels, virtuoso, chat UI).
+ * Inactive providers still receive agent:event updates in the background.
+ */
+export function AgentSessionKeepAliveHost({
+  activeSessionId,
+}: AgentSessionKeepAliveHostProps) {
+  const retainedIds = useRetainedSessionIds(activeSessionId);
+
+  return (
+    <div className="h-full">
+      {retainedIds.map((sessionId) => {
+        const isActive = sessionId === activeSessionId;
+        return (
+          <AgentSessionProvider
+            key={sessionId}
+            sessionId={sessionId}
+            isActive={isActive}
+          >
+            {isActive ? <AgentChatView /> : null}
+          </AgentSessionProvider>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/agent/AgentSessionRoute.tsx
+++ b/src/features/agent/AgentSessionRoute.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { AgentSessionProvider } from '@/context/AgentSessionContext';
-import AgentChatView from './AgentChatView';
+import { AgentSessionKeepAliveHost } from './AgentSessionKeepAliveHost';
 
 /**
  * Session route for /agent/:sessionId.
@@ -15,9 +14,5 @@ export default function AgentSessionRoute() {
     return null;
   }
 
-  return (
-    <AgentSessionProvider sessionId={sessionId}>
-      <AgentChatView />
-    </AgentSessionProvider>
-  );
+  return <AgentSessionKeepAliveHost activeSessionId={sessionId} />;
 }

--- a/src/features/agent/__tests__/AgentChatView.test.tsx
+++ b/src/features/agent/__tests__/AgentChatView.test.tsx
@@ -293,10 +293,7 @@ describe('AgentChatView', () => {
     expect(screen.getByText('mock-messages')).toBeInTheDocument();
     expect(screen.getByText('mock-header')).toBeInTheDocument();
     expect(screen.getByTestId('chat-provider')).toBeInTheDocument();
-    expect(toast.loading).toHaveBeenCalledWith(
-      'Opening session',
-      expect.objectContaining({ id: 'mcp-discovery:session-1' }),
-    );
+    expect(toast.loading).not.toHaveBeenCalled();
   });
 
   it('shows discovery loading toast during proxy initialization', () => {

--- a/src/features/agent/__tests__/AgentSessionKeepAliveHost.test.tsx
+++ b/src/features/agent/__tests__/AgentSessionKeepAliveHost.test.tsx
@@ -1,0 +1,118 @@
+import { render, waitFor, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
+import { useEffect } from 'react';
+
+import {
+  createOpenSessionResponse,
+  listenMock,
+  mockMarkSessionViewed,
+  mockRefreshCompactedRange,
+  openAgentSessionMock,
+  safeInvokeMock,
+} from '@/context/__tests__/agent-session-test-utils';
+import { clearOpenSessionViewCache } from '@/context/agent-session/openSessionViewCache';
+import { useAgentSessionState } from '@/context/AgentSessionContext';
+import { AgentSessionKeepAliveHost } from '../AgentSessionKeepAliveHost';
+
+vi.mock('@/features/agent/AgentChatView', () => ({
+  default: function MockAgentChatView() {
+    const state = useAgentSessionState();
+    return (
+      <div data-testid="chat-view" data-session-id={state.session?.id ?? ''}>
+        {state.session?.id}
+      </div>
+    );
+  },
+}));
+
+function KeepAliveRoute() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  if (!sessionId) {
+    return null;
+  }
+  return <AgentSessionKeepAliveHost activeSessionId={sessionId} />;
+}
+
+function NavigatingHarness({
+  onNavigateReady,
+}: {
+  onNavigateReady: (navigate: ReturnType<typeof useNavigate>) => void;
+}) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    onNavigateReady(navigate);
+  }, [navigate, onNavigateReady]);
+
+  return (
+    <Routes>
+      <Route path="/agent/:sessionId" element={<KeepAliveRoute />} />
+    </Routes>
+  );
+}
+
+describe('AgentSessionKeepAliveHost', () => {
+  const mockUnlisten = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearOpenSessionViewCache();
+    mockMarkSessionViewed.mockResolvedValue(undefined);
+    mockRefreshCompactedRange.mockResolvedValue(undefined);
+    listenMock.mockResolvedValue(mockUnlisten);
+    openAgentSessionMock.mockImplementation(async (sessionId: string) =>
+      createOpenSessionResponse(sessionId),
+    );
+    safeInvokeMock.mockResolvedValue(undefined);
+  });
+
+  it('does not re-open a retained session when switching back', async () => {
+    let navigate: ReturnType<typeof useNavigate> | undefined;
+
+    render(
+      <MemoryRouter initialEntries={['/agent/session-1']}>
+        <NavigatingHarness
+          onNavigateReady={(nav) => {
+            navigate = nav;
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(openAgentSessionMock).toHaveBeenCalledWith('session-1');
+      expect(navigate).toBeDefined();
+    });
+
+    await act(async () => {
+      navigate?.('/agent/session-2');
+    });
+
+    await waitFor(() => {
+      expect(openAgentSessionMock).toHaveBeenCalledWith('session-2');
+    });
+
+    await act(async () => {
+      navigate?.('/agent/session-1');
+    });
+
+    await waitFor(() => {
+      expect(
+        document
+          .querySelector('[data-testid="chat-view"]')
+          ?.getAttribute('data-session-id'),
+      ).toBe('session-1');
+    });
+
+    expect(
+      openAgentSessionMock.mock.calls.filter(([id]) => id === 'session-1'),
+    ).toHaveLength(1);
+  });
+});

--- a/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
+++ b/src/features/agent/hooks/__tests__/useMcpDiscoveryToasts.test.ts
@@ -35,7 +35,7 @@ describe('useMcpDiscoveryToasts', () => {
     vi.clearAllMocks();
   });
 
-  it('shows loading toast while proxy is not ready', () => {
+  it('shows loading toast immediately while external MCP is initializing', () => {
     renderHook(() =>
       useMcpDiscoveryToasts({
         hasSession: true,
@@ -51,6 +51,22 @@ describe('useMcpDiscoveryToasts', () => {
     expect(toast.loading).toHaveBeenCalledWith('Loading MCP: exa (0/1)', {
       id: 'mcp-discovery:s1',
     });
+  });
+
+  it('does not show loading toast during session hydration', () => {
+    renderHook(() =>
+      useMcpDiscoveryToasts({
+        hasSession: true,
+        isProxyReady: false,
+        phase: 'hydrating',
+        initResult: 'pending',
+        servers: [],
+        sessionId: 's-fast',
+        currentStep: 'Starting session...',
+      }),
+    );
+
+    expect(toast.loading).not.toHaveBeenCalled();
   });
 
   it('shows success toast with deterministic ID when discovery completes', () => {
@@ -72,7 +88,7 @@ describe('useMcpDiscoveryToasts', () => {
     );
   });
 
-  it('dismisses loading toast when builtin-only session becomes ready', () => {
+  it('does not toast for builtin-only sessions that become ready', () => {
     let isProxyReady = false;
     let phase: 'hydrating' | 'ready' = 'hydrating';
     let initResult: 'pending' | 'success' = 'pending';
@@ -89,17 +105,13 @@ describe('useMcpDiscoveryToasts', () => {
       }),
     );
 
-    expect(toast.loading).toHaveBeenCalledWith('Starting session...', {
-      id: 'mcp-discovery:s-builtin',
-    });
-    vi.clearAllMocks();
+    expect(toast.loading).not.toHaveBeenCalled();
 
     isProxyReady = true;
     phase = 'ready';
     initResult = 'success';
     rerender();
 
-    expect(toast.dismiss).toHaveBeenCalledWith('mcp-discovery:s-builtin');
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.warning).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();

--- a/src/features/agent/hooks/__tests__/useRetainedSessionIds.test.ts
+++ b/src/features/agent/hooks/__tests__/useRetainedSessionIds.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_RETAINED_AGENT_SESSIONS,
+  useRetainedSessionIds,
+} from '../useRetainedSessionIds';
+
+describe('useRetainedSessionIds', () => {
+  it('keeps the active session first and retains recent ids in MRU order', () => {
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useRetainedSessionIds(activeId),
+      { initialProps: { activeId: 's1' } },
+    );
+
+    expect(result.current).toEqual(['s1']);
+
+    rerender({ activeId: 's2' });
+    expect(result.current).toEqual(['s2', 's1']);
+
+    rerender({ activeId: 's3' });
+    expect(result.current).toEqual(['s3', 's2', 's1']);
+  });
+
+  it('evicts the oldest session past the retention limit', () => {
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useRetainedSessionIds(activeId, 2),
+      { initialProps: { activeId: 's1' } },
+    );
+
+    rerender({ activeId: 's2' });
+    rerender({ activeId: 's3' });
+
+    expect(result.current).toEqual(['s3', 's2']);
+    expect(result.current).not.toContain('s1');
+  });
+
+  it('moves a retained session to the front without duplicating it', () => {
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useRetainedSessionIds(activeId),
+      { initialProps: { activeId: 's1' } },
+    );
+
+    rerender({ activeId: 's2' });
+    rerender({ activeId: 's3' });
+    rerender({ activeId: 's1' });
+
+    expect(result.current).toEqual(['s1', 's3', 's2']);
+  });
+
+  it('defaults to MAX_RETAINED_AGENT_SESSIONS', () => {
+    expect(MAX_RETAINED_AGENT_SESSIONS).toBe(3);
+
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useRetainedSessionIds(activeId),
+      { initialProps: { activeId: 'a' } },
+    );
+
+    rerender({ activeId: 'b' });
+    rerender({ activeId: 'c' });
+    rerender({ activeId: 'd' });
+
+    expect(result.current).toHaveLength(MAX_RETAINED_AGENT_SESSIONS);
+    expect(result.current).toEqual(['d', 'c', 'b']);
+  });
+});

--- a/src/features/agent/hooks/useMcpDiscoveryToasts.ts
+++ b/src/features/agent/hooks/useMcpDiscoveryToasts.ts
@@ -26,8 +26,10 @@ function discoveryToastId(sessionId: string): string {
 }
 
 /**
- * Surfaces MCP discovery progress via Sonner instead of a chat-top banner.
- * Per-server failed/timed_out toasts remain in useMcpServerFailureToasts.
+ * Surfaces external MCP discovery via Sonner instead of a chat-top banner.
+ * Session hydration and builtin-only startups stay silent; the chat overlay
+ * and keep-alive host already cover that wait. Per-server failed/timed_out
+ * toasts remain in useMcpServerFailureToasts.
  */
 export function useMcpDiscoveryToasts({
   hasSession,
@@ -41,12 +43,16 @@ export function useMcpDiscoveryToasts({
   const { t } = useTranslation();
   const resultKeyBySessionRef = useRef<Map<string, string>>(new Map());
 
-  const showLoading = hasSession && !isProxyReady && phase !== 'failed';
+  const hasServers = servers.length > 0;
+  const showLoading =
+    hasSession &&
+    !isProxyReady &&
+    phase === 'initializing' &&
+    hasServers;
   const discoveryFinished =
     isProxyReady || phase === 'failed' || initResult !== 'pending';
   const isTerminalPhase =
     phase === 'ready' || phase === 'degraded' || phase === 'failed';
-  const hasServers = servers.length > 0;
 
   useEffect(() => {
     if (!sessionId || !hasSession) {
@@ -55,17 +61,16 @@ export function useMcpDiscoveryToasts({
 
     const id = discoveryToastId(sessionId);
 
-    if (showLoading) {
-      toast.loading(currentStep || t('agent.statusBar.loadingTools'), {
-        id,
-      });
+    if (!showLoading) {
+      // Session hydration and builtin-only startups stay silent. Dismiss so a
+      // previous MCP loading toast cannot linger after a fast switch.
+      toast.dismiss(id);
       return;
     }
 
-    // Always clear the loading toast once proxy init is no longer in progress.
-    // Builtin-only sessions (servers=[]) never show a result toast, so dismiss is
-    // required here. Sessions with external MCP reuse the same id for success/warn/error.
-    toast.dismiss(id);
+    toast.loading(currentStep || t('agent.statusBar.loadingTools'), {
+      id,
+    });
   }, [sessionId, hasSession, showLoading, currentStep, t]);
 
   useEffect(() => {

--- a/src/features/agent/hooks/useRetainedSessionIds.ts
+++ b/src/features/agent/hooks/useRetainedSessionIds.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+/** How many recently visited sessions keep their AgentSessionProvider mounted. */
+export const MAX_RETAINED_AGENT_SESSIONS = 3;
+
+/**
+ * MRU list of session ids to keep mounted for instant switch-back.
+ * Production callers omit `maxRetained` (uses MAX_RETAINED_AGENT_SESSIONS).
+ * Tests may pass a smaller window to assert eviction without changing the product default.
+ */
+export function useRetainedSessionIds(
+  activeSessionId: string,
+  maxRetained: number = MAX_RETAINED_AGENT_SESSIONS,
+): string[] {
+  const [retainedIds, setRetainedIds] = useState<string[]>([activeSessionId]);
+
+  useEffect(() => {
+    setRetainedIds((previous) => {
+      const withoutActive = previous.filter((id) => id !== activeSessionId);
+      const next = [activeSessionId, ...withoutActive].slice(0, maxRetained);
+      if (
+        next.length === previous.length &&
+        next.every((id, index) => id === previous[index])
+      ) {
+        return previous;
+      }
+      return next;
+    });
+  }, [activeSessionId, maxRetained]);
+
+  return retainedIds;
+}


### PR DESCRIPTION
## Summary
- Keep the last 3 visited `AgentSessionProvider` instances mounted so switching back does not remount and re-hydrate.
- Paint from an in-memory open-session cache, and skip resolve/hydrate/resume on the backend when the session is already active with a ready proxy.
- Show MCP loading toasts only while external servers are initializing, not during session hydration.

## Test plan
- [ ] Open session A, switch to B, then back to A — chat should appear immediately with no loading toast.
- [ ] Open a 4th session and confirm the oldest retained provider unmounts.
- [ ] Cold-open a session with external MCP servers — loading toast appears only during `initializing`.
- [ ] Builtin-only session open — no loading toast; first visit can still show the session overlay.
- [ ] While a session is opening, incoming stream/approval events should still merge into the open snapshot.

Made with [Cursor](https://cursor.com)