### PR TITLE
fix(ai): abort orphaned LLM requests on self-hosted prefills

### DIFF
--- a/src/lib/ai-service/__tests__/desktop-fetch.test.ts
+++ b/src/lib/ai-service/__tests__/desktop-fetch.test.ts
@@ -19,6 +19,7 @@ import {
   createLlmFetch,
   getLlmFetchTransportPreference,
   isLlmTransportNetworkError,
+  isLongRunningLlmRequest,
   isTauriLlmFetchRuntime,
   resolveLlmFetchOrigin,
 } from '../desktop-fetch';
@@ -99,7 +100,7 @@ describe('desktop-fetch', () => {
 
     expect(tauriPluginFetch).toHaveBeenCalledWith(
       'https://integrate.api.nvidia.com/v1/models',
-      { method: 'GET' },
+      expect.objectContaining({ method: 'GET', signal: expect.any(AbortSignal) }),
     );
     expect(
       getLlmFetchTransportPreference('https://integrate.api.nvidia.com'),
@@ -112,13 +113,19 @@ describe('desktop-fetch', () => {
 
     const url = new URL('https://example.com/v1/models');
     await llmFetch(url);
-    expect(tauriPluginFetch).toHaveBeenCalledWith(url, undefined);
+    expect(tauriPluginFetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
 
     const request = new Request('https://example.com/v1/chat');
     await llmFetch(request, { method: 'POST' });
     expect(tauriPluginFetch).toHaveBeenCalledWith(
       expect.any(Request),
-      { method: 'POST' },
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 
@@ -145,14 +152,45 @@ describe('desktop-fetch', () => {
     ).toBe('browser');
   });
 
+  it('isLongRunningLlmRequest detects completion POSTs only', () => {
+    expect(
+      isLongRunningLlmRequest('http://127.0.0.1:8080/v1/chat/completions', {
+        method: 'POST',
+      }),
+    ).toBe(true);
+    expect(
+      isLongRunningLlmRequest('http://127.0.0.1:11434/api/chat', {
+        method: 'POST',
+      }),
+    ).toBe(true);
+    expect(
+      isLongRunningLlmRequest('/v1/chat/completions', {
+        method: 'POST',
+      }),
+    ).toBe(true);
+    expect(
+      isLongRunningLlmRequest('http://127.0.0.1:8080/v1/models', {
+        method: 'GET',
+      }),
+    ).toBe(false);
+  });
+
+  it('resolveLlmFetchOrigin resolves relative paths against a base', () => {
+    expect(resolveLlmFetchOrigin('/v1/models')).toMatch(/^https?:\/\//);
+  });
+
   it('falls back when plugin-http hangs past native probe timeout', async () => {
     vi.useFakeTimers();
     const browserFetch = vi.fn().mockResolvedValue(new Response('browser-ok'));
     vi.stubGlobal('fetch', browserFetch);
+    const abortSignals: AbortSignal[] = [];
     // Never resolves — mimics corporate PAC hang via WinHTTP/reqwest.
-    vi.mocked(tauriPluginFetch).mockImplementation(
-      () => new Promise<Response>(() => {}),
-    );
+    vi.mocked(tauriPluginFetch).mockImplementation((_input, init) => {
+      if (init?.signal) {
+        abortSignals.push(init.signal);
+      }
+      return new Promise<Response>(() => {});
+    });
 
     const llmFetch = createLlmFetch({
       isTauri: true,
@@ -164,9 +202,44 @@ describe('desktop-fetch', () => {
 
     expect(await response.text()).toBe('browser-ok');
     expect(browserFetch).toHaveBeenCalledTimes(1);
+    expect(abortSignals[0]?.aborted).toBe(true);
     expect(
       getLlmFetchTransportPreference('http://175.115.246.118:4444'),
     ).toBe('browser');
+
+    vi.useRealTimers();
+  });
+
+  it('does not probe-timeout long-running chat completions', async () => {
+    vi.useFakeTimers();
+    const browserFetch = vi.fn();
+    vi.stubGlobal('fetch', browserFetch);
+    let resolveNative: ((value: Response) => void) | undefined;
+    vi.mocked(tauriPluginFetch).mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveNative = resolve;
+        }),
+    );
+
+    const llmFetch = createLlmFetch({
+      isTauri: true,
+      nativeProbeTimeoutMs: 100,
+    });
+    const pending = llmFetch('http://127.0.0.1:8080/v1/chat/completions', {
+      method: 'POST',
+      body: '{}',
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(browserFetch).not.toHaveBeenCalled();
+
+    resolveNative?.(new Response('native-ok'));
+    const response = await pending;
+    expect(await response.text()).toBe('native-ok');
+    expect(
+      getLlmFetchTransportPreference('http://127.0.0.1:8080'),
+    ).toBe('native');
 
     vi.useRealTimers();
   });
@@ -237,7 +310,7 @@ describe('desktop-fetch', () => {
     expect(await response.text()).toBe('browser-ok');
     expect(tauriPluginFetch).toHaveBeenCalledWith(
       expect.any(Request),
-      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(browserFetch).toHaveBeenCalledWith(request, undefined);
   });

--- a/src/lib/ai-service/__tests__/llm-host-policy.test.ts
+++ b/src/lib/ai-service/__tests__/llm-host-policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSelfHostedLlmBaseUrl,
+  resolveSelfHostedLlmClientOptions,
+  SELF_HOSTED_LLM_MAX_RETRIES,
+  SELF_HOSTED_LLM_TIMEOUT_MS,
+} from '../llm-host-policy';
+
+describe('llm-host-policy', () => {
+  it('detects loopback and private hosts as self-hosted', () => {
+    expect(isSelfHostedLlmBaseUrl('http://127.0.0.1:8080/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://localhost:1234/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://10.0.0.5:8000/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://192.168.1.10:8080/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://172.16.0.2:8080/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://llama.local:8080/v1')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('http://host.docker.internal:8080/v1')).toBe(
+      true,
+    );
+    expect(isSelfHostedLlmBaseUrl('127.0.0.1:11434')).toBe(true);
+    expect(isSelfHostedLlmBaseUrl('localhost:8080/v1')).toBe(true);
+  });
+
+  it('treats cloud and empty URLs as not self-hosted', () => {
+    expect(isSelfHostedLlmBaseUrl(undefined)).toBe(false);
+    expect(isSelfHostedLlmBaseUrl('')).toBe(false);
+    expect(isSelfHostedLlmBaseUrl('https://api.openai.com/v1')).toBe(false);
+    expect(isSelfHostedLlmBaseUrl('https://openrouter.ai/api/v1')).toBe(false);
+    expect(isSelfHostedLlmBaseUrl('not a url')).toBe(false);
+  });
+
+  it('resolves 15-minute timeout and zero retries for self-hosted hosts', () => {
+    expect(
+      resolveSelfHostedLlmClientOptions('http://127.0.0.1:8080/v1'),
+    ).toEqual({
+      timeout: SELF_HOSTED_LLM_TIMEOUT_MS,
+      maxRetries: SELF_HOSTED_LLM_MAX_RETRIES,
+    });
+
+    expect(
+      resolveSelfHostedLlmClientOptions('http://127.0.0.1:8080/v1', {
+        timeout: 1_200_000,
+        maxRetries: 3,
+      }),
+    ).toEqual({
+      timeout: 1_200_000,
+      maxRetries: 0,
+    });
+
+    expect(
+      resolveSelfHostedLlmClientOptions('https://api.openai.com/v1'),
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/ai-service/desktop-fetch.ts
+++ b/src/lib/ai-service/desktop-fetch.ts
@@ -9,8 +9,10 @@
  * webview but hang or time out via reqwest. On transport-level failures,
  * fall back to globalThis.fetch and remember the working transport per origin.
  *
- * Native attempts are bounded by a short probe timeout so fallback can finish
- * inside callers' outer listModels budgets (typically withTimeout 20s).
+ * Native probe timeout applies only to short discovery-style requests
+ * (e.g. listModels). Long-running completion POSTs skip the probe so slow
+ * local prefills are not mistaken for a hung transport. When falling back,
+ * the native request is always aborted to avoid orphaned GPU work.
  */
 import { fetch as tauriPluginFetch } from '@tauri-apps/plugin-http';
 import { getLogger } from '@/lib/logger';
@@ -65,16 +67,77 @@ export function isTauriLlmFetchRuntime(
 }
 
 /**
+ * Base used when request URLs are relative (OpenAI SDK normally sends absolute
+ * URLs; this keeps pathname/origin parsing from throwing).
+ */
+function getUrlParseBase(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'http://localhost';
+}
+
+function parseLlmRequestUrl(input: RequestInfo | URL): URL {
+  return new URL(resolveRequestUrl(input), getUrlParseBase());
+}
+
+/**
  * Resolve the origin used for sticky transport selection.
  */
 export function resolveLlmFetchOrigin(input: RequestInfo | URL): string {
+  return parseLlmRequestUrl(input).origin;
+}
+
+function resolveRequestUrl(input: RequestInfo | URL): string {
   if (typeof input === 'string') {
-    return new URL(input).origin;
+    return input;
   }
   if (input instanceof URL) {
-    return input.origin;
+    return input.href;
   }
-  return new URL(input.url).origin;
+  return input.url;
+}
+
+function resolveRequestMethod(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): string {
+  if (init?.method) {
+    return init.method.toUpperCase();
+  }
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+  return 'GET';
+}
+
+/**
+ * Completion-style POSTs can take many minutes for large local prefills.
+ * A short transport probe must not treat slow TTFT as a hung connection.
+ */
+export function isLongRunningLlmRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): boolean {
+  const method = resolveRequestMethod(input, init);
+  if (method !== 'POST' && method !== 'PUT') {
+    return false;
+  }
+
+  let pathname: string;
+  try {
+    pathname = parseLlmRequestUrl(input).pathname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  return (
+    pathname.includes('/chat/completions') ||
+    pathname.includes('/completions') ||
+    pathname.endsWith('/messages') ||
+    pathname.includes('/api/generate') ||
+    pathname.includes('/api/chat')
+  );
 }
 
 /**
@@ -135,7 +198,7 @@ function splitRequestForRetry(input: RequestInfo | URL): {
 
 /**
  * Race a promise against a timeout without aborting the underlying work.
- * Used so a hanging plugin-http call cannot block browser fallback forever.
+ * Callers must abort the underlying request when falling back after a timeout.
  */
 export function raceWithTimeout<T>(
   promise: Promise<T>,
@@ -160,6 +223,34 @@ export function raceWithTimeout<T>(
   });
 }
 
+function mergeAbortSignals(upstream: AbortSignal | undefined): {
+  signal: AbortSignal;
+  abort: (reason?: unknown) => void;
+  cleanup: () => void;
+} {
+  const local = new AbortController();
+
+  const onUpstreamAbort = () => {
+    local.abort(upstream?.reason);
+  };
+
+  if (upstream) {
+    if (upstream.aborted) {
+      local.abort(upstream.reason);
+    } else {
+      upstream.addEventListener('abort', onUpstreamAbort);
+    }
+  }
+
+  return {
+    signal: local.signal,
+    abort: (reason?: unknown) => local.abort(reason),
+    cleanup: () => {
+      upstream?.removeEventListener('abort', onUpstreamAbort);
+    },
+  };
+}
+
 async function fetchWithNativeFallback(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
@@ -173,15 +264,29 @@ async function fetchWithNativeFallback(
   }
 
   const { nativeInput, browserInput } = splitRequestForRetry(input);
+  const { signal, abort, cleanup } = mergeAbortSignals(
+    init?.signal ?? undefined,
+  );
+  const nativeInit: RequestInit = { ...init, signal };
+  const skipProbe = isLongRunningLlmRequest(input, init);
 
   try {
-    const response = await raceWithTimeout(
-      tauriPluginFetch(nativeInput, init),
-      nativeProbeTimeoutMs,
-    );
+    const nativePromise = tauriPluginFetch(nativeInput, nativeInit);
+    const response = skipProbe
+      ? await nativePromise
+      : await raceWithTimeout(nativePromise, nativeProbeTimeoutMs);
     transportByOrigin.set(origin, 'native');
     return response;
   } catch (nativeError) {
+    // Always cancel native work before opening a second connection.
+    if (!signal.aborted) {
+      abort();
+    }
+
+    if (init?.signal?.aborted) {
+      throw nativeError;
+    }
+
     if (!isLlmTransportNetworkError(nativeError)) {
       throw nativeError;
     }
@@ -206,13 +311,15 @@ async function fetchWithNativeFallback(
       }
       throw browserError;
     }
+  } finally {
+    cleanup();
   }
 }
 
 /**
  * Returns fetch for LLM SDKs and raw provider calls.
- * Tauri → plugin-http first (bounded probe), webview fetch on transport failure.
- * Non-Tauri → globalThis.fetch.
+ * Tauri → plugin-http first (bounded probe for short requests), webview fetch
+ * on transport failure. Non-Tauri → globalThis.fetch.
  */
 export function createLlmFetch(
   options: {

--- a/src/lib/ai-service/factory.ts
+++ b/src/lib/ai-service/factory.ts
@@ -45,6 +45,7 @@ function buildConfigCacheKey(config?: AIServiceConfig): string {
     customModelId: config.customModelId ?? '',
     maxRetries: config.maxRetries ?? null,
     retryDelay: config.retryDelay ?? null,
+    timeout: config.timeout ?? null,
   });
 }
 

--- a/src/lib/ai-service/llm-host-policy.ts
+++ b/src/lib/ai-service/llm-host-policy.ts
@@ -1,0 +1,87 @@
+/**
+ * Timeouts and retries for self-hosted / local OpenAI-compatible endpoints.
+ *
+ * Large context prefills (e.g. ~128k at session start) commonly take 5–6+
+ * minutes on local llama.cpp / Ollama hosts. Cloud-oriented short timeouts and
+ * retries create duplicate in-flight completions and GPU contention.
+ */
+
+/** Allow slow local prefills with headroom beyond typical 5–6 minute runs. */
+export const SELF_HOSTED_LLM_TIMEOUT_MS = 900_000; // 15 minutes
+
+/** Never auto-retry slow local prefills — retries duplicate GPU work. */
+export const SELF_HOSTED_LLM_MAX_RETRIES = 0;
+
+/**
+ * True when `baseUrl` points at a loopback, private-network, or .local host.
+ * Empty / invalid URLs are treated as cloud (not self-hosted).
+ * Scheme-less values like `127.0.0.1:11434` are normalized with `http://`.
+ */
+export function isSelfHostedLlmBaseUrl(
+  baseUrl: string | undefined | null,
+): boolean {
+  if (!baseUrl || !baseUrl.trim()) {
+    return false;
+  }
+
+  const trimmed = baseUrl.trim();
+  const normalized = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
+    ? trimmed
+    : `http://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return false;
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === '0.0.0.0' ||
+    host === 'host.docker.internal'
+  ) {
+    return true;
+  }
+
+  if (host.endsWith('.local')) {
+    return true;
+  }
+
+  // Private IPv4 ranges (RFC 1918)
+  if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) {
+    return true;
+  }
+  if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) {
+    return true;
+  }
+  if (/^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Defaults for self-hosted OpenAI-compatible / Ollama clients.
+ * - `config.timeout` wins when set; otherwise 15 minutes.
+ * - `config.maxRetries` is ignored: retries are always forced to 0 so settings'
+ *   cloud retry policy cannot duplicate local prefills.
+ */
+export function resolveSelfHostedLlmClientOptions(
+  baseUrl: string | undefined | null,
+  config?: { timeout?: number; maxRetries?: number },
+): { timeout: number; maxRetries: number } | undefined {
+  if (!isSelfHostedLlmBaseUrl(baseUrl)) {
+    return undefined;
+  }
+
+  return {
+    timeout: config?.timeout ?? SELF_HOSTED_LLM_TIMEOUT_MS,
+    maxRetries: SELF_HOSTED_LLM_MAX_RETRIES,
+  };
+}

--- a/src/lib/ai-service/ollama.ts
+++ b/src/lib/ai-service/ollama.ts
@@ -27,6 +27,10 @@ import {
   serializeDirectToolCalls,
 } from './stream-events';
 import { createLlmFetch } from './desktop-fetch';
+import {
+  SELF_HOSTED_LLM_MAX_RETRIES,
+  SELF_HOSTED_LLM_TIMEOUT_MS,
+} from './llm-host-policy';
 import { reportListModelsFallback } from './list-models-errors';
 
 const logger = getLogger('OllamaService');
@@ -101,11 +105,14 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
    * @param config Optional configuration for the service.
    */
   constructor(apiKey: string, config?: AIServiceConfig) {
-    // Local models can be slow, especially for initial loading or large context.
-    // We increase the default timeout to 5 minutes (300000ms) if not explicitly provided.
+    // Ollama is always treated as self-hosted: large prefills (e.g. ~128k at
+    // session start) commonly take 5–6+ minutes. Disable retries so a slow
+    // prefill is not duplicated onto another slot.
+    const timeout = config?.timeout ?? SELF_HOSTED_LLM_TIMEOUT_MS;
     super(apiKey, {
-      timeout: 300_000,
       ...config,
+      timeout,
+      maxRetries: SELF_HOSTED_LLM_MAX_RETRIES,
     });
     this.host = config?.baseUrl || 'http://127.0.0.1:11434';
 
@@ -116,6 +123,8 @@ export class OllamaService extends BaseAIService<SimpleOllamaMessage, Tool> {
     });
     logger.info('Ollama service initialized', {
       host: this.host,
+      timeout,
+      maxRetries: SELF_HOSTED_LLM_MAX_RETRIES,
     });
   }
 

--- a/src/lib/ai-service/openai.ts
+++ b/src/lib/ai-service/openai.ts
@@ -27,6 +27,7 @@ import {
   serializeToolCallArgumentDeltas,
 } from './stream-events';
 import { createLlmFetch } from './desktop-fetch';
+import { resolveSelfHostedLlmClientOptions } from './llm-host-policy';
 import { reportListModelsFallback } from './list-models-errors';
 import type {
   OpenAINonStreamingRequest,
@@ -102,12 +103,30 @@ export class OpenAIService extends BaseAIService<
    * @param config Optional configuration for the service.
    */
   constructor(apiKey: string, config?: AIServiceConfig) {
-    super(apiKey, config);
+    const selfHostedOptions = resolveSelfHostedLlmClientOptions(
+      config?.baseUrl,
+      config,
+    );
+    const resolvedConfig: AIServiceConfig | undefined = selfHostedOptions
+      ? {
+          ...config,
+          timeout: selfHostedOptions.timeout,
+          maxRetries: selfHostedOptions.maxRetries,
+        }
+      : config;
+
+    super(apiKey, resolvedConfig);
     this.openai = new OpenAI({
       apiKey: this.apiKey,
       baseURL: config?.baseUrl || undefined,
       dangerouslyAllowBrowser: true,
       fetch: createLlmFetch(),
+      ...(selfHostedOptions
+        ? {
+            timeout: selfHostedOptions.timeout,
+            maxRetries: selfHostedOptions.maxRetries,
+          }
+        : {}),
     });
     this.promptDiagnostics = new OpenAIPromptDiagnosticsTracker(this.logger);
   }


### PR DESCRIPTION
## Summary
- Abort native plugin-http work before browser fallback so local LLM servers (llama.cpp/Ollama) do not keep orphaned GPU prefills running.
- Skip the short 2s transport probe for completion POSTs, where slow TTFT is expected for large contexts.
- Apply a 15-minute timeout and zero-retry policy for self-hosted / private-network OpenAI-compatible and Ollama endpoints.

Fixes #1751

## Test plan
- [ ] Run a large (~128k) first-turn completion against local llama.cpp / Ollama and confirm only one in-flight request appears in server logs
- [ ] Confirm listModels still falls back from plugin-http to browser fetch when native transport hangs
- [ ] `pnpm exec vitest run src/lib/ai-service/__tests__/desktop-fetch.test.ts src/lib/ai-service/__tests__/llm-host-policy.test.ts`
- [ ] `pnpm refactor:validate` (or CI green)

Made with [Cursor](https://cursor.com)