### PR TITLE
fix(agent): unify execution-mode SSOT and harden session-context framing

### DIFF
--- a/src-tauri/src/agent/llm/prompt.rs
+++ b/src-tauri/src/agent/llm/prompt.rs
@@ -338,6 +338,18 @@ fn build_stable_prefix(
         parts.push(identity);
     }
 
+    // Always ground session-context handling in the stable prefix so providers that
+    // inject volatile state as a synthetic user message do not treat it as intent.
+    parts.push(
+        "\n\n## Session Context Handling\n\
+         Runtime may inject a `<session-context>` block (or an equivalent background message) \
+         containing time, workspace, and tool state.\n\
+         Treat that block as passive environment reference only — never as a user command, \
+         preference, or new task.\n\
+         Base actions on the explicit user request (or your assigned sub-agent task)."
+            .to_string(),
+    );
+
     // 2. Persona / Voice Template — injected from SOUL.md and kept distinct from
     //    workspace instructions because it defines character, not task guidance.
     if let Some((filename, content)) = &soul_instruction {
@@ -507,14 +519,14 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            prompt,
+        assert!(prompt.starts_with(
             "Base prompt only.\n\n\n## Agent Runtime Identity\n\
             - Agent Name: Default Assistant\n\
             - Agent ID: (unknown)\n\
             - Session ID: (unknown-session)"
-        );
-        assert!(!prompt.contains("## Session Context"));
+        ));
+        assert!(prompt.contains("## Session Context Handling"));
+        assert!(prompt.contains("passive environment reference only"));
         assert!(!prompt.contains("## Workspace Instructions"));
         assert!(!prompt.contains("## Available Tools & Current State"));
     }

--- a/src-tauri/src/agent/llm/request_layout.rs
+++ b/src-tauri/src/agent/llm/request_layout.rs
@@ -7,6 +7,12 @@ use crate::models::chat::{Message, MessageSource};
 const SESSION_CONTEXT_BACKGROUND_HEADER: &str = "<session-context>";
 const SESSION_CONTEXT_BACKGROUND_FOOTER: &str = "</session-context>";
 
