### PR TITLE
fix(workspace): keep handoff process IDs visible after sync timeout

### DIFF
--- a/src-tauri/src/mcp/builtin/workspace/context.rs
+++ b/src-tauri/src/mcp/builtin/workspace/context.rs
@@ -115,9 +115,19 @@ pub async fn build_workspace_live_state(
     }
 }
 
+/// How long a terminal process stays visible as "Recently Finished" in service context.
+/// Bridges sync-timeout handoff tool messages (still "running") and the next turn's
+/// live context after the process exits between turns.
+pub const RECENT_FINISHED_CONTEXT_SECS: i64 = 60;
+
+/// Cap listed recently-finished processes to keep the prompt compact.
+pub const MAX_RECENT_FINISHED_IN_CONTEXT: usize = 3;
+
 /// Format the Running Processes section for the workspace service context.
 ///
 /// Awaits the registry lock so lock contention never produces a false "None".
+/// Only active (Starting/Running) processes are listed here; see
+/// [`format_recently_finished_processes_text`] for terminal entries still in the registry.
 pub async fn format_running_processes_text(
     process_registry: &terminal_manager::ProcessRegistry,
     session_id: &str,
@@ -150,6 +160,89 @@ pub async fn format_running_processes_text(
     }
 }
 
+fn is_recently_finished_entry(
+    entry: &terminal_manager::ProcessEntry,
+    now: chrono::DateTime<chrono::Utc>,
+    window: chrono::Duration,
+) -> bool {
+    if !terminal_manager::is_terminal_process_status(&entry.status) {
+        return false;
+    }
+    let Some(finished_at) = entry.finished_at else {
+        return false;
+    };
+    now.signed_duration_since(finished_at) <= window
+}
+
+/// Count session processes that finished within [`RECENT_FINISHED_CONTEXT_SECS`].
+///
+/// Used to skip idle service-context caching while handoff IDs remain queryable.
+pub async fn count_recently_finished_processes(
+    process_registry: &terminal_manager::ProcessRegistry,
+    session_id: &str,
+) -> usize {
+    let reg = process_registry.read().await;
+    let now = chrono::Utc::now();
+    let window = chrono::Duration::seconds(RECENT_FINISHED_CONTEXT_SECS);
+    reg.entries
+        .values()
+        .filter(|e| e.session_id == session_id)
+        .filter(|e| is_recently_finished_entry(e, now, window))
+        .count()
+}
+
+/// Format recently finished (still-registered) processes for service context.
+///
+/// Returns `None` when there are none. Keeps sync-timeout handoff processIds
+/// visible after they leave the Running set so the next turn does not only see
+/// `Running Processes: None`.
+pub async fn format_recently_finished_processes_text(
+    process_registry: &terminal_manager::ProcessRegistry,
+    session_id: &str,
+) -> Option<String> {
+    let reg = process_registry.read().await;
+    let now = chrono::Utc::now();
+    let window = chrono::Duration::seconds(RECENT_FINISHED_CONTEXT_SECS);
+
+    let mut finished: Vec<&terminal_manager::ProcessEntry> = reg
+        .entries
+        .values()
+        .filter(|e| e.session_id == session_id)
+        .filter(|e| is_recently_finished_entry(e, now, window))
+        .collect();
+
+    if finished.is_empty() {
+        return None;
+    }
+
+    finished.sort_by(|left, right| {
+        right
+            .finished_at
+            .cmp(&left.finished_at)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let total = finished.len();
+    let lines: Vec<String> = finished
+        .into_iter()
+        .take(MAX_RECENT_FINISHED_IN_CONTEXT)
+        .map(|entry| {
+            let status = terminal_manager::process_status_label(&entry.status);
+            let exit = entry
+                .exit_code
+                .map(|code| format!(", exit {code}"))
+                .unwrap_or_default();
+            let display_cmd = crate::utils::truncate_chars(&entry.command, 60);
+            format!("  • {} [{status}{exit}] - {display_cmd}", entry.id)
+        })
+        .collect();
+
+    let list = lines.join("\n");
+    Some(format!(
+        "{total} (still queryable via waitForProcess/readProcessOutput)\n{list}"
+    ))
+}
+
 /// Build the service context prompt text used in BuiltinMCPServer::get_service_context.
 pub async fn build_context_prompt(
     session_id: &str,
@@ -159,8 +252,14 @@ pub async fn build_context_prompt(
 ) -> String {
     let state = build_workspace_live_state(session_id, session_manager, shell_manager).await;
 
-    // Running processes with IDs for AI visibility (finished-only totals omitted — no actionable IDs).
+    // Active processes plus a short recently-finished window so handoff IDs stay
+    // visible after natural exit between turns (full finished history omitted).
     let running_processes_text = format_running_processes_text(process_registry, session_id).await;
+    let recently_finished_line =
+        match format_recently_finished_processes_text(process_registry, session_id).await {
+            Some(text) => format!("\n- Recently Finished: {text}"),
+            None => String::new(),
+        };
 
     let file_tools_list = workspace_file_tools_context_list();
     let isolation_lines = if state.is_docker {
@@ -185,7 +284,7 @@ pub async fn build_context_prompt(
 - Persistent Shell CWD: {shell_cwd}
 {platform_info}
 {shell_info}
-- Running Processes: {running_processes_text}
+- Running Processes: {running_processes_text}{recently_finished_line}
 - Internal Paths: `.libragent/tmp/` (process I/O), `.libragent/exports/` (exported files) are hidden from listing to keep workspace clean.",
         workspace_dir = state.workspace_dir,
         shell_cwd = state.shell_cwd,

--- a/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
+++ b/src-tauri/src/mcp/builtin/workspace/handlers/terminal/wait.rs
@@ -107,6 +107,10 @@ impl WorkspaceServer {
                     | terminal_manager::ProcessStatus::Failed
                     | terminal_manager::ProcessStatus::Killed
             ) {
+                // Drop idle "Running Processes: None" cache so the next turn can
+                // pick up the Recently Finished window for this processId.
+                self.invalidate_context_cache().await;
+
                 let response = serde_json::json!({
                     "process_id": process_id,
                     "status": terminal_manager::process_status_label(&status),

--- a/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
+++ b/src-tauri/src/mcp/builtin/workspace/workspace_server.rs
@@ -821,6 +821,8 @@ impl WorkspaceServer {
         };
 
         let (mut running_count, mut total_count) = count_processes().await;
+        let mut recent_finished_count =
+            context::count_recently_finished_processes(&self.process_registry, &session_id).await;
 
         // Rebuild once if a process finished during prompt construction.
         // Prevents returning/caching a stale "Running Processes: <id>" line when the
@@ -838,12 +840,16 @@ impl WorkspaceServer {
             )
             .await;
             (running_count, total_count) = count_processes().await;
+            recent_finished_count =
+                context::count_recently_finished_processes(&self.process_registry, &session_id)
+                    .await;
         }
 
-        // Only cache a consistent idle snapshot. Active process lists must stay
-        // live — natural exit can change status without a tool call.
-        let prompt_is_idle = context_prompt.contains("- Running Processes: None");
-        if running_count == 0 && prompt_is_idle {
+        // Only cache a consistent idle snapshot. Active or recently-finished lists
+        // must stay live — natural exit / handoff windows change without a tool call.
+        let prompt_is_idle = context_prompt.contains("- Running Processes: None")
+            && !context_prompt.contains("- Recently Finished:");
+        if running_count == 0 && recent_finished_count == 0 && prompt_is_idle {
             let mut guard = self.context_cache.write().await;
             *guard = Some((context_prompt.clone(), std::time::Instant::now()));
         } else {
@@ -859,6 +865,7 @@ impl WorkspaceServer {
                 "processes": {
                     "running": running_count,
                     "total": total_count,
+                    "recent_finished": recent_finished_count,
                 },
                 "shell_active": !shell_cwd.is_empty(),
                 "tools_count": Self::tools_static().len()

--- a/src-tauri/tests/integration/service_context_noise_tests.rs
+++ b/src-tauri/tests/integration/service_context_noise_tests.rs
@@ -142,9 +142,45 @@ async fn workspace_service_context_running_processes_track_lifecycle() {
         after_finish.context_prompt
     );
     assert!(
-        !after_finish.context_prompt.contains(&process_id),
-        "finished process id must not remain listed as running: {}",
+        after_finish.context_prompt.contains(&process_id),
+        "recently finished handoff id must remain in Recently Finished: {}",
         after_finish.context_prompt
+    );
+    assert!(
+        after_finish.context_prompt.contains("- Recently Finished:"),
+        "must expose Recently Finished section after exit: {}",
+        after_finish.context_prompt
+    );
+    let recent_finished = after_finish
+        .structured_state
+        .as_ref()
+        .and_then(|state| state.get("processes"))
+        .and_then(|processes| processes.get("recent_finished"))
+        .and_then(|value| value.as_u64());
+    assert_eq!(
+        recent_finished,
+        Some(1),
+        "structured state should count the recent finished process: {:?}",
+        after_finish.structured_state
+    );
+
+    // Idle None must not be TTL-cached while a recently finished id is still queryable.
+    let second_look = server.get_service_context(None).await;
+    let was_cached = second_look
+        .structured_state
+        .as_ref()
+        .and_then(|state| state.get("cached"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    assert!(
+        !was_cached,
+        "must not cache idle context while Recently Finished is present: {:?}",
+        second_look.structured_state
+    );
+    assert!(
+        second_look.context_prompt.contains(&process_id),
+        "second look must still show the handoff id: {}",
+        second_look.context_prompt
     );
 }
 

--- a/src-tauri/tests/workspace_running_processes_context_tests.rs
+++ b/src-tauri/tests/workspace_running_processes_context_tests.rs
@@ -3,7 +3,10 @@
 //! Avoids constructing WorkspaceServer (full Tauri/WebView link path can fail to
 //! start on Windows with STATUS_ENTRYPOINT_NOT_FOUND).
 
-use tauri_mcp_agent_lib::mcp::builtin::workspace::context::format_running_processes_text;
+use tauri_mcp_agent_lib::mcp::builtin::workspace::context::{
+    count_recently_finished_processes, format_recently_finished_processes_text,
+    format_running_processes_text,
+};
 use tauri_mcp_agent_lib::mcp::builtin::workspace::terminal_manager::{
     create_process_registry, ProcessEntry, ProcessStatus,
 };
@@ -28,6 +31,17 @@ fn sample_entry(id: &str, session_id: &str, status: ProcessStatus) -> ProcessEnt
         consecutive_running_polls: 0,
         first_running_poll_at: None,
     }
+}
+
+fn finished_entry(
+    id: &str,
+    session_id: &str,
+    finished_at: chrono::DateTime<chrono::Utc>,
+) -> ProcessEntry {
+    let mut entry = sample_entry(id, session_id, ProcessStatus::Finished);
+    entry.exit_code = Some(0);
+    entry.finished_at = Some(finished_at);
+    entry
 }
 
 #[tokio::test]
@@ -78,4 +92,68 @@ async fn format_running_processes_reports_none_when_idle() {
 
     let text = format_running_processes_text(&registry, "session-1").await;
     assert_eq!(text, "None");
+}
+
+#[tokio::test]
+async fn recently_finished_lists_handoff_ids_within_window() {
+    let registry = create_process_registry();
+    let now = chrono::Utc::now();
+    {
+        let mut reg = registry.write().await;
+        reg.entries.insert(
+            "sync_123".to_string(),
+            finished_entry("sync_123", "session-1", now),
+        );
+        reg.entries.insert(
+            "old_done".to_string(),
+            finished_entry(
+                "old_done",
+                "session-1",
+                now - chrono::Duration::seconds(120),
+            ),
+        );
+        reg.entries.insert(
+            "other_sess".to_string(),
+            finished_entry("other_sess", "session-2", now),
+        );
+        // Terminal without finished_at must not appear (not proven recent).
+        reg.entries.insert(
+            "no_ts".to_string(),
+            sample_entry("no_ts", "session-1", ProcessStatus::Finished),
+        );
+    }
+
+    let text = format_recently_finished_processes_text(&registry, "session-1")
+        .await
+        .expect("recent finished should be present");
+    assert!(
+        text.contains("sync_123"),
+        "recent handoff id must stay visible: {text}"
+    );
+    assert!(
+        text.contains("waitForProcess"),
+        "must hint query tools: {text}"
+    );
+    assert!(
+        !text.contains("old_done"),
+        "outside window must be omitted: {text}"
+    );
+    assert!(
+        !text.contains("other_sess"),
+        "other session must not leak: {text}"
+    );
+    assert!(
+        !text.contains("no_ts"),
+        "finished without finished_at must be omitted: {text}"
+    );
+
+    assert_eq!(
+        count_recently_finished_processes(&registry, "session-1").await,
+        1
+    );
+    assert!(
+        format_recently_finished_processes_text(&registry, "session-empty")
+            .await
+            .is_none()
+    );
 }


### PR DESCRIPTION
## Summary
- After `runShell` sync-timeout handoff, a process can finish between turns while the prior tool message still says `running`; service context used to show only `Running Processes: None`, confusing the agent.
- Add a short **Recently Finished** window (60s, max 3) with queryable process IDs, skip idle `None` caching while that window is active, and invalidate context cache when `waitForProcess` returns a terminal status.

## Test plan
- [ ] `cargo test --test workspace_running_processes_context_tests`
- [ ] On Linux/macOS: `cargo test --test integration_tests workspace_service_context_running_processes_track_lifecycle`
- [ ] Manual: `runShell` with short sync timeout on a longer command → after process exits, next turn service context lists the handoff id under Recently Finished (not bare None alone)

Made with [Cursor](https://cursor.com)