### PR TITLE
fix(mcp): clarify active-session tool immutability (#1754)

### DIFF
--- a/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
+++ b/src-tauri/src/mcp/builtin/agent/handlers/configs.rs
@@ -387,8 +387,8 @@ pub async fn update_agent(
                 )
                 .with_guidance(vec![
                     "This restriction prevents privilege escalation and identity drift during a session.".to_string(),
-                    "If this task requires a different configuration, delegate it using another agent configuration with the required permissions."
-                        .to_string(),
+                    "Active session tool access is fixed at session start; updating a template cannot inject tools into this running session.".to_string(),
+                    "If this task requires a different configuration, delegate it using another agent configuration with the required permissions.".to_string(),
                     "List available agent configurations, then start a new delegated session with one that can perform the change."
                         .to_string(),
                 ])
@@ -455,8 +455,9 @@ pub async fn update_agent(
                     &config,
                 ),
                 vec![
-                    "Inspect the configuration details to verify the changes".to_string(),
-                    "Start a new delegated session to apply the updated configuration".to_string(),
+                    "This updates the agent template only — it does not change tools in any currently running session.".to_string(),
+                    "Inspect the configuration details to verify the changes.".to_string(),
+                    "Start a new session (or agent__startSession with this config) to apply the updated tool access.".to_string(),
                 ],
             );
 

--- a/src-tauri/src/mcp/builtin/agent/tools.rs
+++ b/src-tauri/src/mcp/builtin/agent/tools.rs
@@ -43,7 +43,7 @@ fn create_tool() -> MCPTool {
                 ("name".to_string(), string_prop_required("Unique name for the agent configuration.")),
                 ("description".to_string(), string_prop(None, None, Some("Short description of what this agent does. If omitted, the configuration is created without a description."))),
                 ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("List of optional builtin service aliases to add beyond the always-on core services (e.g. ['planning', 'browser', 'knowledge']). Core services remain enabled even when you pass a restricted list. If omitted (or []), only core services are enabled — list optional aliases explicitly when needed."))),
-                ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("List of external MCP server IDs to allow (e.g. ['github', 'google-search']). If omitted, the configuration leaves external MCP server overrides unset."))),
+                ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("List of external MCP server IDs to allow for sessions started from this config (e.g. ['github', 'google-search']). If omitted, the configuration leaves external MCP server overrides unset."))),
                 ("systemPrompt".to_string(), string_prop(None, None, Some("The core personality and instructions for the agent. If omitted, no custom system prompt is stored."))),
             ],
             vec!["name".to_string()],