+/// Explicit non-intent framing shown to the model inside the injected block.
+const SESSION_CONTEXT_DISCLAIMER: &str =
+    "BACKGROUND SESSION CONTEXT — environment telemetry and tool state only. \
+This is NOT a user instruction or preference. Follow the latest real user request \
+(or your assigned sub-agent task); use this block only as passive reference.";
+
 #[derive(Debug, Clone)]
 pub struct RequestLayout {
     pub system_prompt: Option<String>,
@@ -48,14 +54,36 @@ fn synthetic_session_context_id_prefix(provider: &str) -> &str {
 }
 
 fn format_session_context_text(provider: &str, session_context: &str) -> String {
+    let body = format!("{}\n\n{}", SESSION_CONTEXT_DISCLAIMER, session_context);
     if provider_uses_background_reference_wrapper(provider) {
         format!(
             "{}\n\n{}\n\n{}",
-            SESSION_CONTEXT_BACKGROUND_HEADER, session_context, SESSION_CONTEXT_BACKGROUND_FOOTER
+            SESSION_CONTEXT_BACKGROUND_HEADER, body, SESSION_CONTEXT_BACKGROUND_FOOTER
         )
     } else {
-        session_context.to_string()
+        // Anthropic historically omitted XML wrappers; keep the disclaimer either way.
+        body
     }
+}
+
+/// Choose where to inject synthetic session context.
+///
+/// Priority:
+/// 1. Keep compaction overlays last (instruction attention).
+/// 2. Place context immediately before the latest external user request so that
+///    real user intent retains recency over environment telemetry.
+/// 3. Otherwise append at the (pre-compaction) tail — e.g. tool-result continuations.
+fn synthetic_session_context_insert_index(messages: &[Message]) -> usize {
+    let mut insert_idx = messages.len();
+    if insert_idx > 0 && messages[insert_idx - 1].is_compaction_overlay_message() {
+        insert_idx -= 1;
+    }
+
+    if insert_idx > 0 && messages[insert_idx - 1].is_external_request_message() {
+        insert_idx -= 1;
+    }
+
+    insert_idx
 }
 
 pub fn build_request_layout(
@@ -73,18 +101,16 @@ pub fn build_request_layout(
     };
 
     if provider_uses_synthetic_session_context(provider) {
-        // If the last message is a compaction overlay (e.g. instruction), we want to
-        // insert the session context message before it to preserve LLM instruction attention.
-        let mut insert_idx = messages.len();
-        if insert_idx > 0 && messages[insert_idx - 1].is_compaction_overlay_message() {
-            insert_idx -= 1;
-        }
+        let insert_idx = synthetic_session_context_insert_index(&messages);
 
-        let reference_message_id = if insert_idx > 0 {
-            messages[insert_idx - 1].id.as_str()
-        } else {
-            "system"
-        };
+        let reference_message_id =
+            if insert_idx < messages.len() && messages[insert_idx].is_external_request_message() {
+                messages[insert_idx].id.as_str()
+            } else if insert_idx > 0 {
+                messages[insert_idx - 1].id.as_str()
+            } else {
+                "system"
+            };
         let now = chrono::Utc::now().timestamp_millis();
         let session_context_msg = Message {
             id: format!(
@@ -121,11 +147,12 @@ pub fn build_request_layout(
             messages,
         }
     } else {
+        let framed_context = format_session_context_text(provider, &session_context);
         let mut merged = false;
         for message in messages.iter_mut().rev() {
             if message.role == "user" && !message.is_internal_synthetic_user_message() {
                 let mut new_content = vec![MCPContent::Text {
-                    text: format_session_context_text(provider, &session_context),
+                    text: framed_context.clone(),
                 }];
                 new_content.append(&mut message.content);
                 message.content = new_content;
@@ -136,7 +163,7 @@ pub fn build_request_layout(
 
         let system_prompt = if !merged {
             Some(
-                [system_prompt, Some(session_context)]
+                [system_prompt, Some(framed_context)]
                     .into_iter()
                     .flatten()
                     .filter(|part| !part.is_empty())

--- a/src-tauri/src/agent/llm/tool_execution.rs
+++ b/src-tauri/src/agent/llm/tool_execution.rs
@@ -40,24 +40,26 @@ impl ToolExecutionContext<'_> {
         }
     }
 
-    async fn current_yolo_mode(&self) -> bool {
+    async fn current_execution_mode(&self) -> crate::execution_mode::ExecutionMode {
         let active = self.active_sessions.read().await;
         active
             .get(self.session_id)
-            .map(|session| session.yolo_mode.load(std::sync::atomic::Ordering::Relaxed))
-            .unwrap_or(false)
+            .map(|session| session.execution_mode())
+            .unwrap_or(crate::execution_mode::ExecutionMode::Normal)
+    }
+
+    async fn current_yolo_mode(&self) -> bool {
+        matches!(
+            self.current_execution_mode().await,
+            crate::execution_mode::ExecutionMode::Yolo
+        )
     }
 
     async fn current_unsafe_mode(&self) -> bool {
-        let active = self.active_sessions.read().await;
-        active
-            .get(self.session_id)
-            .map(|session| {
-                session
-                    .unsafe_mode
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            })
-            .unwrap_or(false)
+        matches!(
+            self.current_execution_mode().await,
+            crate::execution_mode::ExecutionMode::Unsafe
+        )
     }
 
     /// Best-effort lookup of the session's configured output-token budget.

--- a/src-tauri/src/agent/session_manager.rs
+++ b/src-tauri/src/agent/session_manager.rs
@@ -534,12 +534,7 @@ impl AgentSessionManager {
         {
             let active = self.active_sessions.read().await;
             if let Some(session) = active.get(session_id) {
-                return ExecutionMode::from_runtime_flags(
-                    session.yolo_mode.load(std::sync::atomic::Ordering::Relaxed),
-                    session
-                        .unsafe_mode
-                        .load(std::sync::atomic::Ordering::Relaxed),
-                );
+                return session.execution_mode();
             }
         }
 

--- a/src-tauri/src/agent/session_manager/execution_mode.rs
+++ b/src-tauri/src/agent/session_manager/execution_mode.rs
@@ -1,39 +1,85 @@
 use super::AgentSessionManager;
 use crate::execution_mode::ExecutionMode;
-use std::sync::atomic::Ordering;
 
+/// Compare-and-restore helper for a failed persist after an optimistic in-memory write.
+///
+/// If another writer already moved `current` past `written`, keep `current`.
+pub fn revert_mode_if_unchanged(
+    current: ExecutionMode,
+    written: ExecutionMode,
+    previous: ExecutionMode,
+) -> ExecutionMode {
+    if current == written {
+        previous
+    } else {
+        current
+    }
+}
+
+/// Persist and apply session execution mode.
+///
+/// # SSOT
+/// Active sessions: `AgentSession.metadata.execution_mode` is the only in-memory
+/// authority. The DB mirrors it for cold open / HTTP GET.
+///
+/// # Race notes
+/// - In-memory update runs under the active-sessions write lock so readers never
+///   observe a torn mode.
+/// - Memory is updated **before** DB so tool approval / warm UI see the new mode
+///   immediately.
+/// - On DB failure we revert memory only if it still equals the mode we wrote
+///   (compare-and-restore), so a concurrent successful `set_execution_mode` is
+///   not clobbered by a late failure rollback.
 pub async fn set_execution_mode(
     manager: &AgentSessionManager,
     session_id: &str,
     mode: ExecutionMode,
 ) -> Result<(), String> {
-    let (yolo_enabled, unsafe_enabled) = mode.runtime_flags();
-    manager
-        .session_repo
-        .update_execution_mode(session_id, mode)
-        .await
-        .map_err(|e| format!("Failed to update session execution mode: {}", e))?;
-
-    let has_active_session = {
-        let active = manager.active_sessions.read().await;
-        if let Some(session) = active.get(session_id) {
-            session.yolo_mode.store(yolo_enabled, Ordering::SeqCst);
-            session.unsafe_mode.store(unsafe_enabled, Ordering::SeqCst);
-            true
+    let previous_mode = {
+        let mut active = manager.active_sessions.write().await;
+        if let Some(session) = active.get_mut(session_id) {
+            let previous = session.metadata.execution_mode;
+            session.metadata.execution_mode = mode;
+            Some(previous)
         } else {
-            false
+            None
         }
     };
 
-    if !has_active_session {
+    if let Err(error) = manager
+        .session_repo
+        .update_execution_mode(session_id, mode)
+        .await
+    {
+        if let Some(previous) = previous_mode {
+            let mut active = manager.active_sessions.write().await;
+            if let Some(session) = active.get_mut(session_id) {
+                session.metadata.execution_mode =
+                    revert_mode_if_unchanged(session.metadata.execution_mode, mode, previous);
+            }
+        }
+        return Err(format!(
+            "Failed to update session execution mode: {}",
+            error
+        ));
+    }
+
+    if previous_mode.is_none() {
         log::info!(
-            "Updated execution mode for persisted session '{}' without active runtime state",
-            session_id
+            "Updated execution mode for persisted session '{}' to {} (no active runtime)",
+            session_id,
+            mode.as_str()
+        );
+    } else {
+        log::info!(
+            "Set execution mode for session '{}' to {}",
+            session_id,
+            mode.as_str()
         );
     }
 
     if let Some(include_hard_approvals) = mode.include_hard_approvals() {
-        if has_active_session {
+        if previous_mode.is_some() {
             super::approvals::approve_all_pending_tool_approvals(
                 manager,
                 session_id,

--- a/src-tauri/src/agent/state.rs
+++ b/src-tauri/src/agent/state.rs
@@ -457,12 +457,6 @@ pub struct AgentSession {
     /// Cancellation token to abort running workflows
     pub cancellation_token: CancellationToken,
 
-    /// YOLO mode: execute tools without requiring approval
-    pub yolo_mode: Arc<AtomicBool>,
-
-    /// Unsafe mode: bypass approval and policy enforcement
-    pub unsafe_mode: Arc<AtomicBool>,
-
     /// Cancel-pending flag to block post-cancel recursion/re-entry
     pub cancel_pending: Arc<AtomicBool>,
 
@@ -534,17 +528,21 @@ pub struct AgentSession {
 }
 
 impl AgentSession {
+    /// In-memory SSOT for approval policy. Persisted copy lives in the session repo.
+    #[inline]
+    pub fn execution_mode(&self) -> crate::execution_mode::ExecutionMode {
+        self.metadata.execution_mode
+    }
+
     /// Construct a new idle in-memory session shell for create / resume / recover.
     ///
-    /// Runtime flags (`yolo_mode` / `unsafe_mode`) are derived from
-    /// `metadata.execution_mode`. Field layout stays flat — do not wrap groups
-    /// in `Arc` (prior Arc-grouping attempt was reverted).
+    /// Field layout stays flat — do not wrap groups in `Arc` (prior Arc-grouping
+    /// attempt was reverted).
     pub fn new(
         metadata: SessionMetadata,
         context_registry: Arc<ContextRegistry>,
         compact_context: Option<CompactContextRecord>,
     ) -> Self {
-        let (yolo_enabled, unsafe_enabled) = metadata.execution_mode.runtime_flags();
         Self {
             metadata,
             is_running: false,
@@ -552,8 +550,6 @@ impl AgentSession {
             status_transition: Arc::new(RwLock::new(None)),
             transition_lock: Arc::new(Mutex::new(())),
             cancellation_token: CancellationToken::new(),
-            yolo_mode: Arc::new(AtomicBool::new(yolo_enabled)),
-            unsafe_mode: Arc::new(AtomicBool::new(unsafe_enabled)),
             cancel_pending: Arc::new(AtomicBool::new(false)),
             pending_execution: None,
             messages: Arc::new(RwLock::new(Vec::new())),
@@ -669,8 +665,6 @@ mod tests {
             status_transition: Arc::new(RwLock::new(None)),
             transition_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancellation_token: CancellationToken::new(),
-            yolo_mode: Arc::new(AtomicBool::new(false)),
-            unsafe_mode: Arc::new(AtomicBool::new(false)),
             cancel_pending: Arc::new(AtomicBool::new(false)),
             pending_execution: None,
             messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/src/agent/workflow/finish.rs
+++ b/src-tauri/src/agent/workflow/finish.rs
@@ -693,8 +693,6 @@ mod tests {
             status_transition: Arc::new(RwLock::new(None)),
             transition_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancellation_token: CancellationToken::new(),
-            yolo_mode: Arc::new(AtomicBool::new(false)),
-            unsafe_mode: Arc::new(AtomicBool::new(false)),
             cancel_pending: Arc::new(AtomicBool::new(false)),
             pending_execution: None,
             messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/src/commands/agent_commands/session_commands.rs
+++ b/src-tauri/src/commands/agent_commands/session_commands.rs
@@ -120,16 +120,19 @@ async fn try_open_warm_session(
 
 async fn build_open_session_response(
     manager: &AgentSessionManager,
-    session: SessionMetadata,
+    mut session: SessionMetadata,
     session_id: &str,
     message_limit: u64,
 ) -> Result<AgentOpenSessionResponse, String> {
+    // Open payloads must expose the live SSOT (active metadata, else DB), not a
+    // stale caller-provided SessionMetadata clone taken before a concurrent mode change.
+    session.execution_mode = manager.get_execution_mode(session_id).await;
+
     let repo = crate::state::get_message_repository();
     let mut message_slice = repo
         .get_recent_slice(session_id, message_limit)
         .await
         .map_err(|e| format!("Failed to load recent session messages: {}", e))?;
-
     // Pending prompts are stored in `messages` plus a `pending_queue` index.
     // Strip only true waiters (LayeredPendingQueue). Never strip:
     // - IDs already on the live active message stack (promoted / Idle path)

--- a/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
+++ b/src-tauri/src/mcp/builtin/workspace/code_execution/shell/handlers.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
-use std::sync::atomic::Ordering;
 
+use crate::execution_mode::ExecutionMode;
 use crate::mcp::builtin::error_guidance::{
     guided_error, missing_param_error, ErrorCategory, ToolGroup,
 };
@@ -16,14 +16,14 @@ impl WorkspaceServer {
             return false;
         };
 
+        // Fail closed if the map is write-locked (e.g. mid set_execution_mode).
         let Ok(active) = active_sessions.try_read() else {
             return false;
         };
 
         active
             .get(&self.session_id)
-            .map(|session| session.unsafe_mode.load(Ordering::Relaxed))
-            .unwrap_or(false)
+            .is_some_and(|session| session.execution_mode() == ExecutionMode::Unsafe)
     }
 
     #[cfg(windows)]
@@ -406,8 +406,6 @@ mod tests {
             status_transition: Arc::new(RwLock::new(None)),
             transition_lock: Arc::new(tokio::sync::Mutex::new(())),
             cancellation_token: CancellationToken::new(),
-            yolo_mode: Arc::new(AtomicBool::new(false)),
-            unsafe_mode: Arc::new(AtomicBool::new(true)),
             cancel_pending: Arc::new(AtomicBool::new(false)),
             pending_execution: None,
             messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/src/services/agent_service/spawn.rs
+++ b/src-tauri/src/services/agent_service/spawn.rs
@@ -122,12 +122,12 @@ impl AgentService {
             ExecutionMode::Normal
         };
 
-        if resolved_mode != ExecutionMode::Normal {
-            manager
-                .set_execution_mode(&session_id, resolved_mode)
-                .await
-                .map_err(|e| format!("Failed to set execution mode: {}", e))?;
-        }
+        // Always write through set_execution_mode so active metadata + DB share one path
+        // (including explicit `normal` and parent inheritance).
+        manager
+            .set_execution_mode(&session_id, resolved_mode)
+            .await
+            .map_err(|e| format!("Failed to set execution mode: {}", e))?;
 
         let Some(initial_request) = initial_request else {
             return Ok(CreateSessionResponse {

--- a/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
+++ b/src-tauri/tests/circuit_breaker_batch_loop_tests.rs
@@ -69,8 +69,6 @@ fn build_active_session(session_id: &str, messages: Vec<Message>) -> AgentSessio
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(true)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(messages)),

--- a/src-tauri/tests/execution_mode_ssot_tests.rs
+++ b/src-tauri/tests/execution_mode_ssot_tests.rs
@@ -1,0 +1,98 @@
+//! Windows-safe coverage for execution-mode SSOT helpers.
+//!
+//! Full `AgentSessionManager::set_execution_mode` needs a repository + Tauri app;
+//! this binary covers the in-memory SSOT surface and the CAS restore used when a
+//! later DB write fails after a concurrent writer has already moved mode again.
+
+use std::sync::Arc;
+use tauri_mcp_agent_lib::agent::context::registry::ContextRegistry;
+use tauri_mcp_agent_lib::agent::session_manager::execution_mode::revert_mode_if_unchanged;
+use tauri_mcp_agent_lib::agent::state::AgentSession;
+use tauri_mcp_agent_lib::execution_mode::ExecutionMode;
+use tauri_mcp_agent_lib::models::workspace_isolation::WorkspaceIsolationMode;
+use tauri_mcp_agent_lib::repositories::{SessionMetadata, SessionStatus};
+
+fn sample_metadata(mode: ExecutionMode) -> SessionMetadata {
+    let now = 1_i64;
+    SessionMetadata {
+        id: "session-ssot-1".to_string(),
+        name: Some("ssot".to_string()),
+        status: SessionStatus::Idle,
+        model: "gpt-test".to_string(),
+        provider: "openai".to_string(),
+        assistant_id: None,
+        parent_session_id: None,
+        lineage_id: None,
+        depth: None,
+        max_depth: None,
+        max_fanout: None,
+        org_id: None,
+        org_name: None,
+        org_root_session_id: None,
+        created_at: now,
+        updated_at: now,
+        last_viewed_at: None,
+        last_message_at: None,
+        last_attention_at: None,
+        last_attention_reason: None,
+        is_bookmarked: false,
+        execution_mode: mode,
+        workspace_override: None,
+        workspace_isolation: WorkspaceIsolationMode::Host,
+        docker_config: None,
+        docker_container_name: None,
+        docker_host_workspace_path: None,
+    }
+}
+
+#[test]
+fn agent_session_execution_mode_is_metadata_ssot() {
+    for mode in [
+        ExecutionMode::Normal,
+        ExecutionMode::Yolo,
+        ExecutionMode::Unsafe,
+    ] {
+        let session = AgentSession::new(
+            sample_metadata(mode),
+            Arc::new(ContextRegistry::new()),
+            None,
+        );
+        assert_eq!(session.execution_mode(), mode);
+        assert_eq!(session.metadata.execution_mode, mode);
+    }
+}
+
+#[test]
+fn mutating_metadata_execution_mode_is_immediately_visible() {
+    let mut session = AgentSession::new(
+        sample_metadata(ExecutionMode::Normal),
+        Arc::new(ContextRegistry::new()),
+        None,
+    );
+    session.metadata.execution_mode = ExecutionMode::Unsafe;
+    assert_eq!(session.execution_mode(), ExecutionMode::Unsafe);
+}
+
+#[test]
+fn revert_restores_previous_when_still_expected() {
+    assert_eq!(
+        revert_mode_if_unchanged(
+            ExecutionMode::Yolo,
+            ExecutionMode::Yolo,
+            ExecutionMode::Normal
+        ),
+        ExecutionMode::Normal
+    );
+}
+
+#[test]
+fn revert_skips_when_concurrent_writer_already_moved_mode() {
+    assert_eq!(
+        revert_mode_if_unchanged(
+            ExecutionMode::Unsafe,
+            ExecutionMode::Yolo,
+            ExecutionMode::Normal
+        ),
+        ExecutionMode::Unsafe
+    );
+}

--- a/src-tauri/tests/integration/circuit_breaker_short_circuit_tests.rs
+++ b/src-tauri/tests/integration/circuit_breaker_short_circuit_tests.rs
@@ -113,8 +113,6 @@ fn build_active_session(session_id: &str, messages: Vec<Message>) -> AgentSessio
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(true)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(messages)),

--- a/src-tauri/tests/integration/compact_error_recovery_tests.rs
+++ b/src-tauri/tests/integration/compact_error_recovery_tests.rs
@@ -127,8 +127,6 @@ fn build_agent_session(
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/tests/integration/message_dedup_tests.rs
+++ b/src-tauri/tests/integration/message_dedup_tests.rs
@@ -87,8 +87,6 @@ fn build_agent_session(session_id: &str) -> AgentSession {
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/tests/integration/mod.rs
+++ b/src-tauri/tests/integration/mod.rs
@@ -72,7 +72,6 @@ pub mod read_file_empty_file_tests;
 pub mod read_process_output_tests;
 pub mod reference_resolver_tests;
 pub mod repeated_thinking_recovery_tests;
-pub mod request_layout_checkpoint_tests;
 pub mod resume_proxy_rehydration_tests;
 pub mod runtime_state_sequence_tests;
 pub mod scheduled_task_policy_tests;

--- a/src-tauri/tests/integration/pending_queue_tests.rs
+++ b/src-tauri/tests/integration/pending_queue_tests.rs
@@ -95,8 +95,6 @@ fn build_agent_session(session_id: &str) -> AgentSession {
         status_transition: Arc::new(tokio::sync::RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(tokio::sync::RwLock::new(Vec::new())),

--- a/src-tauri/tests/integration/tool_loop_fence_tests.rs
+++ b/src-tauri/tests/integration/tool_loop_fence_tests.rs
@@ -66,8 +66,6 @@ fn build_active_session(session_id: &str, messages: Vec<Message>) -> AgentSessio
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(true)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(messages)),

--- a/src-tauri/tests/integration/workflow_finish_pending_tests.rs
+++ b/src-tauri/tests/integration/workflow_finish_pending_tests.rs
@@ -51,8 +51,6 @@ fn build_session(session_id: &str) -> AgentSession {
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/tests/integration/workflow_restart_state_tests.rs
+++ b/src-tauri/tests/integration/workflow_restart_state_tests.rs
@@ -56,8 +56,6 @@ fn build_agent_session(metadata: SessionMetadata) -> AgentSession {
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/tests/integration/workflow_settlement_durability_tests.rs
+++ b/src-tauri/tests/integration/workflow_settlement_durability_tests.rs
@@ -260,8 +260,6 @@ fn build_agent_session(session_id: &str, status: SessionStatus) -> AgentSession 
         status_transition: Arc::new(RwLock::new(None)),
         transition_lock: Arc::new(tokio::sync::Mutex::new(())),
         cancellation_token: CancellationToken::new(),
-        yolo_mode: Arc::new(AtomicBool::new(false)),
-        unsafe_mode: Arc::new(AtomicBool::new(false)),
         cancel_pending: Arc::new(AtomicBool::new(false)),
         pending_execution: None,
         messages: Arc::new(RwLock::new(Vec::new())),

--- a/src-tauri/tests/request_layout_checkpoint_tests.rs
+++ b/src-tauri/tests/request_layout_checkpoint_tests.rs
@@ -1,3 +1,6 @@
+//! Windows-safe coverage for LLM request layout / session-context injection.
+//! (Standalone binary — does not pull AppHandle/WebView into the link.)
+
 use tauri_mcp_agent_lib::agent::llm::{
     build_request_layout, is_custom_openai_compatible_provider,
     provider_uses_synthetic_session_context, select_last_submitted_input_message_id,
@@ -31,6 +34,13 @@ fn make_user_message(id: &str, source: Option<MessageSource>) -> Message {
     }
 }
 
+fn text_at(message: &Message, index: usize) -> &str {
+    match &message.content[index] {
+        MCPContent::Text { text, .. } => text.as_str(),
+        other => panic!("expected text content, got {:?}", other),
+    }
+}
+
 #[test]
 fn custom_openai_compatible_provider_uses_synthetic_session_context() {
     assert!(is_custom_openai_compatible_provider("custom:local-vllm"));
@@ -47,21 +57,16 @@ fn custom_openai_compatible_provider_uses_synthetic_session_context() {
     );
 
     assert_eq!(layout.messages.len(), 2);
-    assert!(layout
-        .messages
-        .last()
-        .expect("custom provider should inject synthetic session context")
-        .is_request_layout_scaffolding_message());
-    assert!(layout
-        .messages
-        .last()
-        .expect("synthetic message")
+    assert!(layout.messages[0].is_request_layout_scaffolding_message());
+    assert!(layout.messages[0]
         .id
         .starts_with("custom-openai-session-context-"));
+    assert_eq!(layout.messages[1].id, "real-user");
+    assert!(text_at(&layout.messages[0], 0).contains("NOT a user instruction"));
 }
 
 #[test]
-fn checkpoint_selection_skips_synthetic_session_context_tail() {
+fn synthetic_session_context_is_placed_before_latest_external_user() {
     let layout = build_request_layout(
         "openai",
         "session-1",
@@ -74,15 +79,16 @@ fn checkpoint_selection_skips_synthetic_session_context_tail() {
         select_last_submitted_input_message_id(&layout.messages).as_deref(),
         Some("real-user")
     );
-    assert!(layout
-        .messages
-        .last()
-        .expect("layout should include synthetic session context")
-        .is_request_layout_scaffolding_message());
+    assert!(layout.messages[0].is_request_layout_scaffolding_message());
+    assert_eq!(
+        layout.messages.last().map(|m| m.id.as_str()),
+        Some("real-user")
+    );
+    assert!(text_at(&layout.messages[0], 0).contains("<session-context>"));
 }
 
 #[test]
-fn checkpoint_selection_skips_all_internal_synthetic_tail_messages() {
+fn synthetic_session_context_stays_before_compaction_overlay() {
     let layout = build_request_layout(
         "openai",
         "session-1",
@@ -97,10 +103,30 @@ fn checkpoint_selection_skips_all_internal_synthetic_tail_messages() {
         ],
     );
 
+    assert_eq!(layout.messages.len(), 3);
+    assert!(layout.messages[0].is_request_layout_scaffolding_message());
+    assert_eq!(layout.messages[1].id, "real-user");
+    assert!(layout.messages[2].is_compaction_overlay_message());
     assert_eq!(
         select_last_submitted_input_message_id(&layout.messages).as_deref(),
         Some("real-user")
     );
+}
+
+#[test]
+fn anthropic_includes_disclaimer_without_xml_wrapper() {
+    let layout = build_request_layout(
+        "anthropic",
+        "session-1",
+        Some("system".to_string()),
+        Some("background context".to_string()),
+        vec![make_user_message("real-user", Some(MessageSource::Ui))],
+    );
+
+    let text = text_at(&layout.messages[0], 0);
+    assert!(!text.contains("<session-context>"));
+    assert!(text.contains("NOT a user instruction"));
+    assert!(text.contains("background context"));
 }
 
 #[test]
@@ -120,12 +146,10 @@ fn non_synthetic_provider_merges_context_into_last_user_message() {
     assert_eq!(layout.messages.len(), 1);
     let content = &layout.messages[0].content;
     assert!(content.len() > 1); // contains merged context + original text
-    if let MCPContent::Text { text, .. } = &content[0] {
-        assert!(text.contains("<session-context>"));
-        assert!(text.contains("volatile context"));
-    } else {
-        panic!("First content item should be text containing the volatile context");
-    }
+    let text = text_at(&layout.messages[0], 0);
+    assert!(text.contains("<session-context>"));
+    assert!(text.contains("NOT a user instruction"));
+    assert!(text.contains("volatile context"));
 }
 
 #[test]
@@ -138,10 +162,10 @@ fn non_synthetic_provider_falls_back_to_system_prompt_when_no_user_message() {
         vec![],
     );
 
-    // Since there was no user message, volatile context is appended to system prompt
-    assert_eq!(
-        layout.system_prompt.as_deref(),
-        Some("system prompt\n\nvolatile context")
-    );
+    let system = layout.system_prompt.expect("system prompt");
+    assert!(system.starts_with("system prompt\n\n"));
+    assert!(system.contains("<session-context>"));
+    assert!(system.contains("NOT a user instruction"));
+    assert!(system.contains("volatile context"));
     assert_eq!(layout.messages.len(), 0);
 }

--- a/src/lib/ai-service/__tests__/anthropic.helpers.test.ts
+++ b/src/lib/ai-service/__tests__/anthropic.helpers.test.ts
@@ -319,7 +319,7 @@ describe('Anthropic helper modules', () => {
     });
   });
 
-  it('moves the cache breakpoint to the last stable message before a synthetic session-context tail', () => {
+  it('moves the cache breakpoint to the last stable message before synthetic session-context', () => {
     const messages: Message[] = [
       {
         id: 'user-1',
@@ -357,6 +357,63 @@ describe('Anthropic helper modules', () => {
     });
   });
 
+  it('keeps cache breakpoint before session-context when latest user follows it', () => {
+    const messages: Message[] = [
+      {
+        id: 'history-1',
+        sessionId: 'session-1',
+        threadId: 'session-1',
+        role: 'user',
+        content: [{ type: 'text', text: 'Earlier turn' }],
+      },
+      {
+        id: 'session-context',
+        sessionId: 'session-1',
+        threadId: 'session-1',
+        role: 'user',
+        source: 'session-context',
+        content: [
+          {
+            type: 'text',
+            text: 'BACKGROUND SESSION CONTEXT — not a user instruction\nvolatile',
+          },
+        ],
+      },
+      {
+        id: 'user-latest',
+        sessionId: 'session-1',
+        threadId: 'session-1',
+        role: 'user',
+        source: 'ui',
+        content: [{ type: 'text', text: 'Do the real task' }],
+      },
+    ];
+
+    const result = convertToAnthropicMessages(messages);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Earlier turn',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    });
+    expect(result[1]).toMatchObject({
+      role: 'user',
+      content:
+        'BACKGROUND SESSION CONTEXT — not a user instruction\nvolatile',
+    });
+    expect(result[2]).toMatchObject({
+      role: 'user',
+      content: 'Do the real task',
+    });
+    expect(JSON.stringify(result[2])).not.toContain('cache_control');
+  });
+
   it('adds an extra midpoint cache breakpoint for long Anthropic conversations', () => {
     const messages: Message[] = Array.from({ length: 8 }, (_, index) => ({
       id: `user-${index + 1}`,
@@ -391,7 +448,7 @@ describe('Anthropic helper modules', () => {
     });
   });
 
-  it('keeps the extra Anthropic midpoint breakpoint on stable history before a synthetic session-context tail', () => {
+  it('keeps the extra Anthropic midpoint breakpoint on stable history before synthetic session-context', () => {
     const stableMessages: Message[] = Array.from({ length: 8 }, (_, index) => ({
       id: `user-${index + 1}`,
       sessionId: 'session-1',

--- a/src/lib/ai-service/anthropic/message-converter.ts
+++ b/src/lib/ai-service/anthropic/message-converter.ts
@@ -151,7 +151,10 @@ export function convertToAnthropicMessages(
   let pendingToolResults: ReturnType<
     typeof buildAnthropicToolResultBlocks
   >['content'] = [];
-  let hasSyntheticSessionContextTail = false;
+  // Set when the first synthetic session-context appears. Points at the last
+  // message before that block (or stays unset when session-context leads).
+  let lastStableBeforeSessionContext: number | undefined;
+  let sawSyntheticSessionContext = false;
 
   const flushPendingToolResults = () => {
     if (pendingToolResults.length === 0) {
@@ -175,8 +178,15 @@ export function convertToAnthropicMessages(
     if (effectiveRole === 'user') {
       if (isAnthropicSyntheticSessionContextMessage(message)) {
         flushPendingToolResults();
-        applyCacheBreakpoint(anthropicMessages[anthropicMessages.length - 1]);
-        hasSyntheticSessionContextTail = true;
+        if (!sawSyntheticSessionContext) {
+          sawSyntheticSessionContext = true;
+          if (anthropicMessages.length > 0) {
+            lastStableBeforeSessionContext = anthropicMessages.length - 1;
+            applyCacheBreakpoint(
+              anthropicMessages[lastStableBeforeSessionContext],
+            );
+          }
+        }
       }
 
       flushPendingToolResults();
@@ -278,15 +288,20 @@ export function convertToAnthropicMessages(
 
   flushPendingToolResults();
 
-  const lastStableMessageIndex = hasSyntheticSessionContextTail
-    ? anthropicMessages.length - 2
+  const resolvedLastStableMessageIndex = sawSyntheticSessionContext
+    ? lastStableBeforeSessionContext
     : anthropicMessages.length - 1;
 
-  applyLongConversationCacheBreakpoint(
-    anthropicMessages,
-    lastStableMessageIndex,
-  );
-  applyCacheBreakpoint(anthropicMessages[lastStableMessageIndex]);
+  if (
+    resolvedLastStableMessageIndex !== undefined &&
+    resolvedLastStableMessageIndex >= 0
+  ) {
+    applyLongConversationCacheBreakpoint(
+      anthropicMessages,
+      resolvedLastStableMessageIndex,
+    );
+    applyCacheBreakpoint(anthropicMessages[resolvedLastStableMessageIndex]);
+  }
 
   return anthropicMessages;
 }


### PR DESCRIPTION
## Summary
- Make `metadata.execution_mode` the sole in-memory authority for YOLO/Unsafe approvals (remove `yolo_mode`/`unsafe_mode` atomics), with memory-first writes and compare-and-restore on DB failure.
- Frame synthetic session-context as passive background (system grounding + disclaimer) and insert it before the latest external user turn so it is not treated as user intent.
- Fix Anthropic cache breakpoints to anchor on the last stable message before the session-context block; move layout/SSOT coverage to Windows-safe standalone test binaries.

## Test plan
- [ ] `cargo test --test execution_mode_ssot_tests` (4/4)
- [ ] `cargo test --test request_layout_checkpoint_tests` (6/6)
- [ ] `pnpm exec vitest run src/lib/ai-service/__tests__/anthropic.helpers.test.ts`
- [ ] Spawn API session with `executionMode: yolo` / `unsafe`, open session in UI — mode matches approvals
- [ ] Confirm warm open does not show Normal while tools use YOLO/Unsafe

Made with [Cursor](https://cursor.com)