@@ -118,15 +118,16 @@ fn update_tool() -> MCPTool {
         name: "updateAgent".to_string(),
         title: Some("Update Agent Configuration".to_string()),
         description: tool_description(
-            "Update an existing agent configuration including system prompt and tool access.",
+            "Update an existing agent configuration template (system prompt and tool access). Changes apply to future sessions only — they cannot add or modify tools in a currently active session.",
             &["Configuration ID from agent__listAgents(type='configs')."],
             &[
                 "Pass the config id and only the fields to change.",
                 "Model selection and sampling defaults are controlled elsewhere — not via this tool.",
+                "You cannot update the assistant configuration your current session is already running as.",
             ],
             &[
-                "Verify capabilities with agent__listAgents(verbose=true).",
-                "Attach MCP servers using IDs from tool__listServers.",
+                "Verify the template with agent__listAgents(verbose=true).",
+                "Start a new session (or agent__startSession) to run with the updated tool access.",
             ],
         ),
         input_schema: object_prop(
@@ -144,7 +145,7 @@ fn update_tool() -> MCPTool {
                     string_prop(None, None, Some("New description. If omitted, keep the current description unchanged.")),
                 ),
                 ("builtinCapabilities".to_string(), array_schema(string_prop(None, None, None), Some("Replace the optional builtin service aliases that are added on top of the always-on core services. If omitted, keep the current optional builtin capability list unchanged."))),
-                ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("Replace the allowed external MCP server IDs. If omitted, keep the current external MCP server list unchanged."))),
+                ("externalMcpServers".to_string(), array_schema(string_prop(None, None, None), Some("Replace the allowed external MCP server IDs for future sessions using this config. Does not change tools in currently running sessions. If omitted, keep the current external MCP server list unchanged."))),
                 (
                     "systemPrompt".to_string(),
                     string_prop(None, None, Some("New system instructions. If omitted, keep the current system prompt unchanged.")),

--- a/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
+++ b/src-tauri/src/mcp/builtin/error_guidance/guidance.rs
@@ -474,8 +474,8 @@ impl SuccessHint {
                 "Use agent__startSession to begin work with this agent".to_string(),
             ],
             ("updateAgent", ToolGroup::Agent) => vec![
-                "Use agent__listAgents to verify the configuration updates".to_string(),
-                "Use agent__startSession to apply changes in a new session".to_string(),
+                "Use agent__listAgents to verify the template updates".to_string(),
+                "Start a new session (or agent__startSession) — updates do not change tools in already-running sessions".to_string(),
             ],
             ("startSession", ToolGroup::Agent) => vec![
                 "Use agent__messageToSession only for follow-up instructions after the session starts"

--- a/src-tauri/src/mcp/builtin/tool/mod.rs
+++ b/src-tauri/src/mcp/builtin/tool/mod.rs
@@ -46,7 +46,7 @@ impl BuiltinMCPServer for ToolServer {
             "registerServer" => operations::register_server(self, args).await,
             "updateServer" => operations::update_server(self, args).await,
             "deleteServer" => operations::delete_server(self, args).await,
-            "verifyServer" => operations::verify_server(self, args).await,
+            "verifyServer" => operations::verify_server(self, args, session_id.as_deref()).await,
             _ => Err(format!("Unknown tool: {}", tool_name)),
         }
         .or_else(|e| {

--- a/src-tauri/src/mcp/builtin/tool/operations.rs
+++ b/src-tauri/src/mcp/builtin/tool/operations.rs
@@ -231,8 +231,9 @@ pub async fn register_server(_server: &ToolServer, args: Value) -> Result<MCPRes
             name, id
         ),
         vec![
-            "Use tool__listServers to verify the registered server.".to_string(),
-            "To enable this server, add its Server ID to an agent using agent__updateAgent(id:\"<agentId>\", externalMcpServers:[...]).".to_string(),
+            "Use tool__listServers({\"availability\":\"inventory\"}) to confirm the registered server.".to_string(),
+            "Attach this Server ID to an agent config with agent__updateAgent(id:\"<agentId>\", externalMcpServers:[...]). That updates the template for future sessions only — it cannot add tools to your currently active session.".to_string(),
+            "Confirm what this session can call with tool__listServers({\"availability\":\"session\"}).".to_string(),
         ],
     );
     Ok(hint.to_mcp_result_with_data(Some(json!({ "name": name, "id": id }))))
@@ -464,7 +465,11 @@ pub async fn update_server(_server: &ToolServer, args: Value) -> Result<MCPResul
 }
 
 /// Verify server configuration and connectivity
-pub async fn verify_server(_server: &ToolServer, args: Value) -> Result<MCPResult, String> {
+pub async fn verify_server(
+    _server: &ToolServer,
+    args: Value,
+    session_id: Option<&str>,
+) -> Result<MCPResult, String> {
     use crate::mcp::types::TransportConfig;
     use std::time::Instant;
 
@@ -478,6 +483,10 @@ pub async fn verify_server(_server: &ToolServer, args: Value) -> Result<MCPResul
         Some(details) => details,
         Option::None => return Ok(not_found_error("Server", name, ToolGroup::Tool)),
     };
+
+    let access = load_session_tool_access(session_id).await;
+    let (session_status, session_access_line) =
+        access.external_access_report(session_id, &id, name);
 
     // Determine transport type
     let (transport_type, transport_details) = match &config.transport {
@@ -525,23 +534,36 @@ pub async fn verify_server(_server: &ToolServer, args: Value) -> Result<MCPResul
             }
 
             let result_text = format!(
-                "✓ Server '{}' (ID: {}) verification successful\n\n\
+                "✓ Server '{}' (ID: {}) connectivity verification successful\n\n\
                 Transport: {}\n\
                 {}\n\
                 Status: Connected and responsive\n\
-                Available tools: {} (cached — use tool__listServers to inspect inventory)\n\
-                Connection latency: {}ms\n\n\
-                The server is properly configured and ready to use.",
-                name, id, transport_type, transport_details, tool_count, latency_ms
+                Tools discovered: {} (cached metadata — not the same as session-callable access)\n\
+                Connection latency: {}ms\n\
+                {}\n\n\
+                Verification only confirms the server config can connect. It does not enable tools in your currently active session.",
+                name,
+                id,
+                transport_type,
+                transport_details,
+                tool_count,
+                latency_ms,
+                session_access_line
             );
 
             Ok(SuccessHint::new(
                 result_text,
-                vec!["Server configuration is valid and operational".to_string()],
+                vec![
+                    "Use tool__listServers({\"availability\":\"session\"}) to see tools callable in this session.".to_string(),
+                    "agent__updateAgent attaches servers to an agent template for future sessions only; start a new session (or agent__startSession) to run with that access.".to_string(),
+                ],
             )
-            .to_mcp_result_with_data(Some(
-                json!({ "name": name, "id": id, "toolCount": tool_count }),
-            )))
+            .to_mcp_result_with_data(Some(json!({
+                "name": name,
+                "id": id,
+                "toolCount": tool_count,
+                "sessionStatus": session_status,
+            }))))
         }
         Err(error) => {
             let error_msg = format!("✗ Server '{}' verification failed", name);
@@ -888,9 +910,10 @@ pub async fn list_tools(args: Value, session_id: Option<&str>) -> Result<MCPResu
             .map(|(name, id)| format!("  • {} → \"{}\"", name, id))
             .collect();
         format!(
-            "\n\n---\n📌 To enable these external servers:\n\
+            "\n\n---\n📌 External server IDs (inventory only — not auto-enabled in this session):\n\
             Server IDs found:\n(this page only)\n{}\n\n\
-            To assign them to an agent, call:\n  agent__updateAgent(id: \"<agentId>\", externalMcpServers: [\"<id_1>\", \"...\"])\n\n\
+            To attach them to an agent template for future sessions, call:\n  agent__updateAgent(id: \"<agentId>\", externalMcpServers: [\"<id_1>\", \"...\"])\n\n\
+            Note: agent__updateAgent cannot add or modify tools in your currently active session. Active session tool access is fixed at session start. Use availability='session' to see what you can call right now; start a new session (or agent__startSession) to run with an updated config.\n\n\
             Use agent__listAgents(type: \"configs\") to find your target agent ID.",
             ids_list.join("\n")
         )
@@ -900,11 +923,11 @@ pub async fn list_tools(args: Value, session_id: Option<&str>) -> Result<MCPResu
 
     let mut hints = if session_view {
         vec![
-            "Session mode shows whether the current session can actually call each tool. Use availability='inventory' to list all platform tools regardless of current access.".to_string(),
+            "Session mode shows whether the current session can actually call each tool. Use availability='inventory' to browse registered platform tools regardless of current access.".to_string(),
         ]
     } else {
         vec![
-            "Inventory mode shows all registered platform tools. Use availability='session' to see which ones are actively permitted in the current session.".to_string(),
+            "Inventory mode lists registered platform tools; listing or verifying a server does not make it callable here. Use availability='session' for tools permitted in the current session.".to_string(),
         ]
     };
     if !force_verify && include_external {

--- a/src-tauri/src/mcp/builtin/tool/tools.rs
+++ b/src-tauri/src/mcp/builtin/tool/tools.rs
@@ -146,9 +146,9 @@ pub fn register_server_tool() -> MCPTool {
                 "Configure transport (stdio, http, or http-sse) with required fields.",
             ],
             &[
-                "Verify connectivity with tool__verifyServer.",
-                "Attach the server ID to an agent via agent__updateAgent.",
-                "Discover available tools with tool__listServers.",
+                "Verify connectivity with tool__verifyServer (connectivity only — not session enablement).",
+                "Attach the server ID to an agent template via agent__updateAgent for future sessions; start a new session to use it.",
+                "Confirm callable tools with tool__listServers({\"availability\":\"session\"}).",
             ],
         ),
         input_schema: object_prop(
@@ -264,14 +264,14 @@ pub fn verify_server_tool() -> MCPTool {
         name: "verifyServer".to_string(),
         title: Some("Verify Server".to_string()),
         description: tool_description(
-            "Verify a saved external MCP server configuration and refresh its cached tools.",
+            "Verify a saved external MCP server can connect and refresh its cached tool metadata. This does not enable tools in the currently active session.",
             &["Server must already be registered via tool__registerServer."],
             &[
                 "Pass the server slug name.",
                 "Wait for connectivity check and tool cache refresh.",
             ],
             &[
-                "Browse refreshed tools with tool__listServers (scope='external').",
+                "Check session-callable tools with tool__listServers({\"availability\":\"session\"}).",
                 "Fix transport settings with tool__updateServer if verification fails.",
             ],
         ),
@@ -303,7 +303,7 @@ pub fn list_tools_tool() -> MCPTool {
             ],
             &[
                 "Register missing servers with tool__registerServer.",
-                "Attach external server IDs to agents via agent__updateAgent.",
+                "Attach external server IDs to agent templates via agent__updateAgent for future sessions only; active session tools stay fixed until a new session starts.",
             ],
         ),
         input_schema: object_prop(

--- a/src-tauri/src/mcp/builtin/utils.rs
+++ b/src-tauri/src/mcp/builtin/utils.rs
@@ -792,6 +792,35 @@ impl SessionToolAccess {
             }
         }
     }
+
+    /// Session-access label for verify/list reports.
+    ///
+    /// Without a session context, returns `"Unknown"` instead of `"Unsupported…"`,
+    /// so text and structured `sessionStatus` stay aligned and do not imply a deny decision.
+    pub fn external_access_report(
+        &self,
+        session_id: Option<&str>,
+        server_id: &str,
+        server_name: &str,
+    ) -> (&'static str, String) {
+        match session_id {
+            Some(sid) => {
+                let (status, _) = self.external_status(server_id, server_name);
+                (
+                    status,
+                    format!(
+                        "Session access for '{}': {} — verification does not grant tools to an already-running session.",
+                        sid, status
+                    ),
+                )
+            }
+            None => (
+                "Unknown",
+                "Session access: unknown (no session context) — verification only checks connectivity."
+                    .to_string(),
+            ),
+        }
+    }
 }
 
 pub async fn load_session_tool_access(session_id: Option<&str>) -> SessionToolAccess {

--- a/src-tauri/src/mcp/error_normalization.rs
+++ b/src-tauri/src/mcp/error_normalization.rs
@@ -121,10 +121,10 @@ pub async fn missing_external_tool_result(
                 "Use tool__listServers({\"availability\":\"session\"}) to inspect the tools callable right now in this session.".to_string(),
                 "Use tool__listServers({\"availability\":\"inventory\"}) to inspect registered external servers, inventory, and Server IDs.".to_string(),
                 format!(
-                    "If this session should gain access, attach Server ID \"{}\" with agent__updateAgent(id:\"<agentId>\", externalMcpServers:[\"{}\", ...]).",
+                    "agent__updateAgent(id:\"<agentId>\", externalMcpServers:[\"{}\", ...]) attaches Server ID \"{}\" to an agent template for future sessions only — it cannot add tools to this already-running session.",
                     server.id, server.id
                 ),
-                "If changing the current agent is the wrong move, use agent__listAgents(type=\"configs\") to find a better-equipped agent and delegate with agent__startSession(agentId:\"<agentId>\", task:\"...\").".to_string(),
+                "To use this server now, delegate with agent__startSession(agentId:\"<agentId>\", task:\"...\") using a config that already includes it, or continue with tools shown by availability='session'.".to_string(),
             ],
         ),
         Ok(None) => external_tool_error_result(

--- a/src-tauri/tests/integration/external_tool_recovery_tests.rs
+++ b/src-tauri/tests/integration/external_tool_recovery_tests.rs
@@ -205,8 +205,12 @@ async fn detached_external_server_returns_delegate_or_attach_guidance() {
         "guidance should explain how to attach the missing server: {text}"
     );
     assert!(
-        text.contains("agent__listAgents(type=\"configs\")"),
-        "guidance should point toward alternative agents: {text}"
+        text.contains("future sessions only"),
+        "guidance must state updateAgent is future-session-only: {text}"
+    );
+    assert!(
+        text.contains("already-running session"),
+        "guidance must state updateAgent cannot change the current session: {text}"
     );
     assert!(
         text.contains("agent__startSession"),

--- a/src-tauri/tests/integration/tool_discovery_guidance_tests.rs
+++ b/src-tauri/tests/integration/tool_discovery_guidance_tests.rs
@@ -176,6 +176,15 @@ async fn tool_list_uses_canonical_agent_update_guidance() {
         "tool discovery guidance should point to canonical agent__updateAgent: {text}"
     );
     assert!(
+        text.contains("currently active session")
+            || text.contains("future sessions"),
+        "inventory guidance must state session immutability / future-session-only attachment: {text}"
+    );
+    assert!(
+        !text.contains("To enable these external servers:"),
+        "inventory guidance must not imply mid-session enablement: {text}"
+    );
+    assert!(
         !text.contains("updateAssistant("),
         "tool discovery guidance should not mention legacy updateAssistant alias: {text}"
     );

--- a/src-tauri/tests/verify_session_access_report_tests.rs
+++ b/src-tauri/tests/verify_session_access_report_tests.rs
@@ -1,0 +1,73 @@
+//! Windows-safe coverage for verifyServer session-access reporting (#1754).
+//! Standalone binary — does not pull AppHandle/WebView into the link.
+
+use std::collections::HashSet;
+use tauri_mcp_agent_lib::mcp::builtin::utils::SessionToolAccess;
+
+fn access_with_external_ids(ids: &[&str]) -> SessionToolAccess {
+    SessionToolAccess {
+        session_id: Some("sess-1".to_string()),
+        allowed_builtin_aliases: None,
+        allowed_external_server_ids: Some(ids.iter().map(|id| (*id).to_string()).collect()),
+        agent_id: Some("agent-1".to_string()),
+    }
+}
+
+#[test]
+fn external_access_report_unknown_without_session_context() {
+    let access = SessionToolAccess {
+        session_id: None,
+        allowed_builtin_aliases: None,
+        allowed_external_server_ids: None,
+        agent_id: None,
+    };
+
+    let (status, line) = access.external_access_report(None, "srv-1", "gemini");
+    assert_eq!(status, "Unknown");
+    assert!(
+        line.contains("unknown (no session context)"),
+        "text must stay aligned with Unknown status: {line}"
+    );
+    assert!(
+        !line.contains("[Unsupported in current session]"),
+        "no-session branch must not imply a deny decision: {line}"
+    );
+}
+
+#[test]
+fn external_access_report_ready_when_server_attached() {
+    let access = access_with_external_ids(&["srv-ready"]);
+    let (status, line) = access.external_access_report(Some("sess-1"), "srv-ready", "gemini");
+    assert_eq!(status, "[Ready]");
+    assert!(
+        line.contains("[Ready]"),
+        "ready status must appear in the report line: {line}"
+    );
+    assert!(
+        line.contains("already-running session"),
+        "report must still clarify verification does not mutate the session: {line}"
+    );
+}
+
+#[test]
+fn external_access_report_unsupported_when_server_detached() {
+    let access = access_with_external_ids(&["other-server"]);
+    let (status, line) = access.external_access_report(Some("sess-1"), "srv-missing", "gemini");
+    assert_eq!(status, "[Unsupported in current session]");
+    assert!(
+        line.contains("[Unsupported in current session]"),
+        "unsupported status must appear in the report line: {line}"
+    );
+}
+
+#[test]
+fn external_access_report_unsupported_when_allow_list_empty() {
+    let access = SessionToolAccess {
+        session_id: Some("sess-1".to_string()),
+        allowed_builtin_aliases: None,
+        allowed_external_server_ids: Some(HashSet::new()),
+        agent_id: Some("agent-1".to_string()),
+    };
+    let (status, _) = access.external_access_report(Some("sess-1"), "srv-1", "gemini");
+    assert_eq!(status, "[Unsupported in current session]");
+}


### PR DESCRIPTION
## Summary
- Stop `tool__listServers` / `tool__verifyServer` / `agent__updateAgent` from implying mid-session MCP enablement; inventory and verify only report registration/connectivity.
- `verifyServer` now reports session access (`[Ready]` / `[Unsupported…]` / `Unknown`) so agents can tell verified ≠ callable in the current session.
- Tighten recovery/discovery guidance and tests so attachment is documented as future-session-only; no benchmark-only tool hiding.

Fixes #1754

## Test plan
- [ ] `cargo test --test verify_session_access_report_tests`
- [ ] On Linux/macOS CI: `tool_discovery_guidance_tests` + `external_tool_recovery_tests`
- [ ] Manually: `tool__listServers` inventory no longer says `To enable these external servers`
- [ ] Manually: `tool__verifyServer` on a detached server reports Unsupported and does not say ready to use
- [ ] Manually: `agent__updateAgent` description/success hints state future sessions only

Made with [Cursor](https://cursor.com)